### PR TITLE
Revert "Make Unique Index Name Unique #6516"

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1041,8 +1041,7 @@ class Forge
 
             if (in_array($i, $this->uniqueKeys, true)) {
                 $sqls[] = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table)
-                    . ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_'
-                    . implode('_', $this->keys[$i]) . '_u')
+                    . ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
                     . ' UNIQUE (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ')';
 
                 continue;

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -212,8 +212,7 @@ class Forge extends BaseForge
 
             $unique = in_array($i, $this->uniqueKeys, true) ? 'UNIQUE ' : '';
 
-            $sql .= ",\n\t{$unique}KEY " . $this->db->escapeIdentifiers(implode('_', $this->keys[$i])
-                . (in_array($i, $this->uniqueKeys, true) ? '_u' : ''))
+            $sql .= ",\n\t{$unique}KEY " . $this->db->escapeIdentifiers(implode('_', $this->keys[$i]))
                 . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ')';
         }
 

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -258,8 +258,7 @@ class Forge extends BaseForge
             if (in_array($i, $this->uniqueKeys, true)) {
                 $sqls[] = 'ALTER TABLE '
                     . $this->db->escapeIdentifiers($this->db->schema) . '.' . $this->db->escapeIdentifiers($table)
-                    . ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_'
-                    . implode('_', $this->keys[$i]) . '_u')
+                    . ' ADD CONSTRAINT ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
                     . ' UNIQUE (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
 
                 continue;

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -176,8 +176,7 @@ class Forge extends BaseForge
             }
 
             if (in_array($i, $this->uniqueKeys, true)) {
-                $sqls[] = 'CREATE UNIQUE INDEX ' . $this->db->escapeIdentifiers($table . '_'
-                    . implode('_', $this->keys[$i]) . '_u')
+                $sqls[] = 'CREATE UNIQUE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
                     . ' ON ' . $this->db->escapeIdentifiers($table)
                     . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1081,9 +1081,9 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['code_company']->type, 'INDEX');
 
-            $this->assertSame($keys['code_active_u']->name, 'code_active_u');
-            $this->assertSame($keys['code_active_u']->fields, ['code', 'active']);
-            $this->assertSame($keys['code_active_u']->type, 'UNIQUE');
+            $this->assertSame($keys['code_active']->name, 'code_active');
+            $this->assertSame($keys['code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'Postgre') {
             $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
             $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
@@ -1093,9 +1093,9 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
 
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->name, 'db_forge_test_1_code_active_u');
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->fields, ['code', 'active']);
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->type, 'UNIQUE');
+            $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
+            $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'SQLite3') {
             $this->assertSame($keys['PRIMARY']->name, 'PRIMARY');
             $this->assertSame($keys['PRIMARY']->fields, ['id']);
@@ -1105,9 +1105,9 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
 
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->name, 'db_forge_test_1_code_active_u');
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->fields, ['code', 'active']);
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->type, 'UNIQUE');
+            $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
+            $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'SQLSRV') {
             $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
             $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
@@ -1117,9 +1117,9 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
 
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->name, 'db_forge_test_1_code_active_u');
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->fields, ['code', 'active']);
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->type, 'UNIQUE');
+            $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
+            $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         } elseif ($this->db->DBDriver === 'OCI8') {
             $this->assertSame($keys['pk_db_forge_test_1']->name, 'pk_db_forge_test_1');
             $this->assertSame($keys['pk_db_forge_test_1']->fields, ['id']);
@@ -1129,9 +1129,9 @@ final class ForgeTest extends CIUnitTestCase
             $this->assertSame($keys['db_forge_test_1_code_company']->fields, ['code', 'company']);
             $this->assertSame($keys['db_forge_test_1_code_company']->type, 'INDEX');
 
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->name, 'db_forge_test_1_code_active_u');
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->fields, ['code', 'active']);
-            $this->assertSame($keys['db_forge_test_1_code_active_u']->type, 'UNIQUE');
+            $this->assertSame($keys['db_forge_test_1_code_active']->name, 'db_forge_test_1_code_active');
+            $this->assertSame($keys['db_forge_test_1_code_active']->fields, ['code', 'active']);
+            $this->assertSame($keys['db_forge_test_1_code_active']->type, 'UNIQUE');
         }
 
         $this->forge->dropTable('forge_test_1', true);

--- a/tests/system/Database/Live/SQLite/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite/AlterTableTest.php
@@ -110,8 +110,8 @@ final class AlterTableTest extends CIUnitTestCase
         $this->assertCount(3, $keys);
         $this->assertArrayHasKey('foo_name', $keys);
         $this->assertSame(['fields' => ['name'], 'type' => 'index'], $keys['foo_name']);
-        $this->assertArrayHasKey('foo_email_u', $keys);
-        $this->assertSame(['fields' => ['email'], 'type' => 'unique'], $keys['foo_email_u']);
+        $this->assertArrayHasKey('foo_email', $keys);
+        $this->assertSame(['fields' => ['email'], 'type' => 'unique'], $keys['foo_email']);
         $this->assertArrayHasKey('primary', $keys);
         $this->assertSame(['fields' => ['id'], 'type' => 'primary'], $keys['primary']);
     }
@@ -141,7 +141,7 @@ final class AlterTableTest extends CIUnitTestCase
         $oldKeys = $this->db->getIndexData('foo');
 
         $this->assertArrayHasKey('foo_name', $oldKeys);
-        $this->assertArrayHasKey('foo_email_u', $oldKeys);
+        $this->assertArrayHasKey('foo_email', $oldKeys);
 
         $result = $this->table
             ->fromTable('foo')
@@ -151,7 +151,7 @@ final class AlterTableTest extends CIUnitTestCase
         $newKeys = $this->db->getIndexData('foo');
 
         $this->assertArrayNotHasKey('foo_name', $newKeys);
-        $this->assertArrayHasKey('foo_email_u', $newKeys);
+        $this->assertArrayHasKey('foo_email', $newKeys);
 
         $this->assertTrue($result);
     }

--- a/tests/system/Database/Live/SQLite/GetIndexDataTest.php
+++ b/tests/system/Database/Live/SQLite/GetIndexDataTest.php
@@ -81,11 +81,11 @@ final class GetIndexDataTest extends CIUnitTestCase
         $row->type                  = 'PRIMARY';
         $expectedIndexes['PRIMARY'] = $row;
 
-        $row                                 = new stdclass();
-        $row->name                           = 'testuser_email_u';
-        $row->fields                         = ['email'];
-        $row->type                           = 'UNIQUE';
-        $expectedIndexes['testuser_email_u'] = $row;
+        $row                               = new stdclass();
+        $row->name                         = 'testuser_email';
+        $row->fields                       = ['email'];
+        $row->type                         = 'UNIQUE';
+        $expectedIndexes['testuser_email'] = $row;
 
         $row                                 = new stdclass();
         $row->name                           = 'testuser_country';
@@ -98,8 +98,8 @@ final class GetIndexDataTest extends CIUnitTestCase
         $this->assertSame($expectedIndexes['PRIMARY']->fields, $indexes['PRIMARY']->fields);
         $this->assertSame($expectedIndexes['PRIMARY']->type, $indexes['PRIMARY']->type);
 
-        $this->assertSame($expectedIndexes['testuser_email_u']->fields, $indexes['testuser_email_u']->fields);
-        $this->assertSame($expectedIndexes['testuser_email_u']->type, $indexes['testuser_email_u']->type);
+        $this->assertSame($expectedIndexes['testuser_email']->fields, $indexes['testuser_email']->fields);
+        $this->assertSame($expectedIndexes['testuser_email']->type, $indexes['testuser_email']->type);
 
         $this->assertSame($expectedIndexes['testuser_country']->fields, $indexes['testuser_country']->fields);
         $this->assertSame($expectedIndexes['testuser_country']->type, $indexes['testuser_country']->type);

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -45,7 +45,6 @@ Others
 - ``RouteCollection::resetRoutes()`` resets Auto-Discovery of Routes. Previously once discovered, RouteCollection never discover Routes files again even if ``RouteCollection::resetRoutes()`` is called.
 - ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there
   is a ``CITestStreamFilter::registration()`` method for this. See :ref:`upgrade-430-stream-filter` for details.
-- ``Forge::addUniqueKey()`` now applies ``_u`` suffix to the constraint name. This was done to ensure a unique index name.
 
 Method Signature Changes
 ========================


### PR DESCRIPTION
**Description**
Reverts #6516

This reverts commit 22f9797390be4e883bd37ec3e03b8b55f05dbd96, reversing changes made to 6561bd709f8b7960ec858afa1b2a0723e683b73f.

Conflicts:
	user_guide_src/source/changelogs/v4.3.0.rst

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

