### PR TITLE
docs: added about signing gpg to old commit

### DIFF
--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -183,9 +183,17 @@ Just make sure that your commits in a feature branch are all related.
 
 Almost developer forgot signing GPG with params `-S` in commiting like `git commit -S -m "Signed GPG"`, you can signing old commit to keep secure.
 
+Latests commit :
 ```console
 > git switch your-branch
 > git commit --amend --no-edit -n -S
+> git push --force-with-lease origin your-branch
+```
+
+All commit (will be change date commit to today) :
+```console
+> git switch your-branch
+> git rebase -i --root --exec 'git commit --amend --no-edit -n -S'
 > git push --force-with-lease origin your-branch
 ```
 

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -179,6 +179,21 @@ For instance, to commit your work from a debugging session:
 
 Just make sure that your commits in a feature branch are all related.
 
+### Signing GPG Old Commits
+
+Almost developer forgot signing GPG with params `-S` in commiting like `git commit -S -m "Signed GPG"`, you can signing old commit to keep secure.
+
+```console
+> git switch your-branch
+> git commit --amend --no-edit -n -S
+> git push --force-with-lease origin your-branch
+```
+
+But developer can secure commit without `-S` in `git commit`, you can set `git config --global commit.gpgsign true` and `git config --global user.signingkey 3AC5C34371567BD2` to all local repostory local or without `--global` to one local repostory.
+
+> **Note**
+> `3AC5C34371567BD2` is your GPG Key ID
+
 ### Changing a Commit Message
 
 See <https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message>.


### PR DESCRIPTION
**Description**
Adding how to signing gpg to old commit.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
