### PR TITLE
docs: improve changelogs

### DIFF
--- a/user_guide_src/source/changelogs/v4.2.6.rst
+++ b/user_guide_src/source/changelogs/v4.2.6.rst
@@ -33,6 +33,7 @@ Bugs Fixed
 **********
 
 Many bugs fixed, but notably:
-- AssertionError occurs when using Validation in CLI `https://github.com/codeigniter4/CodeIgniter4/pull/6452`
+
+- AssertionError occurs when using Validation in CLI `#6452 <https://github.com/codeigniter4/CodeIgniter4/pull/6452>`_
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.

--- a/user_guide_src/source/changelogs/v4.2.7.rst
+++ b/user_guide_src/source/changelogs/v4.2.7.rst
@@ -9,6 +9,12 @@ Release Date: October 6, 2022
     :local:
     :depth: 2
 
+SECURITY
+********
+
+- *Secure or HttpOnly flag set in Config\Cookie is not reflected in Cookies issued* was fixed. See the `Security advisory GHSA-745p-r637-7vvp <https://github.com/codeigniter4/CodeIgniter4/security/advisories/GHSA-745p-r637-7vvp>`_ for more information.
+- Fixed a bug that prevents CSP headers from being sent when ``Config\ContentSecurityPolicy::$autoNonce`` is false.
+
 BREAKING
 ********
 
@@ -39,7 +45,5 @@ none.
 
 Bugs Fixed
 **********
-
-- Fixed a bug that prevents CSP headers from being sent when ``Config\ContentSecurityPolicy::$autoNonce`` is false.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
- add SECURITY section in 4.2.7 changelog
- fix link to PR in 4.2.6 changelog

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

