### PR TITLE
tests: added test for `timezone_select` function in Date Helper

### DIFF
--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use DateTimeZone;
 
 /**
  * @internal
@@ -33,5 +34,56 @@ final class DateHelperTest extends CIUnitTestCase
     {
         // Chicago should be two hours ahead of Vancouver
         $this->assertCloseEnough(7200, now('America/Chicago') - now('America/Vancouver'));
+    }
+
+    public function testTimezoneSelectDefault()
+    {
+        $timezones = DateTimeZone::listIdentifiers(DateTimeZone::ALL, null);
+
+        $expected = "<select name='timezone' class='custom-select'>" . PHP_EOL;
+
+        foreach ($timezones as $timezone) {
+            $selected = ($timezone === 'Asia/Jakarta') ? 'selected' : '';
+            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>" . PHP_EOL;
+        }
+
+        $expected .= ('</select>' . PHP_EOL);
+
+        $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta'));
+    }
+
+    public function testTimezoneSelectSpecific()
+    {
+        $spesificRegion = DateTimeZone::ASIA;
+        $timezones      = DateTimeZone::listIdentifiers($spesificRegion, null);
+
+        $expected = "<select name='timezone' class='custom-select'>" . PHP_EOL;
+
+        foreach ($timezones as $timezone) {
+            $selected = ($timezone === 'Asia/Jakarta') ? 'selected' : '';
+            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>" . PHP_EOL;
+        }
+
+        $expected .= ('</select>' . PHP_EOL);
+
+        $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion));
+    }
+
+    public function testTimezoneSelectSingle()
+    {
+        $spesificRegion = DateTimeZone::PER_COUNTRY;
+        $country        = 'ID';
+        $timezones      = DateTimeZone::listIdentifiers($spesificRegion, $country);
+
+        $expected = "<select name='timezone' class='custom-select'>" . PHP_EOL;
+
+        foreach ($timezones as $timezone) {
+            $selected = ($timezone === 'Asia/Jakarta') ? 'selected' : '';
+            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>" . PHP_EOL;
+        }
+
+        $expected .= ('</select>' . PHP_EOL);
+
+        $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion, $country));
     }
 }


### PR DESCRIPTION
**Description**
Added tests for `timezone_select()` in Date Helper.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
