### PR TITLE
Add `group_to_single_imports` option to `single_import_per_statement`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -93,6 +93,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    'single_import_per_statement' => ['group_to_single_imports' => true],
     'single_line_comment_spacing' => true,
     'statement_indentation'       => true,
     // >>>>>>>>>>>>>>>>>>>>>>>>>

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -85,6 +85,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    'single_import_per_statement' => ['group_to_single_imports' => true],
     'single_line_comment_spacing' => true,
     'statement_indentation'       => true,
     // >>>>>>>>>>>>>>>>>>>>>>>>>

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -87,6 +87,7 @@ $overrides = [
             ['var', 'phpstan-var', 'psalm-var'],
         ],
     ],
+    'single_import_per_statement' => ['group_to_single_imports' => true],
     'single_line_comment_spacing' => true,
     'statement_indentation'       => true,
     // >>>>>>>>>>>>>>>>>>>>>>>>>


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe single_import_per_statement
Description of single_import_per_statement rule.
There MUST be one use keyword per declaration.

Fixer is configurable using following option:
* group_to_single_imports (bool): whether to change group imports into single imports; defaults to true

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,4 @@
    <?php
   -use Foo, Sample, Sample\Sample as Sample2;
   +use Foo;
   +use Sample;
   +use Sample\Sample as Sample2;

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['group_to_single_imports' => true].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,6 +1,4 @@
    <?php
   -use Space\Models\ {
   -    TestModelA,
   -    TestModelB,
   -    TestModel,
   -};
   +use Space\Models\TestModelA;
   +use Space\Models\TestModelB;
   +use Space\Models\TestModel;

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
