### PR TITLE
fix: script_tag() does not work with CSP

### DIFF
--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -194,7 +194,9 @@ if (! function_exists('script_tag')) {
      */
     function script_tag($src = '', bool $indexPage = false): string
     {
-        $script = '<script ';
+        $cspNonce = csp_script_nonce();
+        $cspNonce = $cspNonce ? ' ' . $cspNonce : $cspNonce;
+        $script   = '<script' . $cspNonce . ' ';
         if (! is_array($src)) {
             $src = ['src' => $src];
         }

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -11,8 +11,10 @@
 
 namespace CodeIgniter\Helpers;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
 
 /**
  * @internal
@@ -267,6 +269,28 @@ final class HTMLHelperTest extends CIUnitTestCase
         $target   = ['src' => 'js/mystyles.js', 'charset' => 'UTF-8', 'defer' => '', 'async' => null];
         $expected = '<script src="http://example.com/js/mystyles.js" charset="UTF-8" defer="" async type="text/javascript"></script>';
         $this->assertSame($expected, script_tag($target));
+    }
+
+    public function testScriptTagWithCsp()
+    {
+        // Reset CSP object
+        $this->resetServices();
+
+        $config             = new App();
+        $config->CSPEnabled = true;
+        Factories::injectMock('config', 'App', $config);
+
+        $target = 'http://site.com/js/mystyles.js';
+        $html   = script_tag($target);
+
+        $this->assertMatchesRegularExpression(
+            '!<script nonce="\w+?" src="http://site.com/js/mystyles.js".*?>!u',
+            $html
+        );
+
+        // Reset CSP object
+        $this->resetFactories();
+        $this->resetServices();
     }
 
     /**


### PR DESCRIPTION
**Description**
Related #6604
- add nonce when CSP is enabled

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

