### PR TITLE
test:  remove $request->uri

### DIFF
--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -209,8 +209,8 @@ final class ArrayHelperTest extends CIUnitTestCase
     /**
      * @dataProvider deepSearchProvider
      *
-     * @param mixed $key
-     * @param mixed $expected
+     * @param int|string        $key
+     * @param array|string|null $expected
      */
     public function testArrayDeepSearch($key, $expected)
     {
@@ -247,12 +247,8 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider sortByMultipleKeysProvider
-     *
-     * @param mixed $data
-     * @param mixed $sortColumns
-     * @param mixed $expected
      */
-    public function testArraySortByMultipleKeysWithArray($data, $sortColumns, $expected)
+    public function testArraySortByMultipleKeysWithArray(array $data, array $sortColumns, array $expected)
     {
         $success = array_sort_by_multiple_keys($data, $sortColumns);
 
@@ -262,12 +258,8 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider sortByMultipleKeysProvider
-     *
-     * @param mixed $data
-     * @param mixed $sortColumns
-     * @param mixed $expected
      */
-    public function testArraySortByMultipleKeysWithObjects($data, $sortColumns, $expected)
+    public function testArraySortByMultipleKeysWithObjects(array $data, array $sortColumns, array $expected)
     {
         // Morph to objects
         foreach ($data as $index => $dataSet) {
@@ -282,12 +274,8 @@ final class ArrayHelperTest extends CIUnitTestCase
 
     /**
      * @dataProvider sortByMultipleKeysProvider
-     *
-     * @param mixed $data
-     * @param mixed $sortColumns
-     * @param mixed $expected
      */
-    public function testArraySortByMultipleKeysFailsEmptyParameter($data, $sortColumns, $expected)
+    public function testArraySortByMultipleKeysFailsEmptyParameter(array $data, array $sortColumns, array $expected)
     {
         // Both filled
         $success = array_sort_by_multiple_keys($data, $sortColumns);

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -11,7 +11,6 @@
 
 namespace CodeIgniter\Helpers;
 
-use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
@@ -34,7 +33,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->resetServices();
     }
 
-    private function getRequest(): IncomingRequest
+    private function setRequest(): void
     {
         $uri = new URI('http://example.com/');
         Services::injectMock('uri', $uri);
@@ -43,12 +42,13 @@ final class FormHelperTest extends CIUnitTestCase
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
 
-        return Services::request($config);
+        $request = Services::request($config);
+        Services::injectMock('request', $request);
     }
 
     public function testFormOpenBasic()
     {
-        $request = $this->getRequest();
+        $request = $this->setRequest();
         Services::injectMock('request', $request);
 
         $before = (new Filters())->globals['before'];
@@ -77,8 +77,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenHasLocale()
     {
-        $request = $this->getRequest();
-        Services::injectMock('request', $request);
+        $this->setRequest();
 
         $expected = <<<'EOH'
             <form action="http://example.com/index.php/en/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
@@ -95,8 +94,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithoutAction()
     {
-        $request = $this->getRequest();
-        Services::injectMock('request', $request);
+        $this->setRequest();
 
         $before = (new Filters())->globals['before'];
         if (in_array('csrf', $before, true) || array_key_exists('csrf', $before)) {
@@ -123,8 +121,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithoutMethod()
     {
-        $request = $this->getRequest();
-        Services::injectMock('request', $request);
+        $this->setRequest();
 
         $before = (new Filters())->globals['before'];
         if (in_array('csrf', $before, true) || array_key_exists('csrf', $before)) {
@@ -151,8 +148,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithHidden()
     {
-        $request = $this->getRequest();
-        Services::injectMock('request', $request);
+        $this->setRequest();
 
         $before = (new Filters())->globals['before'];
         if (in_array('csrf', $before, true) || array_key_exists('csrf', $before)) {
@@ -186,8 +182,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenMultipart()
     {
-        $request = $this->getRequest();
-        Services::injectMock('request', $request);
+        $this->setRequest();
 
         $before = (new Filters())->globals['before'];
         if (in_array('csrf', $before, true) || array_key_exists('csrf', $before)) {

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -29,15 +29,18 @@ final class FormHelperTest extends CIUnitTestCase
         parent::setUp();
 
         helper('form');
+
+        $this->resetServices();
     }
 
     public function testFormOpenBasic()
     {
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
         $config            = new App();
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
         $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
 
@@ -67,11 +70,12 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenHasLocale()
     {
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
         $config            = new App();
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
         $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
         $expected = <<<'EOH'
@@ -89,11 +93,12 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithoutAction()
     {
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
         $config            = new App();
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
         $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
 
@@ -122,11 +127,12 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithoutMethod()
     {
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
         $config            = new App();
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
         $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
 
@@ -155,11 +161,12 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithHidden()
     {
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
         $config            = new App();
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
         $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
 
@@ -195,11 +202,12 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenMultipart()
     {
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
         $config            = new App();
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
         $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/');
 
         Services::injectMock('request', $request);
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Helpers;
 
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
@@ -33,15 +34,21 @@ final class FormHelperTest extends CIUnitTestCase
         $this->resetServices();
     }
 
-    public function testFormOpenBasic()
+    private function getRequest(): IncomingRequest
     {
         $uri = new URI('http://example.com/');
         Services::injectMock('uri', $uri);
+
         $config            = new App();
         $config->baseURL   = '';
         $config->indexPage = 'index.php';
-        $request           = Services::request($config);
 
+        return Services::request($config);
+    }
+
+    public function testFormOpenBasic()
+    {
+        $request = $this->getRequest();
         Services::injectMock('request', $request);
 
         $before = (new Filters())->globals['before'];
@@ -70,14 +77,9 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenHasLocale()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-        $config            = new App();
-        $config->baseURL   = '';
-        $config->indexPage = 'index.php';
-        $request           = Services::request($config);
-
+        $request = $this->getRequest();
         Services::injectMock('request', $request);
+
         $expected = <<<'EOH'
             <form action="http://example.com/index.php/en/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
 
@@ -93,13 +95,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithoutAction()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-        $config            = new App();
-        $config->baseURL   = '';
-        $config->indexPage = 'index.php';
-        $request           = Services::request($config);
-
+        $request = $this->getRequest();
         Services::injectMock('request', $request);
 
         $before = (new Filters())->globals['before'];
@@ -127,13 +123,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithoutMethod()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-        $config            = new App();
-        $config->baseURL   = '';
-        $config->indexPage = 'index.php';
-        $request           = Services::request($config);
-
+        $request = $this->getRequest();
         Services::injectMock('request', $request);
 
         $before = (new Filters())->globals['before'];
@@ -161,13 +151,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenWithHidden()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-        $config            = new App();
-        $config->baseURL   = '';
-        $config->indexPage = 'index.php';
-        $request           = Services::request($config);
-
+        $request = $this->getRequest();
         Services::injectMock('request', $request);
 
         $before = (new Filters())->globals['before'];
@@ -202,13 +186,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormOpenMultipart()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-        $config            = new App();
-        $config->baseURL   = '';
-        $config->indexPage = 'index.php';
-        $request           = Services::request($config);
-
+        $request = $this->getRequest();
         Services::injectMock('request', $request);
 
         $before = (new Filters())->globals['before'];

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -145,7 +145,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertSame('/assets/image.jpg', uri_string());
+        $this->assertSame('assets/image.jpg', uri_string());
     }
 
     public function testUriStringRelative()
@@ -172,7 +172,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertSame('/assets/image.jpg', uri_string());
+        $this->assertSame('assets/image.jpg', uri_string());
     }
 
     public function testUriStringNoTrailingSlashRelative()
@@ -220,7 +220,7 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         Services::injectMock('request', $request);
 
-        $this->assertSame('/subfolder/assets/image.jpg', uri_string());
+        $this->assertSame('subfolder/assets/image.jpg', uri_string());
     }
 
     public function testUriStringSubfolderRelative()

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -140,13 +140,19 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 
-        $uri = new URI('http://example.com/assets/image.jpg');
+        $uri = 'http://example.com/assets/image.jpg';
+        $this->setService($uri);
+
+        $this->assertSame('assets/image.jpg', uri_string());
+    }
+
+    private function setService(string $uri): void
+    {
+        $uri = new URI($uri);
         Services::injectMock('uri', $uri);
 
         $request = Services::request($this->config);
         Services::injectMock('request', $request);
-
-        $this->assertSame('assets/image.jpg', uri_string());
     }
 
     public function testUriStringRelative()
@@ -154,11 +160,8 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 
-        $uri = new URI('http://example.com/assets/image.jpg');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/assets/image.jpg';
+        $this->setService($uri);
 
         $this->assertSame('assets/image.jpg', uri_string(true));
     }
@@ -170,11 +173,8 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         $this->config->baseURL = 'http://example.com';
 
-        $uri = new URI('http://example.com/assets/image.jpg');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/assets/image.jpg';
+        $this->setService($uri);
 
         $this->assertSame('assets/image.jpg', uri_string());
     }
@@ -186,33 +186,24 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         $this->config->baseURL = 'http://example.com';
 
-        $uri = new URI('http://example.com/assets/image.jpg');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/assets/image.jpg';
+        $this->setService($uri);
 
         $this->assertSame('assets/image.jpg', uri_string(true));
     }
 
     public function testUriStringEmptyAbsolute()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/';
+        $this->setService($uri);
 
         $this->assertSame('/', uri_string());
     }
 
     public function testUriStringEmptyRelative()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/';
+        $this->setService($uri);
 
         $this->assertSame('', uri_string(true));
     }
@@ -224,11 +215,8 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         $this->config->baseURL = 'http://example.com/subfolder/';
 
-        $uri = new URI('http://example.com/subfolder/assets/image.jpg');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/subfolder/assets/image.jpg';
+        $this->setService($uri);
 
         $this->assertSame('subfolder/assets/image.jpg', uri_string());
     }
@@ -241,12 +229,8 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         $this->config->baseURL = 'http://example.com/subfolder/';
 
-        $uri = new URI('http://example.com/subfolder/assets/image.jpg');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/subfolder/assets/image.jpg';
+        $this->setService($uri);
 
         $this->assertSame('assets/image.jpg', uri_string(true));
     }
@@ -300,11 +284,8 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/' . $currentPath;
 
-        $uri = new URI('http://example.com/' . $currentPath);
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request();
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/' . $currentPath;
+        $this->setService($uri);
 
         $this->assertSame($expected, url_is($testPath));
     }
@@ -319,11 +300,8 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         $this->config->indexPage = '';
 
-        $uri = new URI('http://example.com/' . $currentPath);
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/' . $currentPath;
+        $this->setService($uri);
 
         $this->assertSame($expected, url_is($testPath));
     }
@@ -339,11 +317,8 @@ final class CurrentUrlTest extends CIUnitTestCase
 
         $this->config->baseURL = 'http://example.com/subfolder/';
 
-        $uri = new URI('http://example.com/subfolder/' . $currentPath);
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/subfolder/' . $currentPath;
+        $this->setService($uri);
 
         $this->assertSame($expected, url_is($testPath));
     }

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -140,9 +140,10 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/assets/image.jpg');
+        $uri = new URI('http://example.com/assets/image.jpg');
+        Services::injectMock('uri', $uri);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('assets/image.jpg', uri_string());
@@ -153,9 +154,10 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/assets/image.jpg');
+        $uri = new URI('http://example.com/assets/image.jpg');
+        Services::injectMock('uri', $uri);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('assets/image.jpg', uri_string(true));
@@ -167,9 +169,11 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 
         $this->config->baseURL = 'http://example.com';
-        $request               = Services::request($this->config);
-        $request->uri          = new URI('http://example.com/assets/image.jpg');
 
+        $uri = new URI('http://example.com/assets/image.jpg');
+        Services::injectMock('uri', $uri);
+
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('assets/image.jpg', uri_string());
@@ -181,9 +185,11 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
 
         $this->config->baseURL = 'http://example.com';
-        $request               = Services::request($this->config);
-        $request->uri          = new URI('http://example.com/assets/image.jpg');
 
+        $uri = new URI('http://example.com/assets/image.jpg');
+        Services::injectMock('uri', $uri);
+
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('assets/image.jpg', uri_string(true));
@@ -191,9 +197,10 @@ final class CurrentUrlTest extends CIUnitTestCase
 
     public function testUriStringEmptyAbsolute()
     {
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('/', uri_string());
@@ -201,9 +208,10 @@ final class CurrentUrlTest extends CIUnitTestCase
 
     public function testUriStringEmptyRelative()
     {
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('', uri_string(true));
@@ -215,9 +223,11 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/subfolder/assets/image.jpg';
 
         $this->config->baseURL = 'http://example.com/subfolder/';
-        $request               = Services::request($this->config);
-        $request->uri          = new URI('http://example.com/subfolder/assets/image.jpg');
 
+        $uri = new URI('http://example.com/subfolder/assets/image.jpg');
+        Services::injectMock('uri', $uri);
+
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('subfolder/assets/image.jpg', uri_string());
@@ -230,8 +240,11 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/subfolder/index.php';
 
         $this->config->baseURL = 'http://example.com/subfolder/';
-        $request               = Services::request($this->config);
-        $request->uri          = new URI('http://example.com/subfolder/assets/image.jpg');
+
+        $uri = new URI('http://example.com/subfolder/assets/image.jpg');
+        Services::injectMock('uri', $uri);
+
+        $request = Services::request($this->config);
 
         Services::injectMock('request', $request);
 
@@ -287,8 +300,10 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/' . $currentPath;
 
-        $request      = Services::request();
-        $request->uri = new URI('http://example.com/' . $currentPath);
+        $uri = new URI('http://example.com/' . $currentPath);
+        Services::injectMock('uri', $uri);
+
+        $request = Services::request();
         Services::injectMock('request', $request);
 
         $this->assertSame($expected, url_is($testPath));
@@ -299,12 +314,15 @@ final class CurrentUrlTest extends CIUnitTestCase
      */
     public function testUrlIsNoIndex(string $currentPath, string $testPath, bool $expected)
     {
-        $_SERVER['HTTP_HOST']    = 'example.com';
-        $_SERVER['REQUEST_URI']  = '/' . $currentPath;
+        $_SERVER['HTTP_HOST']   = 'example.com';
+        $_SERVER['REQUEST_URI'] = '/' . $currentPath;
+
         $this->config->indexPage = '';
 
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/' . $currentPath);
+        $uri = new URI('http://example.com/' . $currentPath);
+        Services::injectMock('uri', $uri);
+
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame($expected, url_is($testPath));
@@ -318,10 +336,13 @@ final class CurrentUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/' . $currentPath;
         $_SERVER['SCRIPT_NAME'] = '/subfolder/index.php';
-        $this->config->baseURL  = 'http://example.com/subfolder/';
 
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/subfolder/' . $currentPath);
+        $this->config->baseURL = 'http://example.com/subfolder/';
+
+        $uri = new URI('http://example.com/subfolder/' . $currentPath);
+        Services::injectMock('uri', $uri);
+
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame($expected, url_is($testPath));

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -55,15 +55,22 @@ final class MiscUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_REFERER']      = $uri1;
         $_SESSION['_ci_previous_url'] = $uri2;
 
-        $uri = new URI('http://example.com/public');
+        $this->config->baseURL = 'http://example.com/public';
+
+        $uri = 'http://example.com/public';
+        $this->setRequest($uri);
+
+        $this->assertSame($uri2, previous_url());
+    }
+
+    private function setRequest(string $uri): void
+    {
+        $uri = new URI($uri);
         Services::injectMock('uri', $uri);
 
         // Since we're on a CLI, we must provide our own URI
-        $this->config->baseURL = 'http://example.com/public';
-        $request               = Services::request($this->config);
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
-
-        $this->assertSame($uri2, previous_url());
     }
 
     public function testPreviousURLUsesRefererIfNeeded()
@@ -72,13 +79,10 @@ final class MiscUrlTest extends CIUnitTestCase
 
         $_SERVER['HTTP_REFERER'] = $uri1;
 
-        $uri = new URI('http://example.com/public');
-        Services::injectMock('uri', $uri);
-
-        // Since we're on a CLI, we must provide our own URI
         $this->config->baseURL = 'http://example.com/public';
-        $request               = Services::request($this->config);
-        Services::injectMock('request', $request);
+
+        $uri = 'http://example.com/public';
+        $this->setRequest($uri);
 
         $this->assertSame($uri1, previous_url());
     }
@@ -87,23 +91,18 @@ final class MiscUrlTest extends CIUnitTestCase
 
     public function testIndexPage()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uri = 'http://example.com/';
+        $this->setRequest($uri);
 
         $this->assertSame('index.php', index_page());
     }
 
     public function testIndexPageAlt()
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-
         $this->config->indexPage = 'banana.php';
-        $request                 = Services::request($this->config);
-        Services::injectMock('request', $request);
+
+        $uri = 'http://example.com/';
+        $this->setRequest($uri);
 
         $this->assertSame('banana.php', index_page($this->config));
     }
@@ -163,11 +162,8 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchor($expected = '', $uri = '', $title = '', $attributes = '')
     {
-        $uriObj = new URI('http://example.com/');
-        Services::injectMock('uri', $uriObj);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uriString = 'http://example.com/';
+        $this->setRequest($uriString);
 
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
@@ -231,12 +227,10 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorNoindex($expected = '', $uri = '', $title = '', $attributes = '')
     {
-        $uriObj = new URI('http://example.com/');
-        Services::injectMock('uri', $uriObj);
-
         $this->config->indexPage = '';
-        $request                 = Services::request($this->config);
-        Services::injectMock('request', $request);
+
+        $uriString = 'http://example.com/';
+        $this->setRequest($uriString);
 
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
@@ -290,12 +284,10 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorTargetted($expected = '', $uri = '', $title = '', $attributes = '')
     {
-        $uriObj = new URI('http://example.com/');
-        Services::injectMock('uri', $uriObj);
-
         $this->config->indexPage = '';
-        $request                 = Services::request($this->config);
-        Services::injectMock('request', $request);
+
+        $uriString = 'http://example.com/';
+        $this->setRequest($uriString);
 
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
@@ -338,11 +330,8 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorExamples($expected = '', $uri = '', $title = '', $attributes = '')
     {
-        $uriObj = new URI('http://example.com/');
-        Services::injectMock('uri', $uriObj);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uriString = 'http://example.com/';
+        $this->setRequest($uriString);
 
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
@@ -399,11 +388,8 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorPopup($expected = '', $uri = '', $title = '', $attributes = false)
     {
-        $uriObj = new URI('http://example.com/');
-        Services::injectMock('uri', $uriObj);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uriString = 'http://example.com/';
+        $this->setRequest($uriString);
 
         $this->assertSame($expected, anchor_popup($uri, $title, $attributes, $this->config));
     }
@@ -441,11 +427,8 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testMailto($expected = '', $email = '', $title = '', $attributes = '')
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::request($this->config);
-        Services::injectMock('request', $request);
+        $uriString = 'http://example.com/';
+        $this->setRequest($uriString);
 
         $this->assertSame($expected, mailto($email, $title, $attributes));
     }
@@ -483,11 +466,8 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testSafeMailto($expected = '', $email = '', $title = '', $attributes = '')
     {
-        $uri = new URI('http://example.com/');
-        Services::injectMock('uri', $uri);
-
-        $request = Services::incomingrequest($this->config);
-        Services::injectMock('request', $request);
+        $uriString = 'http://example.com/';
+        $this->setRequest($uriString);
 
         $this->assertSame($expected, safe_mailto($email, $title, $attributes));
     }

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -55,11 +55,12 @@ final class MiscUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_REFERER']      = $uri1;
         $_SESSION['_ci_previous_url'] = $uri2;
 
+        $uri = new URI('http://example.com/public');
+        Services::injectMock('uri', $uri);
+
         // Since we're on a CLI, we must provide our own URI
         $this->config->baseURL = 'http://example.com/public';
         $request               = Services::request($this->config);
-        $request->uri          = new URI('http://example.com/public');
-
         Services::injectMock('request', $request);
 
         $this->assertSame($uri2, previous_url());
@@ -71,11 +72,12 @@ final class MiscUrlTest extends CIUnitTestCase
 
         $_SERVER['HTTP_REFERER'] = $uri1;
 
+        $uri = new URI('http://example.com/public');
+        Services::injectMock('uri', $uri);
+
         // Since we're on a CLI, we must provide our own URI
         $this->config->baseURL = 'http://example.com/public';
         $request               = Services::request($this->config);
-        $request->uri          = new URI('http://example.com/public');
-
         Services::injectMock('request', $request);
 
         $this->assertSame($uri1, previous_url());
@@ -85,9 +87,10 @@ final class MiscUrlTest extends CIUnitTestCase
 
     public function testIndexPage()
     {
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame('index.php', index_page());
@@ -95,10 +98,11 @@ final class MiscUrlTest extends CIUnitTestCase
 
     public function testIndexPageAlt()
     {
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
+
         $this->config->indexPage = 'banana.php';
         $request                 = Services::request($this->config);
-        $request->uri            = new URI('http://example.com/');
-
         Services::injectMock('request', $request);
 
         $this->assertSame('banana.php', index_page($this->config));
@@ -159,10 +163,12 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchor($expected = '', $uri = '', $title = '', $attributes = '')
     {
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uriObj = new URI('http://example.com/');
+        Services::injectMock('uri', $uriObj);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
+
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
@@ -225,11 +231,13 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorNoindex($expected = '', $uri = '', $title = '', $attributes = '')
     {
+        $uriObj = new URI('http://example.com/');
+        Services::injectMock('uri', $uriObj);
+
         $this->config->indexPage = '';
         $request                 = Services::request($this->config);
-        $request->uri            = new URI('http://example.com/');
-
         Services::injectMock('request', $request);
+
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
@@ -282,11 +290,13 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorTargetted($expected = '', $uri = '', $title = '', $attributes = '')
     {
+        $uriObj = new URI('http://example.com/');
+        Services::injectMock('uri', $uriObj);
+
         $this->config->indexPage = '';
         $request                 = Services::request($this->config);
-        $request->uri            = new URI('http://example.com/');
-
         Services::injectMock('request', $request);
+
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
@@ -328,10 +338,12 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorExamples($expected = '', $uri = '', $title = '', $attributes = '')
     {
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uriObj = new URI('http://example.com/');
+        Services::injectMock('uri', $uriObj);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
+
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
@@ -387,10 +399,12 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testAnchorPopup($expected = '', $uri = '', $title = '', $attributes = false)
     {
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uriObj = new URI('http://example.com/');
+        Services::injectMock('uri', $uriObj);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
+
         $this->assertSame($expected, anchor_popup($uri, $title, $attributes, $this->config));
     }
 
@@ -427,9 +441,10 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testMailto($expected = '', $email = '', $title = '', $attributes = '')
     {
-        $request      = Services::request($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
 
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame($expected, mailto($email, $title, $attributes));
@@ -468,9 +483,10 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testSafeMailto($expected = '', $email = '', $title = '', $attributes = '')
     {
-        $request      = Services::incomingrequest($this->config);
-        $request->uri = new URI('http://example.com/');
+        $uri = new URI('http://example.com/');
+        Services::injectMock('uri', $uri);
 
+        $request = Services::incomingrequest($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame($expected, safe_mailto($email, $title, $attributes));

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -279,10 +279,11 @@ final class SiteUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/ci/v4/x/y';
 
+        $uri = new URI('http://example.com/ci/v4/x/y');
+        Services::injectMock('uri', $uri);
+
         $this->config->baseURL = 'http://example.com/ci/v4/';
         $request               = Services::request($this->config);
-        $request->uri          = new URI('http://example.com/ci/v4/x/y');
-
         Services::injectMock('request', $request);
 
         $this->assertSame('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $this->config));


### PR DESCRIPTION
**Description**
`IncomingRequest::$uri` will be protected.

- fix incorrect assertions https://github.com/codeigniter4/CodeIgniter4/commit/c42b1bfc2670d598c6431e217fc0176efcf4ace9
- refactor

**Confirm the output of `uri_string()`**

```diff
diff --git a/app/Config/Routes.php b/app/Config/Routes.php
index 0bfdce972..8650842af 100644
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -35,7 +35,7 @@ $routes->set404Override();
 
 // We get a performance increase by specifying the default
 // route since we don't have to scan directories.
-$routes->get('/', 'Home::index');
+$routes->get('assets/(:any)', 'Home::index');
 
 /*
  * --------------------------------------------------------------------
diff --git a/app/Controllers/Home.php b/app/Controllers/Home.php
index 7f867e95f..b8cd3af74 100644
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -6,6 +6,6 @@ class Home extends BaseController
 {
     public function index()
     {
-        return view('welcome_message');
+        dd(uri_string());
     }
 }
```

Navigate to http://localhost:8080/assets/image.jpg
You will see:
```
uri_string() string (16) "assets/image.jpg"
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
