### PR TITLE
docs: fix incorrect link to a method in routing.rst

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -556,7 +556,7 @@ a valid class/method pair, just like you would show in any route, or a Closure:
 
 .. note:: The ``set404Override()`` method does not change the Response status code to ``404``.
     If you don't set the status code in the controller you set, the default status code ``200``
-    will be returned. See :php:func:`Response::setStatusCode() <setStatusCode>` for
+    will be returned. See :php:meth:`CodeIgniter\\HTTP\\Response::setStatusCode()` for
     information on how to set the status code.
 
 Route Processing by Priority


### PR DESCRIPTION
**Description**
- fix RST link to a method reference

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
