### PR TITLE
Enable `ensure_single_space` option of `whitespace_after_comma_in_array`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -100,6 +100,7 @@ $overrides = [
         'space'                => 'none',
         'space_multiple_catch' => 'none',
     ],
+    'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
     // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -92,6 +92,7 @@ $overrides = [
         'space'                => 'none',
         'space_multiple_catch' => 'none',
     ],
+    'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
     // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -94,6 +94,7 @@ $overrides = [
         'space'                => 'none',
         'space_multiple_catch' => 'none',
     ],
+    'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
     // >>>>>>>>>>>>>>>>>>>>>>>>>
 ];
 

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -149,7 +149,7 @@ if (! function_exists('entities_to_ascii')) {
         if ($all) {
             return str_replace(
                 ['&amp;', '&lt;', '&gt;', '&quot;', '&apos;', '&#45;'],
-                ['&', '<', '>', '"', "'",  '-'],
+                ['&', '<', '>', '"', "'", '-'],
                 $str
             );
         }

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -190,43 +190,43 @@ final class BaseConnectionTest extends CIUnitTestCase
         yield from [
             // $prefixSingle, $protectIdentifiers, $fieldExists, $item, $expected
             'empty string'        => [false, true, true, '', ''],
-            'empty string prefix' => [true,  true, true, '', '"test_"'], // Incorrect usage? or should be ''?
+            'empty string prefix' => [true, true, true, '', '"test_"'], // Incorrect usage? or should be ''?
 
             'single table'        => [false, true, false, 'jobs', '"jobs"'],
-            'single table prefix' => [true,  true, false, 'jobs', '"test_jobs"'],
+            'single table prefix' => [true, true, false, 'jobs', '"test_jobs"'],
 
             'string'        => [false, true, true, "'Accountant'", "'Accountant'"],
-            'single prefix' => [true,  true, true, "'Accountant'", "'Accountant'"],
+            'single prefix' => [true, true, true, "'Accountant'", "'Accountant'"],
 
             'numbers only'        => [false, true, false, '12345', '12345'], // Should be quoted?
-            'numbers only prefix' => [true,  true, false, '12345', '"test_12345"'],
+            'numbers only prefix' => [true, true, false, '12345', '"test_12345"'],
 
             'table AS alias'        => [false, true, false, 'role AS myRole', '"role" AS "myRole"'],
-            'table AS alias prefix' => [true,  true, false, 'role AS myRole', '"test_role" AS "myRole"'],
+            'table AS alias prefix' => [true, true, false, 'role AS myRole', '"test_role" AS "myRole"'],
 
             'quoted table'        => [false, true, false, '"jobs"', '"jobs"'],
-            'quoted table prefix' => [true,  true, false, '"jobs"', '"test_jobs"'],
+            'quoted table prefix' => [true, true, false, '"jobs"', '"test_jobs"'],
 
             'quoted table alias'        => [false, true, false, '"jobs" "j"', '"jobs" "j"'],
-            'quoted table alias prefix' => [true,  true, false, '"jobs" "j"', '"test_jobs" "j"'],
+            'quoted table alias prefix' => [true, true, false, '"jobs" "j"', '"test_jobs" "j"'],
 
             'table.*'             => [false, true, true, 'jobs.*', '"test_jobs".*'], // Prefixed because it has segments
-            'table.* prefix'      => [true,  true, true, 'jobs.*', '"test_jobs".*'],
+            'table.* prefix'      => [true, true, true, 'jobs.*', '"test_jobs".*'],
             'table.column'        => [false, true, true, 'users.id', '"test_users"."id"'], // Prefixed because it has segments
-            'table.column prefix' => [true,  true, true, 'users.id', '"test_users"."id"'],
+            'table.column prefix' => [true, true, true, 'users.id', '"test_users"."id"'],
             'table.column AS'     => [
                 false, true, true,
                 'users.id AS user_id',
                 '"test_users"."id" AS "user_id"', // Prefixed because it has segments
             ],
             'table.column AS prefix' => [
-                true,  true, true,
+                true, true, true,
                 'users.id AS user_id',
                 '"test_users"."id" AS "user_id"',
             ],
 
             'function table.column'        => [false, true, true, 'LOWER(jobs.name)', 'LOWER(jobs.name)'],
-            'function table.column prefix' => [true,  true, true, 'LOWER(jobs.name)', 'LOWER(jobs.name)'],
+            'function table.column prefix' => [true, true, true, 'LOWER(jobs.name)', 'LOWER(jobs.name)'],
 
             'function only'   => [false, true, true, 'RAND()', 'RAND()'],
             'function column' => [false, true, true, 'SUM(id)', 'SUM(id)'],

--- a/user_guide_src/source/outgoing/table/002.php
+++ b/user_guide_src/source/outgoing/table/002.php
@@ -4,8 +4,8 @@ $table = new \CodeIgniter\View\Table();
 
 $data = [
     ['Name', 'Color', 'Size'],
-    ['Fred', 'Blue',  'Small'],
-    ['Mary', 'Red',   'Large'],
+    ['Fred', 'Blue', 'Small'],
+    ['Mary', 'Red', 'Large'],
     ['John', 'Green', 'Medium'],
 ];
 


### PR DESCRIPTION
**Description**
```console
$ vendor/bin/php-cs-fixer describe whitespace_after_comma_in_array
Description of whitespace_after_comma_in_array rule.
In array declaration, there MUST be a whitespace after each comma.

Fixer is configurable using following option:
* ensure_single_space (bool): if there are only horizontal whitespaces after the comma then ensure it is a single space; defaults to false 

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -$sample = array(1,'a',$b,);
   +$sample = array(1, 'a', $b, );

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['ensure_single_space' => true].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -$sample = [1,2, 3,  4,    5];
   +$sample = [1, 2, 3, 4, 5];

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
