### PR TITLE
docs: deprecated CodeIgniter::$path and CodeIgniter::setPath()

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -130,6 +130,8 @@ class CodeIgniter
      * Request path to use.
      *
      * @var string
+     *
+     * @deprecated No longer used.
      */
     protected $path;
 
@@ -789,7 +791,7 @@ class CodeIgniter
 
     /**
      * Determines the path to use for us to try to route to, based
-     * on user input (setPath), or the CLI/IncomingRequest path.
+     * on the CLI/IncomingRequest path.
      *
      * @return string
      */
@@ -806,9 +808,11 @@ class CodeIgniter
      * Allows the request path to be set from outside the class,
      * instead of relying on CLIRequest or IncomingRequest for the path.
      *
-     * This is primarily used by the Console.
+     * This is not used now.
      *
      * @return $this
+     *
+     * @deprecated No longer used.
      */
     public function setPath(string $path)
     {

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -192,6 +192,7 @@ Deprecations
 - ``RouteCollection::fillRouteParams()`` is deprecated. Use ``RouteCollection::buildReverseRoute()`` instead.
 - ``BaseBuilder::setUpdateBatch()`` and ``BaseBuilder::setInsertBatch()`` are deprecated. Use ``BaseBuilder::setData()`` instead.
 - The public property ``Response::$CSP`` is deprecated. It will be protected. Use ``Response::getCSP()`` instead.
+- ``CodeIgniter::$path`` and ``CodeIgniter::setPath()`` are deprecated. No longer used.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
They are no longer used, because of the refactoring for Spark processing in 4.3.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

