### PR TITLE
feat: add manual config for Composer package auto-discovery

### DIFF
--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -39,7 +39,7 @@ class Modules extends BaseModules
      *   [
      *       'only' => [
      *           // List up all packages to auto-discover
-     *           'codeigniter4/sheild',
+     *           'codeigniter4/shield',
      *       ],
      *   ]
      *   or

--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -32,6 +32,29 @@ class Modules extends BaseModules
     public $discoverInComposer = true;
 
     /**
+     * The Composer package list for Auto-Discovery
+     * This setting is optional.
+     *
+     * E.g.:
+     *   [
+     *       'only' => [
+     *           // List up all packages to auto-discover
+     *           'codeigniter4/sheild',
+     *       ],
+     *   ]
+     *   or
+     *   [
+     *       'exclude' => [
+     *           // List up packages to exclude.
+     *           'pestphp/pest',
+     *       ],
+     *   ]
+     *
+     * @var array
+     */
+    public $composerPackages = [];
+
+    /**
      * --------------------------------------------------------------------------
      * Auto-Discovery Rules
      * --------------------------------------------------------------------------

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Autoloader;
 
 use Composer\Autoload\ClassLoader;
+use Composer\InstalledVersions;
 use Config\Autoload;
 use Config\Modules;
 use InvalidArgumentException;
@@ -137,7 +138,7 @@ class Autoloader
 
         // Should we load through Composer's namespaces, also?
         if ($modules->discoverInComposer) {
-            $this->loadComposerNamespaces($composer);
+            $this->loadComposerNamespaces($composer, $modules->composerPackages);
         }
 
         unset($composer);
@@ -360,20 +361,53 @@ class Autoloader
         return $cleanFilename;
     }
 
-    private function loadComposerNamespaces(ClassLoader $composer): void
+    private function loadComposerNamespaces(ClassLoader $composer, array $composerPackages): void
     {
-        $paths = $composer->getPrefixesPsr4();
+        $namespacePaths = $composer->getPrefixesPsr4();
 
         // Get rid of CodeIgniter so we don't have duplicates
-        if (isset($paths['CodeIgniter\\'])) {
-            unset($paths['CodeIgniter\\']);
+        if (isset($namespacePaths['CodeIgniter\\'])) {
+            unset($namespacePaths['CodeIgniter\\']);
+        }
+
+        $packageList = InstalledVersions::getAllRawData()[0]['versions'];
+
+        // Get install paths of packages to add namespace for auto-discovery.
+        $only         = $composerPackages['only'] ?? [];
+        $exclude      = $composerPackages['exclude'] ?? [];
+        $installPaths = [];
+        if ($only !== []) {
+            foreach ($packageList as $packageName => $data) {
+                if (in_array($packageName, $only, true) && isset($data['install_path'])) {
+                    $installPaths[] = $data['install_path'];
+                }
+            }
+        } else {
+            foreach ($packageList as $packageName => $data) {
+                if (! in_array($packageName, $exclude, true) && isset($data['install_path'])) {
+                    $installPaths[] = $data['install_path'];
+                }
+            }
         }
 
         $newPaths = [];
 
-        foreach ($paths as $key => $value) {
-            // Composer stores namespaces with trailing slash. We don't.
-            $newPaths[rtrim($key, '\\ ')] = $value;
+        foreach ($namespacePaths as $namespace => $srcPaths) {
+            $add = false;
+
+            foreach ($srcPaths as $path) {
+                foreach ($installPaths as $installPath) {
+                    if ($installPath === substr($path, 0, strlen($installPath))) {
+                        $add = true;
+                        break 2;
+                    }
+                }
+            }
+
+            if ($add) {
+                // Composer stores namespaces with trailing slash. We don't.
+                $newPaths[rtrim($namespace, '\\ ')] = $srcPaths;
+            }
         }
 
         $this->addNamespace($newPaths);

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Autoloader;
 
+use CodeIgniter\Exceptions\ConfigException;
 use Composer\Autoload\ClassLoader;
 use Composer\InstalledVersions;
 use Config\Autoload;
@@ -372,9 +373,14 @@ class Autoloader
 
         $packageList = InstalledVersions::getAllRawData()[0]['versions'];
 
+        // Check config for $composerPackages.
+        $only    = $composerPackages['only'] ?? [];
+        $exclude = $composerPackages['exclude'] ?? [];
+        if ($only !== [] && $exclude !== []) {
+            throw new ConfigException('Cannot use "only" and "exclude" at the same time in "Config\Modules::$composerPackages".');
+        }
+
         // Get install paths of packages to add namespace for auto-discovery.
-        $only         = $composerPackages['only'] ?? [];
-        $exclude      = $composerPackages['exclude'] ?? [];
         $installPaths = [];
         if ($only !== []) {
             foreach ($packageList as $packageName => $data) {

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -286,6 +286,45 @@ final class AutoloaderTest extends CIUnitTestCase
         $this->assertStringContainsString(VENDORPATH, $namespaces['Psr\Log'][1]);
     }
 
+    public function testComposerPackagesOnly()
+    {
+        $config                      = new Autoload();
+        $config->psr4                = [];
+        $modules                     = new Modules();
+        $modules->discoverInComposer = true;
+        $modules->composerPackages   = ['only' => ['laminas/laminas-escaper']];
+
+        $loader = new Autoloader();
+        $loader->initialize($config, $modules);
+
+        $namespaces = $loader->getNamespace();
+
+        $this->assertCount(1, $namespaces);
+        $this->assertStringContainsString(VENDORPATH, $namespaces['Laminas\Escaper'][0]);
+    }
+
+    public function testComposerPackagesExlcude()
+    {
+        $config                      = new Autoload();
+        $config->psr4                = [];
+        $modules                     = new Modules();
+        $modules->discoverInComposer = true;
+        $modules->composerPackages   = [
+            'exclude' => [
+                'psr/log',
+                'laminas/laminas-escaper',
+            ],
+        ];
+
+        $loader = new Autoloader();
+        $loader->initialize($config, $modules);
+
+        $namespaces = $loader->getNamespace();
+
+        $this->assertArrayNotHasKey('Psr\Log', $namespaces);
+        $this->assertArrayNotHasKey('Laminas\\Escaper', $namespaces);
+    }
+
     public function testFindsComposerRoutesWithComposerPathNotFound()
     {
         $composerPath = COMPOSER_PATH;

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -303,7 +303,7 @@ final class AutoloaderTest extends CIUnitTestCase
         $this->assertStringContainsString(VENDORPATH, $namespaces['Laminas\Escaper'][0]);
     }
 
-    public function testComposerPackagesExlcude()
+    public function testComposerPackagesExclude()
     {
         $config                      = new Autoload();
         $config->psr4                = [];

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Autoloader;
 
 use App\Controllers\Home;
+use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Autoload;
 use Config\Modules;
@@ -323,6 +324,24 @@ final class AutoloaderTest extends CIUnitTestCase
 
         $this->assertArrayNotHasKey('Psr\Log', $namespaces);
         $this->assertArrayNotHasKey('Laminas\\Escaper', $namespaces);
+    }
+
+    public function testComposerPackagesOnlyAndExclude()
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Cannot use "only" and "exclude" at the same time in "Config\Modules::$composerPackages".');
+
+        $config                      = new Autoload();
+        $config->psr4                = [];
+        $modules                     = new Modules();
+        $modules->discoverInComposer = true;
+        $modules->composerPackages   = [
+            'only'    => ['laminas/laminas-escaper'],
+            'exclude' => ['psr/log'],
+        ];
+
+        $loader = new Autoloader();
+        $loader->initialize($config, $modules);
     }
 
     public function testFindsComposerRoutesWithComposerPathNotFound()

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -136,6 +136,7 @@ Others
 ======
 
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
+- Now you can specify Composer packages to auto-discover manually. See :ref:`Code Modules <modules-specify-composer-packages>`.
 
 Changes
 *******

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -129,7 +129,7 @@ Disable Composer Package Discovery
 ----------------------------------
 
 If you do not want all of Composer's known directories to be scanned when locating files, you can turn this off
-by editing the ``$discoverInComposer`` variable in ``Config\Modules.php``:
+by editing the ``$discoverInComposer`` variable in **app/Config/Modules.php**:
 
 .. literalinclude:: modules/004.php
 

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -110,6 +110,24 @@ Discovery and Composer
 Packages installed via Composer using PSR-4 namespaces will also be discovered by default.
 PSR-0 namespaced packages will not be detected.
 
+.. _modules-specify-composer-packages:
+
+Specify Composer Packages
+-------------------------
+
+.. versionadded:: 4.3.0
+
+To avoid wasting time scanning for irrelevant Composer packages, you can manually specify packages to discover by editing the ``$composerPackages`` variable in **app/Config/Modules.php**:
+
+.. literalinclude:: modules/013.php
+
+Alternatively, you can specify which packages to exclude from discovery.
+
+.. literalinclude:: modules/014.php
+
+Disable Composer Package Discovery
+----------------------------------
+
 If you do not want all of Composer's known directories to be scanned when locating files, you can turn this off
 by editing the ``$discoverInComposer`` variable in ``Config\Modules.php``:
 

--- a/user_guide_src/source/general/modules/013.php
+++ b/user_guide_src/source/general/modules/013.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Modules\Modules as BaseModules;
+
+class Modules extends BaseModules
+{
+    // ...
+
+    public $composerPackages = [
+        'only' => [
+            // List up all packages to auto-discover
+            'codeigniter4/shield',
+        ],
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/general/modules/014.php
+++ b/user_guide_src/source/general/modules/014.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Modules\Modules as BaseModules;
+
+class Modules extends BaseModules
+{
+    // ...
+
+    public $composerPackages = [
+        'exclude' => [
+            // List up packages to exclude.
+            'pestphp/pest',
+        ],
+    ];
+
+    // ...
+}


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=82772

Problems:
- Currently, auto-discovery searches the namespaces of all Composer packages. However, some packages may accidentally have files in the same directory as CI4, and loading the file may cause an error.
- It is useless to search files in Composer packages that are not CI4 modules.

This PR allows you to specify the packages to be searched by configuration.

- add optional config in `Config\Modules`
  - `$composerPackages['only']`: If you set this, only listed packages are searched for auto-discovery
  - `$composerPackages['exclude']`: If you set this, these packages are excluded for auto-discovery

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
