### PR TITLE
fix: routes registration bug

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -110,7 +110,7 @@ class RouteCollection implements RouteCollectionInterface
      *     verb => [
      *         routeName => [
      *             'route' => [
-     *                 routeKey => handler,
+     *                 routeKey(or from) => handler,
      *             ]
      *         ]
      *     ],
@@ -133,6 +133,14 @@ class RouteCollection implements RouteCollectionInterface
      * Array of routes options
      *
      * @var array
+     *
+     * [
+     *     verb => [
+     *         routeKey(or from) => [
+     *             key => value,
+     *         ]
+     *     ],
+     * ]
      */
     protected $routesOptions = [];
 
@@ -1239,12 +1247,16 @@ class RouteCollection implements RouteCollectionInterface
 
         $name = $options['as'] ?? $from;
 
+        helper('array');
+
         // Don't overwrite any existing 'froms' so that auto-discovered routes
         // do not overwrite any app/Config/Routes settings. The app
         // routes should always be the "source of truth".
         // this works only because discovered routes are added just prior
         // to attempting to route the request.
-        if (isset($this->routes[$verb][$name]) && ! $overwrite) {
+        $fromExists = (dot_array_search('*.route.' . $from, $this->routes[$verb] ?? []) === null)
+            ? false : true;
+        if ((isset($this->routes[$verb][$name]) || $fromExists) && ! $overwrite) {
             return;
         }
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1254,8 +1254,7 @@ class RouteCollection implements RouteCollectionInterface
         // routes should always be the "source of truth".
         // this works only because discovered routes are added just prior
         // to attempting to route the request.
-        $fromExists = (dot_array_search('*.route.' . $from, $this->routes[$verb] ?? []) === null)
-            ? false : true;
+        $fromExists = dot_array_search('*.route.' . $from, $this->routes[$verb] ?? []) !== null;
         if ((isset($this->routes[$verb][$name]) || $fromExists) && ! $overwrite) {
             return;
         }

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -73,12 +73,12 @@ final class RedirectResponseTest extends CIUnitTestCase
         $this->assertTrue($response->hasHeader('Location'));
         $this->assertSame('http://example.com/index.php/exampleRoute', $response->getHeaderLine('Location'));
 
-        $this->routes->add('exampleRoute', 'Home::index', ['as' => 'home']);
+        $this->routes->add('exampleRoute2', 'Home::index', ['as' => 'home']);
 
         $response->route('home');
 
         $this->assertTrue($response->hasHeader('Location'));
-        $this->assertSame('http://example.com/index.php/exampleRoute', $response->getHeaderLine('Location'));
+        $this->assertSame('http://example.com/index.php/exampleRoute2', $response->getHeaderLine('Location'));
     }
 
     public function testRedirectRouteBadNamedRoute()

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -11,7 +11,6 @@
 
 namespace CodeIgniter\Router;
 
-use App\Controllers\Home;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
@@ -1489,12 +1488,12 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->setDefaultController('Home');
         $routes->setDefaultMethod('index');
 
+        // The subdomain of the current URL is `doc`, so this route is registered.
         $routes->get('/', '\App\Controllers\Site\CDoc::index', ['subdomain' => 'doc', 'as' => 'doc_index']);
+        // The subdomain route is already registered, so this route is not registered.
         $routes->get('/', 'Home::index');
 
-        // the second rule applies, so overwrites the first
-        $expects = '\\' . Home::class;
-
+        $expects = '\App\Controllers\Site\CDoc';
         $this->assertSame($expects, $router->handle('/'));
     }
 

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1188,24 +1188,20 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($options, ['as' => 'admin', 'foo' => 'baz']);
     }
 
-    public function testRoutesOptionsWithSameFromTwoRoutes()
+    /**
+     * @dataProvider optionsProvider
+     */
+    public function testRoutesOptionsWithSameFromTwoRoutes(array $options1, array $options2)
     {
         $routes = $this->getCollector();
 
         // This is the first route for `administrator`.
-        $options1 = [
-            'as'  => 'admin',
-            'foo' => 'options1',
-        ];
         $routes->get(
             'administrator',
             static function () {},
             $options1
         );
         // The second route for `administrator` should be ignored.
-        $options2 = [
-            'foo' => 'options2',
-        ];
         $routes->get(
             'administrator',
             static function () {},
@@ -1215,6 +1211,48 @@ final class RouteCollectionTest extends CIUnitTestCase
         $options = $routes->getRoutesOptions('administrator');
 
         $this->assertSame($options, $options1);
+    }
+
+    public function optionsProvider()
+    {
+        yield from [
+            [
+                [
+                    'foo' => 'options1',
+                ],
+                [
+                    'foo' => 'options2',
+                ],
+            ],
+            [
+                [
+                    'as'  => 'admin',
+                    'foo' => 'options1',
+                ],
+                [
+                    'foo' => 'options2',
+                ],
+            ],
+            [
+                [
+                    'foo' => 'options1',
+                ],
+                [
+                    'as'  => 'admin',
+                    'foo' => 'options2',
+                ],
+            ],
+            [
+                [
+                    'as'  => 'admin',
+                    'foo' => 'options1',
+                ],
+                [
+                    'as'  => 'admin',
+                    'foo' => 'options2',
+                ],
+            ],
+        ];
     }
 
     public function testRoutesOptionsForDifferentVerbs()

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1189,6 +1189,35 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($options, ['as' => 'admin', 'foo' => 'baz']);
     }
 
+    public function testRoutesOptionsWithSameFromTwoRoutes()
+    {
+        $routes = $this->getCollector();
+
+        // This is the first route for `administrator`.
+        $options1 = [
+            'as'  => 'admin',
+            'foo' => 'options1',
+        ];
+        $routes->get(
+            'administrator',
+            static function () {},
+            $options1
+        );
+        // The second route for `administrator` should be ignored.
+        $options2 = [
+            'foo' => 'options2',
+        ];
+        $routes->get(
+            'administrator',
+            static function () {},
+            $options2
+        );
+
+        $options = $routes->getRoutesOptions('administrator');
+
+        $this->assertSame($options, $options1);
+    }
+
     public function testRoutesOptionsForDifferentVerbs()
     {
         $routes = $this->getCollector();


### PR DESCRIPTION
**Description**
If there are two routes having the same `from` but with the different name,
the first route is not registered correctly.

- fix RouteCollection
- fix incorrect tests

**How to Reproduce the Bug**
```php
$routes->get('/', static fn () => 'Hello World!', ['as' => 'RouteName']);
$routes->get('/', 'Home::index');
```
Before:
```
+--------+--------+------------------------------------------+----------------+---------------+
| Method | Route  | Handler                                  | Before Filters | After Filters |
+--------+--------+------------------------------------------+----------------+---------------+
| GET    | /      | \App\Controllers\Home::index             |                | toolbar       |
| CLI    | ci(.*) | \CodeIgniter\CLI\CommandRunner::index/$1 |                |               |
+--------+--------+------------------------------------------+----------------+---------------+
```
After:
```
+--------+--------+------------------------------------------+----------------+---------------+
| Method | Route  | Handler                                  | Before Filters | After Filters |
+--------+--------+------------------------------------------+----------------+---------------+
| GET    | /      | (Closure)                                |                | toolbar       |
| CLI    | ci(.*) | \CodeIgniter\CLI\CommandRunner::index/$1 |                |               |
+--------+--------+------------------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

