### PR TITLE
Create Forge::dropPrimaryKey()

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -167,7 +167,7 @@ class Forge
      *
      * @var string
      */
-    protected $dropConstraintStr;
+    protected $dropConstraintStr;'ALTER TABLE %s DROP CONSTRAINT %s'
 
     /**
      * DROP INDEX statement
@@ -452,6 +452,20 @@ class Forge
 
             return false;
         }
+
+        return $this->db->query($sql);
+    }
+
+    /**
+     * Drop Primary Key
+     */
+    public function dropPrimaryKey(string $table): bool
+    {
+        $sql = sprintf(
+            'ALTER TABLE %s DROP CONSTRAINT %s',
+            $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
+            $this->db->escapeIdentifiers('pk_' . $this->db->DBPrefix . $table),
+        );
 
         return $this->db->query($sql);
     }

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -167,7 +167,7 @@ class Forge
      *
      * @var string
      */
-    protected $dropConstraintStr;'ALTER TABLE %s DROP CONSTRAINT %s'
+    protected $dropConstraintStr;
 
     /**
      * DROP INDEX statement

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -236,4 +236,17 @@ class Forge extends BaseForge
 
         return $this->db->query($sql);
     }
+
+    /**
+     * Drop Primary Key
+     */
+    public function dropPrimaryKey(string $table): bool
+    {
+        $sql = sprintf(
+            'ALTER TABLE %s DROP PRIMARY KEY',
+            $this->db->escapeIdentifiers($this->db->DBPrefix . $table)
+        );
+
+        return $this->db->query($sql);
+    }
 }

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -250,4 +250,16 @@ class Forge extends BaseForge
             ->dropForeignKey($foreignName)
             ->run();
     }
+
+    /**
+     * Drop Primary Key
+     */
+    public function dropPrimaryKey(string $table): bool
+    {
+        $sqlTable = new Table($this->db, $this);
+
+        return $sqlTable->fromTable($this->db->DBPrefix . $table)
+            ->dropPrimaryKey()
+            ->run();
+    }
 }

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -195,6 +195,20 @@ class Table
     }
 
     /**
+     * Drops the primary key
+     */
+    public function dropPrimaryKey(): Table
+    {
+        $primaryIndexes = array_filter($this->keys, static fn ($index) => strtolower($index['type']) === 'primary');
+
+        foreach (array_keys($primaryIndexes) as $key) {
+            unset($this->keys[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Drops a foreign key from this table so that
      * it won't be recreated in the future.
      *

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1372,4 +1372,40 @@ final class ForgeTest extends CIUnitTestCase
 
         $this->assertFalse($this->db->fieldExists('text_with_constraint', 'user'));
     }
+
+    public function testDropPrimaryKey()
+    {
+        $this->forge->dropTable('forge_test_users', true);
+
+        $this->forge->addField([
+            'id' => [
+                'type'       => 'INTEGER',
+                'constraint' => 11,
+            ],
+            'second_id' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+            ],
+            'name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+            ],
+        ]);
+        $primaryKeys = ['id', 'second_id'];
+        $this->forge->addPrimaryKey($primaryKeys);
+        $this->forge->createTable('forge_test_users', true);
+
+        $indexes = $this->db->getIndexData('forge_test_users');
+
+        $this->assertCount(1, $indexes);
+        $this->assertSame($primaryKeys, current($indexes)->fields);
+
+        $this->forge->dropPrimaryKey('forge_test_users');
+
+        $indexes = $this->db->getIndexData('forge_test_users');
+
+        $this->assertCount(0, $indexes);
+
+        $this->forge->dropTable('forge_test_users', true);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -72,6 +72,7 @@ Database
 - SQLite :ref:`BaseConnection::getIndexData() <db-metadata-getindexdata>` now can return pseudo index named ``PRIMARY`` for `AUTOINCREMENT` column, and each returned index data has ``type`` property.
 - SQLSRV now automatically drops ``DEFAULT`` constraint when using :ref:`Forge::dropColumn() <db-forge-dropColumn>`.
 - ``BaseConnection::escape()`` now excludes the ``RawSql`` data type. This allows passing SQL strings into data.
+- The new method ``Forge::dropPrimaryKey()`` allows dropping the primary key on a table.
 
 Model
 =====

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -229,6 +229,13 @@ Execute a DROP KEY.
 
 .. literalinclude:: forge/020.php
 
+Dropping a Primary Key
+======================
+
+Execute a DROP PRIMARY KEY.
+
+.. literalinclude:: forge/028.php
+
 Renaming a Table
 ================
 

--- a/user_guide_src/source/dbmgmt/forge/028.php
+++ b/user_guide_src/source/dbmgmt/forge/028.php
@@ -1,0 +1,5 @@
+<?php
+
+// MySqli Produces: ALTER TABLE `tablename` DROP PRIMARY KEY
+// Others Produces: ALTER TABLE `tablename` DROP CONSTRAINT `pk_tablename`
+$forge->dropPrimaryKey('tablename');


### PR DESCRIPTION
This PR creates a method to drop primary keys from a table.

This is the second part of https://github.com/codeigniter4/CodeIgniter4/pull/6430

This solves part of https://github.com/codeigniter4/CodeIgniter4/issues/4653

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
