### PR TITLE
chore: change Psalm errorLevel to 8

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="1"
+    errorLevel="8"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
**Description**
I don't know why, but when we installed Psalm, there was 100 and more errors.
But I ran today, there are more than 10,000 errors with level 1.

level 8:
```
------------------------------
129 errors found
------------------------------
9614 other issues found.
You can display them with --show-info=true
------------------------------
Psalm can automatically fix 3995 of these issues.
Run Psalm again with 
--alter --issues=MissingReturnType,InvalidReturnType,InvalidNullableReturnType,InvalidFalsableReturnType,MissingClosureReturnType,MissingParamType --dry-run
to see what it can fix.
------------------------------
```

level 1:
```
------------------------------
17813 errors found
------------------------------
Psalm can automatically fix 4067 of these issues.
Run Psalm again with 
--alter --issues=MissingReturnType,InvalidReturnType,UnnecessaryVarAnnotation,InvalidNullableReturnType,UnusedVariable,InvalidFalsableReturnType,MissingClosureReturnType,MissingParamType --dry-run
to see what it can fix.
------------------------------
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide

