### PR TITLE
fix: validation change behavior regex match in `integer` and `numeric` to php function

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -131,7 +131,7 @@ class FormatRules
      */
     public function integer(?string $str = null): bool
     {
-        return (bool) preg_match('/\A[\-+]?\d+\z/', $str ?? '');
+        return is_int($str);
     }
 
     /**
@@ -155,8 +155,7 @@ class FormatRules
      */
     public function numeric(?string $str = null): bool
     {
-        // @see https://regex101.com/r/bb9wtr/2
-        return (bool) preg_match('/\A[\-+]?\d*\.?\d+\z/', $str ?? '');
+        return is_numeric($str);
     }
 
     /**

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -128,8 +128,10 @@ class FormatRules
 
     /**
      * Integer
+     *
+     * @param string|int|null $str
      */
-    public function integer(?string $str = null): bool
+    public function integer($str = null): bool
     {
         return is_int($str);
     }

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -129,7 +129,7 @@ class FormatRules
     /**
      * Integer
      *
-     * @param int|string|null $str
+     * @param int|null $str
      */
     public function integer($str = null): bool
     {

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -129,7 +129,7 @@ class FormatRules
     /**
      * Integer
      *
-     * @param string|int|null $str
+     * @param int|string|null $str
      */
     public function integer($str = null): bool
     {

--- a/system/Validation/StrictRules/FormatRules.php
+++ b/system/Validation/StrictRules/FormatRules.php
@@ -184,18 +184,10 @@ class FormatRules
     /**
      * Integer
      *
-     * @param mixed $str
+     * @param int|null $str
      */
     public function integer($str = null): bool
     {
-        if (is_int($str)) {
-            $str = (string) $str;
-        }
-
-        if (! is_string($str)) {
-            return false;
-        }
-
         return $this->nonStrictFormatRules->integer($str);
     }
 
@@ -238,7 +230,7 @@ class FormatRules
     /**
      * Numeric
      *
-     * @param mixed $str
+     * @param float|int|string|null $str
      */
     public function numeric($str = null): bool
     {

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -655,7 +655,7 @@ final class CodeIgniterTest extends CIUnitTestCase
             $routes->add($testingUrl, static function () {
                 CodeIgniter::cache(0); // Dont cache the page in the run() function because CodeIgniter class will create default $cacheConfig and overwrite settings from the dataProvider
                 $response = Services::response();
-                $string = 'This is a test page, to check cache configuration';
+                $string   = 'This is a test page, to check cache configuration';
 
                 return $response->setBody($string);
             });

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -881,8 +881,12 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         yield from [
             [
-                '0',
+                1,
                 true,
+            ],
+            [
+                '0',
+                false,
             ],
             [
                 '42',

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -809,9 +809,9 @@ final class FormatRulesTest extends CIUnitTestCase
         $data = [
             'foo' => $value,
         ];
-        $this->assertsame($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
-    
+
     public function integerInvalidTypeDataProvider(): Generator
     {
         // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
@@ -858,7 +858,7 @@ final class FormatRulesTest extends CIUnitTestCase
         $data = [
             'foo' => $value,
         ];
-        $this->assertsame($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public function numericInvalidTypeDataProvider(): Generator

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -811,11 +811,41 @@ final class FormatRulesTest extends CIUnitTestCase
         ];
         $this->assertsame($expected, $this->validation->run($data));
     }
+    
+    public function integerInvalidTypeDataProvider(): Generator
+    {
+        // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
+        // yield 'array with int' => [
+        // [555],
+        // false,
+        // ];
+
+        // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
+        // yield 'empty array' => [
+        // [],
+        // false,
+        // ];
+
+        yield 'bool true' => [
+            true,
+            false,
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
 
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
      *
-     * @dataProvider integerInvalidTypeDataProvider
+     * @dataProvider numericInvalidTypeDataProvider
      *
      * @param mixed $value
      */
@@ -831,15 +861,15 @@ final class FormatRulesTest extends CIUnitTestCase
         $this->assertsame($expected, $this->validation->run($data));
     }
 
-    public function integerInvalidTypeDataProvider(): Generator
+    public function numericInvalidTypeDataProvider(): Generator
     {
-        // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
+        // TypeError : CodeIgniter\Validation\FormatRules::numeric(): Argument #1 ($str) must be of type ?string, array given
         // yield 'array with int' => [
         // [555],
         // false,
         // ];
 
-        // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
+        // TypeError : CodeIgniter\Validation\FormatRules::numeric(): Argument #1 ($str) must be of type ?string, array given
         // yield 'empty array' => [
         // [],
         // false,
@@ -863,6 +893,8 @@ final class FormatRulesTest extends CIUnitTestCase
 
     /**
      * @dataProvider integerProvider
+     *
+     * @param int|string $str
      */
     public function testInteger($str, bool $expected): void
     {
@@ -885,16 +917,20 @@ final class FormatRulesTest extends CIUnitTestCase
                 true,
             ],
             [
+                1.5,
+                false,
+            ],
+            [
                 '0',
                 false,
             ],
             [
                 '42',
-                true,
+                false,
             ],
             [
                 '-1',
-                true,
+                false,
             ],
             [
                 "+42\n",

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -894,7 +894,7 @@ final class FormatRulesTest extends CIUnitTestCase
     /**
      * @dataProvider integerProvider
      *
-     * @param int|string $str
+     * @param int|string|null $str
      */
     public function testInteger($str, bool $expected): void
     {

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -864,7 +864,7 @@ final class FormatRulesTest extends CIUnitTestCase
     /**
      * @dataProvider integerProvider
      */
-    public function testInteger(?string $str, bool $expected): void
+    public function testInteger($str, bool $expected): void
     {
         $data = [
             'foo' => $str,

--- a/tests/system/Validation/StrictRules/FormatRulesTest.php
+++ b/tests/system/Validation/StrictRules/FormatRulesTest.php
@@ -813,25 +813,6 @@ final class FormatRulesTest extends CIUnitTestCase
         $this->assertsame($expected, $this->validation->run($data));
     }
 
-    /**
-     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
-     *
-     * @dataProvider integerInvalidTypeDataProvider
-     *
-     * @param mixed $value
-     */
-    public function testNumericWithInvalidTypeData($value, bool $expected): void
-    {
-        $this->validation->setRules([
-            'foo' => 'numeric',
-        ]);
-
-        $data = [
-            'foo' => $value,
-        ];
-        $this->assertsame($expected, $this->validation->run($data));
-    }
-
     public function integerInvalidTypeDataProvider(): Generator
     {
         yield 'array with int' => [
@@ -861,9 +842,48 @@ final class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider integerProvider
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
+     *
+     * @dataProvider numericInvalidTypeDataProvider
+     *
+     * @param mixed $value
      */
-    public function testInteger(?string $str, bool $expected): void
+    public function testNumericWithInvalidTypeData($value, bool $expected): void
+    {
+        $this->validation->setRules([
+            'foo' => 'numeric',
+        ]);
+
+        $data = [
+            'foo' => $value,
+        ];
+        $this->assertsame($expected, $this->validation->run($data));
+    }
+
+    public function numericInvalidTypeDataProvider(): Generator
+    {
+        yield 'bool true' => [
+            true,
+            false,
+        ];
+
+        yield 'bool false' => [
+            false,
+            false,
+        ];
+
+        yield 'null' => [
+            null,
+            false,
+        ];
+    }
+
+    /**
+     * @dataProvider integerProvider
+     *
+     * @param int|string|null $str
+     */
+    public function testInteger($str, bool $expected): void
     {
         $data = [
             'foo' => $str,
@@ -880,16 +900,24 @@ final class FormatRulesTest extends CIUnitTestCase
     {
         yield from [
             [
-                '0',
+                1,
                 true,
+            ],
+            [
+                1.5,
+                false,
+            ],
+            [
+                '0',
+                false,
             ],
             [
                 '42',
-                true,
+                false,
             ],
             [
                 '-1',
-                true,
+                false,
             ],
             [
                 "+42\n",

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -211,7 +211,6 @@ It works for most basic cases like validating POST data.
 
 However, for example, if you use JSON input data, it may be a type of bool/null/array.
 When you validate the boolean ``true``, it is converted to string ``'1'`` with the Traditional rule classes.
-If you validate it with the ``integer`` rule, ``'1'`` passes the validation.
 
 The **Strict Rules** don't use implicit type conversion.
 


### PR DESCRIPTION
**Description**
Fixed #6489

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
