### PR TITLE
Bug: showError in CLI/BaseCommand use hardcoded error view path

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -119,8 +119,9 @@ abstract class BaseCommand
     {
         $exception = $e;
         $message   = $e->getMessage();
+        $config    = config('Exceptions');
 
-        require APPPATH . 'Views/errors/cli/error_exception.php';
+        require $config->errorViewPath . '/cli/error_exception.php';
     }
 
     /**


### PR DESCRIPTION
Fix #6656

**Description**

When you :
- change the location of the views used to generate errors,
- provide a new path in \Config\Exceptions::$errorViewPath,
- and then run a CLI command generating an exception :

the error message is complaining about the location of the error_exception.php file... because the view path is hardcoded.

So instead of using a hardcoded directory for the error_exception.php file,

we should use the provided errorViewPath from \Config\Exceptions::$errorViewPath

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
