### PR TITLE
Add options to `new_with_braces`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -62,6 +62,10 @@ $overrides = [
         'closure_function_spacing'   => 'one',
         'trailing_comma_single_line' => false,
     ],
+    'new_with_braces' => [
+        'named_class'     => true,
+        'anonymous_class' => true,
+    ],
     'no_multiple_statements_per_line' => true,
     'no_trailing_comma_in_singleline' => [
         'elements' => [

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -54,6 +54,10 @@ $overrides = [
         'closure_function_spacing'   => 'one',
         'trailing_comma_single_line' => false,
     ],
+    'new_with_braces' => [
+        'named_class'     => true,
+        'anonymous_class' => true,
+    ],
     'no_multiple_statements_per_line' => true,
     'no_trailing_comma_in_singleline' => [
         'elements' => [

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -56,6 +56,10 @@ $overrides = [
         'closure_function_spacing'   => 'one',
         'trailing_comma_single_line' => false,
     ],
+    'new_with_braces' => [
+        'named_class'     => true,
+        'anonymous_class' => true,
+    ],
     'no_multiple_statements_per_line' => true,
     'no_trailing_comma_in_singleline' => [
         'elements' => [


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe new_with_braces     
Description of new_with_braces rule.
All instances created with `new` keyword must (not) be followed by braces.

Fixer is configurable using following options:
* named_class (bool): whether named classes should be followed by parentheses; defaults to true
* anonymous_class (bool): whether anonymous classes should be followed by parentheses; defaults to true

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,4 +1,4 @@
    <?php

   -$x = new X;
   -$y = new class {};
   +$x = new X();
   +$y = new class() {};

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['anonymous_class' => false].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,3 +1,3 @@
    <?php

   -$y = new class() {};
   +$y = new class {};

   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['named_class' => false].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,3 +1,3 @@
    <?php

   -$x = new X();
   +$x = new X;

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
