### PR TITLE
test: fix ResponseTest::testSetDateRemembersDateInUTC

### DIFF
--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -50,7 +50,7 @@ final class DownloadResponseTest extends CIUnitTestCase
     {
         $response = new DownloadResponse('unit-test.txt', true);
 
-        $datetime = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $datetime = DateTime::createFromFormat('!Y-m-d', '2000-03-10');
         $response->setDate($datetime);
 
         $date = clone $datetime;

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -50,9 +50,10 @@ final class DownloadResponseTest extends CIUnitTestCase
     {
         $response = new DownloadResponse('unit-test.txt', true);
 
-        $response->setDate(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
+        $datetime = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $response->setDate($datetime);
 
-        $date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $date = clone $datetime;
         $date->setTimezone(new DateTimeZone('UTC'));
 
         $header = $response->getHeaderLine('Date');

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -144,9 +144,10 @@ final class ResponseTest extends CIUnitTestCase
     {
         $response = new Response(new App());
 
-        $response->setDate(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
+        $datetime = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $response->setDate($datetime);
 
-        $date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $date = clone $datetime;
         $date->setTimezone(new DateTimeZone('UTC'));
 
         $header = $response->getHeaderLine('Date');

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -144,7 +144,7 @@ final class ResponseTest extends CIUnitTestCase
     {
         $response = new Response(new App());
 
-        $datetime = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $datetime = DateTime::createFromFormat('!Y-m-d', '2000-03-10');
         $response->setDate($datetime);
 
         $date = clone $datetime;


### PR DESCRIPTION
**Description**
Fixes #5486

- fix tests that depend on time

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

