### PR TITLE
When/WhenNot methods for db in a trait

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Database;
 use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Traits\ConditionalTrait;
 use InvalidArgumentException;
 
 /**
@@ -25,6 +26,8 @@ use InvalidArgumentException;
  */
 class BaseBuilder
 {
+    use ConditionalTrait;
+
     /**
      * Reset DELETE data flag
      *

--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Traits;
+
+trait ConditionalTrait
+{
+    /**
+     * Only runs the query when $condition evaluates to true
+     *
+     * @param array|bool|float|int|object|resource|string|null $condition
+     */
+    public function when($condition, callable $callback, ?callable $defaultCallback = null): self
+    {
+        if ($condition) {
+            $callback($this, $condition);
+        } elseif ($defaultCallback) {
+            $defaultCallback($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Only runs the query when $condition evaluates to false
+     *
+     * @param array|bool|float|int|object|resource|string|null $condition
+     */
+    public function whenNot($condition, callable $callback, ?callable $defaultCallback = null): self
+    {
+        if (! $condition) {
+            $callback($this, $condition);
+        } elseif ($defaultCallback) {
+            $defaultCallback($this);
+        }
+
+        return $this;
+    }
+}

--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -17,6 +17,8 @@ trait ConditionalTrait
      * Only runs the query when $condition evaluates to true
      *
      * @param array|bool|float|int|object|resource|string|null $condition
+     *
+     * @return $this
      */
     public function when($condition, callable $callback, ?callable $defaultCallback = null): self
     {
@@ -33,6 +35,8 @@ trait ConditionalTrait
      * Only runs the query when $condition evaluates to false
      *
      * @param array|bool|float|int|object|resource|string|null $condition
+     *
+     * @return $this
      */
     public function whenNot($condition, callable $callback, ?callable $defaultCallback = null): self
     {

--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -16,6 +16,12 @@ trait ConditionalTrait
     /**
      * Only runs the query when $condition evaluates to true
      *
+     * @template TWhen of mixed
+     *
+     * @phpstan-param TWhen                         $condition
+     * @phpstan-param callable(self, TWhen): mixed  $callback
+     * @phpstan-param (callable(self): mixed)|null  $defaultCallback
+     *
      * @param array|bool|float|int|object|resource|string|null $condition
      *
      * @return $this
@@ -39,6 +45,8 @@ trait ConditionalTrait
      * @phpstan-param TWhenNot                        $condition
      * @phpstan-param callable(self, TWhenNot): mixed $callback
      * @phpstan-param (callable(self): mixed)|null    $defaultCallback
+     *
+     * @param array|bool|float|int|object|resource|string|null $condition
      *
      * @return $this
      */

--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -21,7 +21,6 @@ trait ConditionalTrait
      * @phpstan-param TWhen                         $condition
      * @phpstan-param callable(self, TWhen): mixed  $callback
      * @phpstan-param (callable(self): mixed)|null  $defaultCallback
-     *
      * @param array|bool|float|int|object|resource|string|null $condition
      *
      * @return $this
@@ -45,7 +44,6 @@ trait ConditionalTrait
      * @phpstan-param TWhenNot                        $condition
      * @phpstan-param callable(self, TWhenNot): mixed $callback
      * @phpstan-param (callable(self): mixed)|null    $defaultCallback
-     *
      * @param array|bool|float|int|object|resource|string|null $condition
      *
      * @return $this

--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -34,7 +34,11 @@ trait ConditionalTrait
     /**
      * Only runs the query when $condition evaluates to false
      *
-     * @param array|bool|float|int|object|resource|string|null $condition
+     * @template TWhenNot of mixed
+     *
+     * @phpstan-param TWhenNot                        $condition
+     * @phpstan-param callable(self, TWhenNot): mixed $callback
+     * @phpstan-param (callable(self): mixed)|null    $defaultCallback
      *
      * @return $this
      */

--- a/tests/system/Database/Builder/WhenTest.php
+++ b/tests/system/Database/Builder/WhenTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Builder;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+
+/**
+ * @internal
+ */
+final class WhenTest extends CIUnitTestCase
+{
+    /**
+     * @var MockConnection
+     */
+    protected $db;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = new MockConnection([]);
+    }
+
+    public function testWhenTrue()
+    {
+        $builder = $this->db->table('jobs');
+
+        $expectedSQL = 'SELECT * FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+        $builder = $builder->when(true, static function ($query) {
+            $query->select('id');
+        });
+
+        $expectedSQL = 'SELECT "id" FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenTruthy()
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->when('abc', static function ($query) {
+            $query->select('id');
+        });
+
+        $expectedSQL = 'SELECT "id" FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenRunsDefaultWhenFalse()
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->when(false, static function ($query) {
+            $query->select('id');
+        }, static function ($query) {
+            $query->select('name');
+        });
+
+        $expectedSQL = 'SELECT "name" FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenDoesntModifyWhenFalse()
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->when(false, static function ($query) {
+            $query->select('id');
+        });
+
+        $expectedSQL = 'SELECT * FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenPassesParemeters()
+    {
+        $builder = $this->db->table('jobs');
+        $name    = 'developer';
+
+        $builder = $builder->when($name, static function ($query, $name) {
+            $query->where('name', $name);
+        });
+
+        $expectedSQL = 'SELECT * FROM "jobs" WHERE "name" = \'developer\'';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenNotFalse()
+    {
+        $builder = $this->db->table('jobs');
+
+        $expectedSQL = 'SELECT * FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+        $builder = $builder->whenNot(false, static function ($query) {
+            $query->select('id');
+        });
+
+        $expectedSQL = 'SELECT "id" FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenNotFalsey()
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->whenNot('0', static function ($query) {
+            $query->select('id');
+        });
+
+        $expectedSQL = 'SELECT "id" FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenNotRunsDefaultWhenTrue()
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->whenNot(true, static function ($query) {
+            $query->select('id');
+        }, static function ($query) {
+            $query->select('name');
+        });
+
+        $expectedSQL = 'SELECT "name" FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenNotDoesntModifyWhenFalse()
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->whenNot(true, static function ($query) {
+            $query->select('id');
+        });
+
+        $expectedSQL = 'SELECT * FROM "jobs"';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testWhenNotPassesParemeters()
+    {
+        $builder = $this->db->table('jobs');
+        $name    = '0';
+
+        $builder = $builder->whenNot($name, static function ($query, $name) {
+            $query->where('name', $name);
+        });
+
+        $expectedSQL = 'SELECT * FROM "jobs" WHERE "name" = \'0\'';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+}

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -126,6 +126,7 @@ Database
 - Improved the SQL structure for ``Builder::updateBatch()``. See :ref:`update-batch` for the details.
 - Improved data returned by ``BaseConnection::getForeignKeyData()``. All DBMS returns the same structure.
 - ``Forge::addForeignKey()`` now includes a name parameter to manual set foreign key names. Not supported in SQLite3.
+- Added ``when()`` and ``whenNot()` methods to conditionally add clauses to the query. See :ref:`BaseBuilder::when() <db-builder-when>` for details.
 
 Model
 =====

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -126,7 +126,7 @@ Database
 - Improved the SQL structure for ``Builder::updateBatch()``. See :ref:`update-batch` for the details.
 - Improved data returned by ``BaseConnection::getForeignKeyData()``. All DBMS returns the same structure.
 - ``Forge::addForeignKey()`` now includes a name parameter to manual set foreign key names. Not supported in SQLite3.
-- Added ``when()`` and ``whenNot()` methods to conditionally add clauses to the query. See :ref:`BaseBuilder::when() <db-builder-when>` for details.
+- Added ``when()`` and ``whenNot()`` methods to conditionally add clauses to the query. See :ref:`BaseBuilder::when() <db-builder-when>` for details.
 
 Model
 =====

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1022,6 +1022,42 @@ that it produces a **DELETE** SQL string instead of an **INSERT** SQL string.
 
 For more information view documentation for ``$builder->getCompiledInsert()``.
 
+**********************
+Conditional Statements
+**********************
+
+.. _db-builder-when:
+
+$builder->when()
+------------------
+
+This allows modifying the query based on a condition without breaking out of the
+query builder chain. The first parameter is the condition, and it should evaluate
+to a boolean. The second parameter is a callable that will be ran
+when the condition is true.
+
+For example, you might only want to apply a given WHERE statement based on the
+value sent within an HTTP request:
+
+.. literalinclude:: query_builder/105.php
+
+Since the condition is evaluated as ``true``, the callable will be called. The value
+set in the condition will be passed as the second parameter to the callable so it
+can be used in the query.
+
+Sometimes you might want to apply a different statement if the condition evaluates to false.
+This can be accomplished by providing a second closure:
+
+.. literalinclude:: query_builder/106.php
+
+$builder->whenNot()
+-------------------
+
+This works exactly the same way as ``$builder->when()`` except that it will
+only run the callable when the condition evaluates to ``false``, instead of ``true`` like ``when()``.
+
+.. literalinclude:: query_builder/107.php
+
 ***************
 Method Chaining
 ***************

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1028,8 +1028,11 @@ Conditional Statements
 
 .. _db-builder-when:
 
+When
+====
+
 $builder->when()
-------------------
+----------------
 
 This allows modifying the query based on a condition without breaking out of the
 query builder chain. The first parameter is the condition, and it should evaluate
@@ -1049,6 +1052,9 @@ Sometimes you might want to apply a different statement if the condition evaluat
 This can be accomplished by providing a second closure:
 
 .. literalinclude:: query_builder/106.php
+
+WhenNot
+=======
 
 $builder->whenNot()
 -------------------

--- a/user_guide_src/source/database/query_builder/105.php
+++ b/user_guide_src/source/database/query_builder/105.php
@@ -1,0 +1,9 @@
+<?php
+
+$status = service('request')->getPost('status');
+
+$users = $this->db->table('users')
+    ->when($status, static function ($query, $status) {
+        $query->where('status', $status);
+    })
+    ->get();

--- a/user_guide_src/source/database/query_builder/106.php
+++ b/user_guide_src/source/database/query_builder/106.php
@@ -1,0 +1,11 @@
+<?php
+
+$onlyInactive = service('request')->getPost('return_inactive');
+
+$users = $this->db->table('users')
+    ->when($onlyInactive, static function ($query, $onlyInactive) {
+        $query->where('status', 'inactive');
+    }, static function ($query) {
+        $query->where('status', 'active');
+    })
+    ->get();

--- a/user_guide_src/source/database/query_builder/107.php
+++ b/user_guide_src/source/database/query_builder/107.php
@@ -1,3 +1,5 @@
+<?php
+
 $status = service('request')->getPost('status');
 
 $users = $this->db->table('users')

--- a/user_guide_src/source/database/query_builder/107.php
+++ b/user_guide_src/source/database/query_builder/107.php
@@ -1,0 +1,7 @@
+$status = service('request')->getPost('status');
+
+$users = $this->db->table('users')
+    ->whenNot($status, static function ($query, $status) {
+        $query->where('active', 0);
+    })
+    ->get();


### PR DESCRIPTION
This replaces #6329. It adds a new `ConditionalTrait` to CodeIgniter that can be used to add `when()` and `whenNot()` methods in various places in the framework. This PR adds it to the database layer for inline conditions to queries. 

Instead of: 

```php
$query = $this->where('foo', $foo);

if ($bar) {
    $query = $query->where('bar', $bar);
}

return $query->findAll();
```

you can now do: 

```php
return $query->where('foo', $foo)
    ->when($bar, static function($query) {
        return $query->where('bar', $bar);
    })
    ->findAll();
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
