### PR TITLE
docs: remove incorrect `--no-dev` option

### DIFF
--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -128,9 +128,6 @@ In your project root::
 
     > composer require codeigniter4/framework
 
-As with the earlier composer install method, you can omit installing
-phpunit and its dependencies by adding the ``--no-dev`` argument to the ``composer require`` command.
-
 Setting Up
 ----------
 


### PR DESCRIPTION
**Description**
Fixes #6560

There is not `--no-dev` option in `require`
https://getcomposer.org/doc/03-cli.md#require-r

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
