### PR TITLE
Allow HTTP/3 to work and not be blocked.

### DIFF
--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -34,6 +34,7 @@ class Message implements MessageInterface
         '1.0',
         '1.1',
         '2.0',
+        '3.0',
     ];
 
     /**

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -287,6 +287,22 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertSame('2.0', $response->getProtocolVersion());
     }
 
+    public function testSupportsHttp3()
+    {
+        $_SERVER['argv'] = ['index.php', '/'];
+        $_SERVER['argc'] = 2;
+
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/3.0';
+
+        ob_start();
+        $this->codeigniter->run();
+        ob_get_clean();
+
+        $response = $this->getPrivateProperty($this->codeigniter, 'response');
+
+        $this->assertSame('3.0', $response->getProtocolVersion());
+    }
+
     public function testIgnoringErrorSuppressedByAt()
     {
         $_SERVER['argv'] = ['index.php', '/'];

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -102,6 +102,7 @@ Commands
 - Now ``spark routes`` command shows route names. See :ref:`URI Routing <routing-spark-routes>`.
 - Help information for a spark command can now be accessed using the ``--help`` option (e.g. ``php spark serve --help``)
 - Added methods ``CLI::promptByMultipleKeys()`` to support multiple value in input, unlike ``promptByKey()``. See :ref:`prompt-by-multiple-keys` for details.
+- HTTP/3 is now considered a valid protocol.
 
 Testing
 =======


### PR DESCRIPTION
Currently, CodeIgniter blocks HTTP/3 and doesn't consider it a valid version. Chrome, Edge, Firefox, and Safari all support this, though Safari has support turned off by default. 

While this doesn't add any specific feature support, it does it from being ignored as a valid protocol.