### PR TITLE
test: fix Error ini_set(): Session ini settings cannot be changed

### DIFF
--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -12,16 +12,9 @@
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\HTTP\URI;
-use CodeIgniter\Session\Handlers\ArrayHandler;
-use CodeIgniter\Session\Handlers\FileHandler;
-use CodeIgniter\Session\Session;
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Mock\MockSession;
-use CodeIgniter\Test\TestLogger;
 use Config\App;
-use Config\App as AppConfig;
 use Config\Filters;
-use Config\Logger as LoggerConfig;
 use Config\Services;
 
 /**
@@ -33,11 +26,11 @@ final class FormHelperTest extends CIUnitTestCase
 {
     protected function setUp(): void
     {
+        $this->resetServices();
+
         parent::setUp();
 
         helper('form');
-
-        $this->resetServices();
     }
 
     private function setRequest(): void
@@ -917,46 +910,8 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame('', set_radio('code', 'beta', false));
     }
 
-    private function createSession($options = []): Session
-    {
-        $defaults = [
-            'sessionDriver'            => FileHandler::class,
-            'sessionCookieName'        => 'ci_session',
-            'sessionExpiration'        => 7200,
-            'sessionSavePath'          => '',
-            'sessionMatchIP'           => false,
-            'sessionTimeToUpdate'      => 300,
-            'sessionRegenerateDestroy' => false,
-            'cookieDomain'             => '',
-            'cookiePrefix'             => '',
-            'cookiePath'               => '/',
-            'cookieSecure'             => false,
-            'cookieSameSite'           => 'Lax',
-        ];
-
-        $config    = array_merge($defaults, $options);
-        $appConfig = new AppConfig();
-
-        foreach ($config as $key => $c) {
-            $appConfig->{$key} = $c;
-        }
-
-        $session = new MockSession(new ArrayHandler($appConfig, '127.0.0.1'), $appConfig);
-        $session->setLogger(new TestLogger(new LoggerConfig()));
-
-        return $session;
-    }
-
-    private function setSession(): void
-    {
-        $session = $this->createSession();
-        Services::injectMock('session', $session);
-    }
-
     public function testValidationErrorsFromSession()
     {
-        $this->setSession();
-
         $_SESSION = ['_ci_validation_errors' => ['foo' => 'bar']];
 
         $this->assertSame(['foo' => 'bar'], validation_errors());
@@ -966,8 +921,6 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testValidationErrorsFromValidation()
     {
-        $this->setSession();
-
         $validation = Services::validation();
         $validation->setRule('id', 'ID', 'required')->run([]);
 
@@ -976,8 +929,6 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testValidationListErrors()
     {
-        $this->setSession();
-
         $validation = Services::validation();
         $validation->setRule('id', 'ID', 'required')->run([]);
 
@@ -988,8 +939,6 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testValidationShowError()
     {
-        $this->setSession();
-
         $validation = Services::validation();
         $validation->setRule('id', 'ID', 'required')->run([]);
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/actions/runs/3186033007/jobs/5196234573#step:14:264

```
    1) CodeIgniter\Helpers\FormHelperTest::testValidationErrorsFromSession
    ErrorException: ini_set(): Session ini settings cannot be changed after headers have already been sent
    
    /.../CodeIgniter4/system/Session/Handlers/FileHandler.php:71
    /.../CodeIgniter4/system/Config/Services.php:659
    /.../CodeIgniter4/system/Config/BaseService.php:253
    /.../CodeIgniter4/system/Config/BaseService.php:194
    /.../CodeIgniter4/system/Config/Services.php:638
    /.../CodeIgniter4/system/Config/BaseService.php:253
    /.../CodeIgniter4/system/Common.php:945
    /.../CodeIgniter4/system/Helpers/form_helper.php:701
    /.../CodeIgniter4/tests/system/Helpers/FormHelperTest.php:917
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

