### PR TITLE
fix: `$cleanValidationRules` does not work in Model updates

### DIFF
--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -373,7 +373,7 @@ final class ValidationModelTest extends LiveModelTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/6577
      */
-    public function testUpdateEntityWithCleanRulesFalse()
+    public function testUpdateEntityWithPropertyCleanValidationRulesTrueAndCallingCleanRulesFalse()
     {
         $model = new class () extends Model {
             protected $table           = 'test';
@@ -400,7 +400,7 @@ final class ValidationModelTest extends LiveModelTestCase
         // Change field1 value.
         $entity->field1 = '';
 
-        // Set $cleanValidationRules to false.
+        // Set $cleanValidationRules to false by cleanRules()
         $model->cleanRules(false)->save($entity);
 
         $errors = $model->errors();
@@ -411,7 +411,7 @@ final class ValidationModelTest extends LiveModelTestCase
         );
     }
 
-    public function testUpdateEntityWithCleanValidationRulesFalse()
+    public function testUpdateEntityWithPropertyCleanValidationRulesFalse()
     {
         $model = new class () extends Model {
             protected $table           = 'test';

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -441,7 +441,6 @@ final class ValidationModelTest extends LiveModelTestCase
         // Change field1 value.
         $entity->field1 = '';
 
-        // Set $cleanValidationRules to false.
         $model->save($entity);
 
         $errors = $model->errors();

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -469,7 +469,7 @@ final class ValidationModelTest extends LiveModelTestCase
         $entity = new SimpleEntity();
         $entity->setAttributes([
             'field1' => 'value1',
-            'field2' => '',
+            // field2 is missing
             'field3' => '',
             'field4' => '',
         ]);

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -408,7 +408,7 @@ standard, without duplicating code. The Model class provides a way to automatica
 prior to saving to the database with the ``insert()``, ``update()``, or ``save()`` methods.
 
 .. important:: When you update data, by default, the validation in the model class only
-    validate provided fields. This is to avoid validation errors when updating only some fields.
+    validates provided fields. This is to avoid validation errors when updating only some fields.
 
     But this means ``required*`` rules do not work as expected when updating.
     If you want to check required fields, you can change the behavior by configuration.

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -191,9 +191,24 @@ $skipValidation
 ---------------
 
 Whether validation should be skipped during all **inserts** and **updates**. The default
-value is false, meaning that data will always attempt to be validated. This is
+value is ``false``, meaning that data will always attempt to be validated. This is
 primarily used by the ``skipValidation()`` method, but may be changed to ``true`` so
 this model will never validate.
+
+.. _clean-validation-rules:
+
+$cleanValidationRules
+---------------------
+
+Whether validation rules should be removed that do not exist in the passed data.
+This is used in **updates**.
+The default value is ``true``, meaning that validation rules for the fields
+that are not present in the passed data will be (temporarily) removed before the validation.
+This is to avoid validation errors when updating only some fields.
+
+You can also change the value by the ``cleanRules()`` method.
+
+.. note:: Prior to v4.2.7, ``$cleanValidationRules`` did not work due to a bug.
 
 $beforeInsert
 -------------
@@ -392,9 +407,12 @@ For many people, validating data in the model is the preferred way to ensure the
 standard, without duplicating code. The Model class provides a way to automatically have all data validated
 prior to saving to the database with the ``insert()``, ``update()``, or ``save()`` methods.
 
-.. important:: When you update data, the validation in the model class only validate provided fields.
-    So when you set the rule ``required``, if you don't pass the required field data,
-    the validation won't fail. This is to avoid validation errors when updating only some fields.
+.. important:: When you update data, by default, the validation in the model class only
+    validate provided fields. This is to avoid validation errors when updating only some fields.
+
+    But this means ``required*`` rules do not work as expected when updating.
+    If you want to check required fields, you can change the behavior by configuration.
+    See :ref:`clean-validation-rules` for details.
 
 The first step is to fill out the ``$validationRules`` class property with the fields and rules that should
 be applied. If you have custom error message that you want to use, place them in the ``$validationMessages`` array:


### PR DESCRIPTION
**Description**
Fixes #6577

When you update data, the validation in the model class only validates provided fields.
Model has the property `$this->cleanValidationRules` but it is not able to be used. (Probably a bug)
This PR makes that you can use `$this->cleanValidationRules` and you can change it with `cleanRules()` at runtime.

1. Validation in `insert()`/`insertBatch()` always uses entire rules (force to set `$this->cleanValidationRules = false`).
2. Validation in `update()`/`updateBatch()`/`replace()` uses `$this->cleanValidationRules` value.
3. You can change `$this->cleanValidationRules` value with `cleanRules()`.
4. If `$this->cleanValidationRules = false`, get all data (`$onlyChanged = false`) from the Entity.

Related: #6459

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
