### PR TITLE
fix: inconsistent new line view in `date_helper`

### DIFF
--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -54,13 +54,13 @@ if (! function_exists('timezone_select')) {
     {
         $timezones = DateTimeZone::listIdentifiers($what, $country);
 
-        $buffer = "<select name='timezone' class='{$class}'>" . PHP_EOL;
+        $buffer = "<select name='timezone' class='{$class}'>\n";
 
         foreach ($timezones as $timezone) {
             $selected = ($timezone === $default) ? 'selected' : '';
-            $buffer .= "<option value='{$timezone}' {$selected}>{$timezone}</option>" . PHP_EOL;
+            $buffer .= "<option value='{$timezone}' {$selected}>{$timezone}</option>\n";
         }
 
-        return $buffer . ('</select>' . PHP_EOL);
+        return $buffer . ("</select>\n");
     }
 }

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -40,14 +40,14 @@ final class DateHelperTest extends CIUnitTestCase
     {
         $timezones = DateTimeZone::listIdentifiers(DateTimeZone::ALL, null);
 
-        $expected = "<select name='timezone' class='custom-select'>" . PHP_EOL;
+        $expected = "<select name='timezone' class='custom-select'>\n";
 
         foreach ($timezones as $timezone) {
             $selected = ($timezone === 'Asia/Jakarta') ? 'selected' : '';
-            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>" . PHP_EOL;
+            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>\n";
         }
 
-        $expected .= ('</select>' . PHP_EOL);
+        $expected .= ("</select>\n");
 
         $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta'));
     }
@@ -57,14 +57,14 @@ final class DateHelperTest extends CIUnitTestCase
         $spesificRegion = DateTimeZone::ASIA;
         $timezones      = DateTimeZone::listIdentifiers($spesificRegion, null);
 
-        $expected = "<select name='timezone' class='custom-select'>" . PHP_EOL;
+        $expected = "<select name='timezone' class='custom-select'>\n";
 
         foreach ($timezones as $timezone) {
             $selected = ($timezone === 'Asia/Jakarta') ? 'selected' : '';
-            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>" . PHP_EOL;
+            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>\n";
         }
 
-        $expected .= ('</select>' . PHP_EOL);
+        $expected .= ("</select>\n");
 
         $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion));
     }
@@ -75,14 +75,14 @@ final class DateHelperTest extends CIUnitTestCase
         $country        = 'ID';
         $timezones      = DateTimeZone::listIdentifiers($spesificRegion, $country);
 
-        $expected = "<select name='timezone' class='custom-select'>" . PHP_EOL;
+        $expected = "<select name='timezone' class='custom-select'>\n";
 
         foreach ($timezones as $timezone) {
             $selected = ($timezone === 'Asia/Jakarta') ? 'selected' : '';
-            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>" . PHP_EOL;
+            $expected .= "<option value='{$timezone}' {$selected}>{$timezone}</option>\n";
         }
 
-        $expected .= ('</select>' . PHP_EOL);
+        $expected .= ("</select>\n");
 
         $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion, $country));
     }


### PR DESCRIPTION
**Description**
By [comment](https://github.com/codeigniter4/CodeIgniter4/pull/6575#issuecomment-1256792923), other helper like form & html using `\n` to view newline.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
