### PR TITLE
chore: update phpstan-baseline.neon.dist for PHPStan 1.8.7

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -51,7 +51,7 @@ parameters:
 			path: system/Cache/Handlers/RedisHandler.php
 
 		-
-			message: "#^Strict comparison using === between array and array{} will always evaluate to false\\.$#"
+			message: "#^Strict comparison using === between array<mixed, mixed> and array{} will always evaluate to false\\.$#"
 			count: 1
 			path: system/CLI/Console.php
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/actions/runs/3186033011

It seems the error message has been changed:
```
 ------ ----------------------------------------------------------------------------------------------------
  Line   system/CLI/Console.php
 ------ ----------------------------------------------------------------------------------------------------
  71     Strict comparison using === between array<mixed, mixed> and array{} will always evaluate to false.
 ------ ----------------------------------------------------------------------------------------------------
```
But the `$params` may be empty array, so it still seems false positive.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
