### PR TITLE
add: set up "script_name" to handle every request by index.php file.

### DIFF
--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -27,7 +27,7 @@ if (PHP_SAPI === 'cli') {
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
 // All request handle by index.php file.
-$_SERVER['SCRIPT_NAME'] = 'index.php';
+$_SERVER['SCRIPT_NAME'] = '/index.php';
 
 // Front Controller path - expected to be in the default folder
 $fcpath = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR;

--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -27,7 +27,7 @@ if (PHP_SAPI === 'cli') {
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
 // All request handle by index.php file.
-$_SERVER["SCRIPT_NAME"] = 'index.php';
+$_SERVER['SCRIPT_NAME'] = 'index.php';
 
 // Front Controller path - expected to be in the default folder
 $fcpath = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR;

--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -26,6 +26,9 @@ if (PHP_SAPI === 'cli') {
 
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
+// All request handle by index.php file.
+$_SERVER["SCRIPT_NAME"] = 'index.php';
+
 // Front Controller path - expected to be in the default folder
 $fcpath = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR;
 


### PR DESCRIPTION
**Description**
Fixed #6232 
Add `$_SERVER["SCRIPT_NAME"] = 'index.php'` to route the request to handle by `index.php`, then no more the scenario that always `welcome page` with any request.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
