### PR TITLE
fix: make note PR branch to comment only

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
+<!--
+
 Each pull request should address a single issue and have a meaningful title.
 
 - All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
 - PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__
 
+-->
 **Description**
 Explain what you have changed, and why.
 


### PR DESCRIPTION
**Description**
I think make this comment only, if everyone who made PR didn't show this info.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
