### PR TITLE
Enable `no_useless_nullsafe_operator`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -43,6 +43,7 @@ $overrides = [
     'blank_line_between_import_groups' => true,
     'control_structure_braces'         => true,
     'no_multiple_statements_per_line'  => true,
+    'no_useless_nullsafe_operator'     => true,
     'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -35,6 +35,7 @@ $overrides = [
     'blank_line_between_import_groups' => true,
     'control_structure_braces'         => true,
     'no_multiple_statements_per_line'  => true,
+    'no_useless_nullsafe_operator'     => true,
     'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -37,6 +37,7 @@ $overrides = [
     'blank_line_between_import_groups' => true,
     'control_structure_braces'         => true,
     'no_multiple_statements_per_line'  => true,
+    'no_useless_nullsafe_operator'     => true,
     'phpdoc_separation'                => [
         'groups' => [
             ['immutable', 'psalm-immutable'],


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe no_useless_nullsafe_operator   
Description of no_useless_nullsafe_operator rule.
There should not be useless `null-safe-operators` `?->` used.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,7 +1,7 @@
    <?php
    class Foo extends Bar
    {
        public function test() {
   -        echo $this?->parentMethod();
   +        echo $this->parentMethod();
        }
    }

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
