### PR TITLE
Fixed a bug that URLs with trailing newlines do not become invalid in validation.

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -293,7 +293,7 @@ class FormatRules
             return false;
         }
 
-        if (preg_match('/^(?:([^:]*)\:)?\/\/(.+)$/', $str, $matches)) {
+        if (preg_match('/\A(?:([^:]*)\:)?\/\/(.+)\z/', $str, $matches)) {
             if (! in_array($matches[1], ['http', 'https'], true)) {
                 return false;
             }

--- a/tests/system/Validation/StrictRules/FormatRulesTest.php
+++ b/tests/system/Validation/StrictRules/FormatRulesTest.php
@@ -217,6 +217,11 @@ final class FormatRulesTest extends CIUnitTestCase
                 false,
                 false,
             ],
+            [
+                "http://www.codeigniter.com\n",
+                false,
+                false,
+            ],
         ];
     }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

The Is_valid_url rule is considered valid when the URL contains a newline at the end.

I think it is invalid.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
