### PR TITLE
fix: CSP autoNonce = false

### DIFF
--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -300,11 +300,10 @@ class ContentSecurityPolicy
      */
     public function finalize(ResponseInterface $response)
     {
-        if ($this->autoNonce === false) {
-            return;
+        if ($this->autoNonce) {
+            $this->generateNonces($response);
         }
 
-        $this->generateNonces($response);
         $this->buildHeaders($response);
     }
 

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\TestResponse;
 use Config\App;
 use Config\ContentSecurityPolicy as CSPConfig;
 
@@ -534,7 +535,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
 
         $this->assertStringContainsString('{csp-script-nonce}', $response->getBody());
 
-        $result = new \CodeIgniter\Test\TestResponse($response);
+        $result = new TestResponse($response);
         $result->assertHeader('Content-Security-Policy');
     }
 
@@ -553,7 +554,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
 
         $this->assertStringContainsString('{csp-style-nonce}', $response->getBody());
 
-        $result = new \CodeIgniter\Test\TestResponse($response);
+        $result = new TestResponse($response);
         $result->assertHeader('Content-Security-Policy');
     }
 

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -533,6 +533,9 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $csp->finalize($response);
 
         $this->assertStringContainsString('{csp-script-nonce}', $response->getBody());
+
+        $result = new \CodeIgniter\Test\TestResponse($response);
+        $result->assertHeader('Content-Security-Policy');
     }
 
     public function testBodyStyleNonceDisableAutoNonce()
@@ -549,6 +552,9 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $csp->finalize($response);
 
         $this->assertStringContainsString('{csp-style-nonce}', $response->getBody());
+
+        $result = new \CodeIgniter\Test\TestResponse($response);
+        $result->assertHeader('Content-Security-Policy');
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -33,6 +33,6 @@ none.
 Bugs Fixed
 **********
 
-none.
+- Fixed a bug that prevents CSP headers from being sent when ``Config\ContentSecurityPolicy::$autoNonce`` is false.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=83041

**Manual Testing**
```php
<?php

namespace App\Controllers;

class Home extends BaseController
{
    public function index()
    {
        return "<html><script>alert('XSS');</script></html>";
    }
}
```
```diff
diff --git a/app/Config/App.php b/app/Config/App.php
index 79e5741b4..7b56cf601 100644
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -462,5 +462,5 @@ class App extends BaseConfig
      *
      * @var bool
      */
-    public $CSPEnabled = false;
+    public $CSPEnabled = true;
 }
diff --git a/app/Config/ContentSecurityPolicy.php b/app/Config/ContentSecurityPolicy.php
index 0be616301..ff1361ffe 100644
--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -184,5 +184,5 @@ class ContentSecurityPolicy extends BaseConfig
      *
      * @var bool
      */
-    public $autoNonce = true;
+    public $autoNonce = false;
 }
```
Navigate http://localhost:8080/, and you don't see the alert.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

