### PR TITLE
tests: adding case `word_censor` and ascii entities in text helper

### DIFF
--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -160,6 +160,9 @@ final class TextHelperTest extends CIUnitTestCase
     public function testAsciiToEntities()
     {
         $strs = [
+            'Œ'              => '&#338;',
+            'Âé'             => '&#194;&#233;',
+            'Â? '            => '&#194;? ',
             '“‘ “test” '     => '&#8220;&#8216; &#8220;test&#8221; ',
             '†¥¨ˆøåß∂ƒ©˙∆˚¬' => '&#8224;&#165;&#168;&#710;&#248;&#229;&#223;&#8706;&#402;&#169;&#729;&#8710;&#730;&#172;',
         ];
@@ -172,6 +175,9 @@ final class TextHelperTest extends CIUnitTestCase
     public function testEntitiesToAscii()
     {
         $strs = [
+            '&#338;'                                                                                  => 'Œ',
+            '&#194;&#233;'                                                                            => 'Âé',
+            '&#194;? '                                                                                => 'Â? ',
             '&#8220;&#8216; &#8220;test&#8221; '                                                      => '“‘ “test” ',
             '&#8224;&#165;&#168;&#710;&#248;&#229;&#223;&#8706;&#402;&#169;&#729;&#8710;&#730;&#172;' => '†¥¨ˆøåß∂ƒ©˙∆˚¬',
         ];
@@ -202,11 +208,19 @@ final class TextHelperTest extends CIUnitTestCase
 
     public function testCensoredWords()
     {
+        $this->assertSame('fuck', word_censor('fuck', []));
+    }
+
+    public function testCensoredWordsWithReplacement()
+    {
         $censored = [
             'boob',
             'nerd',
             'ass',
+            'asshole',
             'fart',
+            'fuck',
+            'fucking',
         ];
         $strs = [
             'Ted bobbled the ball'         => 'Ted bobbled the ball',
@@ -219,6 +233,29 @@ final class TextHelperTest extends CIUnitTestCase
 
         foreach ($strs as $str => $expect) {
             $this->assertSame($expect, word_censor($str, $censored, '$*#'));
+        }
+    }
+
+    public function testCensoredWordsNonReplacement()
+    {
+        $censored = [
+            'boob',
+            'nerd',
+            'ass',
+            'asshole',
+            'fart',
+            'fuck',
+            'fucking',
+        ];
+        $strs = [
+            'How are you today?'          => 'How are you today?',
+            'I am fine, thankyou!'        => 'I am fine, thankyou!',
+            'Are you fucking kidding me?' => 'Are you ####### kidding me?',
+            'Fucking asshole!'            => '####### #######!',
+        ];
+
+        foreach ($strs as $str => $expect) {
+            $this->assertSame($expect, word_censor($str, $censored));
         }
     }
 

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -254,8 +254,8 @@ final class TextHelperTest extends CIUnitTestCase
             'Fucking asshole!'            => '####### #######!',
         ];
 
-        foreach ($strs as $str => $expect) {
-            $this->assertSame($expect, word_censor($str, $censored));
+        foreach ($strs as $str => $expected) {
+            $this->assertSame($expected, word_censor($str, $censored));
         }
     }
 


### PR DESCRIPTION
**Description**
Increase coverage in text helper.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
