### PR TITLE
fix: safe_mailto() does not work with CSP

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -369,7 +369,9 @@ if (! function_exists('safe_mailto')) {
         $x = array_reverse($x);
 
         // improve obfuscation by eliminating newlines & whitespace
-        $output = '<script type="text/javascript">'
+        $cspNonce = csp_script_nonce();
+        $cspNonce = $cspNonce ? ' ' . $cspNonce : $cspNonce;
+        $output   = '<script type="text/javascript"' . $cspNonce . '>'
                 . 'var l=new Array();';
 
         foreach ($x as $i => $value) {

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -468,7 +468,7 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testSafeMailto($expected = '', $email = '', $title = '', $attributes = '')
     {
-        $request      = Services::request($this->config);
+        $request      = Services::incomingrequest($this->config);
         $request->uri = new URI('http://example.com/');
 
         Services::injectMock('request', $request);

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -476,6 +476,16 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($expected, safe_mailto($email, $title, $attributes));
     }
 
+    public function testSafeMailtoWithCsp()
+    {
+        $this->config->CSPEnabled = true;
+        Factories::injectMock('config', 'App', $this->config);
+
+        $html = safe_mailto('foo@example.jp', 'Foo');
+
+        $this->assertMatchesRegularExpression('/<script .*?nonce="\w+?".*?>/u', $html);
+    }
+
     // Test auto_link
 
     public function autolinkUrls()


### PR DESCRIPTION
**Description**
Fixes  #6602

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
