### PR TITLE
fix: default values for Session Redis Handler

### DIFF
--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -58,6 +58,8 @@ class RedisHandler extends BaseHandler
     protected $sessionExpiration = 7200;
 
     /**
+     * @param string $ipAddress User's IP address
+     *
      * @throws SessionException
      */
     public function __construct(AppConfig $config, string $ipAddress)

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -85,7 +85,7 @@ class RedisHandler extends BaseHandler
                 'port'     => empty($matches[2]) ? self::REDIS_DEFAULT_PORT : $matches[2],
                 'password' => preg_match('#auth=([^\s&]+)#', $matches[3], $match) ? $match[1] : null,
                 'database' => preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : 0,
-                'timeout'  => preg_match('#timeout=(\d+\.\d+)#', $matches[3], $match) ? (float) $match[1] : 0,
+                'timeout'  => preg_match('#timeout=(\d+\.\d+|\d+)#', $matches[3], $match) ? (float) $match[1] : 0,
             ];
 
             preg_match('#prefix=([^\s&]+)#', $matches[3], $match) && $this->keyPrefix = $match[1];

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -266,14 +266,15 @@ class RedisHandler extends BaseHandler
      */
     protected function lockSession(string $sessionID): bool
     {
+        $lockKey = $this->keyPrefix . $sessionID . ':lock';
+
         // PHP 7 reuses the SessionHandler object on regeneration,
         // so we need to check here if the lock key is for the
         // correct session ID.
-        if ($this->lockKey === $this->keyPrefix . $sessionID . ':lock') {
+        if ($this->lockKey === $lockKey) {
             return $this->redis->expire($this->lockKey, 300);
         }
 
-        $lockKey = $this->keyPrefix . $sessionID . ':lock';
         $attempt = 0;
 
         do {

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -23,6 +23,11 @@ use ReturnTypeWillChange;
 class RedisHandler extends BaseHandler
 {
     /**
+     * @var int
+     */
+    private const REDIS_DEFAULT_PORT = 6379;
+
+    /**
      * phpRedis instance
      *
      * @var Redis|null
@@ -77,7 +82,7 @@ class RedisHandler extends BaseHandler
 
             $this->savePath = [
                 'host'     => $matches[1],
-                'port'     => empty($matches[2]) ? 6379 : $matches[2],
+                'port'     => empty($matches[2]) ? self::REDIS_DEFAULT_PORT : $matches[2],
                 'password' => preg_match('#auth=([^\s&]+)#', $matches[3], $match) ? $match[1] : null,
                 'database' => preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : 0,
                 'timeout'  => preg_match('#timeout=(\d+\.\d+)#', $matches[3], $match) ? (float) $match[1] : 0,

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -71,6 +71,19 @@ class RedisHandler extends BaseHandler
     {
         parent::__construct($config, $ipAddress);
 
+        $this->setSavePath();
+
+        if ($this->matchIP === true) {
+            $this->keyPrefix .= $this->ipAddress . ':';
+        }
+
+        $this->sessionExpiration = empty($config->sessionExpiration)
+            ? (int) ini_get('session.gc_maxlifetime')
+            : (int) $config->sessionExpiration;
+    }
+
+    protected function setSavePath(): void
+    {
         if (empty($this->savePath)) {
             throw SessionException::forEmptySavepath();
         }
@@ -92,14 +105,6 @@ class RedisHandler extends BaseHandler
         } else {
             throw SessionException::forInvalidSavePathFormat($this->savePath);
         }
-
-        if ($this->matchIP === true) {
-            $this->keyPrefix .= $this->ipAddress . ':';
-        }
-
-        $this->sessionExpiration = empty($config->sessionExpiration)
-            ? (int) ini_get('session.gc_maxlifetime')
-            : (int) $config->sessionExpiration;
     }
 
     /**

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -22,9 +22,6 @@ use ReturnTypeWillChange;
  */
 class RedisHandler extends BaseHandler
 {
-    /**
-     * @var int
-     */
     private const REDIS_DEFAULT_PORT = 6379;
 
     /**

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -75,10 +75,10 @@ class RedisHandler extends BaseHandler
 
             $this->savePath = [
                 'host'     => $matches[1],
-                'port'     => empty($matches[2]) ? null : $matches[2],
+                'port'     => empty($matches[2]) ? 6379 : $matches[2],
                 'password' => preg_match('#auth=([^\s&]+)#', $matches[3], $match) ? $match[1] : null,
-                'database' => preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : null,
-                'timeout'  => preg_match('#timeout=(\d+\.\d+)#', $matches[3], $match) ? (float) $match[1] : null,
+                'database' => preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : 0,
+                'timeout'  => preg_match('#timeout=(\d+\.\d+)#', $matches[3], $match) ? (float) $match[1] : 0,
             ];
 
             preg_match('#prefix=([^\s&]+)#', $matches[3], $match) && $this->keyPrefix = $match[1];

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -98,7 +98,7 @@ class RedisHandler extends BaseHandler
                 'port'     => empty($matches[2]) ? self::REDIS_DEFAULT_PORT : $matches[2],
                 'password' => preg_match('#auth=([^\s&]+)#', $matches[3], $match) ? $match[1] : null,
                 'database' => preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : 0,
-                'timeout'  => preg_match('#timeout=(\d+\.\d+|\d+)#', $matches[3], $match) ? (float) $match[1] : 0,
+                'timeout'  => preg_match('#timeout=(\d+\.\d+|\d+)#', $matches[3], $match) ? (float) $match[1] : 0.0,
             ];
 
             preg_match('#prefix=([^\s&]+)#', $matches[3], $match) && $this->keyPrefix = $match[1];

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -22,7 +22,7 @@ use ReturnTypeWillChange;
  */
 class RedisHandler extends BaseHandler
 {
-    private const REDIS_DEFAULT_PORT = 6379;
+    private const DEFAULT_PORT = 6379;
 
     /**
      * phpRedis instance
@@ -92,7 +92,7 @@ class RedisHandler extends BaseHandler
 
             $this->savePath = [
                 'host'     => $matches[1],
-                'port'     => empty($matches[2]) ? self::REDIS_DEFAULT_PORT : $matches[2],
+                'port'     => empty($matches[2]) ? self::DEFAULT_PORT : $matches[2],
                 'password' => preg_match('#auth=([^\s&]+)#', $matches[3], $match) ? $match[1] : null,
                 'database' => preg_match('#database=(\d+)#', $matches[3], $match) ? (int) $match[1] : 0,
                 'timeout'  => preg_match('#timeout=(\d+\.\d+|\d+)#', $matches[3], $match) ? (float) $match[1] : 0.0,

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -63,6 +63,28 @@ final class RedisHandlerTest extends CIUnitTestCase
         return new RedisHandler($appConfig, $this->userIpAddress);
     }
 
+    public function testSavePathTimeoutFloat()
+    {
+        $handler = $this->getInstance(
+            ['sessionSavePath' => 'tcp://127.0.0.1:6379?timeout=2.5']
+        );
+
+        $savePath = $this->getPrivateProperty($handler, 'savePath');
+
+        $this->assertSame(2.5, $savePath['timeout']);
+    }
+
+    public function testSavePathTimeoutInt()
+    {
+        $handler = $this->getInstance(
+            ['sessionSavePath' => 'tcp://127.0.0.1:6379?timeout=10']
+        );
+
+        $savePath = $this->getPrivateProperty($handler, 'savePath');
+
+        $this->assertSame(10.0, $savePath['timeout']);
+    }
+
     public function testOpen()
     {
         $handler = $this->getInstance();

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Session\Handlers\Database;
+
+use CodeIgniter\Session\Handlers\RedisHandler;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App as AppConfig;
+use Redis;
+
+/**
+ * @internal
+ */
+final class RedisHandlerTest extends CIUnitTestCase
+{
+    private string $sessionName     = 'ci_session';
+    private string $sessionSavePath = 'tcp://127.0.0.1:6379';
+    private string $userIpAddress   = '127.0.0.1';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! class_exists(Redis::class)) {
+            $this->markTestSkipped(
+                'Redis Session Handler requires PHP Redis extention and Redis server'
+            );
+        }
+    }
+
+    private function getInstance($options = [])
+    {
+        $defaults = [
+            'sessionDriver'            => RedisHandler::class,
+            'sessionCookieName'        => $this->sessionName,
+            'sessionExpiration'        => 7200,
+            'sessionSavePath'          => $this->sessionSavePath,
+            'sessionMatchIP'           => false,
+            'sessionTimeToUpdate'      => 300,
+            'sessionRegenerateDestroy' => false,
+            'cookieDomain'             => '',
+            'cookiePrefix'             => '',
+            'cookiePath'               => '/',
+            'cookieSecure'             => false,
+            'cookieSameSite'           => 'Lax',
+        ];
+
+        $config    = array_merge($defaults, $options);
+        $appConfig = new AppConfig();
+
+        foreach ($config as $key => $c) {
+            $appConfig->{$key} = $c;
+        }
+
+        return new RedisHandler($appConfig, $this->userIpAddress);
+    }
+
+    public function testOpen()
+    {
+        $handler = $this->getInstance();
+        $this->assertTrue($handler->open($this->sessionSavePath, $this->sessionName));
+    }
+
+    public function testWrite()
+    {
+        $handler = $this->getInstance();
+        $handler->open($this->sessionSavePath, $this->sessionName);
+        $handler->read('555556b43phsnnf8if6bo33b635e4447');
+
+        $data = <<<'DATA'
+            __ci_last_regenerate|i:1664607454;_ci_previous_url|s:32:"http://localhost:8080/index.php/";key|s:5:"value";
+            DATA;
+        $this->assertTrue($handler->write('555556b43phsnnf8if6bo33b635e4447', $data));
+
+        $handler->close();
+    }
+
+    public function testReadSuccess()
+    {
+        $handler = $this->getInstance();
+        $handler->open($this->sessionSavePath, $this->sessionName);
+
+        $expected = <<<'DATA'
+            __ci_last_regenerate|i:1664607454;_ci_previous_url|s:32:"http://localhost:8080/index.php/";key|s:5:"value";
+            DATA;
+        $this->assertSame($expected, $handler->read('555556b43phsnnf8if6bo33b635e4447'));
+
+        $handler->close();
+    }
+
+    public function testReadFailure()
+    {
+        $handler = $this->getInstance();
+        $handler->open($this->sessionSavePath, $this->sessionName);
+
+        $this->assertSame('', $handler->read('123456b43phsnnf8if6bo33b635e4321'));
+
+        $handler->close();
+    }
+
+    public function testGC()
+    {
+        $handler = $this->getInstance();
+        $this->assertSame(1, $handler->gc(3600));
+    }
+}

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -17,6 +17,8 @@ use Config\App as AppConfig;
 use Redis;
 
 /**
+ * @requires extension redis
+ *
  * @internal
  */
 final class RedisHandlerTest extends CIUnitTestCase
@@ -24,17 +26,6 @@ final class RedisHandlerTest extends CIUnitTestCase
     private string $sessionName     = 'ci_session';
     private string $sessionSavePath = 'tcp://127.0.0.1:6379';
     private string $userIpAddress   = '127.0.0.1';
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        if (! class_exists(Redis::class)) {
-            $this->markTestSkipped(
-                'Redis Session Handler requires PHP Redis extention and Redis server'
-            );
-        }
-    }
 
     private function getInstance($options = [])
     {


### PR DESCRIPTION
**Description**
Fixes  #6512

Make the same as Cache Redis config.
https://github.com/codeigniter4/CodeIgniter4/blob/ed0cdd00eaf20f7d6efb373af991111ead4fece8/app/Config/Cache.php#L155-L161

Ref, https://github.com/phpredis/phpredis#php-session-handler

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

