### PR TITLE
refactor: make $precision int in View Filter round

### DIFF
--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -208,15 +208,18 @@ class Filters
      *  - ceil      always rounds up
      *  - floor     always rounds down
      *
-     * @param int|string $precision
+     * @param int|string $precision precision or type
      *
      * @return float|string
      */
     public static function round(string $value, $precision = 2, string $type = 'common')
     {
+        // In case that $precision is a type like `{ value1|round(ceil) }`
         if (! is_numeric($precision)) {
             $type      = $precision;
             $precision = 2;
+        } else {
+            $precision = (int) $precision;
         }
 
         switch ($type) {

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -270,13 +270,15 @@ final class ParserFilterTest extends CIUnitTestCase
         $parser = new Parser($this->config, $this->viewsDir, $this->loader);
 
         $data = [
-            'value1' => 5.55,
+            'value1' => 5.555,
         ];
 
-        $template = '{ value1|round(1) } { value1|round(1, common) } { value1|round(ceil) } { value1|round(floor) } { value1|round(unknown) }';
+        $template = '{ value1|round(1) } / { value1|round(1, common) }'
+            . ' / { value1|round(ceil) } / { value1|round(floor) }'
+            . ' / { value1|round(unknown) }';
 
         $parser->setData($data);
-        $this->assertSame('5.6 5.6 6 5 5.55', $parser->renderString($template));
+        $this->assertSame('5.6 / 5.6 / 6 / 5 / 5.555', $parser->renderString($template));
     }
 
     public function testStripTags()


### PR DESCRIPTION
**Description**
The second parameter of PHP function `round()` should be int.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
