### PR TITLE
Allow Cells to be auto-located within */Cells directories

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -641,6 +641,11 @@ parameters:
 			path: system/View/Cell.php
 
 		-
+			message: "#^Call to an undefined static method CodeIgniter\\\\Config\\\\Factories\\:\\:cells\\(\\)\\.$#"
+			count: 1
+			path: system/View/Cell.php
+
+		-
 			message: "#^Property Config\\\\View\\:\\:\\$plugins \\(array\\) on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: system/View/Parser.php

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -198,7 +198,16 @@ class Cell
         }
 
         if (! class_exists($class, true)) {
-            throw ViewException::forInvalidCellClass($class);
+            // If we don't know the fully qualified name,
+            // use the locator service to find it in Cells/* folders.
+            $locator   = Services::locator();
+            $classPath = $locator->search('Cells/' . $class);
+
+            if (empty($classPath)) {
+                throw ViewException::forInvalidCellClass($class);
+            }
+
+            $class = $locator->getClassname($classPath[0]);
         }
 
         if (empty($method)) {

--- a/tests/_support/Cells/StarterCell.php
+++ b/tests/_support/Cells/StarterCell.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Cells;
+
+/**
+ * Class StarterCell
+ *
+ * This class is only used to provide a reference point
+ * during tests to make sure that things work as expected.
+ */
+class StarterCell
+{
+    public function hello($params)
+    {
+        $name = $params['name'] ?? 'World';
+
+        return "Hello {$name}!";
+    }
+}

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -251,4 +251,10 @@ final class CellTest extends CIUnitTestCase
     {
         $this->assertSame(Response::class, $this->cell->render('\Tests\Support\View\SampleClassWithInitController::index'));
     }
+
+    public function testLocateCellSuccess()
+    {
+        $this->assertSame('Hello World!', $this->cell->render('StarterCell::hello'));
+        $this->assertSame('Hello CodeIgniter!', $this->cell->render('StarterCell::hello', ['name' => 'CodeIgniter']));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -154,6 +154,7 @@ Others
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
 - Now you can specify Composer packages to auto-discover manually. See :ref:`Code Modules <modules-specify-composer-packages>`.
 - Added new ``$routes->view()`` method to return a the view directly. See :ref:`View Routes <view-routes>`.
+- View Cells are now first-class citizens and can located in the ``app/Cells`` directory. See :ref:`View Cells <view-cells>`.
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -154,7 +154,7 @@ Others
 - Added ``$routes->useSupportedLocalesOnly(true)`` so that the Router returns 404 Not Found if the locale in the URL is not supported in ``Config\App::$supportedLocales``. See :ref:`Localization <localization-in-routes>`
 - Now you can specify Composer packages to auto-discover manually. See :ref:`Code Modules <modules-specify-composer-packages>`.
 - Added new ``$routes->view()`` method to return a the view directly. See :ref:`View Routes <view-routes>`.
-- View Cells are now first-class citizens and can located in the ``app/Cells`` directory. See :ref:`View Cells <view-cells>`.
+- View Cells are now first-class citizens and can located in the **app/Cells** directory. See :ref:`View Cells <view-cells-app-cells>`.
 
 Changes
 *******

--- a/user_guide_src/source/outgoing/view_cells.rst
+++ b/user_guide_src/source/outgoing/view_cells.rst
@@ -2,22 +2,19 @@
 View Cells
 ##########
 
-View Cells allow you to insert HTML that is generated outside of your controller. It simply calls the specified
-class and method, which must return a string of valid HTML. This method could be in any callable method, found in any class
-that the autoloader can locate. The only restriction is that the class can not have any constructor parameters.
-This is intended to be used within views, and is a great aid to modularizing your code.
+View Cells allow you to insert HTML that is generated outside of your controller. It simply calls the specified class and method, which must return a string of valid HTML. This method could be in any callable method, found in any class that the autoloader can locate. The only restriction is that the class can not have any constructor parameters. This is intended to be used within views, and is a great aid to modularizing your code.
 ::
 
     <?= view_cell('\App\Libraries\Blog::recentPosts') ?>
 
-In this example, the class ``App\Libraries\Blog`` is loaded, and the method ``recentPosts()`` is run. The method
-must return the generated HTML as a string. The method can be either a static method or not. Either way works.
+In this example, the class ``App\Libraries\Blog`` is loaded, and the method ``recentPosts()`` is run. The method must return the generated HTML as a string. The method can be either a static method or not. Either way works.
 
-If the Cell is a class, you can locate it in the ``app/Cells`` directory and it can be discovered automatically,
-allowing the use of just the class name and method.
+If the Cell is a class, you can locate it in the ``app/Cells`` directory and it can be discovered automatically, allowing the use of just the class name and method.
 
 ::
         <?= view_cell('Blog::recentPosts') ?>
+
+This respects the ``Config\Factories->preferApp`` setting, so if you have a class in both ``app/Cells`` and ``MyNamespace/Cells``, the one in ``app/Cells`` will be used when ``preferApp`` is ``true``.
 
 Cell Parameters
 ---------------

--- a/user_guide_src/source/outgoing/view_cells.rst
+++ b/user_guide_src/source/outgoing/view_cells.rst
@@ -9,12 +9,15 @@ View Cells allow you to insert HTML that is generated outside of your controller
 
 In this example, the class ``App\Libraries\Blog`` is loaded, and the method ``recentPosts()`` is run. The method must return the generated HTML as a string. The method can be either a static method or not. Either way works.
 
-If the Cell is a class, you can locate it in the ``app/Cells`` directory and it can be discovered automatically, allowing the use of just the class name and method.
+.. _view-cells-app-cells:
 
-::
+app/Cells
+---------
+
+Since v4.3.0, if the Cell is a class, you can locate it in the **app/Cells** directory and it can be discovered automatically, allowing the use of just the class name and method::
         <?= view_cell('Blog::recentPosts') ?>
 
-This respects the ``Config\Factories->preferApp`` setting, so if you have a class in both ``app/Cells`` and ``MyNamespace/Cells``, the one in ``app/Cells`` will be used when ``preferApp`` is ``true``.
+This respects the :ref:`Factories preferApp option <factories-options>`, so if you have a class in both **app/Cells** and **MyNamespace/Cells**, the one in **app/Cells** will be used when ``preferApp`` is ``true``.
 
 Cell Parameters
 ---------------

--- a/user_guide_src/source/outgoing/view_cells.rst
+++ b/user_guide_src/source/outgoing/view_cells.rst
@@ -13,6 +13,12 @@ This is intended to be used within views, and is a great aid to modularizing you
 In this example, the class ``App\Libraries\Blog`` is loaded, and the method ``recentPosts()`` is run. The method
 must return the generated HTML as a string. The method can be either a static method or not. Either way works.
 
+If the Cell is a class, you can locate it in the ``app/Cells`` directory and it can be discovered automatically,
+allowing the use of just the class name and method.
+
+::
+        <?= view_cell('Blog::recentPosts') ?>
+
 Cell Parameters
 ---------------
 


### PR DESCRIPTION
Currently, when calling a View Cell you must enter the fully qualified class name. This change uses the ~~`FileLocator`~~ `Factories` class to search for the class within `*/Cells` directories, allowing a simpler naming in views and a more standardized location for them. 

So now we could do: 

```php
<?= view_cell('Blog::recent', 'limit=5') ?>
```

instead of 

```php
<?= view_cell('App\Modules\Blog\Cells\Blog::recent', 'limit=5') ?>
```

and it could be found in `app/Cells`, `App/Modules/Blog/Cells`, or any other namespace's `Cells` folder.