### PR TITLE
docs: replace types `mixed` at `Validation\StrictRules\Rule`.

### DIFF
--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -31,8 +31,8 @@ class Rules
     /**
      * The value does not match another field in $data.
      *
-     * @param mixed $str
-     * @param array $data Other field/value pairs
+     * @param array|bool|float|int|object|string|null $str
+     * @param array                                   $data Other field/value pairs
      */
     public function differs($str, string $field, array $data): bool
     {
@@ -46,7 +46,7 @@ class Rules
     /**
      * Equals the static value provided.
      *
-     * @param mixed $str
+     * @param string|null $str
      */
     public function equals($str, string $val): bool
     {
@@ -57,7 +57,7 @@ class Rules
      * Returns true if $str is $val characters long.
      * $val = "5" (one) | "5,8,12" (multiple values)
      *
-     * @param mixed $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function exact_length($str, string $val): bool
     {
@@ -71,7 +71,7 @@ class Rules
     /**
      * Greater than
      *
-     * @param mixed $str expects int|string
+     * @param array|bool|float|int|object|string|null $str expects int|string
      */
     public function greater_than($str, string $min): bool
     {
@@ -89,7 +89,7 @@ class Rules
     /**
      * Equal to or Greater than
      *
-     * @param mixed $str expects int|string
+     * @param array|bool|float|int|object|string|null $str expects int|string
      */
     public function greater_than_equal_to($str, string $min): bool
     {
@@ -113,7 +113,7 @@ class Rules
      *    is_not_unique[table.field,where_field,where_value]
      *    is_not_unique[menu.id,active,1]
      *
-     * @param mixed $str
+     * @param string|null $str
      */
     public function is_not_unique($str, string $field, array $data): bool
     {
@@ -123,7 +123,7 @@ class Rules
     /**
      * Value should be within an array of values
      *
-     * @param mixed $value
+     * @param array|bool|float|int|object|string|null $value
      */
     public function in_list($value, string $list): bool
     {
@@ -147,7 +147,7 @@ class Rules
      *    is_unique[table.field,ignore_field,ignore_value]
      *    is_unique[users.email,id,5]
      *
-     * @param mixed $str
+     * @param string|null $str
      */
     public function is_unique($str, string $field, array $data): bool
     {
@@ -157,7 +157,7 @@ class Rules
     /**
      * Less than
      *
-     * @param mixed $str expects int|string
+     * @param array|bool|float|int|object|string|null $str expects int|string
      */
     public function less_than($str, string $max): bool
     {
@@ -175,7 +175,7 @@ class Rules
     /**
      * Equal to or Less than
      *
-     * @param mixed $str expects int|string
+     * @param array|bool|float|int|object|string|null $str expects int|string
      */
     public function less_than_equal_to($str, string $max): bool
     {
@@ -193,8 +193,8 @@ class Rules
     /**
      * Matches the value of another field in $data.
      *
-     * @param mixed $str
-     * @param array $data Other field/value pairs
+     * @param array|bool|float|int|object|string|null $str
+     * @param array                                   $data Other field/value pairs
      */
     public function matches($str, string $field, array $data): bool
     {
@@ -204,7 +204,7 @@ class Rules
     /**
      * Returns true if $str is $val or fewer characters in length.
      *
-     * @param mixed $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function max_length($str, string $val): bool
     {
@@ -222,7 +222,7 @@ class Rules
     /**
      * Returns true if $str is at least $val length.
      *
-     * @param mixed $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function min_length($str, string $val): bool
     {
@@ -240,7 +240,7 @@ class Rules
     /**
      * Does not equal the static value provided.
      *
-     * @param mixed $str
+     * @param string|null $str
      */
     public function not_equals($str, string $val): bool
     {
@@ -250,7 +250,7 @@ class Rules
     /**
      * Value should not be within an array of values.
      *
-     * @param mixed $value
+     * @param array|bool|float|int|object|string|null $value
      */
     public function not_in_list($value, string $list): bool
     {
@@ -270,7 +270,7 @@ class Rules
     }
 
     /**
-     * @param mixed $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function required($str = null): bool
     {
@@ -285,7 +285,7 @@ class Rules
      *
      *     required_with[password]
      *
-     * @param mixed       $str
+     * @param string|null $str
      * @param string|null $fields List of fields that we should check if present
      * @param array       $data   Complete list of fields from the form
      */

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -46,7 +46,7 @@ class Rules
     /**
      * Equals the static value provided.
      *
-     * @param string|null $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function equals($str, string $val): bool
     {
@@ -113,7 +113,7 @@ class Rules
      *    is_not_unique[table.field,where_field,where_value]
      *    is_not_unique[menu.id,active,1]
      *
-     * @param string|null $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function is_not_unique($str, string $field, array $data): bool
     {
@@ -147,7 +147,7 @@ class Rules
      *    is_unique[table.field,ignore_field,ignore_value]
      *    is_unique[users.email,id,5]
      *
-     * @param string|null $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function is_unique($str, string $field, array $data): bool
     {
@@ -240,7 +240,7 @@ class Rules
     /**
      * Does not equal the static value provided.
      *
-     * @param string|null $str
+     * @param array|bool|float|int|object|string|null $str
      */
     public function not_equals($str, string $val): bool
     {
@@ -285,9 +285,9 @@ class Rules
      *
      *     required_with[password]
      *
-     * @param string|null $str
-     * @param string|null $fields List of fields that we should check if present
-     * @param array       $data   Complete list of fields from the form
+     * @param array|bool|float|int|object|string|null $str
+     * @param string|null                             $fields List of fields that we should check if present
+     * @param array                                   $data   Complete list of fields from the form
      */
     public function required_with($str = null, ?string $fields = null, array $data = []): bool
     {
@@ -302,9 +302,9 @@ class Rules
      *
      *     required_without[id,email]
      *
-     * @param string|null $str
-     * @param string|null $otherFields The param fields of required_without[].
-     * @param string|null $field       This rule param fields aren't present, this field is required.
+     * @param array|bool|float|int|object|string|null $str
+     * @param string|null                             $otherFields The param fields of required_without[].
+     * @param string|null                             $field       This rule param fields aren't present, this field is required.
      */
     public function required_without($str = null, ?string $otherFields = null, array $data = [], ?string $error = null, ?string $field = null): bool
     {


### PR DESCRIPTION
**Description**
See #6310 

If there is `if (! is_string($value))` judgement, I chagned the type `mixed` to `array|bool|float|int|object|string|null`.
If there isn't the judgement of non-string, I changed the type `string|null`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
