### PR TITLE
Remove unneeded `$logger` property in `Session`

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -17,7 +17,6 @@ use Config\App;
 use Config\Cookie as CookieConfig;
 use Config\Services;
 use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
 use SessionHandlerInterface;
 
 /**

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -157,13 +157,6 @@ class Session implements SessionInterface
     protected $sidRegexp;
 
     /**
-     * Logger instance to record error messages and warnings.
-     *
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
      * Constructor.
      *
      * Extract configuration settings and save them here.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
`Session` already imports the `$logger` property through the use of `LoggerAwareTrait`. So this declaration is redundant.

Moreover, if a user accidentally uses `v2` or `v3` of `psr/log`, like [here](https://forum.codeigniter.com/showthread.php?tid=83487) which I think what happened, this will cause an incompatible declaration error.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
