### PR TITLE
Add `inline_constructor_arguments` option to `class_definition`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -41,10 +41,17 @@ $finder = Finder::create()
 $overrides = [
     // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
     'blank_line_between_import_groups' => true,
-    'control_structure_braces'         => true,
-    'no_multiple_statements_per_line'  => true,
-    'no_useless_nullsafe_operator'     => true,
-    'phpdoc_separation'                => [
+    'class_definition'                 => [
+        'multi_line_extends_each_single_line' => true,
+        'single_item_single_line'             => true,
+        'single_line'                         => true,
+        'space_before_parenthesis'            => true,
+        'inline_constructor_arguments'        => true,
+    ],
+    'control_structure_braces'        => true,
+    'no_multiple_statements_per_line' => true,
+    'no_useless_nullsafe_operator'    => true,
+    'phpdoc_separation'               => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -33,10 +33,17 @@ $finder = Finder::create()
 $overrides = [
     // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
     'blank_line_between_import_groups' => true,
-    'control_structure_braces'         => true,
-    'no_multiple_statements_per_line'  => true,
-    'no_useless_nullsafe_operator'     => true,
-    'phpdoc_separation'                => [
+    'class_definition'                 => [
+        'multi_line_extends_each_single_line' => true,
+        'single_item_single_line'             => true,
+        'single_line'                         => true,
+        'space_before_parenthesis'            => true,
+        'inline_constructor_arguments'        => true,
+    ],
+    'control_structure_braces'        => true,
+    'no_multiple_statements_per_line' => true,
+    'no_useless_nullsafe_operator'    => true,
+    'phpdoc_separation'               => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -35,10 +35,17 @@ $overrides = [
     'class_attributes_separation' => false,
     // <<<<<<<<<<<<<<<<<<<<<<<< @TODO TO BE REMOVED ONCE LIVE IN CODING-STANDARD
     'blank_line_between_import_groups' => true,
-    'control_structure_braces'         => true,
-    'no_multiple_statements_per_line'  => true,
-    'no_useless_nullsafe_operator'     => true,
-    'phpdoc_separation'                => [
+    'class_definition'                 => [
+        'multi_line_extends_each_single_line' => true,
+        'single_item_single_line'             => true,
+        'single_line'                         => true,
+        'space_before_parenthesis'            => true,
+        'inline_constructor_arguments'        => true,
+    ],
+    'control_structure_braces'        => true,
+    'no_multiple_statements_per_line' => true,
+    'no_useless_nullsafe_operator'    => true,
+    'phpdoc_separation'               => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe class_definition     
Description of class_definition rule.
Whitespace around the keywords of a class, trait, enum or interfaces definition should be one space.

Fixer is configurable using following options:
* multi_line_extends_each_single_line (bool): whether definitions should be multiline; defaults to false
* single_item_single_line (bool): whether definitions should be single line when including a single item; defaults to false
* single_line (bool): whether definitions should be single line; defaults to false
* space_before_parenthesis (bool): whether there should be a single space after the parenthesis of anonymous class (PSR12) or not; defaults to false
* inline_constructor_arguments (bool): whether constructor argument list in anonymous classes should be single line; defaults to true      

Fixing examples:
 
[REDACTED]

 * Example #6. Fixing with configuration: ['inline_constructor_arguments' => true].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,5 +1,2 @@
    <?php
   -$foo = new class(
   -    $bar,
   -    $baz
   -) {};
   +$foo = new class($bar, $baz) {};

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
