### PR TITLE
docs: change note type for deprecation to `important`

### DIFF
--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -34,7 +34,7 @@ where ``<generator_command>`` will be replaced with the command to check.
     namespace defined in your ``$psr4`` array in ``Config\Autoload`` or defined in your composer autoload
     file. Otherwise, code generation will be interrupted.
 
-.. warning:: Use of ``migrate:create`` to create migration files is now deprecated. It will be removed in
+.. important:: Use of ``migrate:create`` to create migration files is now deprecated. It will be removed in
     future releases. Please use ``make:migration`` as replacement. Also, please use ``make:migration --session``
     to use instead of the deprecated ``session:migration``.
 

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -51,7 +51,7 @@ but you might find they aid readability:
 
 .. literalinclude:: events/004.php
 
-.. note:: The constants ``EVENT_PRIORITY_LOW``, ``EVENT_PRIORITY_NORMAL`` and ``EVENT_PRIORITY_HIGH`` are deprecated, and the definitions are moved to ``app/Config/Constants.php``.
+.. important:: The constants ``EVENT_PRIORITY_LOW``, ``EVENT_PRIORITY_NORMAL`` and ``EVENT_PRIORITY_HIGH`` are deprecated, and the definitions are moved to ``app/Config/Constants.php``. These will be removed in future releases.
 
 Once sorted, all subscribers are executed in order. If any subscriber returns a boolean false value, then execution of
 the subscribers will stop.

--- a/user_guide_src/source/incoming/request.rst
+++ b/user_guide_src/source/incoming/request.rst
@@ -34,7 +34,7 @@ Class Reference
 
     .. php:method:: isValidIP($ip[, $which = ''])
 
-        .. important:: This method is deprecated.
+        .. important:: This method is deprecated. It will be removed in future releases.
 
         :param    string $ip: IP address
         :param    string $which: IP protocol ('ipv4' or 'ipv6')
@@ -53,7 +53,7 @@ Class Reference
 
     .. php:method:: getMethod([$upper = false])
 
-        .. important:: Use of the ``$upper`` parameter is deprecated.
+        .. important:: Use of the ``$upper`` parameter is deprecated. It will be removed in future releases.
 
         :param bool $upper: Whether to return the request method name in upper or lower case
         :returns: HTTP request method

--- a/user_guide_src/source/libraries/cookies.rst
+++ b/user_guide_src/source/libraries/cookies.rst
@@ -326,7 +326,7 @@ Class Reference
 
     .. php:method:: withNeverExpiring()
 
-        .. important:: This method is deprecated.
+        .. important:: This method is deprecated. It will be removed in future releases.
 
         :param string $name:
         :rtype: ``Cookie``


### PR DESCRIPTION
**Description**
To be consistent.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

