### PR TITLE
test: remove Registrar tests for dynamic property

### DIFF
--- a/tests/_support/Config/TestRegistrar.php
+++ b/tests/_support/Config/TestRegistrar.php
@@ -25,11 +25,6 @@ class TestRegistrar
                 'first',
                 'second',
             ],
-            'format' => 'nice',
-            'fruit'  => [
-                'apple',
-                'banana',
-            ],
         ];
     }
 }

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -252,10 +252,6 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->assertSame('bar', $config->foo);
         // add to an existing array property
         $this->assertSame(['baz', 'first', 'second'], $config->bar);
-        // add a new property
-        $this->assertSame('nice', $config->format);
-        // add a new array property
-        $this->assertSame(['apple', 'banana'], $config->fruit);
     }
 
     public function testBadRegistrar()


### PR DESCRIPTION
**Description**
- remove tests for dynamic property

See #6162

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
