### PR TITLE
docs: add about named arguments in Backward Compatibility Notes

### DIFF
--- a/user_guide_src/source/installation/backward_compatibility_notes.rst
+++ b/user_guide_src/source/installation/backward_compatibility_notes.rst
@@ -14,3 +14,4 @@ What are not Breaking Changes
 *****************************
 
 - System messages defined in **system/Language/en/** are strictly for internal framework use and are not covered by backwards compatibility (BC) promise. If developers are relying on language string output they should be checking it against the function call (``lang('...')``), not the content.
+- `Named arguments <https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments>`_ are not covered by backwards compatibility (BC) promise. We may choose to rename method/function parameter names when necessary in order to improve the  codebase.


### PR DESCRIPTION
**Description**
[Named arguments](https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments) are not covered by backwards compatibility (BC) promise.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
