### PR TITLE
refactor: remove unnecessary "&" in Filters

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -147,7 +147,7 @@ class Filters
      */
     public function setResponse(ResponseInterface $response)
     {
-        $this->response = &$response;
+        $this->response = $response;
     }
 
     /**

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -143,7 +143,7 @@ class Filters
     }
 
     /**
-     * Set the response explicity.
+     * Set the response explicitly.
      */
     public function setResponse(ResponseInterface $response)
     {


### PR DESCRIPTION
**Description**
`$response` is an object, so it is passed as an object id.
https://www.php.net/manual/en/language.oop5.references.php

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

