### PR TITLE
Fix DotEnv class turning `export` to empty string

### DIFF
--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -116,7 +116,8 @@ class DotEnv
         $value = trim($value);
 
         // Sanitize the name
-        $name = str_replace(['export', '\'', '"'], '', $name);
+        $name = preg_replace('/^export[ \t]++(\S+)/', '$1', $name);
+        $name = str_replace(['\'', '"'], '', $name);
 
         // Sanitize the value
         $value = $this->sanitizeValue($value);

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -55,14 +55,29 @@ final class DotEnvTest extends CIUnitTestCase
         $this->assertFalse($dotenv->load());
     }
 
-    public function testLoadsVars()
+    /**
+     * @dataProvider provideLoadVars
+     */
+    public function testLoadsVars(string $expected, string $varname)
     {
         $dotenv = new DotEnv($this->fixturesFolder);
         $dotenv->load();
-        $this->assertSame('bar', getenv('FOO'));
-        $this->assertSame('baz', getenv('BAR'));
-        $this->assertSame('with spaces', getenv('SPACED'));
-        $this->assertSame('', getenv('NULL'));
+
+        $this->assertSame($expected, getenv($varname));
+    }
+
+    public function provideLoadVars(): iterable
+    {
+        yield from [
+            ['bar', 'FOO'],
+            ['baz', 'BAR'],
+            ['with spaces', 'SPACED'],
+            ['', 'NULL'],
+            ['exported foo', 'char.expo.foo'],
+            ['variable', 'character.export.var'],
+            ['character', 'char.var'],
+            ['imports', 'char.exports'],
+        ];
     }
 
     /**

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -77,6 +77,7 @@ final class DotEnvTest extends CIUnitTestCase
             ['variable', 'character.export.var'],
             ['character', 'char.var'],
             ['imports', 'char.exports'],
+            ['banana', 'fruit.export'],
         ];
     }
 

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -4,6 +4,11 @@ SPACED="with spaces"
 
 NULL=
 
+char.expo.foo="exported foo"
+character.export.var=variable
+export char.var=character
+export char.exports=imports
+
 SimpleConfig.onedeep=baz
 SimpleConfig.default.name=ci4
 # Use underscore as separator

--- a/tests/system/Config/fixtures/.env
+++ b/tests/system/Config/fixtures/.env
@@ -8,6 +8,7 @@ char.expo.foo="exported foo"
 character.export.var=variable
 export char.var=character
 export char.exports=imports
+fruit.export = "banana"
 
 SimpleConfig.onedeep=baz
 SimpleConfig.default.name=ci4


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Fixes #6621 

I think the bug is on the incorrect sanitization of exported env variables with the syntax `export varname=value`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
