### PR TITLE
fix: ResponseInterface (2)

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -282,10 +282,8 @@ trait ResponseTrait
      * @param string      $description The error message to show the user.
      * @param string|null $code        A custom, API-specific, error code.
      * @param string      $message     A custom "reason" message to return.
-     *
-     * @return Response The value of the Response's send() method.
      */
-    protected function failServerError(string $description = 'Internal Server Error', ?string $code = null, string $message = ''): Response
+    protected function failServerError(string $description = 'Internal Server Error', ?string $code = null, string $message = ''): ResponseInterface
     {
         return $this->fail($description, $this->codes['server_error'], $code, $message);
     }

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\API;
 
 use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
 
@@ -22,8 +21,8 @@ use Config\Services;
  * consistent HTTP responses under a variety of common
  * situations when working as an API.
  *
- * @property IncomingRequest $request
- * @property Response        $response
+ * @property IncomingRequest   $request
+ * @property ResponseInterface $response
  */
 trait ResponseTrait
 {

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\API;
 use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
 
 /**
@@ -85,7 +86,7 @@ trait ResponseTrait
      *
      * @param array|string|null $data
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function respond($data = null, ?int $status = null, string $message = '')
     {
@@ -119,7 +120,7 @@ trait ResponseTrait
      * @param int          $status   HTTP status code
      * @param string|null  $code     Custom, API-specific, error code
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function fail($messages, int $status = 400, ?string $code = null, string $customMessage = '')
     {
@@ -145,7 +146,7 @@ trait ResponseTrait
      *
      * @param array|string|null $data
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function respondCreated($data = null, string $message = '')
     {
@@ -157,7 +158,7 @@ trait ResponseTrait
      *
      * @param array|string|null $data
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function respondDeleted($data = null, string $message = '')
     {
@@ -169,7 +170,7 @@ trait ResponseTrait
      *
      * @param array|string|null $data
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function respondUpdated($data = null, string $message = '')
     {
@@ -180,7 +181,7 @@ trait ResponseTrait
      * Used after a command has been successfully executed but there is no
      * meaningful reply to send back to the client.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function respondNoContent(string $message = 'No Content')
     {
@@ -192,7 +193,7 @@ trait ResponseTrait
      * or had bad authorization credentials. User is encouraged to try again
      * with the proper information.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function failUnauthorized(string $description = 'Unauthorized', ?string $code = null, string $message = '')
     {
@@ -203,7 +204,7 @@ trait ResponseTrait
      * Used when access is always denied to this resource and no amount
      * of trying again will help.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function failForbidden(string $description = 'Forbidden', ?string $code = null, string $message = '')
     {
@@ -213,7 +214,7 @@ trait ResponseTrait
     /**
      * Used when a specified resource cannot be found.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function failNotFound(string $description = 'Not Found', ?string $code = null, string $message = '')
     {
@@ -223,7 +224,7 @@ trait ResponseTrait
     /**
      * Used when the data provided by the client cannot be validated.
      *
-     * @return Response
+     * @return ResponseInterface
      *
      * @deprecated Use failValidationErrors instead
      */
@@ -237,7 +238,7 @@ trait ResponseTrait
      *
      * @param string|string[] $errors
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function failValidationErrors($errors, ?string $code = null, string $message = '')
     {
@@ -247,7 +248,7 @@ trait ResponseTrait
     /**
      * Use when trying to create a new resource and it already exists.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function failResourceExists(string $description = 'Conflict', ?string $code = null, string $message = '')
     {
@@ -259,7 +260,7 @@ trait ResponseTrait
      * Not Found, because here we know the data previously existed, but is now gone,
      * where Not Found means we simply cannot find any information about it.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function failResourceGone(string $description = 'Gone', ?string $code = null, string $message = '')
     {
@@ -269,7 +270,7 @@ trait ResponseTrait
     /**
      * Used when the user has made too many requests for the resource recently.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     protected function failTooManyRequests(string $description = 'Too Many Requests', ?string $code = null, string $message = '')
     {

--- a/system/Common.php
+++ b/system/Common.php
@@ -900,7 +900,7 @@ if (! function_exists('response')) {
     /**
      * Returns the shared Response.
      */
-    function response(): Response
+    function response(): ResponseInterface
     {
         return Services::response();
     }

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -35,7 +35,6 @@ use CodeIgniter\HTTP\Negotiate;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
-use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Images\Handlers\BaseHandler;
@@ -101,7 +100,7 @@ use Config\View as ConfigView;
  * @method static CURLRequest                curlrequest($options = [], ResponseInterface $response = null, App $config = null, $getShared = true)
  * @method static Email                      email($config = null, $getShared = true)
  * @method static EncrypterInterface         encrypter(Encryption $config = null, $getShared = false)
- * @method static Exceptions                 exceptions(ConfigExceptions $config = null, IncomingRequest $request = null, Response $response = null, $getShared = true)
+ * @method static Exceptions                 exceptions(ConfigExceptions $config = null, IncomingRequest $request = null, ResponseInterface $response = null, $getShared = true)
  * @method static Filters                    filters(ConfigFilters $config = null, $getShared = true)
  * @method static Format                     format(ConfigFormat $config = null, $getShared = true)
  * @method static Honeypot                   honeypot(ConfigHoneyPot $config = null, $getShared = true)
@@ -117,7 +116,7 @@ use Config\View as ConfigView;
  * @method static RedirectResponse           redirectresponse(App $config = null, $getShared = true)
  * @method static View                       renderer($viewPath = null, ConfigView $config = null, $getShared = true)
  * @method static IncomingRequest|CLIRequest request(App $config = null, $getShared = true)
- * @method static Response                   response(App $config = null, $getShared = true)
+ * @method static ResponseInterface          response(App $config = null, $getShared = true)
  * @method static Router                     router(RouteCollectionInterface $routes = null, Request $request = null, $getShared = true)
  * @method static RouteCollection            routes($getShared = true)
  * @method static Security                   security(App $config = null, $getShared = true)

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -253,7 +253,7 @@ class Services extends BaseService
     public static function exceptions(
         ?ExceptionsConfig $config = null,
         ?IncomingRequest $request = null,
-        ?Response $response = null,
+        ?ResponseInterface $response = null,
         bool $getShared = true
     ) {
         if ($getShared) {

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -546,7 +546,7 @@ class Services extends BaseService
     /**
      * The Response class models an HTTP response.
      *
-     * @return Response
+     * @return ResponseInterface
      */
     public static function response(?App $config = null, bool $getShared = true)
     {

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -70,7 +70,7 @@ class Exceptions
     /**
      * @param CLIRequest|IncomingRequest $request
      */
-    public function __construct(ExceptionsConfig $config, $request, Response $response)
+    public function __construct(ExceptionsConfig $config, $request, ResponseInterface $response)
     {
         $this->ob_level = ob_get_level();
         $this->viewPath = rtrim($config->errorViewPath, '\\/ ') . DIRECTORY_SEPARATOR;

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -18,7 +18,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\ResponseInterface;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Paths;
 use ErrorException;
@@ -63,7 +63,7 @@ class Exceptions
     /**
      * The outgoing response.
      *
-     * @var Response
+     * @var ResponseInterface
      */
     protected $response;
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -161,9 +161,7 @@ class Toolbar
 
         $data['config'] = Config::display();
 
-        if ($response->getCSP() !== null) {
-            $response->getCSP()->addImageSrc('data:');
-        }
+        $response->getCSP()->addImageSrc('data:');
 
         return json_encode($data);
     }

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -163,8 +163,8 @@ class Toolbar
 
         $data['config'] = Config::display();
 
-        if ($response->CSP !== null) {
-            $response->CSP->addImageSrc('data:');
+        if ($response->getCSP() !== null) {
+            $response->getCSP()->addImageSrc('data:');
         }
 
         return json_encode($data);

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -20,7 +20,6 @@ use CodeIgniter\Format\XMLFormatter;
 use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
-use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
 use Config\Toolbar as ToolbarConfig;
@@ -71,7 +70,6 @@ class Toolbar
      *
      * @param float           $startTime App start time
      * @param IncomingRequest $request
-     * @param Response        $response
      *
      * @return string JSON encoded data
      */
@@ -355,7 +353,6 @@ class Toolbar
     {
         /**
          * @var IncomingRequest|null $request
-         * @var Response|null        $response
          */
         if (CI_DEBUG && ! is_cli()) {
             $app = Services::codeigniter();

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -96,8 +96,6 @@ class CURLRequest extends Request
      *  - baseURI
      *  - timeout
      *  - any other request options to use as defaults.
-     *
-     * @param ResponseInterface $response
      */
     public function __construct(App $config, URI $uri, ?ResponseInterface $response = null, array $options = [])
     {

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -690,11 +690,7 @@ class ContentSecurityPolicy
      */
     protected function buildHeaders(ResponseInterface $response)
     {
-        /**
-         * Ensure both headers are available and arrays...
-         *
-         * @var Response $response
-         */
+        // Ensure both headers are available and arrays...
         $response->setHeader('Content-Security-Policy', []);
         $response->setHeader('Content-Security-Policy-Report-Only', []);
 

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -382,4 +382,13 @@ interface ResponseInterface extends MessageInterface
      * @return DownloadResponse|null
      */
     public function download(string $filename = '', $data = '', bool $setMime = false);
+
+    // --------------------------------------------------------------------
+    // CSP Methods
+    // --------------------------------------------------------------------
+
+    /**
+     * Get Content Security Policy handler.
+     */
+    public function getCSP(): ContentSecurityPolicy;
 }

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -131,7 +131,7 @@ interface ResponseInterface extends MessageInterface
      *
      * @return $this
      *
-     * @throws InvalidArgumentException For invalid status code arguments.
+     * @throws HTTPException For invalid status code arguments.
      */
     public function setStatusCode(int $code, string $reason = '');
 

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -135,7 +135,7 @@ interface ResponseInterface extends MessageInterface
     public function setStatusCode(int $code, string $reason = '');
 
     /**
-     * Gets the response response phrase associated with the status code.
+     * Gets the response phrase associated with the status code.
      *
      * @see http://tools.ietf.org/html/rfc7231#section-6
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Cookie\Cookie;
+use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Pager\PagerInterface;
 use DateTime;
@@ -143,6 +144,22 @@ interface ResponseInterface extends MessageInterface
      * @deprecated Use getReasonPhrase()
      */
     public function getReason(): string;
+
+    /**
+     * Gets the response reason phrase associated with the status code.
+     *
+     * Because a reason phrase is not a required element in a response
+     * status line, the reason phrase value MAY be null. Implementations MAY
+     * choose to return the default RFC 7231 recommended reason phrase (or those
+     * listed in the IANA HTTP Status Code Registry) for the response's
+     * status code.
+     *
+     * @see http://tools.ietf.org/html/rfc7231#section-6
+     * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     *
+     * @return string Reason phrase; must return an empty string if none present.
+     */
+    public function getReasonPhrase();
 
     // --------------------------------------------------------------------
     // Convenience Methods
@@ -352,6 +369,13 @@ interface ResponseInterface extends MessageInterface
      * @return Cookie[]
      */
     public function getCookies();
+
+    /**
+     * Returns the `CookieStore` instance.
+     *
+     * @return CookieStore
+     */
+    public function getCookieStore();
 
     // --------------------------------------------------------------------
     // Response Methods

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -48,6 +48,8 @@ trait ResponseTrait
      * Content security policy handler
      *
      * @var ContentSecurityPolicy
+     *
+     * @TODO Will be protected. Use `getCSP()` instead.
      */
     public $CSP;
 
@@ -794,5 +796,10 @@ trait ResponseTrait
         }
 
         return $response;
+    }
+
+    public function getCSP(): ContentSecurityPolicy
+    {
+        return $this->CSP;
     }
 }

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -49,7 +49,7 @@ trait ResponseTrait
      *
      * @var ContentSecurityPolicy
      *
-     * @TODO Will be protected. Use `getCSP()` instead.
+     * @deprecated Will be protected. Use `getCSP()` instead.
      */
     public $CSP;
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -175,7 +175,7 @@ trait ResponseTrait
     /**
      * Sets the date header
      *
-     * @return Response
+     * @return $this
      */
     public function setDate(DateTime $date)
     {
@@ -191,7 +191,7 @@ trait ResponseTrait
      *
      * @see http://tools.ietf.org/html/rfc5988
      *
-     * @return Response
+     * @return $this
      *
      * @todo Recommend moving to Pager
      */
@@ -222,7 +222,7 @@ trait ResponseTrait
      * Sets the Content Type header for this response with the mime type
      * and, optionally, the charset.
      *
-     * @return Response
+     * @return $this
      */
     public function setContentType(string $mime, string $charset = 'UTF-8')
     {
@@ -336,7 +336,7 @@ trait ResponseTrait
      * Sets the appropriate headers to ensure this response
      * is not cached by the browsers.
      *
-     * @return Response
+     * @return $this
      *
      * @todo Recommend researching these directives, might need: 'private', 'no-transform', 'no-store', 'must-revalidate'
      *
@@ -374,7 +374,7 @@ trait ResponseTrait
      *  - proxy-revalidate
      *  - no-transform
      *
-     * @return Response
+     * @return $this
      */
     public function setCache(array $options = [])
     {
@@ -411,7 +411,7 @@ trait ResponseTrait
      *
      * @param DateTime|string $date
      *
-     * @return Response
+     * @return $this
      */
     public function setLastModified($date)
     {
@@ -454,7 +454,7 @@ trait ResponseTrait
     /**
      * Sends the headers of this HTTP response to the browser.
      *
-     * @return Response
+     * @return $this
      */
     public function sendHeaders()
     {
@@ -483,7 +483,7 @@ trait ResponseTrait
     /**
      * Sends the Body of the message to the browser.
      *
-     * @return Response
+     * @return $this
      */
     public function sendBody()
     {

--- a/system/RESTful/ResourceController.php
+++ b/system/RESTful/ResourceController.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\RESTful;
 
 use CodeIgniter\API\ResponseTrait;
-use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\ResponseInterface;
 
 /**
  * An extendable controller to provide a RESTful API for a resource.
@@ -24,7 +24,7 @@ class ResourceController extends BaseResource
     /**
      * Return an array of resource objects, themselves in array format
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function index()
     {
@@ -36,7 +36,7 @@ class ResourceController extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function show($id = null)
     {
@@ -46,7 +46,7 @@ class ResourceController extends BaseResource
     /**
      * Return a new resource object, with default properties
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function new()
     {
@@ -56,7 +56,7 @@ class ResourceController extends BaseResource
     /**
      * Create a new resource object, from "posted" parameters
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function create()
     {
@@ -68,7 +68,7 @@ class ResourceController extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function edit($id = null)
     {
@@ -80,7 +80,7 @@ class ResourceController extends BaseResource
      *
      * @param string|null|int$id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function update($id = null)
     {
@@ -92,7 +92,7 @@ class ResourceController extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function delete($id = null)
     {

--- a/system/RESTful/ResourcePresenter.php
+++ b/system/RESTful/ResourcePresenter.php
@@ -11,7 +11,7 @@
 
 namespace CodeIgniter\RESTful;
 
-use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\ResponseInterface;
 
 /**
  * An extendable controller to help provide a UI for a resource.
@@ -21,7 +21,7 @@ class ResourcePresenter extends BaseResource
     /**
      * Present a view of resource objects
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function index()
     {
@@ -33,7 +33,7 @@ class ResourcePresenter extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function show($id = null)
     {
@@ -43,7 +43,7 @@ class ResourcePresenter extends BaseResource
     /**
      * Present a view to present a new single resource object
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function new()
     {
@@ -54,7 +54,7 @@ class ResourcePresenter extends BaseResource
      * Process the creation/insertion of a new resource object.
      * This should be a POST.
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function create()
     {
@@ -66,7 +66,7 @@ class ResourcePresenter extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function edit($id = null)
     {
@@ -79,7 +79,7 @@ class ResourcePresenter extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function update($id = null)
     {
@@ -91,7 +91,7 @@ class ResourcePresenter extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function remove($id = null)
     {
@@ -103,7 +103,7 @@ class ResourcePresenter extends BaseResource
      *
      * @param int|string|null $id
      *
-     * @return Response|string|void
+     * @return ResponseInterface|string|void
      */
     public function delete($id = null)
     {

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -15,7 +15,6 @@ use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
-use CodeIgniter\HTTP\Response;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Session\Session;
 use Config\App;
@@ -571,7 +570,6 @@ class Security implements SecurityInterface
             ]
         );
 
-        /** @var Response $response */
         $response = Services::response();
         $response->setCookie($this->cookie);
     }

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Session;
 
 use CodeIgniter\Cookie\Cookie;
-use CodeIgniter\HTTP\Response;
 use Config\App;
 use Config\Cookie as CookieConfig;
 use Config\Services;
@@ -930,7 +929,6 @@ class Session implements SessionInterface
         $expiration   = $this->sessionExpiration === 0 ? 0 : time() + $this->sessionExpiration;
         $this->cookie = $this->cookie->withValue(session_id())->withExpires($expiration);
 
-        /** @var Response $response */
         $response = Services::response();
         $response->setCookie($this->cookie);
     }

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Test;
 use CodeIgniter\Controller;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\URI;
 use Config\App;
 use Config\Services;
@@ -55,7 +55,7 @@ trait ControllerTestTrait
     /**
      * Response.
      *
-     * @var Response
+     * @var ResponseInterface
      */
     protected $response;
 
@@ -177,7 +177,7 @@ trait ControllerTestTrait
         }
 
         // If the controller did not return a response then start one
-        if (! $response instanceof Response) {
+        if (! $response instanceof ResponseInterface) {
             $response = $this->response;
         }
 
@@ -244,7 +244,7 @@ trait ControllerTestTrait
     /**
      * Set controller's response, with method chaining.
      *
-     * @param mixed $response
+     * @param ResponseInterface $response
      *
      * @return $this
      */

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Test;
 
 use CodeIgniter\Controller;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\URI;
 use Config\App;
 use Config\Services;
@@ -58,7 +58,7 @@ trait ControllerTester
     /**
      * Response.
      *
-     * @var Response
+     * @var ResponseInterface
      */
     protected $response;
 
@@ -182,7 +182,7 @@ trait ControllerTester
             $output = ob_get_clean();
 
             // If the controller returned a response, use it
-            if (isset($response) && $response instanceof Response) {
+            if (isset($response) && $response instanceof ResponseInterface) {
                 $result->setResponse($response);
             }
 

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -40,7 +40,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $config->CSPEnabled = $CSPEnabled;
         $this->response     = new Response($config);
         $this->response->pretend(false);
-        $this->csp = $this->response->CSP;
+        $this->csp = $this->response->getCSP();
     }
 
     protected function work(string $parm = 'Hello')
@@ -635,7 +635,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
     {
         $this->prepare(false);
         $this->work();
-        $this->response->CSP->addStyleSrc('https://example.com');
+        $this->response->getCSP()->addStyleSrc('https://example.com');
 
         $this->assertHeaderNotEmitted('content-security-policy', true);
     }

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -55,6 +55,7 @@ Interface Changes
 
 - Added missing ``getBody()``, ``hasHeader()`` and ``getHeaderLine()`` method in ``MessageInterface``.
 - Now ``ResponseInterface`` extends ``MessageInterface``.
+- Added missing ``ResponseInterface::getCSP()`` (and ``Response::getCSP()``), ``ResponseInterface::getReasonPhrase()`` and ``ResponseInterface::getCookieStore()`` methods.
 
 Method Signature Changes
 ========================
@@ -96,6 +97,10 @@ Others
 - ``BaseBuilder::_updateBatch()``
     - The second parameter ``$values`` has changed to ``$keys``.
     - The third parameter ``$index`` has changed to ``$values``. The parameter type also has changed to ``array``.
+- The return type of ``API\ResponseTrait::failServerError()`` has been changed to ``ResponseInterface``.
+- The following methods have been changed to accept ``ResponseInterface`` as a parameter instead of ``Response``.
+    - ``Debug\Exceptions::__construct()``
+    - ``Services::exceptions()``
 
 Enhancements
 ************
@@ -186,6 +191,7 @@ Deprecations
 - ``RouteCollection::localizeRoute()`` is deprecated.
 - ``RouteCollection::fillRouteParams()`` is deprecated. Use ``RouteCollection::buildReverseRoute()`` instead.
 - ``BaseBuilder::setUpdateBatch()`` and ``BaseBuilder::setInsertBatch()`` are deprecated. Use ``BaseBuilder::setData()`` instead.
+- The public property ``Response::$CSP`` is deprecated. It will be protected. Use ``Response::getCSP()`` instead.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
~~Needs to rebase after merging #6556~~

**Description**
Ref #4356

Now the framework depends on ResponseInterface, not Response.

Add
- `Response::getCSP()`
- `ResponseInterface::getCSP()`
- `ResponseInterface::getReasonPhrase()`
- `ResponseInterface::getCookieStore()`

Change APIs
- `API\ResponseTrait::failServerError()`
- `Services::exceptions()`
- `Debug\Exceptions::__construct()`

Deprecate
- `Response::$CSP`.  It is now `public`, but should be protected.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

