### PR TITLE
Prep for 4.2.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v4.2.6](https://github.com/codeigniter4/CodeIgniter4/tree/v4.2.6) (2022-09-04)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.2.5...v4.2.6)
+
+### Fixed Bugs
+* fix: AssertionError occurs when using Validation in CLI by @daycry in https://github.com/codeigniter4/CodeIgniter4/pull/6452
+* fix: [Validation] JSON data may cause "Array to string conversion" error by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6467
+* Fix fatal error gets turned to `0` severity on shutdown handler by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/6472
+* Fix redis cache increment/decrement methods by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/6473
+* Fix broken caching system when array of allowed parameters used by @JavaDeveloperKiev in https://github.com/codeigniter4/CodeIgniter4/pull/6475
+* fix: Strict Validation Rules greater_than/less_than by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6492
+
+### Refactoring
+* refactor: fix PHPStan errors by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6470
+* Bump `friendsofphp/php-cs-fixer` to `~3.11.0` by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/6471
+* Fix overlooked coding style violations by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/6491
+
 ## [v4.2.5](https://github.com/codeigniter4/CodeIgniter4/tree/v4.2.5) (2022-08-28)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.2.4...v4.2.5)
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -47,7 +47,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.2.5';
+    public const CI_VERSION = '4.2.6';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.2.7
     v4.2.6
     v4.2.5
     v4.2.4

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -1,9 +1,9 @@
-Version 4.2.6
+Version 4.2.7
 #############
 
-Release Date: September 4, 2022
+Release Date: Unreleased
 
-**4.2.6 release of CodeIgniter4**
+**4.2.7 release of CodeIgniter4**
 
 .. contents::
     :local:
@@ -27,12 +27,11 @@ none.
 Deprecations
 ************
 
-- :php:meth:`CodeIgniter\\Cookie\\Cookie::withNeverExpiring()` is deprecated.
+none.
 
 Bugs Fixed
 **********
 
-Many bugs fixed, but notably:
-- AssertionError occurs when using Validation in CLI `https://github.com/codeigniter4/CodeIgniter4/pull/6452`
+none.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2022 CodeIgniter Foundation'
 version = '4.2'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.2.5'
+release = '4.2.6'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_426.rst
+++ b/user_guide_src/source/installation/upgrade_426.rst
@@ -1,0 +1,32 @@
+#############################
+Upgrading from 4.2.5 to 4.2.6
+#############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+
+Project Files
+*************
+
+A few files in the **project space** (root, app, public, writable) received cosmetic updates.
+You need not touch these files at all. There are some third-party CodeIgniter modules available
+to assist with merging changes to the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+* app/Config/App.php
+* app/Config/ContentSecurityPolicy.php
+* app/Config/Routes.php
+* app/Config/Validation.php

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -16,6 +16,7 @@ See also :doc:`./backward_compatibility_notes`.
 
     backward_compatibility_notes
 
+    upgrade_426
     upgrade_425
     upgrade_423
     upgrade_422


### PR DESCRIPTION
**Description**
Updates changelog and version references for `4.2.6`.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
