### PR TITLE
fix: replace "`" in lang strings

### DIFF
--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -55,7 +55,7 @@ return [
     'localeNotSupported' => 'Locale is not supported: {0}',
 
     // CSRF
-    // @deprecated use `Security.disallowedAction`
+    // @deprecated use 'Security.disallowedAction'
     'disallowedAction' => 'The action you requested is not allowed.',
 
     // Uploaded file moving

--- a/system/Language/en/Session.php
+++ b/system/Language/en/Session.php
@@ -11,7 +11,7 @@
 
 // Session language settings
 return [
-    'missingDatabaseTable'   => '`sessionSavePath` must have the table name for the Database Session Handler to work.',
+    'missingDatabaseTable'   => '"sessionSavePath" must have the table name for the Database Session Handler to work.',
     'invalidSavePath'        => 'Session: Configured save path "{0}" is not a directory, does not exist or cannot be created.',
     'writeProtectedSavePath' => 'Session: Configured save path "{0}" is not writable by the PHP process.',
     'emptySavePath'          => 'Session: No save path configured.',


### PR DESCRIPTION
**Description**
Follow-up #6474

- replace `` ` ``

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

