### PR TITLE
test: update TimeTest::testToDatabase()

### DIFF
--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1166,7 +1166,7 @@ final class TimeTest extends CIUnitTestCase
 
         $time = Time::parse('2017-01-12 00:00', 'America/Chicago');
 
-        $this->assertSame('۲۰۱۷-۰۱-۱۲ ۰۰:۰۰:۰۰', (string) $time);
+        $this->assertSame('2017-01-12 00:00:00', (string) $time);
         $this->assertSame('2017-01-12 00:00:00', $time->toDatabase());
 
         Locale::setDefault($currentLocale);


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/6461

```diff
There was 1 failure:

1) CodeIgniter\I18n\TimeTest::testToDatabase
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'۲۰۱۷-۰۱-۱۲ ۰۰:۰۰:۰۰'
+'2017-01-12 00:00:00'

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/I18n/TimeTest.php:1169
phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97
```
https://github.com/codeigniter4/CodeIgniter4/runs/8238507830?check_suite_focus=true

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

