### PR TITLE
docs: add Warning to `$routes->map()`

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -327,6 +327,9 @@ You can use the ``add()`` method:
 Mapping Multiple Routes
 =======================
 
+.. warning:: The ``map()`` method is not recommended as well as ``add()``
+    because it calls ``add()`` internally.
+
 While the ``add()`` method is simple to use, it is often handier to work with multiple routes at once, using
 the ``map()`` method. Instead of calling the ``add()`` method for each route that you need to add, you can
 define an array of routes and then pass it as the first parameter to the ``map()`` method:

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -210,15 +210,6 @@ a simple view:
 
 .. literalinclude:: routing/020.php
 
-Mapping Multiple Routes
-=======================
-
-While the ``add()`` method is simple to use, it is often handier to work with multiple routes at once, using
-the ``map()`` method. Instead of calling the ``add()`` method for each route that you need to add, you can
-define an array of routes and then pass it as the first parameter to the ``map()`` method:
-
-.. literalinclude:: routing/021.php
-
 .. _redirecting-routes:
 
 Redirecting Routes
@@ -332,6 +323,15 @@ You can use the ``add()`` method:
 .. note:: Using the HTTP-verb-based routes will also provide a slight performance increase, since
     only routes that match the current request method are stored, resulting in fewer routes to scan through
     when trying to find a match.
+
+Mapping Multiple Routes
+=======================
+
+While the ``add()`` method is simple to use, it is often handier to work with multiple routes at once, using
+the ``map()`` method. Instead of calling the ``add()`` method for each route that you need to add, you can
+define an array of routes and then pass it as the first parameter to the ``map()`` method:
+
+.. literalinclude:: routing/021.php
 
 .. _command-line-only-routes:
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -310,15 +310,15 @@ This has the added benefit of making the views more readable, too.
 Routes with any HTTP verbs
 ==========================
 
-It is possible to define a route with any HTTP verbs.
-You can use the ``add()`` method:
-
-.. literalinclude:: routing/031.php
-
 .. warning:: While the ``add()`` method seems to be convenient, it is recommended to always use the HTTP-verb-based
     routes, described above, as it is more secure. If you use the :doc:`CSRF protection </libraries/security>`, it does not protect **GET**
     requests. If the URI specified in the ``add()`` method is accessible by the GET method, the CSRF protection
     will not work.
+
+It is possible to define a route with any HTTP verbs.
+You can use the ``add()`` method:
+
+.. literalinclude:: routing/031.php
 
 .. note:: Using the HTTP-verb-based routes will also provide a slight performance increase, since
     only routes that match the current request method are stored, resulting in fewer routes to scan through


### PR DESCRIPTION
**Description**
- The `map()` method is not recommended as well as `add()` because it calls `add()` internally.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

