### PR TITLE
Add `order` option to `phpdoc_order`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -68,7 +68,10 @@ $overrides = [
         ],
     ],
     'no_useless_nullsafe_operator' => true,
-    'phpdoc_separation'            => [
+    'phpdoc_order'                 => [
+        'order' => ['param', 'return', 'throws'],
+    ],
+    'phpdoc_separation' => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -60,7 +60,10 @@ $overrides = [
         ],
     ],
     'no_useless_nullsafe_operator' => true,
-    'phpdoc_separation'            => [
+    'phpdoc_order'                 => [
+        'order' => ['param', 'return', 'throws'],
+    ],
+    'phpdoc_separation' => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -62,7 +62,10 @@ $overrides = [
         ],
     ],
     'no_useless_nullsafe_operator' => true,
-    'phpdoc_separation'            => [
+    'phpdoc_order'                 => [
+        'order' => ['param', 'return', 'throws'],
+    ],
+    'phpdoc_separation' => [
         'groups' => [
             ['immutable', 'psalm-immutable'],
             ['param', 'phpstan-param', 'psalm-param'],

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -326,9 +326,9 @@ abstract class BaseModel
      *
      * @param string $columnName Column Name
      *
-     * @throws DataException
-     *
      * @return array|null The resulting row of data, or null if no data found.
+     *
+     * @throws DataException
      */
     abstract protected function doFindColumn(string $columnName);
 
@@ -392,9 +392,9 @@ abstract class BaseModel
      * @param int         $batchSize The size of the batch to run
      * @param bool        $returnSQL True means SQL is returned, false will execute the query
      *
-     * @throws DatabaseException
-     *
      * @return mixed Number of rows affected or FALSE on failure
+     *
+     * @throws DatabaseException
      */
     abstract protected function doUpdateBatch(?array $set = null, ?string $index = null, int $batchSize = 100, bool $returnSQL = false);
 
@@ -405,9 +405,9 @@ abstract class BaseModel
      * @param array|int|string|null $id    The rows primary key(s)
      * @param bool                  $purge Allows overriding the soft deletes setting.
      *
-     * @throws DatabaseException
-     *
      * @return bool|string
+     *
+     * @throws DatabaseException
      */
     abstract protected function doDelete($id = null, bool $purge = false);
 
@@ -541,9 +541,9 @@ abstract class BaseModel
      *
      * @param string $columnName Column Name
      *
-     * @throws DataException
-     *
      * @return array|null The resulting row of data, or null if no data found.
+     *
+     * @throws DataException
      */
     public function findColumn(string $columnName)
     {
@@ -693,9 +693,9 @@ abstract class BaseModel
      * @param array|object|null $data     Data
      * @param bool              $returnID Whether insert ID should be returned or not.
      *
-     * @throws ReflectionException
-     *
      * @return bool|int|string insert ID or true on success. false on failure.
+     *
+     * @throws ReflectionException
      */
     public function insert($data = null, bool $returnID = true)
     {
@@ -767,9 +767,9 @@ abstract class BaseModel
      * @param int        $batchSize The size of the batch to run
      * @param bool       $testing   True means only number of records is returned, false will execute the query
      *
-     * @throws ReflectionException
-     *
      * @return bool|int Number of rows inserted or FALSE on failure
+     *
+     * @throws ReflectionException
      */
     public function insertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false)
     {
@@ -882,10 +882,10 @@ abstract class BaseModel
      * @param int         $batchSize The size of the batch to run
      * @param bool        $returnSQL True means SQL is returned, false will execute the query
      *
+     * @return mixed Number of rows affected or FALSE on failure
+     *
      * @throws DatabaseException
      * @throws ReflectionException
-     *
-     * @return mixed Number of rows affected or FALSE on failure
      */
     public function updateBatch(?array $set = null, ?string $index = null, int $batchSize = 100, bool $returnSQL = false)
     {
@@ -937,9 +937,9 @@ abstract class BaseModel
      * @param array|int|string|null $id    The rows primary key(s)
      * @param bool                  $purge Allows overriding the soft deletes setting.
      *
-     * @throws DatabaseException
-     *
      * @return BaseResult|bool
+     *
+     * @throws DatabaseException
      */
     public function delete($id = null, bool $purge = false)
     {
@@ -1153,9 +1153,9 @@ abstract class BaseModel
      *
      * @param int|null $userData An optional PHP timestamp to be converted.
      *
-     * @throws ModelException
-     *
      * @return mixed
+     *
+     * @throws ModelException
      */
     protected function setDate(?int $userData = null)
     {
@@ -1177,9 +1177,9 @@ abstract class BaseModel
      *
      * @param int $value value
      *
-     * @throws ModelException
-     *
      * @return int|string
+     *
+     * @throws ModelException
      */
     protected function intToDate(int $value)
     {
@@ -1440,9 +1440,9 @@ abstract class BaseModel
      * @param string $event     Event
      * @param array  $eventData Event Data
      *
-     * @throws DataException
-     *
      * @return mixed
+     *
+     * @throws DataException
      */
     protected function trigger(string $event, array $eventData)
     {
@@ -1501,9 +1501,9 @@ abstract class BaseModel
      * @param bool          $onlyChanged Only Changed Property
      * @param bool          $recursive   If true, inner entities will be casted as array as well
      *
-     * @throws ReflectionException
-     *
      * @return array Array
+     *
+     * @throws ReflectionException
      */
     protected function objectToArray($data, bool $onlyChanged = true, bool $recursive = false): array
     {
@@ -1531,9 +1531,9 @@ abstract class BaseModel
      * @param bool          $onlyChanged Only Changed Property
      * @param bool          $recursive   If true, inner entities will be casted as array as well
      *
-     * @throws ReflectionException
-     *
      * @return array|null Array
+     *
+     * @throws ReflectionException
      */
     protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
     {

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -103,9 +103,9 @@ abstract class BaseCommand
     /**
      * Can be used by a command to run other commands.
      *
-     * @throws ReflectionException
-     *
      * @return mixed
+     *
+     * @throws ReflectionException
      */
     protected function call(string $command, array $params = [])
     {

--- a/system/CLI/CommandRunner.php
+++ b/system/CLI/CommandRunner.php
@@ -42,9 +42,9 @@ class CommandRunner extends Controller
      * @param string $method
      * @param array  $params
      *
-     * @throws ReflectionException
-     *
      * @return mixed
+     *
+     * @throws ReflectionException
      */
     public function _remap($method, $params)
     {
@@ -54,9 +54,9 @@ class CommandRunner extends Controller
     /**
      * Default command.
      *
-     * @throws ReflectionException
-     *
      * @return mixed
+     *
+     * @throws ReflectionException
      */
     public function index(array $params)
     {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -34,9 +34,9 @@ class Console
     /**
      * Runs the current command discovered on the CLI.
      *
-     * @throws Exception
-     *
      * @return mixed
+     *
+     * @throws Exception
      */
     public function run(bool $useSafeOutput = false)
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -285,9 +285,9 @@ class CodeIgniter
      * tries to route the response, loads the controller and generally
      * makes all of the pieces work together.
      *
-     * @throws RedirectException
-     *
      * @return ResponseInterface|void
+     *
+     * @throws RedirectException
      */
     public function run(?RouteCollectionInterface $routes = null, bool $returnResponse = false)
     {
@@ -396,10 +396,10 @@ class CodeIgniter
     /**
      * Handles the main request logic and fires the controller.
      *
+     * @return ResponseInterface
+     *
      * @throws PageNotFoundException
      * @throws RedirectException
-     *
-     * @return ResponseInterface
      */
     protected function handleRequest(?RouteCollectionInterface $routes, Cache $cacheConfig, bool $returnResponse = false)
     {
@@ -649,9 +649,9 @@ class CodeIgniter
     /**
      * Determines if a response has been cached for the given URI.
      *
-     * @throws Exception
-     *
      * @return false|ResponseInterface
+     *
+     * @throws Exception
      */
     public function displayCache(Cache $config)
     {
@@ -754,9 +754,9 @@ class CodeIgniter
      * @param RouteCollectionInterface|null $routes An collection interface to use in place
      *                                              of the config file.
      *
-     * @throws RedirectException
-     *
      * @return string|string[]|null Route filters, that is, the filters specified in the routes file
+     *
+     * @throws RedirectException
      */
     protected function tryToRouteIt(?RouteCollectionInterface $routes = null)
     {

--- a/system/Common.php
+++ b/system/Common.php
@@ -419,9 +419,9 @@ if (! function_exists('esc')) {
      * @param array|string $data
      * @param string       $encoding
      *
-     * @throws InvalidArgumentException
-     *
      * @return array|string
+     *
+     * @throws InvalidArgumentException
      */
     function esc($data, string $context = 'html', ?string $encoding = null)
     {

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -159,9 +159,9 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
     /**
      * Create a new Cookie instance from a `Set-Cookie` header.
      *
-     * @throws CookieException
-     *
      * @return static
+     *
+     * @throws CookieException
      */
     public static function fromHeaderString(string $cookie, bool $raw = false)
     {
@@ -575,9 +575,9 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
      *
      * @param mixed $offset
      *
-     * @throws InvalidArgumentException
-     *
      * @return mixed
+     *
+     * @throws InvalidArgumentException
      */
     #[ReturnTypeWillChange]
     public function offsetGet($offset)

--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -36,9 +36,9 @@ class CookieStore implements Countable, IteratorAggregate
      *
      * @param string[] $headers
      *
-     * @throws CookieException
-     *
      * @return static
+     *
+     * @throws CookieException
      */
     public static function fromCookieHeaders(array $headers, bool $raw = false)
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -476,10 +476,10 @@ class BaseBuilder
      * @used-by selectAvg()
      * @used-by selectSum()
      *
+     * @return $this
+     *
      * @throws DatabaseException
      * @throws DataException
-     *
-     * @return $this
      */
     protected function maxMinAvgSum(string $select = '', string $alias = '', string $type = 'MAX')
     {
@@ -888,9 +888,9 @@ class BaseBuilder
      *
      * @param array|BaseBuilder|Closure|null $values The values searched on, or anonymous function with subquery
      *
-     * @throws InvalidArgumentException
-     *
      * @return $this
+     *
+     * @throws InvalidArgumentException
      */
     protected function _whereIn(?string $key = null, $values = null, bool $not = false, string $type = 'AND ', ?bool $escape = null, string $clause = 'QBWhere')
     {
@@ -1730,9 +1730,9 @@ class BaseBuilder
     /**
      * Compiles batch insert strings and runs the queries
      *
-     * @throws DatabaseException
-     *
      * @return false|int|string[] Number of rows inserted or FALSE on failure, SQL array when testMode
+     *
+     * @throws DatabaseException
      */
     public function insertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100)
     {
@@ -1852,9 +1852,9 @@ class BaseBuilder
     /**
      * Compiles an insert query and returns the sql
      *
-     * @throws DatabaseException
-     *
      * @return bool|string
+     *
+     * @throws DatabaseException
      */
     public function getCompiledInsert(bool $reset = true)
     {
@@ -1885,9 +1885,9 @@ class BaseBuilder
      *
      * @param array|object|null $set
      *
-     * @throws DatabaseException
-     *
      * @return bool
+     *
+     * @throws DatabaseException
      */
     public function insert($set = null, ?bool $escape = null)
     {
@@ -1975,9 +1975,9 @@ class BaseBuilder
     /**
      * Compiles a replace into string and runs the query
      *
-     * @throws DatabaseException
-     *
      * @return BaseResult|false|Query|string
+     *
+     * @throws DatabaseException
      */
     public function replace(?array $set = null)
     {
@@ -2131,9 +2131,9 @@ class BaseBuilder
     /**
      * Compiles an update string and runs the query
      *
-     * @throws DatabaseException
-     *
      * @return false|int|string[] Number of rows affected or FALSE on failure, SQL array when testMode
+     *
+     * @throws DatabaseException
      */
     public function updateBatch(?array $set = null, ?string $index = null, int $batchSize = 100)
     {
@@ -2242,9 +2242,9 @@ class BaseBuilder
      *
      * @param array|object $key
      *
-     * @throws DatabaseException
-     *
      * @return $this|null
+     *
+     * @throws DatabaseException
      */
     public function setUpdateBatch($key, string $index = '', ?bool $escape = null)
     {
@@ -2350,9 +2350,9 @@ class BaseBuilder
      *
      * @param mixed $where
      *
-     * @throws DatabaseException
-     *
      * @return bool|string
+     *
+     * @throws DatabaseException
      */
     public function delete($where = '', ?int $limit = null, bool $resetData = true)
     {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -358,9 +358,9 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Initializes the database connection/settings.
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function initialize()
     {
@@ -862,9 +862,9 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @param array|string $tableName
      *
-     * @throws DatabaseException
-     *
      * @return BaseBuilder
+     *
+     * @throws DatabaseException
      */
     public function table($tableName)
     {
@@ -1361,9 +1361,9 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns an array of table names
      *
-     * @throws DatabaseException
-     *
      * @return array|bool
+     *
+     * @throws DatabaseException
      */
     public function listTables(bool $constrainByPrefix = false)
     {
@@ -1452,9 +1452,9 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Fetch Field Names
      *
-     * @throws DatabaseException
-     *
      * @return array|false
+     *
+     * @throws DatabaseException
      */
     public function getFieldNames(string $table)
     {

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -57,9 +57,9 @@ abstract class BaseUtils
     /**
      * List databases
      *
-     * @throws DatabaseException
-     *
      * @return array|bool
+     *
+     * @throws DatabaseException
      */
     public function listDatabases()
     {
@@ -101,9 +101,9 @@ abstract class BaseUtils
     /**
      * Optimize Table
      *
-     * @throws DatabaseException
-     *
      * @return bool
+     *
+     * @throws DatabaseException
      */
     public function optimizeTable(string $tableName)
     {
@@ -123,9 +123,9 @@ abstract class BaseUtils
     /**
      * Optimize Database
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function optimizeDatabase()
     {
@@ -168,9 +168,9 @@ abstract class BaseUtils
     /**
      * Repair Table
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function repairTable(string $tableName)
     {
@@ -260,9 +260,9 @@ abstract class BaseUtils
      *
      * @param array|string $params
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function backup($params = [])
     {

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -35,9 +35,9 @@ class Database
      * Parses the connection binds and returns an instance of the driver
      * ready to go.
      *
-     * @throws InvalidArgumentException
-     *
      * @return mixed
+     *
+     * @throws InvalidArgumentException
      */
     public function load(array $params = [], string $alias = '')
     {

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -397,9 +397,9 @@ class Forge
      * @param string|string[] $fieldName
      * @param string|string[] $tableField
      *
-     * @throws DatabaseException
-     *
      * @return Forge
+     *
+     * @throws DatabaseException
      */
     public function addForeignKey($fieldName = '', string $tableName = '', $tableField = '', string $onUpdate = '', string $onDelete = '')
     {
@@ -433,9 +433,9 @@ class Forge
     /**
      * Drop Key
      *
-     * @throws DatabaseException
-     *
      * @return bool
+     *
+     * @throws DatabaseException
      */
     public function dropKey(string $table, string $keyName)
     {
@@ -457,9 +457,9 @@ class Forge
     }
 
     /**
-     * @throws DatabaseException
-     *
      * @return BaseResult|bool|false|mixed|Query
+     *
+     * @throws DatabaseException
      */
     public function dropForeignKey(string $table, string $foreignName)
     {
@@ -481,9 +481,9 @@ class Forge
     }
 
     /**
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function createTable(string $table, bool $ifNotExists = false, array $attributes = [])
     {
@@ -573,9 +573,9 @@ class Forge
     }
 
     /**
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function dropTable(string $tableName, bool $ifExists = false, bool $cascade = false)
     {
@@ -639,9 +639,9 @@ class Forge
     }
 
     /**
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function renameTable(string $tableName, string $newTableName)
     {
@@ -716,9 +716,9 @@ class Forge
     /**
      * @param array|string $columnName
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function dropColumn(string $table, $columnName)
     {

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -153,10 +153,10 @@ class MigrationRunner
     /**
      * Locate and run all new migrations
      *
+     * @return bool
+     *
      * @throws ConfigException
      * @throws RuntimeException
-     *
-     * @return bool
      */
     public function latest(?string $group = null)
     {
@@ -221,10 +221,10 @@ class MigrationRunner
      *
      * @param int $targetBatch Target batch number, or negative for a relative batch, 0 for all
      *
+     * @return mixed Current batch number on success, FALSE on failure or no migrations are found
+     *
      * @throws ConfigException
      * @throws RuntimeException
-     *
-     * @return mixed Current batch number on success, FALSE on failure or no migrations are found
      */
     public function regress(int $targetBatch = 0, ?string $group = null)
     {

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -72,9 +72,9 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function connect(bool $persistent = false)
     {
@@ -397,9 +397,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _fieldData(string $table): array
     {
@@ -429,10 +429,10 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
+     * @return stdClass[]
+     *
      * @throws DatabaseException
      * @throws LogicException
-     *
-     * @return stdClass[]
      */
     protected function _indexData(string $table): array
     {
@@ -475,9 +475,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -152,9 +152,9 @@ class Builder extends BaseBuilder
      *
      * @param mixed $where
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function delete($where = '', ?int $limit = null, bool $resetData = true)
     {

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -280,9 +280,9 @@ class Connection extends BaseConnection implements ConnectionInterface
     /**
      * Returns an array of objects with field data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _fieldData(string $table): array
     {
@@ -328,9 +328,9 @@ class Connection extends BaseConnection implements ConnectionInterface
     /**
      * Returns an array of objects with index data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _indexData(string $table): array
     {
@@ -377,9 +377,9 @@ class Connection extends BaseConnection implements ConnectionInterface
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -86,9 +86,9 @@ class Builder extends BaseBuilder
     /**
      * Increments a numeric column by the specified value.
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function increment(string $column, int $value = 1)
     {
@@ -108,9 +108,9 @@ class Builder extends BaseBuilder
     /**
      * Decrements a numeric column by the specified value.
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function decrement(string $column, int $value = 1)
     {
@@ -135,9 +135,9 @@ class Builder extends BaseBuilder
      *
      * @param array|null $set An associative array of insert values
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function replace(?array $set = null)
     {
@@ -204,9 +204,9 @@ class Builder extends BaseBuilder
      *
      * @param mixed $where
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function delete($where = '', ?int $limit = null, bool $resetData = true)
     {

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -240,9 +240,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _fieldData(string $table): array
     {
@@ -275,9 +275,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _indexData(string $table): array
     {
@@ -314,9 +314,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with Foreign key data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _foreignKeyData(string $table): array
     {

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -46,9 +46,9 @@ class PreparedQuery extends BasePreparedQuery
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
      *
-     * @throws Exception
-     *
      * @return mixed
+     *
+     * @throws Exception
      */
     public function _prepare(string $sql, array $options = [])
     {

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -339,9 +339,9 @@ class Builder extends BaseBuilder
     /**
      * Compiles a replace into string and runs the query
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function replace(?array $set = null)
     {
@@ -519,9 +519,9 @@ class Builder extends BaseBuilder
      *
      * @param mixed $where
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function delete($where = '', ?int $limit = null, bool $resetData = true)
     {

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -96,9 +96,9 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function connect(bool $persistent = false)
     {
@@ -219,9 +219,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _indexData(string $table): array
     {
@@ -257,9 +257,9 @@ class Connection extends BaseConnection
      * Returns an array of objects with Foreign key data
      * referenced_object_id  parent_object_id
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _foreignKeyData(string $table): array
     {
@@ -325,9 +325,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _fieldData(string $table): array
     {

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -43,9 +43,9 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $options Options takes an associative array;
      *
-     * @throws Exception
-     *
      * @return mixed
+     *
+     * @throws Exception
      */
     public function _prepare(string $sql, array $options = [])
     {

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -55,9 +55,9 @@ class Connection extends BaseConnection
     /**
      * Connect to the database.
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function connect(bool $persistent = false)
     {
@@ -188,9 +188,9 @@ class Connection extends BaseConnection
     }
 
     /**
-     * @throws DatabaseException
-     *
      * @return array|false
+     *
+     * @throws DatabaseException
      */
     public function getFieldNames(string $table)
     {
@@ -232,9 +232,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with field data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _fieldData(string $table): array
     {
@@ -267,9 +267,9 @@ class Connection extends BaseConnection
     /**
      * Returns an array of objects with index data
      *
-     * @throws DatabaseException
-     *
      * @return stdClass[]
+     *
+     * @throws DatabaseException
      */
     protected function _indexData(string $table): array
     {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -90,9 +90,9 @@ class Result extends BaseResult
      * internally before fetching results to make sure the result set
      * starts at zero.
      *
-     * @throws DatabaseException
-     *
      * @return mixed
+     *
+     * @throws DatabaseException
      */
     public function dataSeek(int $n = 0)
     {

--- a/system/Encryption/EncrypterInterface.php
+++ b/system/Encryption/EncrypterInterface.php
@@ -26,9 +26,9 @@ interface EncrypterInterface
      * @param string            $data   Input data
      * @param array|string|null $params Overridden parameters, specifically the key
      *
-     * @throws EncryptionException
-     *
      * @return string
+     *
+     * @throws EncryptionException
      */
     public function encrypt($data, $params = null);
 
@@ -38,9 +38,9 @@ interface EncrypterInterface
      * @param string            $data   Encrypted data
      * @param array|string|null $params Overridden parameters, specifically the key
      *
-     * @throws EncryptionException
-     *
      * @return string
+     *
+     * @throws EncryptionException
      */
     public function decrypt($data, $params = null);
 }

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -100,9 +100,9 @@ class Encryption
     /**
      * Initialize or re-initialize an encrypter
      *
-     * @throws EncryptionException
-     *
      * @return EncrypterInterface
+     *
+     * @throws EncryptionException
      */
     public function initialize(?EncryptionConfig $config = null)
     {

--- a/system/Entity/Cast/DatetimeCast.php
+++ b/system/Entity/Cast/DatetimeCast.php
@@ -23,9 +23,9 @@ class DatetimeCast extends BaseCast
     /**
      * {@inheritDoc}
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function get($value, array $params = [])
     {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -311,9 +311,9 @@ class Entity implements JsonSerializable
      *
      * @param DateTime|float|int|string|Time $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     protected function mutateDate($value)
     {
@@ -329,9 +329,9 @@ class Entity implements JsonSerializable
      * @param string                     $attribute Attribute name
      * @param string                     $method    Allowed to "get" and "set"
      *
-     * @throws CastException
-     *
      * @return array|bool|float|int|object|string|null
+     *
+     * @throws CastException
      */
     protected function castAs($value, string $attribute, string $method = 'get')
     {
@@ -427,9 +427,9 @@ class Entity implements JsonSerializable
      *
      * @param array|bool|float|int|object|string|null $value
      *
-     * @throws Exception
-     *
      * @return $this
+     *
+     * @throws Exception
      */
     public function __set(string $key, $value = null)
     {
@@ -470,11 +470,11 @@ class Entity implements JsonSerializable
      *  $p = $this->my_property
      *  $p = $this->getMyProperty()
      *
+     * @return array|bool|float|int|object|string|null
+     *
      * @throws Exception
      *
      * @params string $key class property
-     *
-     * @return array|bool|float|int|object|string|null
      */
     public function __get(string $key)
     {

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -352,9 +352,9 @@ class FileCollection implements Countable, IteratorAggregate
      * Yields as an Iterator for the current files.
      * Fulfills IteratorAggregate.
      *
-     * @throws FileNotFoundException
-     *
      * @return Generator<File>
+     *
+     * @throws FileNotFoundException
      */
     public function getIterator(): Generator
     {

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -39,9 +39,9 @@ class CSRF implements FilterInterface
      *
      * @param array|null $arguments
      *
-     * @throws SecurityException
-     *
      * @return RedirectResponse|void
+     *
+     * @throws SecurityException
      */
     public function before(RequestInterface $request, $arguments = null)
     {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -154,9 +154,9 @@ class Filters
      * Runs through all of the filters for the specified
      * uri and position.
      *
-     * @throws FilterException
-     *
      * @return mixed|RequestInterface|ResponseInterface
+     *
+     * @throws FilterException
      */
     public function run(string $uri, string $position = 'before')
     {

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -483,9 +483,9 @@ class CURLRequest extends Request
     /**
      * Set CURL options
      *
-     * @throws InvalidArgumentException
-     *
      * @return array
+     *
+     * @throws InvalidArgumentException
      */
     protected function setCURLOptions(array $curlOptions = [], array $config = [])
     {

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -279,9 +279,9 @@ class DownloadResponse extends Response
     /**
      * output download file text.
      *
-     * @throws DownloadException
-     *
      * @return DownloadResponse
+     *
+     * @throws DownloadException
      */
     public function sendBody()
     {

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -118,11 +118,11 @@ class UploadedFile extends File implements UploadedFileInterface
      * @param bool   $overwrite  State for indicating whether to overwrite the previously generated file with the same
      *                           name or not.
      *
+     * @return bool
+     *
      * @throws InvalidArgumentException if the $path specified is invalid.
      * @throws RuntimeException         on any error during the move operation.
      * @throws RuntimeException         on the second or subsequent call to the method.
-     *
-     * @return bool
      */
     public function move(string $targetPath, ?string $name = null, bool $overwrite = false)
     {

--- a/system/HTTP/MessageInterface.php
+++ b/system/HTTP/MessageInterface.php
@@ -93,9 +93,9 @@ interface MessageInterface
     /**
      * Sets the HTTP protocol version.
      *
-     * @throws HTTPException For invalid protocols
-     *
      * @return $this
+     *
+     * @throws HTTPException For invalid protocols
      */
     public function setProtocolVersion(string $version);
 }

--- a/system/HTTP/MessageTrait.php
+++ b/system/HTTP/MessageTrait.php
@@ -215,9 +215,9 @@ trait MessageTrait
     /**
      * Sets the HTTP protocol version.
      *
-     * @throws HTTPException For invalid protocols
-     *
      * @return $this
+     *
+     * @throws HTTPException For invalid protocols
      */
     public function setProtocolVersion(string $version): self
     {

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -46,9 +46,9 @@ class RedirectResponse extends Response
      *
      * @param string $route Named route or Controller::method
      *
-     * @throws HTTPException
-     *
      * @return $this
+     *
+     * @throws HTTPException
      */
     public function route(string $route, array $params = [], int $code = 302, string $method = 'auto')
     {

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -130,9 +130,9 @@ interface ResponseInterface
      *                       provided status code; if none is provided, will
      *                       default to the IANA name.
      *
-     * @throws InvalidArgumentException For invalid status code arguments.
-     *
      * @return self
+     *
+     * @throws InvalidArgumentException For invalid status code arguments.
      */
     public function setStatusCode(int $code, string $reason = '');
 
@@ -202,9 +202,9 @@ interface ResponseInterface
     /**
      * Returns the current body, converted to JSON is it isn't already.
      *
-     * @throws InvalidArgumentException If the body property is not array.
-     *
      * @return mixed|string
+     *
+     * @throws InvalidArgumentException If the body property is not array.
      */
     public function getJSON();
 
@@ -220,9 +220,9 @@ interface ResponseInterface
     /**
      * Retrieves the current body into XML and returns it.
      *
-     * @throws InvalidArgumentException If the body property is not array.
-     *
      * @return mixed|string
+     *
+     * @throws InvalidArgumentException If the body property is not array.
      */
     public function getXML();
 
@@ -361,9 +361,9 @@ interface ResponseInterface
      * @param string $uri  The URI to redirect to
      * @param int    $code The type of redirection, defaults to 302
      *
-     * @throws HTTPException For invalid status code.
-     *
      * @return $this
+     *
+     * @throws HTTPException For invalid status code.
      */
     public function redirect(string $uri, string $method = 'auto', ?int $code = null);
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -142,9 +142,9 @@ trait ResponseTrait
      *                       provided status code; if none is provided, will
      *                       default to the IANA name.
      *
-     * @throws HTTPException For invalid status code arguments.
-     *
      * @return $this
+     *
+     * @throws HTTPException For invalid status code arguments.
      */
     public function setStatusCode(int $code, string $reason = '')
     {
@@ -251,9 +251,9 @@ trait ResponseTrait
     /**
      * Returns the current body, converted to JSON is it isn't already.
      *
-     * @throws InvalidArgumentException If the body property is not array.
-     *
      * @return mixed|string
+     *
+     * @throws InvalidArgumentException If the body property is not array.
      */
     public function getJSON()
     {
@@ -283,9 +283,9 @@ trait ResponseTrait
     /**
      * Retrieves the current body into XML and returns it.
      *
-     * @throws InvalidArgumentException If the body property is not array.
-     *
      * @return mixed|string
+     *
+     * @throws InvalidArgumentException If the body property is not array.
      */
     public function getXML()
     {
@@ -305,9 +305,9 @@ trait ResponseTrait
      * @param array|string $body
      * @param string       $format Valid: json, xml
      *
-     * @throws InvalidArgumentException If the body property is not string or array.
-     *
      * @return mixed
+     *
+     * @throws InvalidArgumentException If the body property is not string or array.
      */
     protected function formatBody($body, string $format)
     {
@@ -495,9 +495,9 @@ trait ResponseTrait
      * @param string $uri  The URI to redirect to
      * @param int    $code The type of redirection, defaults to 302
      *
-     * @throws HTTPException For invalid status code.
-     *
      * @return $this
+     *
+     * @throws HTTPException For invalid status code.
      */
     public function redirect(string $uri, string $method = 'auto', ?int $code = null)
     {

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -105,9 +105,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function now($timezone = null, ?string $locale = null)
     {
@@ -122,9 +122,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function parse(string $datetime, $timezone = null, ?string $locale = null)
     {
@@ -136,9 +136,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function today($timezone = null, ?string $locale = null)
     {
@@ -150,9 +150,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function yesterday($timezone = null, ?string $locale = null)
     {
@@ -164,9 +164,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function tomorrow($timezone = null, ?string $locale = null)
     {
@@ -179,9 +179,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function createFromDate(?int $year = null, ?int $month = null, ?int $day = null, $timezone = null, ?string $locale = null)
     {
@@ -193,9 +193,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function createFromTime(?int $hour = null, ?int $minutes = null, ?int $seconds = null, $timezone = null, ?string $locale = null)
     {
@@ -207,9 +207,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function create(?int $year = null, ?int $month = null, ?int $day = null, ?int $hour = null, ?int $minutes = null, ?int $seconds = null, $timezone = null, ?string $locale = null)
     {
@@ -231,9 +231,9 @@ class Time extends DateTime
      * @param string                   $datetime
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     #[ReturnTypeWillChange]
     public static function createFromFormat($format, $datetime, $timezone = null)
@@ -250,9 +250,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null)
     {
@@ -265,9 +265,9 @@ class Time extends DateTime
     /**
      * Takes an instance of DateTimeInterface and returns an instance of Time with it's same values.
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public static function createFromInstance(DateTimeInterface $dateTime, ?string $locale = null)
     {
@@ -280,9 +280,9 @@ class Time extends DateTime
     /**
      * Takes an instance of DateTime and returns an instance of Time with it's same values.
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      *
      * @deprecated         Use createFromInstance() instead
      *
@@ -296,9 +296,9 @@ class Time extends DateTime
     /**
      * Converts the current instance to a mutable DateTime object.
      *
-     * @throws Exception
-     *
      * @return DateTime
+     *
+     * @throws Exception
      */
     public function toDateTime()
     {
@@ -455,9 +455,9 @@ class Time extends DateTime
     /**
      * Returns the age in years from the date and 'now'
      *
-     * @throws Exception
-     *
      * @return int
+     *
+     * @throws Exception
      */
     public function getAge()
     {
@@ -519,9 +519,9 @@ class Time extends DateTime
      *
      * @param int|string $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public function setYear($value)
     {
@@ -533,9 +533,9 @@ class Time extends DateTime
      *
      * @param int|string $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public function setMonth($value)
     {
@@ -555,9 +555,9 @@ class Time extends DateTime
      *
      * @param int|string $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public function setDay($value)
     {
@@ -579,9 +579,9 @@ class Time extends DateTime
      *
      * @param int|string $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public function setHour($value)
     {
@@ -597,9 +597,9 @@ class Time extends DateTime
      *
      * @param int|string $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public function setMinute($value)
     {
@@ -615,9 +615,9 @@ class Time extends DateTime
      *
      * @param int|string $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     public function setSecond($value)
     {
@@ -633,9 +633,9 @@ class Time extends DateTime
      *
      * @param int $value
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     protected function setValue(string $name, $value)
     {
@@ -660,9 +660,9 @@ class Time extends DateTime
      *
      * @param DateTimeZone|string $timezone
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     #[ReturnTypeWillChange]
     public function setTimezone($timezone)
@@ -677,9 +677,9 @@ class Time extends DateTime
      *
      * @param int $timestamp
      *
-     * @throws Exception
-     *
      * @return Time
+     *
+     * @throws Exception
      */
     #[ReturnTypeWillChange]
     public function setTimestamp($timestamp)
@@ -854,9 +854,9 @@ class Time extends DateTime
     /**
      * Returns a localized version of the date in Y-m-d format.
      *
-     * @throws Exception
-     *
      * @return string
+     *
+     * @throws Exception
      */
     public function toDateString()
     {
@@ -868,9 +868,9 @@ class Time extends DateTime
      *
      *  i.e. Apr 1, 2017
      *
-     * @throws Exception
-     *
      * @return string
+     *
+     * @throws Exception
      */
     public function toFormattedDateString()
     {
@@ -882,9 +882,9 @@ class Time extends DateTime
      *
      *  i.e. 13:20:33
      *
-     * @throws Exception
-     *
      * @return string
+     *
+     * @throws Exception
      */
     public function toTimeString()
     {
@@ -894,9 +894,9 @@ class Time extends DateTime
     /**
      * Returns the localized value of this instance in $format.
      *
-     * @throws Exception
-     *
      * @return bool|string
+     *
+     * @throws Exception
      */
     public function toLocalizedString(?string $format = null)
     {
@@ -997,9 +997,9 @@ class Time extends DateTime
      *  - in 4 days
      *  - 6 hours ago
      *
-     * @throws Exception
-     *
      * @return mixed
+     *
+     * @throws Exception
      */
     public function humanize()
     {
@@ -1049,9 +1049,9 @@ class Time extends DateTime
     /**
      * @param mixed $testTime
      *
-     * @throws Exception
-     *
      * @return TimeDifference
+     *
+     * @throws Exception
      */
     public function difference($testTime, ?string $timezone = null)
     {
@@ -1070,9 +1070,9 @@ class Time extends DateTime
      *
      * @param mixed $time
      *
-     * @throws Exception
-     *
      * @return DateTime|static
+     *
+     * @throws Exception
      */
     public function getUTCObject($time, ?string $timezone = null)
     {
@@ -1098,9 +1098,9 @@ class Time extends DateTime
      * Primarily used internally to provide the difference and comparison functions,
      * but available for public consumption if they need it.
      *
-     * @throws Exception
-     *
      * @return IntlCalendar
+     *
+     * @throws Exception
      */
     public function getCalendar()
     {

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -172,9 +172,9 @@ abstract class BaseHandler implements ImageHandlerInterface
     /**
      * Verifies that a file has been supplied and it is an image.
      *
-     * @throws ImageException
-     *
      * @return Image The image instance
+     *
+     * @throws ImageException
      */
     protected function image(): Image
     {
@@ -503,9 +503,9 @@ abstract class BaseHandler implements ImageHandlerInterface
      * @param string|null $key    If specified, will only return this piece of EXIF data.
      * @param bool        $silent If true, will not throw our own exceptions.
      *
-     * @throws ImageException
-     *
      * @return mixed
+     *
+     * @throws ImageException
      */
     public function getEXIF(?string $key = null, bool $silent = false)
     {

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -328,9 +328,9 @@ class GDHandler extends BaseHandler
      * @param string $path      Image path
      * @param int    $imageType Image type
      *
-     * @throws ImageException
-     *
      * @return bool|resource
+     *
+     * @throws ImageException
      */
     protected function getImageResource(string $path, int $imageType)
     {

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -52,9 +52,9 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Handles the actual resizing of the image.
      *
-     * @throws Exception
-     *
      * @return ImageMagickHandler
+     *
+     * @throws Exception
      */
     public function _resize(bool $maintainRatio = false)
     {
@@ -79,9 +79,9 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Crops the image.
      *
-     * @throws Exception
-     *
      * @return bool|\CodeIgniter\Images\Handlers\ImageMagickHandler
+     *
+     * @throws Exception
      */
     public function _crop()
     {
@@ -104,9 +104,9 @@ class ImageMagickHandler extends BaseHandler
      * Handles the rotation of an image resource.
      * Doesn't save the image, but replaces the current resource.
      *
-     * @throws Exception
-     *
      * @return $this
+     *
+     * @throws Exception
      */
     protected function _rotate(int $angle)
     {
@@ -125,9 +125,9 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Flattens transparencies, default white background
      *
-     * @throws Exception
-     *
      * @return $this
+     *
+     * @throws Exception
      */
     protected function _flatten(int $red = 255, int $green = 255, int $blue = 255)
     {
@@ -146,9 +146,9 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Flips an image along it's vertical or horizontal axis.
      *
-     * @throws Exception
-     *
      * @return $this
+     *
+     * @throws Exception
      */
     protected function _flip(string $direction)
     {
@@ -180,9 +180,9 @@ class ImageMagickHandler extends BaseHandler
     /**
      * Handles all of the grunt work of resizing, etc.
      *
-     * @throws Exception
-     *
      * @return array Lines of output from shell command
+     *
+     * @throws Exception
      */
     protected function process(string $action, int $quality = 100): array
     {
@@ -269,9 +269,9 @@ class ImageMagickHandler extends BaseHandler
      * To ensure we can use all features, like transparency,
      * during the process, we'll use a PNG as the temp file type.
      *
-     * @throws Exception
-     *
      * @return string
+     *
+     * @throws Exception
      */
     protected function getResourcePath()
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -347,9 +347,9 @@ class Model extends BaseModel
      * @param int         $batchSize The size of the batch to run
      * @param bool        $returnSQL True means SQL is returned, false will execute the query
      *
-     * @throws DatabaseException
-     *
      * @return mixed Number of rows affected or FALSE on failure
+     *
+     * @throws DatabaseException
      */
     protected function doUpdateBatch(?array $set = null, ?string $index = null, int $batchSize = 100, bool $returnSQL = false)
     {
@@ -364,9 +364,9 @@ class Model extends BaseModel
      * @param array|int|string|null $id    The rows primary key(s)
      * @param bool                  $purge Allows overriding the soft deletes setting.
      *
-     * @throws DatabaseException
-     *
      * @return bool|string
+     *
+     * @throws DatabaseException
      */
     protected function doDelete($id = null, bool $purge = false)
     {
@@ -554,9 +554,9 @@ class Model extends BaseModel
     /**
      * Provides a shared instance of the Query Builder.
      *
-     * @throws ModelException
-     *
      * @return BaseBuilder
+     *
+     * @throws ModelException
      */
     public function builder(?string $table = null)
     {
@@ -646,9 +646,9 @@ class Model extends BaseModel
      * @param array|object|null $data
      * @param bool              $returnID Whether insert ID should be returned or not.
      *
-     * @throws ReflectionException
-     *
      * @return BaseResult|false|int|object|string
+     *
+     * @throws ReflectionException
      */
     public function insert($data = null, bool $returnID = true)
     {
@@ -700,9 +700,9 @@ class Model extends BaseModel
      * @param object|string $data
      * @param bool          $recursive If true, inner entities will be casted as array as well
      *
-     * @throws ReflectionException
-     *
      * @return array|null Array
+     *
+     * @throws ReflectionException
      */
     protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
     {

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -155,10 +155,10 @@ class Router implements RouterInterface
     }
 
     /**
+     * @return Closure|string Controller classname or Closure
+     *
      * @throws PageNotFoundException
      * @throws RedirectException
-     *
-     * @return Closure|string Controller classname or Closure
      */
     public function handle(?string $uri = null)
     {
@@ -384,9 +384,9 @@ class Router implements RouterInterface
      *
      * @param string $uri The URI path to compare against the routes
      *
-     * @throws RedirectException
-     *
      * @return bool Whether the route was matched or not.
+     *
+     * @throws RedirectException
      */
     protected function checkRoutes(string $uri): bool
     {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -239,9 +239,9 @@ class Security implements SecurityInterface
     /**
      * CSRF Verify
      *
-     * @throws SecurityException
-     *
      * @return $this|false
+     *
+     * @throws SecurityException
      *
      * @deprecated Use `CodeIgniter\Security\Security::verify()` instead of using this method.
      *
@@ -279,9 +279,9 @@ class Security implements SecurityInterface
     /**
      * CSRF Verify
      *
-     * @throws SecurityException
-     *
      * @return $this
+     *
+     * @throws SecurityException
      */
     public function verify(RequestInterface $request)
     {
@@ -390,9 +390,9 @@ class Security implements SecurityInterface
      *
      * @params string $token CSRF token
      *
-     * @throws InvalidArgumentException "hex2bin(): Hexadecimal input string must have an even length"
-     *
      * @return string CSRF hash
+     *
+     * @throws InvalidArgumentException "hex2bin(): Hexadecimal input string must have an even length"
      */
     protected function derandomize(string $token): string
     {

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -22,9 +22,9 @@ interface SecurityInterface
     /**
      * CSRF Verify
      *
-     * @throws SecurityException
-     *
      * @return $this|false
+     *
+     * @throws SecurityException
      */
     public function verify(RequestInterface $request);
 

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -348,9 +348,9 @@ abstract class CIUnitTestCase extends TestCase
      *
      * @param string|null $expectedMessage
      *
-     * @throws Exception
-     *
      * @return bool
+     *
+     * @throws Exception
      */
     public function assertLogged(string $level, $expectedMessage = null)
     {
@@ -473,9 +473,9 @@ abstract class CIUnitTestCase extends TestCase
      * @param mixed $expected
      * @param mixed $actual
      *
-     * @throws Exception
-     *
      * @return bool|void
+     *
+     * @throws Exception
      */
     public function assertCloseEnoughString($expected, $actual, string $message = '', int $tolerance = 1)
     {

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -145,9 +145,9 @@ trait ControllerTestTrait
      *
      * @param array $params
      *
-     * @throws InvalidArgumentException
-     *
      * @return TestResponse
+     *
+     * @throws InvalidArgumentException
      */
     public function execute(string $method, ...$params)
     {

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -145,9 +145,9 @@ trait ControllerTester
      *
      * @param array $params
      *
-     * @throws InvalidArgumentException
-     *
      * @return ControllerResponse
+     *
+     * @throws InvalidArgumentException
      */
     public function execute(string $method, ...$params)
     {

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -248,9 +248,9 @@ trait DatabaseTestTrait
      * Fetches a single column from a database row with criteria
      * matching $where.
      *
-     * @throws DatabaseException
-     *
      * @return bool
+     *
+     * @throws DatabaseException
      */
     public function grabFromDatabase(string $table, string $column, array $where)
     {

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -364,9 +364,9 @@ class Fabricator
     /**
      * Generate an array of faked data
      *
-     * @throws RuntimeException
-     *
      * @return array An array of faked data
+     *
+     * @throws RuntimeException
      */
     public function makeArray()
     {
@@ -401,9 +401,9 @@ class Fabricator
      *
      * @param string|null $className Class name of the object to create; null to use model default
      *
-     * @throws RuntimeException
-     *
      * @return object An instance of the class with faked data
+     *
+     * @throws RuntimeException
      */
     public function makeObject(?string $className = null): object
     {
@@ -451,9 +451,9 @@ class Fabricator
      * @param int|null $count Optional number to create a collection
      * @param bool     $mock  Whether to execute or mock the insertion
      *
-     * @throws FrameworkException
-     *
      * @return array|object An array or object (based on returnType), or an array of returnTypes
+     *
+     * @throws FrameworkException
      */
     public function create(?int $count = null, bool $mock = false)
     {

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -148,10 +148,10 @@ class FeatureTestCase extends CIUnitTestCase
      * Calls a single URI, executes it, and returns a FeatureResponse
      * instance that can be used to run many assertions against.
      *
+     * @return FeatureResponse
+     *
      * @throws Exception
      * @throws RedirectException
-     *
-     * @return FeatureResponse
      */
     public function call(string $method, string $path, ?array $params = null)
     {
@@ -223,10 +223,10 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs a GET request.
      *
+     * @return FeatureResponse
+     *
      * @throws Exception
      * @throws RedirectException
-     *
-     * @return FeatureResponse
      */
     public function get(string $path, ?array $params = null)
     {
@@ -236,10 +236,10 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs a POST request.
      *
+     * @return FeatureResponse
+     *
      * @throws Exception
      * @throws RedirectException
-     *
-     * @return FeatureResponse
      */
     public function post(string $path, ?array $params = null)
     {
@@ -249,10 +249,10 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs a PUT request
      *
+     * @return FeatureResponse
+     *
      * @throws Exception
      * @throws RedirectException
-     *
-     * @return FeatureResponse
      */
     public function put(string $path, ?array $params = null)
     {
@@ -262,10 +262,10 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performss a PATCH request
      *
+     * @return FeatureResponse
+     *
      * @throws Exception
      * @throws RedirectException
-     *
-     * @return FeatureResponse
      */
     public function patch(string $path, ?array $params = null)
     {
@@ -275,10 +275,10 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs a DELETE request.
      *
+     * @return FeatureResponse
+     *
      * @throws Exception
      * @throws RedirectException
-     *
-     * @return FeatureResponse
      */
     public function delete(string $path, ?array $params = null)
     {
@@ -288,10 +288,10 @@ class FeatureTestCase extends CIUnitTestCase
     /**
      * Performs an OPTIONS request.
      *
+     * @return FeatureResponse
+     *
      * @throws Exception
      * @throws RedirectException
-     *
-     * @return FeatureResponse
      */
     public function options(string $path, ?array $params = null)
     {
@@ -340,9 +340,9 @@ class FeatureTestCase extends CIUnitTestCase
      *
      * Always populate the GET vars based on the URI.
      *
-     * @throws ReflectionException
-     *
      * @return Request
+     *
+     * @throws ReflectionException
      */
     protected function populateGlobals(string $method, Request $request, ?array $params = null)
     {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -138,10 +138,10 @@ trait FeatureTestTrait
      * Calls a single URI, executes it, and returns a TestResponse
      * instance that can be used to run many assertions against.
      *
+     * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
-     *
-     * @return TestResponse
      */
     public function call(string $method, string $path, ?array $params = null)
     {
@@ -213,10 +213,10 @@ trait FeatureTestTrait
     /**
      * Performs a GET request.
      *
+     * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
-     *
-     * @return TestResponse
      */
     public function get(string $path, ?array $params = null)
     {
@@ -226,10 +226,10 @@ trait FeatureTestTrait
     /**
      * Performs a POST request.
      *
+     * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
-     *
-     * @return TestResponse
      */
     public function post(string $path, ?array $params = null)
     {
@@ -239,10 +239,10 @@ trait FeatureTestTrait
     /**
      * Performs a PUT request
      *
+     * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
-     *
-     * @return TestResponse
      */
     public function put(string $path, ?array $params = null)
     {
@@ -252,10 +252,10 @@ trait FeatureTestTrait
     /**
      * Performss a PATCH request
      *
+     * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
-     *
-     * @return TestResponse
      */
     public function patch(string $path, ?array $params = null)
     {
@@ -265,10 +265,10 @@ trait FeatureTestTrait
     /**
      * Performs a DELETE request.
      *
+     * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
-     *
-     * @return TestResponse
      */
     public function delete(string $path, ?array $params = null)
     {
@@ -278,10 +278,10 @@ trait FeatureTestTrait
     /**
      * Performs an OPTIONS request.
      *
+     * @return TestResponse
+     *
      * @throws RedirectException
      * @throws Exception
-     *
-     * @return TestResponse
      */
     public function options(string $path, ?array $params = null)
     {
@@ -335,9 +335,9 @@ trait FeatureTestTrait
      *
      * Always populate the GET vars based on the URI.
      *
-     * @throws ReflectionException
-     *
      * @return Request
+     *
+     * @throws ReflectionException
      */
     protected function populateGlobals(string $method, Request $request, ?array $params = null)
     {

--- a/system/Test/Interfaces/FabricatorModel.php
+++ b/system/Test/Interfaces/FabricatorModel.php
@@ -45,9 +45,9 @@ interface FabricatorModel
      * @param array|object $data
      * @param bool         $returnID Whether insert ID should be returned or not.
      *
-     * @throws ReflectionException
-     *
      * @return bool|int|string
+     *
+     * @throws ReflectionException
      */
     public function insert($data = null, bool $returnID = true);
 

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -29,9 +29,9 @@ trait ReflectionHelper
      * @param object|string $obj    object or class name
      * @param string        $method method name
      *
-     * @throws ReflectionException
-     *
      * @return Closure
+     *
+     * @throws ReflectionException
      */
     public static function getPrivateMethodInvoker($obj, $method)
     {
@@ -48,9 +48,9 @@ trait ReflectionHelper
      * @param object|string $obj
      * @param string        $property
      *
-     * @throws ReflectionException
-     *
      * @return ReflectionProperty
+     *
+     * @throws ReflectionException
      */
     private static function getAccessibleRefProperty($obj, $property)
     {
@@ -83,9 +83,9 @@ trait ReflectionHelper
      * @param object|string $obj      object or class name
      * @param string        $property property name
      *
-     * @throws ReflectionException
-     *
      * @return mixed value
+     *
+     * @throws ReflectionException
      */
     public static function getPrivateProperty($obj, $property)
     {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -416,9 +416,9 @@ class Validation implements ValidationInterface
      *
      * @param array|string $rules
      *
-     * @throws TypeError
-     *
      * @return $this
+     *
+     * @throws TypeError
      */
     public function setRule(string $field, ?string $label, $rules, array $errors = [])
     {
@@ -505,9 +505,9 @@ class Validation implements ValidationInterface
      *
      * @param string $group Group.
      *
-     * @throws InvalidArgumentException If group not found.
-     *
      * @return string[] Rule group.
+     *
+     * @throws InvalidArgumentException If group not found.
      */
     public function getRuleGroup(string $group): array
     {


### PR DESCRIPTION
**Description**
In the past, we are stuck with the default ordering of `['param', 'throws', 'return']`. Now that the fixer is configurable, this proposes to change the ordering to `['param', 'return', 'throws']`.

```console
$ vendor/bin/php-cs-fixer describe phpdoc_order
Description of phpdoc_order rule.
Annotations in PHPDoc should be ordered in defined sequence.

Fixer is configurable using following option:
* order (string[]): sequence in which annotations in PHPDoc should be ordered; defaults to ['param', 'throws', 'return']

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,10 +1,10 @@
    <?php
    /**
     * Hello there!
     *
   - * @throws Exception|RuntimeException foo
     * @custom Test!
   - * @return int  Return the number of changes.
     * @param string $foo
     * @param bool   $bar Bar
   + * @throws Exception|RuntimeException foo
   + * @return int  Return the number of changes.
     */

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['order' => ['param', 'throws', 'return']].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,10 +1,10 @@
    <?php
    /**
     * Hello there!
     *
   - * @throws Exception|RuntimeException foo
     * @custom Test!
   - * @return int  Return the number of changes.
     * @param string $foo
     * @param bool   $bar Bar
   + * @throws Exception|RuntimeException foo
   + * @return int  Return the number of changes.
     */

   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['order' => ['param', 'return', 'throws']].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,10 +1,10 @@
    <?php
    /**
     * Hello there!
     *
   - * @throws Exception|RuntimeException foo
     * @custom Test!
   - * @return int  Return the number of changes.
     * @param string $foo
     * @param bool   $bar Bar
   + * @return int  Return the number of changes.
   + * @throws Exception|RuntimeException foo
     */

   ----------- end diff -----------

 * Example #4. Fixing with configuration: ['order' => ['param', 'custom', 'throws', 'return']].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,10 +1,10 @@
    <?php
    /**
     * Hello there!
     *
   + * @param string $foo
   + * @param bool   $bar Bar
   + * @custom Test!
     * @throws Exception|RuntimeException foo
   - * @custom Test!
     * @return int  Return the number of changes.
   - * @param string $foo
   - * @param bool   $bar Bar
     */

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
