### PR TITLE
Add CLIRequest::getCookie()

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -283,7 +283,7 @@ class CLIRequest extends Request
      */
     public function getCookie($index = null, $filter = null, $flags = null)
     {
-        return null;
+        return $this->returnNullOrEmptyArray($index);
     }
 
     /**

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -279,7 +279,7 @@ class CLIRequest extends Request
      * @param int|null          $filter A filter name to be applied
      * @param mixed             $flags
      *
-     * @return null
+     * @return array|null
      */
     public function getCookie($index = null, $filter = null, $flags = null)
     {

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -273,6 +273,20 @@ class CLIRequest extends Request
     }
 
     /**
+     * This is a place holder for calls from cookie_helper get_cookie().
+     *
+     * @param array|string|null $index  Index for item to be fetched from $_COOKIE
+     * @param int|null          $filter A filter name to be applied
+     * @param mixed             $flags
+     *
+     * @return null
+     */
+    public function getCookie($index = null, $filter = null, $flags = null)
+    {
+        return null;
+    }
+
+    /**
      * @param array|string|null $index
      *
      * @return array|null

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -620,5 +620,7 @@ final class CLIRequestTest extends CIUnitTestCase
     public function testGetCookie()
     {
         $this->assertNull($this->request->getCookie('TESTY'));
+
+        $this->assertSame($this->request->getCookie(), []);
     }
 }

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -616,4 +616,9 @@ final class CLIRequestTest extends CIUnitTestCase
     {
         $this->assertSame('en', $this->request->getLocale());
     }
+
+    public function testGetCookie()
+    {
+        $this->assertNull($this->request->getCookie('TESTY'));
+    }
 }


### PR DESCRIPTION
This PR fixes https://github.com/codeigniter4/CodeIgniter4/issues/6642

It adds the `getCookie()` method to `CLIRequest`. This method may be called by `cookie_helper get_cookie()` where a script is used by both CLI and http.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
