### PR TITLE
Add ability to set index names

### DIFF
--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -237,6 +237,8 @@ class Forge extends BaseForge
 
     /**
      * Drop Primary Key
+     *
+     * @param mixed $keyName
      */
     public function dropPrimaryKey(string $table, string $keyName = ''): bool
     {

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -237,8 +237,6 @@ class Forge extends BaseForge
 
     /**
      * Drop Primary Key
-     *
-     * @param mixed $keyName
      */
     public function dropPrimaryKey(string $table, string $keyName = ''): bool
     {

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -186,7 +186,7 @@ class Forge extends BaseForge
                 . ' IN ' . $field['length'] . ')';
 
             $field['length'] = '(' . max(array_map('mb_strlen', explode("','", mb_substr($field['length'], 2, -2)))) . ')' . $constraint;
-        } elseif (count($this->primaryKeys) === 1 && $field['name'] === $this->primaryKeys[0]) {
+        } elseif (isset($this->primaryKeys['fields']) && count($this->primaryKeys['fields']) === 1 && $field['name'] === $this->primaryKeys['fields'][0]) {
             $field['unique'] = '';
         }
 

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -279,4 +279,14 @@ class Forge extends BaseForge
 
         return $sql;
     }
+
+    /**
+     * Constructs sql to check if key is a constraint.
+     */
+    protected function _dropKeyAsConstraint(string $table, string $constraintName): string
+    {
+        return "SELECT constraint_name FROM all_constraints WHERE table_name = '"
+            . trim($table, '"') . "' AND index_name = '"
+            . trim($constraintName, '"') . "'";
+    }
 }

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -11,6 +11,8 @@
 
 namespace CodeIgniter\Database\Postgre;
 
+use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge as BaseForge;
 
 /**
@@ -64,6 +66,19 @@ class Forge extends BaseForge
      * @internal
      */
     protected $null = 'NULL';
+
+    /**
+     * @var Connection
+     */
+    protected $db;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(BaseConnection $db)
+    {
+        parent::__construct($db);
+    }
 
     /**
      * CREATE TABLE attributes
@@ -194,8 +209,6 @@ class Forge extends BaseForge
     /**
      * Drop Key
      *
-     * @param mixed $prefixKeyName
-     *
      * @return bool
      *
      * @throws DatabaseException
@@ -214,7 +227,7 @@ class Forge extends BaseForge
                WHERE nsp.nspname = '{$this->db->schema}'
                      AND rel.relname = '" . $this->db->DBPrefix . $table . "'
                      AND con.conname = '" . trim($keyName, '"') . "'";
-                     
+
         $constraint = $this->db->query($sql)->getResultArray();
 
         $sql = sprintf(
@@ -223,9 +236,8 @@ class Forge extends BaseForge
             $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
         );
 
-        if (count($constraint) !== 0) {
-            $sqlString = $this->dropConstraintStr;
-            $sql       = sprintf(
+        if ($constraint !== []) {
+            $sql = sprintf(
                 $this->dropConstraintStr,
                 $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
                 $keyName,

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -11,7 +11,6 @@
 
 namespace CodeIgniter\Database\Postgre;
 
-use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge as BaseForge;
 
@@ -71,14 +70,6 @@ class Forge extends BaseForge
      * @var Connection
      */
     protected $db;
-
-    /**
-     * Constructor.
-     */
-    public function __construct(BaseConnection $db)
-    {
-        parent::__construct($db);
-    }
 
     /**
      * CREATE TABLE attributes

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -391,4 +391,50 @@ class Forge extends BaseForge
 
         return $sql;
     }
+
+    /**
+     * Drop Key
+     *
+     * @param mixed $prefixKeyName
+     *
+     * @return bool
+     *
+     * @throws DatabaseException
+     */
+    public function dropKey(string $table, string $keyName, bool $prefixKeyName = true)
+    {
+        $keyName = $this->db->escapeIdentifiers(($prefixKeyName === true ? $this->db->DBPrefix : '') . $keyName);
+
+        // check if key is a constraint
+        $sql = "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+                WHERE TABLE_NAME= '" . $this->db->DBPrefix . $table . "'
+                AND CONSTRAINT_NAME = '" . trim($keyName, '"') . "'";
+
+        $constraint = $this->db->query($sql)->getResultArray();
+
+        $sql = sprintf(
+            $this->dropIndexStr,
+            $keyName,
+            $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
+        );
+
+        if (count($constraint) !== 0) {
+            $sqlString = $this->dropConstraintStr;
+            $sql       = sprintf(
+                $this->dropConstraintStr,
+                $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
+                $keyName,
+            );
+        }
+
+        if ($sql === '') {
+            if ($this->db->DBDebug) {
+                throw new DatabaseException('This feature is not available for the database you are using.');
+            }
+
+            return false;
+        }
+
+        return $this->db->query($sql);
+    }
 }

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -262,9 +262,9 @@ class Forge extends BaseForge
                 continue;
             }
 
-            $keyName = ($this->keys[$i]['keyName'] === '') ?
-                $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]['fields'])) :
-                $this->db->escapeIdentifiers($this->keys[$i]['keyName']);
+            $keyName = $this->db->escapeIdentifiers(($this->keys[$i]['keyName'] === '') ?
+                $table . '_' . implode('_', $this->keys[$i]['fields']) :
+                $this->keys[$i]['keyName']);
 
             if (in_array($i, $this->uniqueKeys, true)) {
                 $sqls[] = 'ALTER TABLE '
@@ -312,7 +312,11 @@ class Forge extends BaseForge
             }
 
             if ($this->primaryKeys['fields'] !== []) {
-                $sql = ",\n\tCONSTRAINT " . ($this->primaryKeys['keyName'] === '' ? $this->db->escapeIdentifiers('pk_' . $table) : $this->primaryKeys['keyName'])
+                $sql = ",\n\tCONSTRAINT " . $this->db->escapeIdentifiers(
+                    ($this->primaryKeys['keyName'] === '' ?
+                    'pk_' . $table :
+                    $this->primaryKeys['keyName'])
+                )
                     . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys['fields'])) . ')';
             }
         }

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Database\SQLSRV;
 
 use CodeIgniter\Database\BaseConnection;
-use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge as BaseForge;
 
 /**
@@ -394,45 +393,12 @@ class Forge extends BaseForge
     }
 
     /**
-     * Drop Key
-     *
-     * @return bool
-     *
-     * @throws DatabaseException
+     * Constructs sql to check if key is a constraint.
      */
-    public function dropKey(string $table, string $keyName, bool $prefixKeyName = true)
+    protected function _dropKeyAsConstraint(string $table, string $constraintName): string
     {
-        $keyName = $this->db->escapeIdentifiers(($prefixKeyName === true ? $this->db->DBPrefix : '') . $keyName);
-
-        // check if key is a constraint
-        $sql = "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
-                WHERE TABLE_NAME= '" . $this->db->DBPrefix . $table . "'
-                AND CONSTRAINT_NAME = '" . trim($keyName, '"') . "'";
-
-        $constraint = $this->db->query($sql)->getResultArray();
-
-        $sql = sprintf(
-            $this->dropIndexStr,
-            $keyName,
-            $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
-        );
-
-        if ($constraint !== []) {
-            $sql = sprintf(
-                $this->dropConstraintStr,
-                $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
-                $keyName,
-            );
-        }
-
-        if ($sql === '') {
-            if ($this->db->DBDebug) {
-                throw new DatabaseException('This feature is not available for the database you are using.');
-            }
-
-            return false;
-        }
-
-        return $this->db->query($sql);
+        return "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+                WHERE TABLE_NAME= '" . trim($table, '"') . "'
+                AND CONSTRAINT_NAME = '" . trim($constraintName, '"') . "'";
     }
 }

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -250,8 +250,6 @@ class Forge extends BaseForge
         $sqls = [];
 
         for ($i = 0, $c = count($this->keys); $i < $c; $i++) {
-            $this->keys[$i]['fields'] = (array) $this->keys[$i]['fields'];
-
             for ($i2 = 0, $c2 = count($this->keys[$i]['fields']); $i2 < $c2; $i2++) {
                 if (! isset($this->fields[$this->keys[$i]['fields'][$i2]])) {
                     unset($this->keys[$i]['fields'][$i2]);

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database\SQLSRV;
 
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge as BaseForge;
 
 /**
@@ -395,8 +396,6 @@ class Forge extends BaseForge
     /**
      * Drop Key
      *
-     * @param mixed $prefixKeyName
-     *
      * @return bool
      *
      * @throws DatabaseException
@@ -418,9 +417,8 @@ class Forge extends BaseForge
             $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
         );
 
-        if (count($constraint) !== 0) {
-            $sqlString = $this->dropConstraintStr;
-            $sql       = sprintf(
+        if ($constraint !== []) {
+            $sql = sprintf(
                 $this->dropConstraintStr,
                 $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
                 $keyName,

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -218,8 +218,6 @@ class Forge extends BaseForge
 
     /**
      * Drop Primary Key
-     *
-     * @param mixed $keyName
      */
     public function dropPrimaryKey(string $table, string $keyName = ''): bool
     {

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -218,6 +218,8 @@ class Forge extends BaseForge
 
     /**
      * Drop Primary Key
+     *
+     * @param mixed $keyName
      */
     public function dropPrimaryKey(string $table, string $keyName = ''): bool
     {

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -157,41 +157,6 @@ class Forge extends BaseForge
     }
 
     /**
-     * Process indexes
-     */
-    protected function _processIndexes(string $table): array
-    {
-        $sqls = [];
-
-        for ($i = 0, $c = count($this->keys); $i < $c; $i++) {
-            $this->keys[$i] = (array) $this->keys[$i];
-
-            for ($i2 = 0, $c2 = count($this->keys[$i]); $i2 < $c2; $i2++) {
-                if (! isset($this->fields[$this->keys[$i][$i2]])) {
-                    unset($this->keys[$i][$i2]);
-                }
-            }
-            if (count($this->keys[$i]) <= 0) {
-                continue;
-            }
-
-            if (in_array($i, $this->uniqueKeys, true)) {
-                $sqls[] = 'CREATE UNIQUE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-                    . ' ON ' . $this->db->escapeIdentifiers($table)
-                    . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
-
-                continue;
-            }
-
-            $sqls[] = 'CREATE INDEX ' . $this->db->escapeIdentifiers($table . '_' . implode('_', $this->keys[$i]))
-                . ' ON ' . $this->db->escapeIdentifiers($table)
-                . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ');';
-        }
-
-        return $sqls;
-    }
-
-    /**
      * Field attribute TYPE
      *
      * Performs a data type mapping between different databases.
@@ -254,7 +219,7 @@ class Forge extends BaseForge
     /**
      * Drop Primary Key
      */
-    public function dropPrimaryKey(string $table): bool
+    public function dropPrimaryKey(string $table, string $keyName = ''): bool
     {
         $sqlTable = new Table($this->db, $this);
 
@@ -263,7 +228,7 @@ class Forge extends BaseForge
             ->run();
     }
 
-    public function addForeignKey($fieldName = '', string $tableName = '', $tableField = '', string $onUpdate = '', string $onDelete = '', string $fkName = '')
+    public function addForeignKey($fieldName = '', string $tableName = '', $tableField = '', string $onUpdate = '', string $onDelete = '', string $fkName = ''): BaseForge
     {
         if ($fkName === '') {
             return parent::addForeignKey($fieldName, $tableName, $tableField, $onUpdate, $onDelete, $fkName);

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -261,18 +261,18 @@ class Table
 
         // Unique/Index keys
         if (is_array($this->keys)) {
-            foreach ($this->keys as $i => $key) {
+            foreach ($this->keys as $keyName => $key) {
                 switch ($key['type']) {
                     case 'primary':
                         $this->forge->addPrimaryKey($key['fields']);
                         break;
 
                     case 'unique':
-                        $this->forge->addUniqueKey($key['fields'], $i);
+                        $this->forge->addUniqueKey($key['fields'], $keyName);
                         break;
 
                     case 'index':
-                        $this->forge->addKey($key['fields'], false, false, $i);
+                        $this->forge->addKey($key['fields'], false, false, $keyName);
                         break;
                 }
             }

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -261,18 +261,18 @@ class Table
 
         // Unique/Index keys
         if (is_array($this->keys)) {
-            foreach ($this->keys as $key) {
+            foreach ($this->keys as $i => $key) {
                 switch ($key['type']) {
                     case 'primary':
                         $this->forge->addPrimaryKey($key['fields']);
                         break;
 
                     case 'unique':
-                        $this->forge->addUniqueKey($key['fields']);
+                        $this->forge->addUniqueKey($key['fields'], $i);
                         break;
 
                     case 'index':
-                        $this->forge->addKey($key['fields']);
+                        $this->forge->addKey($key['fields'], false, false, $i);
                         break;
                 }
             }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1047,6 +1047,8 @@ final class ForgeTest extends CIUnitTestCase
 
     public function testCompositeKey()
     {
+        $this->forge->dropTable('forge_test_1', true);
+
         $this->forge->addField([
             'id' => [
                 'type'           => 'INTEGER',

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -46,7 +46,6 @@ Others
 - ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there
   is a ``CITestStreamFilter::registration()`` method for this. See :ref:`upgrade-430-stream-filter` for details.
 - The data structure returned by :ref:`BaseConnection::getForeignKeyData() <metadata-getforeignkeydata>` has been changed.
-- :php:func:`script_tag()` and :php:func:`safe_mailto()` no longer output ``type="text/javascript"`` in ``<script>`` tag.
 
 .. _v430-interface-changes:
 
@@ -101,6 +100,10 @@ Others
 - The following methods have been changed to accept ``ResponseInterface`` as a parameter instead of ``Response``.
     - ``Debug\Exceptions::__construct()``
     - ``Services::exceptions()``
+- The method signature of ``Forge::dropKey()`` has changed. An additional optional parameter ``$prefixKeyName`` has been added.
+- The method signature of ``Forge::addKey()`` has changed. An additional optional parameter ``$keyName`` has been added.
+- The method signature of ``Forge::addPrimaryKey()`` has changed. An additional optional parameter ``$keyName`` has been added.
+- The method signature of ``Forge::addUniqueKey()`` has changed. An additional optional parameter ``$keyName`` has been added.
 
 Enhancements
 ************
@@ -113,7 +116,6 @@ Commands
 - Now ``spark routes`` command shows route names. See :ref:`URI Routing <routing-spark-routes>`.
 - Help information for a spark command can now be accessed using the ``--help`` option (e.g. ``php spark serve --help``)
 - Added methods ``CLI::promptByMultipleKeys()`` to support multiple value in input, unlike ``promptByKey()``. See :ref:`prompt-by-multiple-keys` for details.
-- HTTP/3 is now considered a valid protocol.
 
 Testing
 =======
@@ -134,6 +136,8 @@ Database
 - Improved data returned by :ref:`BaseConnection::getForeignKeyData() <metadata-getforeignkeydata>`. All DBMS returns the same structure.
 - :php:meth:`CodeIgniter\\Database\\Forge::addForeignKey()` now includes a name parameter to manual set foreign key names. Not supported in SQLite3.
 - Added ``when()`` and ``whenNot()`` methods to conditionally add clauses to the query. See :ref:`BaseBuilder::when() <db-builder-when>` for details.
+- Added the ability to manually set index names. These methods include: ``Forge::addKey()``, ``Forge::addPrimaryKey()``, and ``Forge::addUniqueKey()``
+- Fixed ``Forge::dropKey()`` to allow droping unique indexes. This required the ``DROP CONSTRAINT`` SQL command.
 
 Model
 =====
@@ -155,7 +159,6 @@ Helpers and Functions
 - Added new Form helper function :php:func:`validation_errors()`, :php:func:`validation_list_errors()` and :php:func:`validation_show_error()` to display Validation Errors.
 - You can set the locale to :php:func:`route_to()` if you pass a locale value as the last parameter.
 - Added :php:func:`request()` and :php:func:`response()` functions.
-- Add :php:func:`decamelize()` function to convert camelCase to snake_case.
 
 Others
 ======
@@ -163,8 +166,7 @@ Others
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
 - Now you can specify Composer packages to auto-discover manually. See :ref:`Code Modules <modules-specify-composer-packages>`.
 - Added new ``$routes->view()`` method to return a the view directly. See :ref:`View Routes <view-routes>`.
-- View Cells are now first-class citizens and can located in the **app/Cells** directory. See :ref:`View Cells <app-cells>`.
-- Add ``Controlled Cells`` that provide more structure and flexibility to your View Cells. See :ref:`View Cells <controlled-cells>` for details.
+- View Cells are now first-class citizens and can located in the **app/Cells** directory. See :ref:`View Cells <view-cells-app-cells>`.
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -46,6 +46,7 @@ Others
 - ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there
   is a ``CITestStreamFilter::registration()`` method for this. See :ref:`upgrade-430-stream-filter` for details.
 - The data structure returned by :ref:`BaseConnection::getForeignKeyData() <metadata-getforeignkeydata>` has been changed.
+- :php:func:`script_tag()` and :php:func:`safe_mailto()` no longer output ``type="text/javascript"`` in ``<script>`` tag.
 
 .. _v430-interface-changes:
 
@@ -116,6 +117,7 @@ Commands
 - Now ``spark routes`` command shows route names. See :ref:`URI Routing <routing-spark-routes>`.
 - Help information for a spark command can now be accessed using the ``--help`` option (e.g. ``php spark serve --help``)
 - Added methods ``CLI::promptByMultipleKeys()`` to support multiple value in input, unlike ``promptByKey()``. See :ref:`prompt-by-multiple-keys` for details.
+- HTTP/3 is now considered a valid protocol.
 
 Testing
 =======
@@ -159,6 +161,7 @@ Helpers and Functions
 - Added new Form helper function :php:func:`validation_errors()`, :php:func:`validation_list_errors()` and :php:func:`validation_show_error()` to display Validation Errors.
 - You can set the locale to :php:func:`route_to()` if you pass a locale value as the last parameter.
 - Added :php:func:`request()` and :php:func:`response()` functions.
+- Add :php:func:`decamelize()` function to convert camelCase to snake_case.
 
 Others
 ======
@@ -166,7 +169,8 @@ Others
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
 - Now you can specify Composer packages to auto-discover manually. See :ref:`Code Modules <modules-specify-composer-packages>`.
 - Added new ``$routes->view()`` method to return a the view directly. See :ref:`View Routes <view-routes>`.
-- View Cells are now first-class citizens and can located in the **app/Cells** directory. See :ref:`View Cells <view-cells-app-cells>`.
+- View Cells are now first-class citizens and can located in the **app/Cells** directory. See :ref:`View Cells <app-cells>`.
+- Add ``Controlled Cells`` that provide more structure and flexibility to your View Cells. See :ref:`View Cells <controlled-cells>` for details.
 
 Changes
 *******

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -170,7 +170,7 @@ and unique keys with specific methods:
 
 .. literalinclude:: forge/011.php
 
-.. note:: MySQL and SQLite will assume the name ``PRIMARY`` even if a name is provided.
+.. note:: When you add a primary key, MySQL and SQLite will assume the name ``PRIMARY`` even if a name is provided.
 
 .. _adding-foreign-keys:
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -156,8 +156,9 @@ Adding Keys
 Generally speaking, you'll want your table to have Keys. This is
 accomplished with ``$forge->addKey('field')``. The optional second
 parameter set to true will make it a primary key and the third
-parameter set to true will make it a unique key. Note that ``addKey()``
-must be followed by a call to ``createTable()``.
+parameter set to true will make it a unique key. You may specify a name
+with the fourth parameter. Note that ``addKey()`` must be followed by a
+call to ``createTable()``.
 
 Multiple column non-primary keys must be sent as an array. Sample output
 below is for MySQL.
@@ -340,27 +341,30 @@ Class Reference
 
         Adds a foreign key to the set that will be used to create a table. Usage:  See `Adding Foreign Keys`_.
 
-    .. php:method:: addKey($key[, $primary = false[, $unique = false]])
+    .. php:method:: addKey($key[, $primary = false[, $unique = false[, $keyName = '']]])
 
         :param    mixed    $key: Name of a key field or an array of fields
         :param    bool    $primary: Set to true if it should be a primary key or a regular one
         :param    bool    $unique: Set to true if it should be a unique key or a regular one
+        :param    string    $keyName: Name of key to be added
         :returns:    \CodeIgniter\Database\Forge instance (method chaining)
         :rtype:    \CodeIgniter\Database\Forge
 
         Adds a key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
 
-    .. php:method:: addPrimaryKey($key)
+    .. php:method:: addPrimaryKey($key[, $keyName = ''])
 
         :param    mixed    $key: Name of a key field or an array of fields
+        :param    string    $keyName: Name of key to be added
         :returns:    \CodeIgniter\Database\Forge instance (method chaining)
         :rtype:    \CodeIgniter\Database\Forge
 
         Adds a primary key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
 
-    .. php:method:: addUniqueKey($key)
+    .. php:method:: addUniqueKey($key[, $keyName = ''])
 
         :param    mixed    $key: Name of a key field or an array of fields
+        :param    string    $keyName: Name of key to be added
         :returns:    \CodeIgniter\Database\Forge instance (method chaining)
         :rtype:    \CodeIgniter\Database\Forge
 
@@ -401,6 +405,25 @@ Class Reference
         :rtype:    bool
 
         Drops a database. Usage:  See `Creating and Dropping Databases`_.
+
+    .. php:method:: dropKey($table, $keyName[, $prefixKeyName = true])
+
+        :param    string    $table: Name of table that has key
+        :param    string    $keyName: Name of key to be dropped
+        :param    string    $prefixKeyName: If database prefix should be added to ``$keyName``
+        :returns:    true on success, false on failure
+        :rtype:    bool
+
+        Drops an index or unique index.
+
+    .. php:method:: dropPrimaryKey($table[, $keyName = ''])
+
+        :param    string    $table: Name of table to drop primary key
+        :param    string    $keyName: Name of primary key to be dropped
+        :returns:    true on success, false on failure
+        :rtype:    bool
+
+        Drops a primary key from a table.
 
     .. php:method:: dropTable($table_name[, $if_exists = false])
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -170,6 +170,8 @@ and unique keys with specific methods:
 
 .. literalinclude:: forge/011.php
 
+.. note:: MySQL and SQLite will assume the name ``PRIMARY`` even if a name is provided.
+
 .. _adding-foreign-keys:
 
 Adding Foreign Keys
@@ -341,6 +343,8 @@ Class Reference
 
         Adds a foreign key to the set that will be used to create a table. Usage:  See `Adding Foreign Keys`_.
 
+        .. note:: ``$fkName`` can be used since v4.3.0.
+
     .. php:method:: addKey($key[, $primary = false[, $unique = false[, $keyName = '']]])
 
         :param    mixed    $key: Name of a key field or an array of fields
@@ -352,6 +356,8 @@ Class Reference
 
         Adds a key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
 
+        .. note:: ``$keyName`` can be used since v4.3.0.
+
     .. php:method:: addPrimaryKey($key[, $keyName = ''])
 
         :param    mixed    $key: Name of a key field or an array of fields
@@ -361,6 +367,8 @@ Class Reference
 
         Adds a primary key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
 
+        .. note:: ``$keyName`` can be used since v4.3.0.
+
     .. php:method:: addUniqueKey($key[, $keyName = ''])
 
         :param    mixed    $key: Name of a key field or an array of fields
@@ -369,6 +377,8 @@ Class Reference
         :rtype:    \CodeIgniter\Database\Forge
 
         Adds a unique key to the set that will be used to create a table. Usage:  See `Adding Keys`_.
+
+        .. note:: ``$keyName`` can be used since v4.3.0.
 
     .. php:method:: createDatabase($dbName[, $ifNotExists = false])
 
@@ -416,6 +426,8 @@ Class Reference
 
         Drops an index or unique index.
 
+        .. note:: ``$keyName`` and ``$prefixKeyName`` can be used since v4.3.0.
+
     .. php:method:: dropPrimaryKey($table[, $keyName = ''])
 
         :param    string    $table: Name of table to drop primary key
@@ -424,6 +436,8 @@ Class Reference
         :rtype:    bool
 
         Drops a primary key from a table.
+
+        .. note:: ``$keyName`` can be used since v4.3.0.
 
     .. php:method:: dropTable($table_name[, $if_exists = false])
 

--- a/user_guide_src/source/dbmgmt/forge/010.php
+++ b/user_guide_src/source/dbmgmt/forge/010.php
@@ -10,8 +10,8 @@ $forge->addKey('site_id', true);
 $forge->addKey('blog_name');
 // gives KEY `blog_name` (`blog_name`)
 
-$forge->addKey(['blog_name', 'blog_label']);
-// gives KEY `blog_name_blog_label` (`blog_name`, `blog_label`)
+$forge->addKey(['blog_name', 'blog_label'], false, false, 'my_key_name');
+// gives KEY `my_key_name` (`blog_name`, `blog_label`)
 
-$forge->addKey(['blog_id', 'uri'], false, true);
-// gives UNIQUE KEY `blog_id_uri` (`blog_id`, `uri`)
+$forge->addKey(['blog_id', 'uri'], false, true, 'my_key_name');
+// gives UNIQUE KEY `my_key_name` (`blog_id`, `uri`)

--- a/user_guide_src/source/dbmgmt/forge/011.php
+++ b/user_guide_src/source/dbmgmt/forge/011.php
@@ -1,7 +1,7 @@
 <?php
 
-$forge->addPrimaryKey('blog_id');
-// gives PRIMARY KEY `blog_id` (`blog_id`)
+$forge->addPrimaryKey('blog_id', 'pd_name');
+// gives PRIMARY KEY `pd_name` (`blog_id`)
 
-$forge->addUniqueKey(['blog_id', 'uri']);
-// gives UNIQUE KEY `blog_id_uri` (`blog_id`, `uri`)
+$forge->addUniqueKey(['blog_id', 'uri'], 'key_name');
+// gives UNIQUE KEY `key_name` (`blog_id`, `uri`)

--- a/user_guide_src/source/dbmgmt/forge/020.php
+++ b/user_guide_src/source/dbmgmt/forge/020.php
@@ -1,4 +1,5 @@
 <?php
 
-// Produces: DROP INDEX `users_index` ON `tablename`
-$forge->dropKey('tablename', 'users_index');
+// For Indexes Produces:        DROP INDEX `users_index` ON `tablename`
+// For Unique Indexes Produces: ALTER TABLE `tablename` DROP CONSTRAINT `users_index`
+$forge->dropKey('tablename', 'users_index', false);


### PR DESCRIPTION
Closes #5075

This PR allows setting the index name.

While testing dropping by the same name I discovered that `dropKey()` was generating errors when dropping a unique index be several of the DBMS. The reason is that some DBMS require `DROP CONSTRAINT` command rather than `DROP INDEX`. I did some extra work to get `dropKey()` to work properly.

MySql and SQLite don't really require a name for Primary Key - though Mysql allows setting the name. When dropping its as simple as `DROP PRIMARY KEY`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
