### PR TITLE
docs: fix `@return` types in CLIRequest

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -223,7 +223,7 @@ class CLIRequest extends Request
      * @param int|null          $filter A filter name to apply.
      * @param mixed|null        $flags
      *
-     * @return null
+     * @return array|null
      */
     public function getGet($index = null, $filter = null, $flags = null)
     {
@@ -237,7 +237,7 @@ class CLIRequest extends Request
      * @param int|null          $filter A filter name to apply
      * @param mixed             $flags
      *
-     * @return null
+     * @return array|null
      */
     public function getPost($index = null, $filter = null, $flags = null)
     {
@@ -251,7 +251,7 @@ class CLIRequest extends Request
      * @param int|null          $filter A filter name to apply
      * @param mixed             $flags
      *
-     * @return null
+     * @return array|null
      */
     public function getPostGet($index = null, $filter = null, $flags = null)
     {
@@ -265,7 +265,7 @@ class CLIRequest extends Request
      * @param int|null          $filter A filter name to apply
      * @param mixed             $flags
      *
-     * @return null
+     * @return array|null
      */
     public function getGetPost($index = null, $filter = null, $flags = null)
     {


### PR DESCRIPTION
**Description**
Follow-up #6421
Related #6646

- fix `@return` types

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

