### PR TITLE
Remove unreleased `Time::toDatabase()`

### DIFF
--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -1179,12 +1179,4 @@ class Time extends DateTime
         $this->timezone = new DateTimeZone($timezone);
         parent::__construct($this->date, $this->timezone);
     }
-
-    /**
-     * Returns the datetime string ('Y-m-d H:i:s') that is safe to databases regardless of locale.
-     */
-    public function toDatabase(): string
-    {
-        return $this->format('Y-m-d H:i:s');
-    }
 }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1158,17 +1158,4 @@ final class TimeTest extends CIUnitTestCase
             ['fa'],
         ];
     }
-
-    public function testToDatabase()
-    {
-        $currentLocale = Locale::getDefault();
-        Locale::setDefault('fa');
-
-        $time = Time::parse('2017-01-12 00:00', 'America/Chicago');
-
-        $this->assertSame('2017-01-12 00:00:00', (string) $time);
-        $this->assertSame('2017-01-12 00:00:00', $time->toDatabase());
-
-        Locale::setDefault($currentLocale);
-    }
 }

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -115,7 +115,6 @@ Libraries
 
 - Added methods ``replace()``, ``addLineAfter()`` and ``addLineBefore()`` to modify files in Publisher. See :ref:`Publisher <publisher-modifying-files>` for details.
 - Now **Encryption** can decrypt data encrypted with CI3's Encryption. See :ref:`encryption-compatible-with-ci3`.
-- Added :ref:`Time::toDatabase() <time-todatabase>` to get a datetime string that can be used with databases regardless of locale.
 
 Helpers and Functions
 =====================

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -173,17 +173,6 @@ Displays just the localized version of time portion of the value:
 
 .. literalinclude:: time/018.php
 
-.. _time-todatabase:
-
-toDatabase()
-============
-
-.. versionadded:: 4.3.0
-
-This method returns a string that can be used with databases regardless of locale.
-
-.. literalinclude:: time/042.php
-
 humanize()
 ==========
 

--- a/user_guide_src/source/libraries/time/042.php
+++ b/user_guide_src/source/libraries/time/042.php
@@ -1,9 +1,0 @@
-<?php
-
-// Locale: en
-$time = Time::parse('March 9, 2016 12:00:00', 'America/Chicago');
-echo $time->toDatabase(); // '2016-03-09 12:00:00'
-
-// Locale: fa
-$time = Time::parse('March 9, 2016 12:00:00', 'America/Chicago');
-echo $time->toDatabase(); // '2016-03-09 12:00:00'


### PR DESCRIPTION
**Description**
Remove `Time::toDatabase()` #6431 because the method is now exactly the same as `__toString()`.
See https://github.com/codeigniter4/CodeIgniter4/pull/6461

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

