### PR TITLE
test: fix failed MigrationRunnerTest

### DIFF
--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -79,8 +79,13 @@ final class MigrationRunnerTest extends CIUnitTestCase
         $db = $this->getPrivateProperty($runner, 'db');
 
         $this->assertInstanceOf(BaseConnection::class, $db);
+        $database = (
+            $dbConfig->tests['DBDriver'] === 'SQLite3'
+            && $dbConfig->tests['database'] !== ':memory:'
+            ? WRITEPATH : ''
+        ) . $dbConfig->tests['database'];
         $this->assertSame(
-            ($dbConfig->tests['DBDriver'] === 'SQLite3' ? WRITEPATH : '') . $dbConfig->tests['database'],
+            $database,
             $this->getPrivateProperty($db, 'database')
         );
         $this->assertSame($dbConfig->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));


### PR DESCRIPTION
**Description**
I don't know why GA check does not fail, but on my local environment the following test always fails.

```console
There was 1 failure:

1) CodeIgniter\Database\Migrations\MigrationRunnerTest::testLoadsDefaultDatabaseWhenNoneSpecified Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'.../CodeIgniter4/writable/:memory:'
+':memory:'

.../CodeIgniter4/tests/system/Database/Migrations/MigrationRunnerTest.php:84
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

