### PR TITLE
Add the `trailing_comma_single_line` option to `function_declaration`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -58,6 +58,10 @@ $overrides = [
         'allow_single_line_empty_anonymous_classes' => true,
         'allow_single_line_anonymous_functions'     => true,
     ],
+    'function_declaration' => [
+        'closure_function_spacing'   => 'one',
+        'trailing_comma_single_line' => false,
+    ],
     'no_multiple_statements_per_line' => true,
     'no_trailing_comma_in_singleline' => [
         'elements' => [

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -50,6 +50,10 @@ $overrides = [
         'allow_single_line_empty_anonymous_classes' => true,
         'allow_single_line_anonymous_functions'     => true,
     ],
+    'function_declaration' => [
+        'closure_function_spacing'   => 'one',
+        'trailing_comma_single_line' => false,
+    ],
     'no_multiple_statements_per_line' => true,
     'no_trailing_comma_in_singleline' => [
         'elements' => [

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -52,6 +52,10 @@ $overrides = [
         'allow_single_line_empty_anonymous_classes' => true,
         'allow_single_line_anonymous_functions'     => true,
     ],
+    'function_declaration' => [
+        'closure_function_spacing'   => 'one',
+        'trailing_comma_single_line' => false,
+    ],
     'no_multiple_statements_per_line' => true,
     'no_trailing_comma_in_singleline' => [
         'elements' => [


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe function_declaration
Description of function_declaration rule.
Spaces should be properly placed in a function declaration.

Fixer is configurable using following options:
* closure_function_spacing ('none', 'one'): spacing to use before open parenthesis for closures; defaults to 'one'
* trailing_comma_single_line (bool): whether trailing commas are allowed in single line signatures; defaults to false

...
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
