### PR TITLE
Refactor: CodeIgniter::generateCacheName()

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -729,18 +729,13 @@ class CodeIgniter
             return md5($this->request->getPath());
         }
 
-        $uri = $this->request->getUri();
-        if ($config->cacheQueryString) {
-            if (is_array($config->cacheQueryString)) {
-                $name = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(['only' => $config->cacheQueryString]));
-            } else {
-                $name = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery());
-            }
-        } else {
-            $name = URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath());
-        }
+        $uri = clone $this->request->getUri();
 
-        return md5($name);
+        $query = $config->cacheQueryString
+            ? $uri->getQuery(is_array($config->cacheQueryString) ? ['only' => $config->cacheQueryString] : [])
+            : '';
+
+        return md5($uri->setFragment('')->setQuery($query));
     }
 
     /**


### PR DESCRIPTION
**Description**
Optimizing the code for getting the URL in the ``CodeIgniter::generateCacheName()`` method.
The change uses cloning the URL object and modifying the properties, instead of calling ``URI::createURIString()`` directly with arguments.

The code is more compact.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide