### PR TITLE
Added view() method to route collections.

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -993,6 +993,21 @@ class RouteCollection implements RouteCollectionInterface
     }
 
     /**
+     * Specifies a route that will only display a view.
+     * Only works for GET requests.
+     */
+    public function view(string $from, string $view, ?array $options = null): RouteCollectionInterface
+    {
+        $to = static function (...$data) use ($view) {
+            return view($view, ['_page' => $data]);
+        };
+
+        $this->create('get', $from, $to, $options);
+
+        return $this;
+    }
+
+    /**
      * Limits the routes to a specified ENVIRONMENT or they won't run.
      */
     public function environment(string $env, Closure $callback): RouteCollectionInterface

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -12,9 +12,11 @@
 namespace CodeIgniter\Router;
 
 use App\Controllers\Home;
+use CodeIgniter\Config\Factory;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\View\View;
 use Config\Modules;
 use Tests\Support\Controllers\Hello;
 
@@ -817,6 +819,16 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes->cli('here', 'there');
         $this->assertSame($expected, $routes->getRoutes('cli'));
+    }
+
+    public function testView()
+    {
+        $routes = $this->getCollector();
+
+        $routes->view('here', 'hello');
+
+        $route = $routes->getRoutes('get')['here'];
+        $this->assertIsCallable($route);
     }
 
     public function testEnvironmentRestricts()

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -127,6 +127,7 @@ Others
 ======
 
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
+- Added new ``$routes->view()`` method to echo the view directly. See :ref:`View Routes <view-routes>`.
 
 Changes
 *******

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -206,9 +206,24 @@ Closures
 
 You can use an anonymous function, or Closure, as the destination that a route maps to. This function will be
 executed when the user visits that URI. This is handy for quickly executing small tasks, or even just showing
-a simple view:
+a simple view.
 
-.. literalinclude:: routing/020.php
+.. literalinclude:: routing/065.php
+
+If you use placeholders within your route, you can access them within the view in a special variable, ``$_page``.
+They are available as an array, indexed in the order they appear in the route.
+
+.. literalinclude:: routing/066.php
+
+.. _view_routes:
+
+Views
+=====
+
+If you just want to render a view out that has no logic associated with it, you can use the ``view()`` method.
+This method accepts the name of the view to load as the ``$to`` parameter.
+
+.. literalinclude:: routing/021.php
 
 Mapping Multiple Routes
 =======================

--- a/user_guide_src/source/incoming/routing/065.php
+++ b/user_guide_src/source/incoming/routing/065.php
@@ -1,0 +1,4 @@
+<?php
+
+// Displays the view in /app/Views/pages/about.php
+$routes->view('about', 'pages/about');

--- a/user_guide_src/source/incoming/routing/066.php
+++ b/user_guide_src/source/incoming/routing/066.php
@@ -1,0 +1,7 @@
+<?php
+
+// Displays the view in /app/Views/map.php
+$routes->view('map/(:segment)/(:segment)', 'map');
+
+// Within the view, you can access the segments with
+// $_page[0] and $_page[1] respectively.


### PR DESCRIPTION
**Description**
Added a new method to simplify rendering out views directly through routes. While you could do this with a closure, this is tidier and easier to read when using many of these. 

This supports static info pages in sites, like About, Privacy, Terms, etc. It also supports a more view-first workflow, where the view is primary object, and View Cells are used to display the dynamic content.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
