### PR TITLE
Enable `no_multiple_statements_per_line`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -42,6 +42,7 @@ $overrides = [
     // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
     'blank_line_between_import_groups' => true,
     'control_structure_braces'         => true,
+    'no_multiple_statements_per_line'  => true,
     'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -34,6 +34,7 @@ $overrides = [
     // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
     'blank_line_between_import_groups' => true,
     'control_structure_braces'         => true,
+    'no_multiple_statements_per_line'  => true,
     'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -36,6 +36,7 @@ $overrides = [
     // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
     'blank_line_between_import_groups' => true,
     'control_structure_braces'         => true,
+    'no_multiple_statements_per_line'  => true,
     'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe no_multiple_statements_per_line  
Description of no_multiple_statements_per_line rule.
There must not be more than one statement per line.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,3 @@
    <?php
   -foo(); bar();
   +foo();
   +bar();

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
