### PR TITLE
Deprecate public properties in IncomingRequest

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -122,6 +122,8 @@ class IncomingRequest extends Request
      * Configuration settings.
      *
      * @var App
+     *
+     * @deprecated Will be protected.
      */
     public $config;
 

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -64,7 +64,7 @@ class IncomingRequest extends Request
      * AFTER the script name. So, if hosted in a sub-folder this will
      * appear different than actual URL. If you need that use getPath().
      *
-     * @TODO should be protected. Use getUri() instead.
+     * @deprecated Will be protected. Use getUri() instead.
      *
      * @var URI
      */

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -83,7 +83,12 @@ class Negotiate
      */
     public function charset(array $supported): string
     {
-        $match = $this->getBestMatch($supported, $this->request->getHeaderLine('accept-charset'), false, true);
+        $match = $this->getBestMatch(
+            $supported,
+            $this->request->getHeaderLine('accept-charset'),
+            false,
+            true
+        );
 
         // If no charset is shown as a match, ignore the directive
         // as allowed by the RFC, and tell it a default value.
@@ -141,8 +146,13 @@ class Negotiate
      *
      * @return string Best match
      */
-    protected function getBestMatch(array $supported, ?string $header = null, bool $enforceTypes = false, bool $strictMatch = false, bool $matchLocales = false): string
-    {
+    protected function getBestMatch(
+        array $supported,
+        ?string $header = null,
+        bool $enforceTypes = false,
+        bool $strictMatch = false,
+        bool $matchLocales = false
+    ): string {
         if (empty($supported)) {
             throw HTTPException::forEmptySupportedNegotiations();
         }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -253,7 +253,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->request->setHeader('Accept-Charset', 'iso-8859-5, unicode-1-1;q=0.8');
 
         $this->assertSame(
-            strtolower($this->request->config->charset),
+            'utf-8',
             $this->request->negotiate('charset', ['iso-8859', 'unicode-1-2'])
         );
     }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -252,13 +252,19 @@ final class IncomingRequestTest extends CIUnitTestCase
         // $_SERVER['HTTP_ACCEPT_CHARSET'] = 'iso-8859-5, unicode-1-1;q=0.8';
         $this->request->setHeader('Accept-Charset', 'iso-8859-5, unicode-1-1;q=0.8');
 
-        $this->assertSame(strtolower($this->request->config->charset), $this->request->negotiate('charset', ['iso-8859', 'unicode-1-2']));
+        $this->assertSame(
+            strtolower($this->request->config->charset),
+            $this->request->negotiate('charset', ['iso-8859', 'unicode-1-2'])
+        );
     }
 
     public function testNegotiatesMedia()
     {
         $this->request->setHeader('Accept', 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
-        $this->assertSame('text/html', $this->request->negotiate('media', ['text/html', 'text/x-c', 'text/x-dvi', 'text/plain']));
+        $this->assertSame(
+            'text/html',
+            $this->request->negotiate('media', ['text/html', 'text/x-c', 'text/x-dvi', 'text/plain'])
+        );
     }
 
     public function testNegotiatesEncoding()

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -200,6 +200,7 @@ Deprecations
 - The public property ``Response::$CSP`` is deprecated. It will be protected. Use ``Response::getCSP()`` instead.
 - ``CodeIgniter::$path`` and ``CodeIgniter::setPath()`` are deprecated. No longer used.
 - The public property ``IncomingRequest::$uri`` is deprecated. It will be protected. Use ``IncomingRequest::getUri()`` instead.
+- The public property ``IncomingRequest::$config`` is deprecated. It will be protected.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -199,6 +199,7 @@ Deprecations
 - ``BaseBuilder::setUpdateBatch()`` and ``BaseBuilder::setInsertBatch()`` are deprecated. Use ``BaseBuilder::setData()`` instead.
 - The public property ``Response::$CSP`` is deprecated. It will be protected. Use ``Response::getCSP()`` instead.
 - ``CodeIgniter::$path`` and ``CodeIgniter::setPath()`` are deprecated. No longer used.
+- The public property ``IncomingRequest::$uri`` is deprecated. It will be protected. Use ``IncomingRequest::getUri()`` instead.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
See #5344

Deprecate
- IncomingRequest::$uri
- IncomingRequest::$config

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

