### PR TITLE
docs: add `.. versionadded:: 4.3.0`, etc.

### DIFF
--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -45,7 +45,7 @@ Others
 - ``RouteCollection::resetRoutes()`` resets Auto-Discovery of Routes. Previously once discovered, RouteCollection never discover Routes files again even if ``RouteCollection::resetRoutes()`` is called.
 - ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there
   is a ``CITestStreamFilter::registration()`` method for this. See :ref:`upgrade-430-stream-filter` for details.
-- The data structure returned by ``BaseConnection::getForeignKeyData()`` has been changed.
+- The data structure returned by :ref:`BaseConnection::getForeignKeyData() <metadata-getforeignkeydata>` has been changed.
 
 .. _v430-interface-changes:
 
@@ -124,8 +124,8 @@ Database
 - ``BaseConnection::escape()`` now excludes the ``RawSql`` data type. This allows passing SQL strings into data.
 - The new method ``Forge::dropPrimaryKey()`` allows dropping the primary key on a table. See :ref:`dropping-a-primary-key`.
 - Improved the SQL structure for ``Builder::updateBatch()``. See :ref:`update-batch` for the details.
-- Improved data returned by ``BaseConnection::getForeignKeyData()``. All DBMS returns the same structure.
-- ``Forge::addForeignKey()`` now includes a name parameter to manual set foreign key names. Not supported in SQLite3.
+- Improved data returned by :ref:`BaseConnection::getForeignKeyData() <metadata-getforeignkeydata>`. All DBMS returns the same structure.
+- :php:meth:`CodeIgniter\\Database\\Forge::addForeignKey()` now includes a name parameter to manual set foreign key names. Not supported in SQLite3.
 - Added ``when()`` and ``whenNot()`` methods to conditionally add clauses to the query. See :ref:`BaseBuilder::when() <db-builder-when>` for details.
 
 Model

--- a/user_guide_src/source/cli/cli_library.rst
+++ b/user_guide_src/source/cli/cli_library.rst
@@ -77,6 +77,8 @@ Finally, you can pass :ref:`validation <validation>` rules to the answer input a
 promptByMultipleKeys()
 ======================
 
+.. versionadded:: 4.3.0
+
 This method is the same as ``promptByKey()``, but it supports multiple value.
 
 .. literalinclude:: cli_library/023.php

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -336,6 +336,8 @@ Class Reference
         :returns:    \CodeIgniter\Database\Forge instance (method chaining)
         :rtype:    \CodeIgniter\Database\Forge
 
+        .. note:: ``$fkName`` can be used since v4.3.0.
+
         Adds a foreign key to the set that will be used to create a table. Usage:  See `Adding Foreign Keys`_.
 
     .. php:method:: addKey($key[, $primary = false[, $unique = false]])

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -183,7 +183,7 @@ You can specify the desired action for the "on delete" and "on update" propertie
 
 .. literalinclude:: forge/013.php
 
-.. note:: SQLite does not support the naming of foreign keys. CodeIgniter will refer to them by ``prefix_table_column_foreign``.
+.. note:: SQLite3 does not support the naming of foreign keys. CodeIgniter will refer to them by ``prefix_table_column_foreign``.
 
 Creating a Table
 ================
@@ -332,7 +332,7 @@ Class Reference
         :param    string|string[]    $tableField: Name of a parent table field or an array of fields
         :param    string    $onUpdate: Desired action for the "on update"
         :param    string    $onDelete: Desired action for the "on delete"
-        :param    string    $fkName: Name of foreign key. This does not work with SQLite
+        :param    string    $fkName: Name of foreign key. This does not work with SQLite3
         :returns:    \CodeIgniter\Database\Forge instance (method chaining)
         :rtype:    \CodeIgniter\Database\Forge
 

--- a/user_guide_src/source/helpers/form_helper.rst
+++ b/user_guide_src/source/helpers/form_helper.rst
@@ -515,7 +515,7 @@ The following functions are available:
     :returns:   The validation errors
     :rtype:    array
 
-    This function was introduced in v4.3.0.
+    .. versionadded:: 4.3.0
 
     Returns the validation errors. First, this function checks the validation errors
     that are stored in the session. To store the errors in the session, you need to use ``withInput()`` with :php:func:`redirect() <redirect>`.
@@ -533,7 +533,7 @@ The following functions are available:
     :returns:    Rendered HTML of the validation errors
     :rtype:    string
 
-    This function was introduced in v4.3.0.
+    .. versionadded:: 4.3.0
 
     Returns the rendered HTML of the validation errors.
 
@@ -553,7 +553,7 @@ The following functions are available:
     :returns:    Rendered HTML of the validation error
     :rtype:    string
 
-    This function was introduced in v4.3.0.
+    .. versionadded:: 4.3.0
 
     Returns a single error for the specified field in formatted HTML.
 

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -159,6 +159,8 @@ CodeIgniter has the following :doc:`command </cli/spark_commands>` to check the 
 filter:check
 ============
 
+.. versionadded:: 4.3.0
+
 Check the filters for the route ``/`` with **GET** method::
 
     > php spark filter:check get /

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -215,6 +215,8 @@ a simple view:
 Views
 =====
 
+.. versionadded:: 4.3.0
+
 If you just want to render a view out that has no logic associated with it, you can use the ``view()`` method.
 This is always treated as GET request.
 This method accepts the name of the view to load as the second parameter.
@@ -781,7 +783,7 @@ The *Method* column shows the HTTP method that the route is listening for.
 
 The *Route* column shows the route (URI path) to match. The route of a defined route is expressed as a regular expression.
 
-The *Name* column shows the route name. ``»`` indicates the name is the same as the route.
+Since v4.3.0, the *Name* column shows the route name. ``»`` indicates the name is the same as the route.
 
 .. important:: The system is not perfect. If you use Custom Placeholders, *Filters* might not be correct. If you want to check filters for a route, you can use :ref:`spark filter:check <spark-filter-check>` command.
 

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -273,6 +273,8 @@ Modifying Files
 replace(string $file, array $replaces): bool
 --------------------------------------------
 
+.. versionadded:: 4.3.0
+
 Replaces the ``$file`` contents. The second parameter ``$replaces`` array specifies the search strings as keys and the replacements as values.
 
 .. literalinclude:: publisher/013.php
@@ -280,12 +282,16 @@ Replaces the ``$file`` contents. The second parameter ``$replaces`` array specif
 addLineAfter(string $file, string $line, string $after): bool
 -------------------------------------------------------------
 
+.. versionadded:: 4.3.0
+
 Adds ``$line`` after a line with specific string ``$after``.
 
 .. literalinclude:: publisher/014.php
 
 addLineBefore(string $file, string $line, string $after): bool
 --------------------------------------------------------------
+
+.. versionadded:: 4.3.0
 
 Adds ``$line`` before a line with specific string ``$after``.
 

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -199,6 +199,8 @@ either the entity or the database. Properties can be cast to any of the followin
 **integer**, **float**, **double**, **string**, **boolean**, **object**, **array**, **datetime**, **timestamp**, **uri** and **int-bool**.
 Add a question mark at the beginning of type to mark property as nullable, i.e., **?string**, **?integer**.
 
+.. note:: **int-bool** can be used since v4.3.0.
+
 For example, if you had a User entity with an ``is_banned`` property, you can cast it as a boolean:
 
 .. literalinclude:: entities/012.php

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -317,7 +317,9 @@ You can retrieve the last inserted row's primary key using the ``getInsertID()``
 allowEmptyInserts()
 -------------------
 
-Since v4.3.0, you can use ``allowEmptyInserts()`` method to insert empty data. The Model throws an exception when you try to insert empty data by default. But if you call this method, the check will no longer be performed.
+.. versionadded:: 4.3.0
+
+You can use ``allowEmptyInserts()`` method to insert empty data. The Model throws an exception when you try to insert empty data by default. But if you call this method, the check will no longer be performed.
 
 .. literalinclude:: model/056.php
 
@@ -616,6 +618,9 @@ These methods can be used to normalize data, hash passwords, save related entiti
 points in the model's execution can be affected, each through a class property: ``$beforeInsert``, ``$afterInsert``,
 ``$beforeInsertBatch``, ``$afterInsertBatch``, ``$beforeUpdate``, ``$afterUpdate``, ``$beforeUpdateBatch``,
 ``$afterUpdateBatch``, ``$afterFind``, and ``$afterDelete``.
+
+.. note:: ``$beforeInsertBatch``, ``$afterInsertBatch``, ``$beforeUpdateBatch`` and
+    ``$afterUpdateBatch`` can be used since v4.3.0.
 
 Defining Callbacks
 ==================

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -257,6 +257,11 @@ component name:
 Testing CLI Output
 ==================
 
+StreamFilterTrait
+-----------------
+
+.. versionadded:: 4.3.0
+
 **StreamFilterTrait** provides an alternate to these helper methods.
 
 You may need to test things that are difficult to test. Sometimes, capturing a stream, like PHP's own STDOUT, or STDERR,
@@ -277,6 +282,9 @@ See :ref:`Testing Traits <testing-overview-traits>`.
 If you override the ``setUp()`` or ``tearDown()`` methods in your test, then you must call the ``parent::setUp()`` and
 ``parent::tearDown()`` methods respectively to configure the ``StreamFilterTrait``.
 
+CITestStreamFilter
+------------------
+
 **CITestStreamFilter** for manual/single use.
 
 If you need to capture streams in only one test, then instead of using the StreamFilterTrait trait, you can manually
@@ -296,6 +304,11 @@ add a filter to streams.
 
 Testing CLI Input
 =================
+
+PhpStreamWrapper
+----------------
+
+.. versionadded:: 4.3.0
 
 **PhpStreamWrapper** provides a way to write tests for methods that require user input,
 such as ``CLI::prompt()``, ``CLI::wait()``, and ``CLI::input()``.


### PR DESCRIPTION
**Description**
So that users of older versions will not be confused when they see the latest docs.

- add that new feature can be used from v4.3.0
- add links to detail pages
- small fixes

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

