### PR TITLE
Enable `statement_indentation`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -57,6 +57,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    'statement_indentation' => true,
     // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -49,6 +49,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    'statement_indentation' => true,
     // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -51,6 +51,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    'statement_indentation' => true,
     // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe statement_indentation      
Description of statement_indentation rule.
Each statement must be indented.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,7 +1,7 @@
    <?php
    if ($baz == true) {
   -  echo "foo";
   +    echo "foo";
    }
    else {
   -      echo "bar";
   +    echo "bar";
    }

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
