### PR TITLE
fix: ResponseInterface (1)

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -138,6 +138,8 @@ class CodeIgniter
      * to keep from setting headers/cookies/etc
      *
      * @var bool
+     *
+     * @deprecated No longer used.
      */
     protected $useSafeOutput = false;
 
@@ -340,7 +342,7 @@ class CodeIgniter
                 return $response;
             }
 
-            $this->response->pretend($this->useSafeOutput)->send();
+            $this->response->send();
             $this->callExit(EXIT_SUCCESS);
 
             return;
@@ -371,6 +373,8 @@ class CodeIgniter
      * not complain when ini_set() function is used.
      *
      * @return $this
+     *
+     * @deprecated No longer used.
      */
     public function useSafeOutput(bool $safe = true)
     {
@@ -433,7 +437,7 @@ class CodeIgniter
 
         // If a ResponseInterface instance is returned then send it back to the client and stop
         if ($possibleResponse instanceof ResponseInterface) {
-            return $returnResponse ? $possibleResponse : $possibleResponse->pretend($this->useSafeOutput)->send();
+            return $returnResponse ? $possibleResponse : $possibleResponse->send();
         }
 
         if ($possibleResponse instanceof Request) {
@@ -1057,7 +1061,7 @@ class CodeIgniter
      */
     protected function sendResponse()
     {
-        $this->response->pretend($this->useSafeOutput)->send();
+        $this->response->send();
     }
 
     /**

--- a/system/HTTP/MessageInterface.php
+++ b/system/HTTP/MessageInterface.php
@@ -28,6 +28,15 @@ interface MessageInterface
     public function setBody($data);
 
     /**
+     * Gets the body of the message.
+     *
+     * @return string|null
+     *
+     * @TODO Incompatible return type with PSR-7
+     */
+    public function getBody();
+
+    /**
      * Appends data to the body of the current message.
      *
      * @param mixed $data
@@ -49,6 +58,17 @@ interface MessageInterface
     public function headers(): array;
 
     /**
+     * Checks if a header exists by the given case-insensitive name.
+     *
+     * @param string $name Case-insensitive header field name.
+     *
+     * @return bool Returns true if any header names match the given header
+     *              name using a case-insensitive string comparison. Returns false if
+     *              no matching header name is found in the message.
+     */
+    public function hasHeader(string $name): bool;
+
+    /**
      * Returns a single Header object. If multiple headers with the same
      * name exist, then will return an array of header objects.
      *
@@ -57,6 +77,19 @@ interface MessageInterface
      * @return array|Header|null
      */
     public function header($name);
+
+    /**
+     * Retrieves a comma-separated string of the values for a single header.
+     *
+     * This method returns all of the header values of the given
+     * case-insensitive header name as a string concatenated together using
+     * a comma.
+     *
+     * NOTE: Not all header values may be appropriately represented using
+     * comma concatenation. For such headers, use getHeader() instead
+     * and supply your own delimiter when concatenating.
+     */
+    public function getHeaderLine(string $name): string;
 
     /**
      * Sets a header and it's value.

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -193,6 +193,8 @@ class Response extends Message implements MessageInterface, ResponseInterface
      * should not be relied on outside of internal testing.
      *
      * @return $this
+     *
+     * @testTag only available to test code
      */
     public function pretend(bool $pretend = true)
     {

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -188,6 +188,7 @@ class Response extends Message implements MessageInterface, ResponseInterface
 
     /**
      * Turns "pretend" mode on or off to aid in testing.
+     *
      * Note that this is not a part of the interface so
      * should not be relied on outside of internal testing.
      *

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -128,7 +128,7 @@ interface ResponseInterface extends MessageInterface
      *                       provided status code; if none is provided, will
      *                       default to the IANA name.
      *
-     * @return self
+     * @return $this
      *
      * @throws InvalidArgumentException For invalid status code arguments.
      */
@@ -151,7 +151,7 @@ interface ResponseInterface extends MessageInterface
     /**
      * Sets the date header
      *
-     * @return ResponseInterface
+     * @return $this
      */
     public function setDate(DateTime $date);
 
@@ -162,6 +162,8 @@ interface ResponseInterface extends MessageInterface
      * preferably, an instance of DateTime.
      *
      * @param DateTime|string $date
+     *
+     * @return $this
      */
     public function setLastModified($date);
 
@@ -170,7 +172,7 @@ interface ResponseInterface extends MessageInterface
      *
      * @see http://tools.ietf.org/html/rfc5988
      *
-     * @return Response
+     * @return $this
      *
      * @todo Recommend moving to Pager
      */
@@ -180,7 +182,7 @@ interface ResponseInterface extends MessageInterface
      * Sets the Content Type header for this response with the mime type
      * and, optionally, the charset.
      *
-     * @return ResponseInterface
+     * @return $this
      */
     public function setContentType(string $mime, string $charset = 'UTF-8');
 
@@ -200,7 +202,7 @@ interface ResponseInterface extends MessageInterface
     /**
      * Returns the current body, converted to JSON is it isn't already.
      *
-     * @return mixed|string
+     * @return bool|string|null
      *
      * @throws InvalidArgumentException If the body property is not array.
      */
@@ -218,7 +220,7 @@ interface ResponseInterface extends MessageInterface
     /**
      * Retrieves the current body into XML and returns it.
      *
-     * @return mixed|string
+     * @return bool|string|null
      *
      * @throws InvalidArgumentException If the body property is not array.
      */
@@ -233,6 +235,8 @@ interface ResponseInterface extends MessageInterface
     /**
      * Sets the appropriate headers to ensure this response
      * is not cached by the browsers.
+     *
+     * @return $this
      */
     public function noCache();
 
@@ -260,7 +264,7 @@ interface ResponseInterface extends MessageInterface
      *  - proxy-revalidate
      *  - no-transform
      *
-     * @return ResponseInterface
+     * @return $this
      */
     public function setCache(array $options = []);
 
@@ -271,21 +275,21 @@ interface ResponseInterface extends MessageInterface
     /**
      * Sends the output to the browser.
      *
-     * @return ResponseInterface
+     * @return $this
      */
     public function send();
 
     /**
      * Sends the headers of this HTTP request to the browser.
      *
-     * @return Response
+     * @return $this
      */
     public function sendHeaders();
 
     /**
      * Sends the Body of the message to the browser.
      *
-     * @return Response
+     * @return $this
      */
     public function sendBody();
 

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -28,10 +28,8 @@ use InvalidArgumentException;
  * - Status code and reason phrase
  * - Headers
  * - Message body
- *
- * @mixin RedirectResponse
  */
-interface ResponseInterface
+interface ResponseInterface extends MessageInterface
 {
     /**
      * Constants for status codes.

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -252,7 +252,7 @@ trait ResponseTrait
     /**
      * Returns the current body, converted to JSON is it isn't already.
      *
-     * @return mixed|string
+     * @return bool|string|null
      *
      * @throws InvalidArgumentException If the body property is not array.
      */
@@ -284,7 +284,7 @@ trait ResponseTrait
     /**
      * Retrieves the current body into XML and returns it.
      *
-     * @return mixed|string
+     * @return bool|string|null
      *
      * @throws InvalidArgumentException If the body property is not array.
      */
@@ -430,7 +430,7 @@ trait ResponseTrait
     /**
      * Sends the output to the browser.
      *
-     * @return Response
+     * @return $this
      */
     public function send()
     {

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -41,6 +41,9 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 
         $this->codeigniter = new MockCodeIgniter(new App());
+
+        $response = Services::response();
+        $response->pretend();
     }
 
     protected function tearDown(): void
@@ -60,7 +63,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 1;
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Welcome to CodeIgniter', $output);
@@ -82,7 +85,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('You want to see "about" page.', $output);
@@ -101,7 +104,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($routes);
+        $this->codeigniter->run($routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Hello', $output);
@@ -120,7 +123,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($routes);
+        $this->codeigniter->run($routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Oops', $output);
@@ -141,7 +144,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($routes);
+        $this->codeigniter->run($routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString('404 Override by Closure.', $output);
@@ -161,7 +164,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('You want to see "about" page.', $output);
@@ -186,7 +189,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString("You want to see 'about' page.", $output);
@@ -213,7 +216,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertSame('some text', $output);
@@ -234,7 +237,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('http://hellowworld.com', $output);
@@ -262,7 +265,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Welcome to CodeIgniter', $output);
@@ -276,7 +279,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/2.0';
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
 
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
@@ -291,7 +294,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         ob_start();
         @unlink('inexistent-file');
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Welcome to CodeIgniter', $output);
@@ -316,7 +319,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertNull($response->header('Location'));
 
         ob_start();
-        $codeigniter->useSafeOutput(true)->run();
+        $codeigniter->run();
         ob_get_clean();
 
         $this->assertSame('https://example.com/', $response->header('Location')->getValue());
@@ -339,7 +342,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
         $this->assertSame('http://example.com/pages/named', $response->header('Location')->getValue());
@@ -362,7 +365,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
         $this->assertSame('http://example.com/pages/uri', $response->header('Location')->getValue());
@@ -386,7 +389,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
         $this->assertSame('http://example.com/pages/notset', $response->header('Location')->getValue());
@@ -409,7 +412,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
 
         $response = $this->getPrivateProperty($this->codeigniter, 'response');
@@ -426,7 +429,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
 
         $this->assertArrayHasKey('_ci_previous_url', $_SESSION);
@@ -450,7 +453,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
 
         $this->assertArrayNotHasKey('_ci_previous_url', $_SESSION);
@@ -474,7 +477,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         Services::injectMock('router', $router);
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
 
         $this->assertArrayNotHasKey('_ci_previous_url', $_SESSION);
@@ -491,7 +494,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Welcome to CodeIgniter', $output);
@@ -510,7 +513,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes->cli('cli', '\Tests\Support\Controllers\Popcorn::index');
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Method Not Allowed', $output);
@@ -534,7 +537,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes->put('/', 'Home::index');
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
 
         $this->assertSame('put', Services::request()->getMethod());
@@ -558,7 +561,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes->get('/', 'Home::index');
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         ob_get_clean();
 
         $this->assertSame('post', Services::request()->getMethod());
@@ -598,7 +601,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         // The first response to be cached.
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('This is a test page', $output);
@@ -608,7 +611,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         // The second response from the Page cache.
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run();
+        $this->codeigniter->run();
         $output = ob_get_clean();
 
         $this->assertStringContainsString('This is a test page', $output);
@@ -666,7 +669,7 @@ final class CodeIgniterTest extends CIUnitTestCase
             Services::injectMock('router', $router);
 
             // Cache the page output using default caching function and $cacheConfig with value from the data provider
-            $this->codeigniter->useSafeOutput(true)->run();
+            $this->codeigniter->run();
             $this->codeigniter->cachePage($cacheConfig); // Cache the page using our own $cacheConfig confugration
         }
 

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -71,6 +71,9 @@ final class ResourceControllerTest extends CIUnitTestCase
 
         $config            = new App();
         $this->codeigniter = new MockCodeIgniter($config);
+
+        $response = Services::response();
+        $response->pretend();
     }
 
     protected function tearDown(): void
@@ -96,7 +99,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;
@@ -118,7 +121,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;
@@ -141,7 +144,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;
@@ -163,7 +166,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;
@@ -184,7 +187,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;
@@ -206,7 +209,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;
@@ -228,7 +231,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;
@@ -250,7 +253,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $error = json_decode($output)->messages->error;

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -90,7 +90,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertSame(lang('RESTful.notImplemented', ['index']), $output);
@@ -112,7 +112,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString(lang('RESTful.notImplemented', ['show']), $output);
@@ -133,7 +133,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString(lang('RESTful.notImplemented', ['new']), $output);
@@ -154,7 +154,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString(lang('RESTful.notImplemented', ['create']), $output);
@@ -176,7 +176,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString(lang('RESTful.notImplemented', ['remove']), $output);
@@ -198,7 +198,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString(lang('RESTful.notImplemented', ['delete']), $output);
@@ -221,7 +221,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString(lang('RESTful.notImplemented', ['edit']), $output);
@@ -243,7 +243,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $this->createCodeigniter();
 
         ob_start();
-        $this->codeigniter->useSafeOutput(true)->run($this->routes);
+        $this->codeigniter->run($this->routes);
         $output = ob_get_clean();
 
         $this->assertStringContainsString(lang('RESTful.notImplemented', ['update']), $output);

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -57,7 +57,7 @@ Interface Changes
 Method Signature Changes
 ========================
 
-.. _v430_validation_changes:
+.. _v430-validation-changes:
 
 Validation Changes
 ------------------

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -46,6 +46,14 @@ Others
 - ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there
   is a ``CITestStreamFilter::registration()`` method for this. See :ref:`upgrade-430-stream-filter` for details.
 
+.. _v430-interface-changes:
+
+Interface Changes
+=================
+
+- Added missing ``getBody()``, ``hasHeader()`` and ``getHeaderLine()`` method in ``MessageInterface``.
+- Now ``ResponseInterface`` extends ``MessageInterface``.
+
 Method Signature Changes
 ========================
 

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -77,7 +77,7 @@ instead of the Validation object.
 Validation Changes
 ==================
 
-- ``ValidationInterface`` has been changed. Implemented classes should likewise add the methods and the parameters so as not to break LSP. See :ref:`v430_validation_changes` for details.
+- ``ValidationInterface`` has been changed. Implemented classes should likewise add the methods and the parameters so as not to break LSP. See :ref:`v430-validation-changes` for details.
 - The return value of  ``Validation::loadRuleGroup()`` has been changed ``null`` to ``[]`` when the ``$group`` is empty. Update the code if you depend on the behavior.
 
 .. _upgrade-430-stream-filter:

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -117,6 +117,11 @@ need to use::
 
 Or use the trait ``CodeIgniter\Test\StreamFilterTrait``. See :ref:`testing-cli-output`.
 
+Interface Changes
+=================
+
+Some interfaces has been fixed. See :ref:`v430-interface-changes` for details.
+
 Others
 ======
 


### PR DESCRIPTION
**Description**
Ref #4356
Fixes #5351

- fix `ResponseInterface`
- fix `MessageInterface`
- deprecate
   - `CodeIgniter::$useSafeOutput`
   - `CodeIgniter::useSafeOutput()`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
