### PR TITLE
docs: replace `mixed` in site_url()

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -74,8 +74,8 @@ if (! function_exists('site_url')) {
     /**
      * Returns a site URL as defined by the App config.
      *
-     * @param mixed    $relativePath URI string or array of URI segments
-     * @param App|null $config       Alternate configuration to use
+     * @param array|string $relativePath URI string or array of URI segments
+     * @param App|null     $config       Alternate configuration to use
      */
     function site_url($relativePath = '', ?string $scheme = null, ?App $config = null): string
     {


### PR DESCRIPTION
**Description**
See #6310

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
