### PR TITLE
fix: error when Config\Modules::$composerPackages is missing

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -139,7 +139,8 @@ class Autoloader
 
         // Should we load through Composer's namespaces, also?
         if ($modules->discoverInComposer) {
-            $this->loadComposerNamespaces($composer, $modules->composerPackages);
+            // @phpstan-ignore-next-line
+            $this->loadComposerNamespaces($composer, $modules->composerPackages ?? []);
         }
 
         unset($composer);


### PR DESCRIPTION
**Description**
Follow-up #6503

Upgrade users will see "PHP Warning:  Undefined property: Config\Modules::$composerPackages".

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

