### PR TITLE
fix: `required_without` rule logic in `Validation` class.

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -280,7 +280,7 @@ class Rules
      *
      * @param string|null $str
      */
-    public function required_without($str = null, ?string $fields = null, array $data = [], ?string $keyField = null): bool
+    public function required_without($str = null, ?string $fields = null, array $data = [], ?string $error = null, ?string $keyField = null): bool
     {
         if ($fields === null || empty($data) || $keyField === null) {
             throw new InvalidArgumentException('You must supply the parameters: fields, data, keyField.');

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -285,7 +285,7 @@ class Rules
     public function required_without($str = null, ?string $otherFields = null, array $data = [], ?string $error = null, ?string $field = null): bool
     {
         if ($otherFields === null || empty($data)) {
-            throw new InvalidArgumentException('You must supply the parameters: fields, data.');
+            throw new InvalidArgumentException('You must supply the parameters: otherFields, data.');
         }
 
         // If the field is present we can safely assume that
@@ -298,8 +298,6 @@ class Rules
             return true;
         }
 
-        $fieldIndex = 0;
-
         // Still here? Then we fail this test if
         // any of the fields are not present in $data
         foreach ($otherFields as $otherField) {
@@ -307,18 +305,18 @@ class Rules
                 return false;
             }
             if (strpos($otherField, '.') !== false) {
-                if ($field === null) {
+                if ($otherField === null) {
                     throw new InvalidArgumentException('You must supply the parameters: keyField.');
                 }
 
                 $fieldData       = dot_array_search($otherField, $data);
                 $fieldSplitArray = explode('.', $field);
-                $fieldIndex      = $fieldSplitArray[1];
+                $fieldKey        = $fieldSplitArray[1];
 
                 if (is_array($fieldData)) {
-                    return ! empty(dot_array_search($otherField, $data)[$fieldIndex]);
+                    return ! empty(dot_array_search($otherField, $data)[$fieldKey]);
                 }
-                $nowField      = str_replace('*', $fieldIndex, $otherField);
+                $nowField      = str_replace('*', $fieldKey, $otherField);
                 $nowFieldVaule = dot_array_search($nowField, $data);
 
                 return null !== $nowFieldVaule;

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -282,8 +282,8 @@ class Rules
      */
     public function required_without($str = null, ?string $fields = null, array $data = [], ?string $error = null, ?string $keyField = null): bool
     {
-        if ($fields === null || empty($data) || $keyField === null) {
-            throw new InvalidArgumentException('You must supply the parameters: fields, data, keyField.');
+        if ($fields === null || empty($data)) {
+            throw new InvalidArgumentException('You must supply the parameters: fields, data');
         }
 
         // If the field is present we can safely assume that
@@ -298,11 +298,6 @@ class Rules
 
         $nowKeyField = 0;
 
-        if (strpos($keyField, '.') !== false) {
-            $keyFieldArray = explode('.', $keyField);
-            $nowKeyField   = $keyFieldArray[1];
-        }
-
         // Still here? Then we fail this test if
         // any of the fields are not present in $data
         foreach ($fields as $field) {
@@ -310,7 +305,14 @@ class Rules
                 return ! empty($data[$field]);
             }
             if (strpos($field, '.') !== false) {
-                $fieldData = dot_array_search($field, $data);
+                if ($keyField == null) {
+                    throw new InvalidArgumentException('You must supply the parameters: keyField');
+                }
+
+                $fieldData     = dot_array_search($field, $data);
+                $keyFieldArray = explode('.', $keyField);
+                $nowKeyField   = $keyFieldArray[1];
+
                 if (is_array($fieldData)) {
                     return ! empty(dot_array_search($field, $data)[$nowKeyField]);
                 }

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -301,11 +301,11 @@ class Rules
         // Still here? Then we fail this test if
         // any of the fields are not present in $data
         foreach ($fields as $field) {
-            if ((strpos($field, '.') === false) && (! array_key_exists($field, $data))) {
-                return ! empty($data[$field]);
+            if ((strpos($field, '.') === false) && (! array_key_exists($field, $data) || empty($data[$field]))) {
+                return false;
             }
             if (strpos($field, '.') !== false) {
-                if ($keyField == null) {
+                if ($keyField === null) {
                     throw new InvalidArgumentException('You must supply the parameters: keyField');
                 }
 

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -280,10 +280,10 @@ class Rules
      *
      * @param string|null $str
      */
-    public function required_without($str = null, ?string $fields = null, array $data = []): bool
+    public function required_without($str = null, ?string $fields = null, array $data = [], string $keyField = null): bool
     {
-        if ($fields === null || empty($data)) {
-            throw new InvalidArgumentException('You must supply the parameters: fields, data.');
+        if ($fields === null || empty($data) || $keyField === null) {
+            throw new InvalidArgumentException('You must supply the parameters: fields, data, keyField.');
         }
 
         // If the field is present we can safely assume that

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -279,11 +279,12 @@ class Rules
      *     required_without[id,email]
      *
      * @param string|null $str
+     * @param string|null $keyField This rule param fields aren't present, this field is required.
      */
     public function required_without($str = null, ?string $fields = null, array $data = [], ?string $error = null, ?string $keyField = null): bool
     {
         if ($fields === null || empty($data)) {
-            throw new InvalidArgumentException('You must supply the parameters: fields, data');
+            throw new InvalidArgumentException('You must supply the parameters: fields, data.');
         }
 
         // If the field is present we can safely assume that
@@ -306,7 +307,7 @@ class Rules
             }
             if (strpos($field, '.') !== false) {
                 if ($keyField === null) {
-                    throw new InvalidArgumentException('You must supply the parameters: keyField');
+                    throw new InvalidArgumentException('You must supply the parameters: keyField.');
                 }
 
                 $fieldData     = dot_array_search($field, $data);

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -279,45 +279,46 @@ class Rules
      *     required_without[id,email]
      *
      * @param string|null $str
-     * @param string|null $keyField This rule param fields aren't present, this field is required.
+     * @param string|null $otherFields The param fields of required_without[].
+     * @param string|null $field       This rule param fields aren't present, this field is required.
      */
-    public function required_without($str = null, ?string $fields = null, array $data = [], ?string $error = null, ?string $keyField = null): bool
+    public function required_without($str = null, ?string $otherFields = null, array $data = [], ?string $error = null, ?string $field = null): bool
     {
-        if ($fields === null || empty($data)) {
+        if ($otherFields === null || empty($data)) {
             throw new InvalidArgumentException('You must supply the parameters: fields, data.');
         }
 
         // If the field is present we can safely assume that
         // the field is here, no matter whether the corresponding
         // search field is present or not.
-        $fields  = explode(',', $fields);
-        $present = $this->required($str ?? '');
+        $otherFields = explode(',', $otherFields);
+        $present     = $this->required($str ?? '');
 
         if ($present) {
             return true;
         }
 
-        $nowKeyField = 0;
+        $fieldIndex = 0;
 
         // Still here? Then we fail this test if
         // any of the fields are not present in $data
-        foreach ($fields as $field) {
-            if ((strpos($field, '.') === false) && (! array_key_exists($field, $data) || empty($data[$field]))) {
+        foreach ($otherFields as $otherField) {
+            if ((strpos($otherField, '.') === false) && (! array_key_exists($otherField, $data) || empty($data[$otherField]))) {
                 return false;
             }
-            if (strpos($field, '.') !== false) {
-                if ($keyField === null) {
+            if (strpos($otherField, '.') !== false) {
+                if ($field === null) {
                     throw new InvalidArgumentException('You must supply the parameters: keyField.');
                 }
 
-                $fieldData     = dot_array_search($field, $data);
-                $keyFieldArray = explode('.', $keyField);
-                $nowKeyField   = $keyFieldArray[1];
+                $fieldData       = dot_array_search($otherField, $data);
+                $fieldSplitArray = explode('.', $field);
+                $fieldIndex      = $fieldSplitArray[1];
 
                 if (is_array($fieldData)) {
-                    return ! empty(dot_array_search($field, $data)[$nowKeyField]);
+                    return ! empty(dot_array_search($otherField, $data)[$fieldIndex]);
                 }
-                $nowField      = str_replace('*', $nowKeyField, $field);
+                $nowField      = str_replace('*', $fieldIndex, $otherField);
                 $nowFieldVaule = dot_array_search($nowField, $data);
 
                 return null !== $nowFieldVaule;

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -305,8 +305,8 @@ class Rules
                 return false;
             }
             if (strpos($otherField, '.') !== false) {
-                if ($otherField === null) {
-                    throw new InvalidArgumentException('You must supply the parameters: keyField.');
+                if ($field === null) {
+                    throw new InvalidArgumentException('You must supply the parameters: field.');
                 }
 
                 $fieldData       = dot_array_search($otherField, $data);

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -296,6 +296,8 @@ class Rules
             return true;
         }
 
+        $nowKeyField = 0;
+
         if (strpos($keyField, '.') !== false) {
             $keyFieldArray = explode('.', $keyField);
             $nowKeyField   = $keyFieldArray[1];
@@ -315,7 +317,7 @@ class Rules
                 $nowField      = str_replace('*', $nowKeyField, $field);
                 $nowFieldVaule = dot_array_search($nowField, $data);
 
-                return (bool) (null !== $nowFieldVaule);
+                return null !== $nowFieldVaule;
             }
         }
 

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -302,7 +302,8 @@ class Rules
      *
      *     required_without[id,email]
      *
-     * @param mixed $str
+     * @param mixed       $str
+     * @param string|null $keyField This rule param fields aren't present, this field is required.
      */
     public function required_without($str = null, ?string $fields = null, array $data = [], ?string $error = null, ?string $keyField = null): bool
     {

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -304,8 +304,8 @@ class Rules
      *
      * @param mixed $str
      */
-    public function required_without($str = null, ?string $fields = null, array $data = []): bool
+    public function required_without($str = null, ?string $fields = null, array $data = [], ?string $error = null, ?string $keyField = null): bool
     {
-        return $this->nonStrictRules->required_without($str, $fields, $data);
+        return $this->nonStrictRules->required_without($str, $fields, $data, $error, $keyField);
     }
 }

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -302,7 +302,7 @@ class Rules
      *
      *     required_without[id,email]
      *
-     * @param mixed       $str
+     * @param string|null $str
      * @param string|null $otherFields The param fields of required_without[].
      * @param string|null $field       This rule param fields aren't present, this field is required.
      */

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -303,10 +303,11 @@ class Rules
      *     required_without[id,email]
      *
      * @param mixed       $str
-     * @param string|null $keyField This rule param fields aren't present, this field is required.
+     * @param string|null $otherFields The param fields of required_without[].
+     * @param string|null $field       This rule param fields aren't present, this field is required.
      */
-    public function required_without($str = null, ?string $fields = null, array $data = [], ?string $error = null, ?string $keyField = null): bool
+    public function required_without($str = null, ?string $otherFields = null, array $data = [], ?string $error = null, ?string $field = null): bool
     {
-        return $this->nonStrictRules->required_without($str, $fields, $data, $error, $keyField);
+        return $this->nonStrictRules->required_without($str, $otherFields, $data, $error, $field);
     }
 }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -312,7 +312,7 @@ class Validation implements ValidationInterface
                     $found  = true;
                     $passed = $param === false
                         ? $set->{$rule}($value, $error)
-                        : $set->{$rule}($value, $param, $data, $error);
+                        : $set->{$rule}($value, $param, $data, $field);
 
                     break;
                 }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -312,7 +312,7 @@ class Validation implements ValidationInterface
                     $found  = true;
                     $passed = $param === false
                         ? $set->{$rule}($value, $error)
-                        : $set->{$rule}($value, $param, $data, $field);
+                        : $set->{$rule}($value, $param, $data, $error, $field);
 
                     break;
                 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1443,4 +1443,26 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
         $this->assertSame('Required *.foo', $this->validation->getError('*.foo'));
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5942
+     */
+    public function testRequireWithoutWithWildCard()
+    {
+        $data = [
+            'a' => [
+                ['b' => 1, 'c' => 2],
+                ['c' => ''],
+            ],
+        ];
+
+        $this->validation->setRules([
+            'a.*.c' => 'required_without[a.*.b]',
+        ])->run($data);
+
+        $this->assertSame(
+            'The a.*.c field is required when a.*.b is not present.',
+            $this->validation->getError('a.1.c')
+        );
+    }
 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1414,13 +1414,20 @@ class ValidationTest extends CIUnitTestCase
                     'credit_amount'  => null,
                     'purpose'        => 'A',
                 ],
+                'account_3' => [
+                    'account_number' => '',
+                    'credit_amount'  => 2000,
+                    'purpose'        => '',
+                ],
             ],
         ];
         $this->validation->run($data);
 
         $this->assertSame([
-            'beneficiaries_accounts.account_2.credit_amount' => 'The CREDIT AMOUNT field is required.',
-            'beneficiaries_accounts.account_2.purpose'       => 'The PURPOSE field must be at least 3 characters in length.',
+            'beneficiaries_accounts.account_3.account_number' => 'The BENEFICIARY ACCOUNT NUMBER field must be exactly 5 characters in length.',
+            'beneficiaries_accounts.account_2.credit_amount'  => 'The CREDIT AMOUNT field is required.',
+            'beneficiaries_accounts.account_2.purpose'        => 'The PURPOSE field must be at least 3 characters in length.',
+            'beneficiaries_accounts.account_3.purpose'        => 'The PURPOSE field is required when BENEFICIARY ACCOUNT NUMBER is not present.',
         ], $this->validation->getErrors());
     }
 

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -14,6 +14,7 @@ BREAKING
 
 - The default values of the parameters in :php:func:`set_cookie()` and :php:meth:`CodeIgniter\\HTTP\\Response::setCookie()` has been fixed. Now the default values of ``$secure`` and ``$httponly`` are ``null``, and these values will be replaced with the ``Config\Cookie`` values.
 -  ``Time::__toString()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale.
+- The Rule of :php:func:`Validation\\Rule::required_without()` parameters are changed and this rule logic is fixed. 
 
 Enhancements
 ************

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -14,7 +14,7 @@ BREAKING
 
 - The default values of the parameters in :php:func:`set_cookie()` and :php:meth:`CodeIgniter\\HTTP\\Response::setCookie()` has been fixed. Now the default values of ``$secure`` and ``$httponly`` are ``null``, and these values will be replaced with the ``Config\Cookie`` values.
 -  ``Time::__toString()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale.
-- The Rule of :php:func:`Validation\\Rule::required_without()` parameters are changed and this rule logic is fixed.
+- The Validation rule ``Validation\Rule::required_without()`` and ``Validation\StrictRules\Rule::required_without()`` parameters have been changed and the logic of these rule has also been fixed.
 
 Enhancements
 ************

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -14,7 +14,7 @@ BREAKING
 
 - The default values of the parameters in :php:func:`set_cookie()` and :php:meth:`CodeIgniter\\HTTP\\Response::setCookie()` has been fixed. Now the default values of ``$secure`` and ``$httponly`` are ``null``, and these values will be replaced with the ``Config\Cookie`` values.
 -  ``Time::__toString()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale.
-- The Rule of :php:func:`Validation\\Rule::required_without()` parameters are changed and this rule logic is fixed. 
+- The Rule of :php:func:`Validation\\Rule::required_without()` parameters are changed and this rule logic is fixed.
 
 Enhancements
 ************

--- a/user_guide_src/source/installation/upgrade_427.rst
+++ b/user_guide_src/source/installation/upgrade_427.rst
@@ -53,6 +53,7 @@ Others
 ======
 
 -  ``Time::__toString()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale. Most locales are not affected by this change. But in a few locales like `ar`, `fa`, ``Time::__toString()`` (or ``(string) $time`` or implicit casting to a string) no longer returns a localized datetime string. if you want to get a localized datetime string, use :ref:`Time::toDateTimeString() <time-todatetimestring>` instead.
+- The rule of ``required_without`` logic is changed to validate each array separately, and the name of parameters are also changed.
 
 Project Files
 *************

--- a/user_guide_src/source/installation/upgrade_427.rst
+++ b/user_guide_src/source/installation/upgrade_427.rst
@@ -53,7 +53,7 @@ Others
 ======
 
 -  ``Time::__toString()`` is now locale-independent. It returns database-compatible strings like '2022-09-07 12:00:00' in any locale. Most locales are not affected by this change. But in a few locales like `ar`, `fa`, ``Time::__toString()`` (or ``(string) $time`` or implicit casting to a string) no longer returns a localized datetime string. if you want to get a localized datetime string, use :ref:`Time::toDateTimeString() <time-todatetimestring>` instead.
-- The rule of ``required_without`` logic is changed to validate each array separately, and the name of parameters are also changed.
+- The logic of Validation rule ``required_without`` has been changed to validate each array item separately when validating fields with asterisk (``*``), and the method signature of the rule method has also been changed. Extending classes should likewise update the parameters so as not to break LSP.
 
 Project Files
 *************


### PR DESCRIPTION
**Description**
Fixed the logic to support #5922 and #5942.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
