### PR TITLE
Enable `no_trailing_comma_in_singleline`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -50,8 +50,16 @@ $overrides = [
     ],
     'control_structure_braces'        => true,
     'no_multiple_statements_per_line' => true,
-    'no_useless_nullsafe_operator'    => true,
-    'phpdoc_separation'               => [
+    'no_trailing_comma_in_singleline' => [
+        'elements' => [
+            'arguments',
+            'array_destructuring',
+            'array',
+            'group_import',
+        ],
+    ],
+    'no_useless_nullsafe_operator' => true,
+    'phpdoc_separation'            => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -42,8 +42,16 @@ $overrides = [
     ],
     'control_structure_braces'        => true,
     'no_multiple_statements_per_line' => true,
-    'no_useless_nullsafe_operator'    => true,
-    'phpdoc_separation'               => [
+    'no_trailing_comma_in_singleline' => [
+        'elements' => [
+            'arguments',
+            'array_destructuring',
+            'array',
+            'group_import',
+        ],
+    ],
+    'no_useless_nullsafe_operator' => true,
+    'phpdoc_separation'            => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -44,8 +44,16 @@ $overrides = [
     ],
     'control_structure_braces'        => true,
     'no_multiple_statements_per_line' => true,
-    'no_useless_nullsafe_operator'    => true,
-    'phpdoc_separation'               => [
+    'no_trailing_comma_in_singleline' => [
+        'elements' => [
+            'arguments',
+            'array_destructuring',
+            'array',
+            'group_import',
+        ],
+    ],
+    'no_useless_nullsafe_operator' => true,
+    'phpdoc_separation'            => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/user_guide_src/source/database/call_function/002.php
+++ b/user_guide_src/source/database/call_function/002.php
@@ -1,3 +1,3 @@
 <?php
 
-$db->callFunction('some_function', $param1, $param2, /* ... */);
+$db->callFunction('some_function', $param1, $param2 /* , ... */);


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe no_trailing_comma_in_singleline
Description of no_trailing_comma_in_singleline rule.
If a list of values separated by a comma is contained on a single line, then the last item MUST NOT have a trailing comma.

Fixer is configurable using following option:
* elements (a subset of ['arguments', 'array_destructuring', 'array', 'group_import']): which elements to fix; defaults to ['arguments', 'array_destructuring', 'array', 'group_import']

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,5 +1,5 @@
    <?php
   -foo($a,);
   -$foo = array(1,);
   -[$foo, $bar,] = $array;
   -use a\{ClassA, ClassB,};
   +foo($a);
   +$foo = array(1);
   +[$foo, $bar] = $array;
   +use a\{ClassA, ClassB};

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['elements' => ['array_destructuring']].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,3 +1,3 @@
    <?php
    foo($a,);
   -[$foo, $bar,] = $array;
   +[$foo, $bar] = $array;

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
