### PR TITLE
docs: fix inappropriate sample code in Response

### DIFF
--- a/user_guide_src/source/outgoing/response/022.php
+++ b/user_guide_src/source/outgoing/response/022.php
@@ -1,4 +1,4 @@
 <?php
 
 $response->setLastModified(date('D, d M Y H:i:s'));
-$response->setLastModified(DateTime::createFromFormat('u', $time));
+$response->setLastModified(DateTime::createFromFormat('U', $timestamp));


### PR DESCRIPTION
**Description**
There are no microseconds in the Last-Modified header:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified

See https://github.com/codeigniter4/CodeIgniter4/pull/6480#discussion_r967081572

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

