### PR TITLE
fix: missing `valid_json` in Validation Language

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -59,6 +59,7 @@ return [
     'valid_url'             => 'The {field} field must contain a valid URL.',
     'valid_url_strict'      => 'The {field} field must contain a valid URL.',
     'valid_date'            => 'The {field} field must contain a valid date.',
+    'valid_json'            => 'The {field} field must contain a valid json.',
 
     // Credit Cards
     'valid_cc_num' => '{field} does not appear to be a valid credit card number.',

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -231,6 +231,7 @@ final class LanguageTest extends CIUnitTestCase
             ['RESTful'],
             ['Router'],
             ['Session'],
+            ['Test'],
             ['Time'],
             ['Validation'],
             ['View'],

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -21,6 +21,11 @@ Enhancements
 
 none.
 
+Message Changes
+***************
+
+- Added missing item `valid_json` in `Language/en/Validation.php`
+
 Changes
 *******
 

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -24,7 +24,7 @@ none.
 Message Changes
 ***************
 
-- Added missing item `valid_json` in `Language/en/Validation.php`
+- Added missing item ``valid_json`` in ``Language/en/Validation.php``
 
 Changes
 *******


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Fixed #6623

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
