### PR TITLE
refactor: replace utf8_encode() with mb_convert_encoding()

### DIFF
--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -157,7 +157,9 @@ class ChromeLoggerHandler extends BaseHandler
             $response = Services::response(null, true);
         }
 
-        $data = base64_encode(utf8_encode(json_encode($this->json)));
+        $data = base64_encode(
+            mb_convert_encoding(json_encode($this->json), 'UTF-8', mb_list_encodings())
+        );
 
         $response->setHeader($this->header, $data);
     }


### PR DESCRIPTION
**Description**
See #6170

See https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

