### PR TITLE
Deallocate prepared statements

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -266,7 +266,12 @@ parameters:
 			path: system/Database/MySQLi/Result.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array<string, int|string|null> and false will always evaluate to false\\.$#"
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 2
+			path: system/Database/OCI8/PreparedQuery.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
 			count: 1
 			path: system/Database/Postgre/Connection.php
 

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -116,6 +116,11 @@ parameters:
 			path: system/Database/Migration.php
 
 		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: system/Database/BasePreparedQuery.php
+
+		-
 			message: "#^Cannot access property \\$errno on bool\\|object\\|resource\\.$#"
 			count: 1
 			path: system/Database/MySQLi/Connection.php
@@ -222,7 +227,7 @@ parameters:
 
 		-
 			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 2
+			count: 1
 			path: system/Database/MySQLi/PreparedQuery.php
 
 		-
@@ -267,7 +272,7 @@ parameters:
 
 		-
 			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 2
+			count: 1
 			path: system/Database/OCI8/PreparedQuery.php
 
 		-
@@ -277,7 +282,7 @@ parameters:
 
 		-
 			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 2
+			count: 1
 			path: system/Database/Postgre/PreparedQuery.php
 
 		-
@@ -292,7 +297,7 @@ parameters:
 
 		-
 			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 2
+			count: 1
 			path: system/Database/SQLSRV/PreparedQuery.php
 
 		-
@@ -367,7 +372,7 @@ parameters:
 
 		-
 			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 2
+			count: 1
 			path: system/Database/SQLite3/PreparedQuery.php
 
 		-

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -216,8 +216,13 @@ parameters:
 			path: system/Database/MySQLi/PreparedQuery.php
 
 		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			message: "#^Cannot call method close\\(\\) on object\\|resource\\.$#"
 			count: 1
+			path: system/Database/MySQLi/PreparedQuery.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 2
 			path: system/Database/MySQLi/PreparedQuery.php
 
 		-
@@ -267,7 +272,7 @@ parameters:
 
 		-
 			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
+			count: 2
 			path: system/Database/Postgre/PreparedQuery.php
 
 		-
@@ -282,7 +287,7 @@ parameters:
 
 		-
 			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
+			count: 2
 			path: system/Database/SQLSRV/PreparedQuery.php
 
 		-
@@ -351,8 +356,13 @@ parameters:
 			path: system/Database/SQLite3/PreparedQuery.php
 
 		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			message: "#^Cannot call method close\\(\\) on object\\|resource\\.$#"
 			count: 1
+			path: system/Database/SQLite3/PreparedQuery.php
+
+		-
+			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 2
 			path: system/Database/SQLite3/PreparedQuery.php
 
 		-

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -116,11 +116,6 @@ parameters:
 			path: system/Database/Migration.php
 
 		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Database/BasePreparedQuery.php
-
-		-
 			message: "#^Cannot access property \\$errno on bool\\|object\\|resource\\.$#"
 			count: 1
 			path: system/Database/MySQLi/Connection.php
@@ -226,11 +221,6 @@ parameters:
 			path: system/Database/MySQLi/PreparedQuery.php
 
 		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Database/MySQLi/PreparedQuery.php
-
-		-
 			message: "#^Cannot access property \\$field_count on object\\|resource\\|false\\.$#"
 			count: 1
 			path: system/Database/MySQLi/Result.php
@@ -271,19 +261,9 @@ parameters:
 			path: system/Database/MySQLi/Result.php
 
 		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Database/OCI8/PreparedQuery.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
 			count: 1
 			path: system/Database/Postgre/Connection.php
-
-		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Database/Postgre/PreparedQuery.php
 
 		-
 			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$schema\\.$#"
@@ -294,11 +274,6 @@ parameters:
 			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$schema\\.$#"
 			count: 13
 			path: system/Database/SQLSRV/Forge.php
-
-		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Database/SQLSRV/PreparedQuery.php
 
 		-
 			message: "#^Cannot call method changes\\(\\) on bool\\|object\\|resource\\.$#"
@@ -367,11 +342,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method close\\(\\) on object\\|resource\\.$#"
-			count: 1
-			path: system/Database/SQLite3/PreparedQuery.php
-
-		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:\\$statement \\(object\\|resource\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: system/Database/SQLite3/PreparedQuery.php
 

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -261,7 +261,7 @@ parameters:
 			path: system/Database/MySQLi/Result.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
+			message: "#^Strict comparison using \\=\\=\\= between array<string, int|string|null> and false will always evaluate to false\\.$#"
 			count: 1
 			path: system/Database/Postgre/Connection.php
 

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -148,6 +148,8 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
     /**
      * Explicitly closes the prepared statement.
+     *
+     * @throws BadMethodCallException
      */
     public function close(): bool
     {

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -157,7 +157,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * The database dependant version of the close method.
      */
-    abstract public function _close(): bool;
+    abstract protected function _close(): bool;
 
     /**
      * Returns the SQL that has been prepared.

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -25,7 +25,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     /**
      * The prepared statement itself.
      *
-     * @var object|resource
+     * @var object|resource|null
      */
     protected $statement;
 
@@ -158,7 +158,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
         try {
             return $this->_close();
         } finally {
-            unset($this->statement);
+            $this->statement = null;
         }
     }
 

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -163,7 +163,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     }
 
     /**
-     * The database dependant version of the close method.
+     * The database-dependent version of the close method.
      */
     abstract protected function _close(): bool;
 

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -151,7 +151,15 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      */
     public function close(): bool
     {
-        return $this->_close();
+        if (! isset($this->statement)) {
+            return true;
+        }
+
+        try {
+            return $this->_close();
+        } finally {
+            unset($this->statement);
+        }
     }
 
     /**

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -147,16 +147,17 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     abstract public function _getResult();
 
     /**
-     * Explicitly closes the statement.
+     * Explicitly closes the prepared statement.
      */
-    public function close()
+    public function close(): bool
     {
-        if (! is_object($this->statement) || ! method_exists($this->statement, 'close')) {
-            return;
-        }
-
-        $this->statement->close();
+        return $this->_close();
     }
+
+    /**
+     * The database dependant version of the close method.
+     */
+    abstract public function _close(): bool;
 
     /**
      * Returns the SQL that has been prepared.

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -152,7 +152,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
     public function close(): bool
     {
         if (! isset($this->statement)) {
-            return true;
+            throw new BadMethodCallException('Cannot call close on a non-existing prepared statement.');
         }
 
         try {

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -89,4 +89,18 @@ class PreparedQuery extends BasePreparedQuery
     {
         return $this->statement->get_result();
     }
+
+    /**
+     * Deallocate prepared statements
+     */
+    public function _close(): bool
+    {
+        $error = true;
+        if (isset($this->statement)) {
+            $error = $this->statement->close();
+            unset($this->statement);
+        }
+
+        return $error;
+    }
 }

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -93,7 +93,7 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Deallocate prepared statements
      */
-    public function _close(): bool
+    protected function _close(): bool
     {
         $error = true;
         if (isset($this->statement)) {

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -95,12 +95,6 @@ class PreparedQuery extends BasePreparedQuery
      */
     protected function _close(): bool
     {
-        $error = true;
-        if (isset($this->statement)) {
-            $error = $this->statement->close();
-            unset($this->statement);
-        }
-
-        return $error;
+        return $this->statement->close();
     }
 }

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -103,13 +103,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
      */
     protected function _close(): bool
     {
-        $error = true;
-        if (isset($this->statement)) {
-            $error = oci_free_statement($this->statement);
-            unset($this->statement);
-        }
-
-        return $error;
+        return oci_free_statement($this->statement);
     }
 
     /**

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -105,7 +105,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
     {
         $error = true;
         if (isset($this->statement)) {
-            $error = (bool) oci_free_statement($this->statement);
+            $error = oci_free_statement($this->statement);
             unset($this->statement);
         }
 

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -99,6 +99,20 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
     }
 
     /**
+     * Deallocate prepared statements
+     */
+    public function _close(): bool
+    {
+        $error = true;
+        if (null !== $this->statement) {
+            $error = oci_free_statement($this->statement);
+            unset($this->statement);
+        }
+
+        return $error;
+    }
+
+    /**
      * Replaces the ? placeholders with :0, :1, etc parameters for use
      * within the prepared query.
      */

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -68,7 +68,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
      */
     public function _execute(array $data): bool
     {
-        if (null === $this->statement) {
+        if (! isset($this->statement)) {
             throw new BadMethodCallException('You must call prepare before trying to execute a prepared statement.');
         }
 
@@ -104,8 +104,8 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
     public function _close(): bool
     {
         $error = true;
-        if (null !== $this->statement) {
-            $error = oci_free_statement($this->statement);
+        if (isset($this->statement)) {
+            $error = (bool) oci_free_statement($this->statement);
             unset($this->statement);
         }
 

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -101,7 +101,7 @@ class PreparedQuery extends BasePreparedQuery implements PreparedQueryInterface
     /**
      * Deallocate prepared statements
      */
-    public function _close(): bool
+    protected function _close(): bool
     {
         $error = true;
         if (isset($this->statement)) {

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -105,7 +105,7 @@ class PreparedQuery extends BasePreparedQuery
     {
         $error = true;
         if (isset($this->statement)) {
-            $error = (bool) pg_query($this->db->connID, 'DEALLOCATE ' . $this->name);
+            $error = (bool) pg_query($this->db->connID, 'DEALLOCATE "' . $this->db->escapeIdentifiers($this->name) . '"');
             unset($this->statement);
         }
 

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -103,13 +103,7 @@ class PreparedQuery extends BasePreparedQuery
      */
     protected function _close(): bool
     {
-        $error = true;
-        if (isset($this->statement)) {
-            $error = (bool) pg_query($this->db->connID, 'DEALLOCATE "' . $this->db->escapeIdentifiers($this->name) . '"');
-            unset($this->statement);
-        }
-
-        return $error;
+        return (bool) pg_query($this->db->connID, 'DEALLOCATE "' . $this->db->escapeIdentifiers($this->name) . '"');
     }
 
     /**

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -101,7 +101,7 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Deallocate prepared statements
      */
-    public function _close(): bool
+    protected function _close(): bool
     {
         $error = true;
         if (isset($this->statement)) {

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -99,6 +99,20 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
+     * Deallocate prepared statements
+     */
+    public function _close(): bool
+    {
+        $error = true;
+        if (isset($this->statement)) {
+            $error = (bool) pg_query($this->db->connID, 'DEALLOCATE ' . $this->name);
+            unset($this->statement);
+        }
+
+        return $error;
+    }
+
+    /**
      * Replaces the ? placeholders with $1, $2, etc parameters for use
      * within the prepared query.
      */

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -103,7 +103,7 @@ class PreparedQuery extends BasePreparedQuery
      */
     protected function _close(): bool
     {
-        return (bool) pg_query($this->db->connID, 'DEALLOCATE "' . $this->db->escapeIdentifiers($this->name) . '"');
+        return pg_query($this->db->connID, 'DEALLOCATE "' . $this->db->escapeIdentifiers($this->name) . '"') !== false;
     }
 
     /**

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -119,7 +119,7 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Deallocate prepared statements
      */
-    public function _close(): bool
+    protected function _close(): bool
     {
         $error = true;
         if (isset($this->statement)) {

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -121,13 +121,7 @@ class PreparedQuery extends BasePreparedQuery
      */
     protected function _close(): bool
     {
-        $error = true;
-        if (isset($this->statement)) {
-            $error = sqlsrv_free_stmt($this->statement);
-            unset($this->statement);
-        }
-
-        return $error;
+        return sqlsrv_free_stmt($this->statement);
     }
 
     /**

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -117,6 +117,20 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
+     * Deallocate prepared statements
+     */
+    public function _close(): bool
+    {
+        $error = true;
+        if (isset($this->statement)) {
+            $error = sqlsrv_free_stmt($this->statement);
+            unset($this->statement);
+        }
+
+        return $error;
+    }
+
+    /**
      * Handle parameters
      */
     protected function parameterize(string $queryString): array

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -93,4 +93,18 @@ class PreparedQuery extends BasePreparedQuery
     {
         return $this->result;
     }
+
+    /**
+     * Deallocate prepared statements
+     */
+    public function _close(): bool
+    {
+        $error = true;
+        if (isset($this->statement)) {
+            $error = $this->statement->close();
+            unset($this->statement);
+        }
+
+        return $error;
+    }
 }

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -95,7 +95,7 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Deallocate prepared statements
      */
-    public function _close(): bool
+    protected function _close(): bool
     {
         $error = true;
         if (isset($this->statement)) {

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -56,8 +56,6 @@ class PreparedQuery extends BasePreparedQuery
     /**
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
-     *
-     * @todo finalize()
      */
     public function _execute(array $data): bool
     {

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -97,12 +97,6 @@ class PreparedQuery extends BasePreparedQuery
      */
     protected function _close(): bool
     {
-        $error = true;
-        if (isset($this->statement)) {
-            $error = $this->statement->close();
-            unset($this->statement);
-        }
-
-        return $error;
+        return $this->statement->close();
     }
 }

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -42,12 +42,10 @@ final class PreparedQueryTest extends CIUnitTestCase
     {
         parent::tearDown();
 
-        if ($this->query !== null) {
-            try {
-                $this->query->close();
-            } catch (BadMethodCallException $e) {
-                $this->query = null;
-            }
+        try {
+            $this->query->close();
+        } catch (BadMethodCallException $e) {
+            $this->query = null;
         }
     }
 

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -43,7 +43,11 @@ final class PreparedQueryTest extends CIUnitTestCase
         parent::tearDown();
 
         if ($this->query !== null) {
-            $this->query->close();
+            try {
+                $this->query->close();
+            } catch (BadMethodCallException $e) {
+                $this->query = null;
+            }
         }
     }
 
@@ -162,10 +166,18 @@ final class PreparedQueryTest extends CIUnitTestCase
 
         $this->query->close();
 
+        // Try to execute a non-existing prepared statement
         try {
             $this->query->execute('bar', 'bar@example.com', 'GB');
         } catch (BadMethodCallException $e) {
             $this->assertSame('You must call prepare before trying to execute a prepared statement.', $e->getMessage());
+        }
+
+        // Try to close a non-existing prepared statement
+        try {
+            $this->query->close();
+        } catch (BadMethodCallException $e) {
+            $this->assertSame('Cannot call close on a non-existing prepared statement.', $e->getMessage());
         }
 
         $this->seeInDatabase($this->db->DBPrefix . 'user', ['name' => 'foo', 'email' => 'foo@example.com']);

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -143,6 +143,7 @@ Database
 - Added the ability to manually set index names. These methods include: ``Forge::addKey()``, ``Forge::addPrimaryKey()``, and ``Forge::addUniqueKey()``
 - Fixed ``Forge::dropKey()`` to allow droping unique indexes. This required the ``DROP CONSTRAINT`` SQL command.
 - Added ``upsert()`` and ``upsertBatch()`` methods to QueryBuilder. See :ref:`upsert-data`.
+- ``BasePreparedQuery::close()`` now deallocates the prepared statement in all DBMS. Previously, they were not deallocated in Postgre, SQLSRV and OCI8. See :ref:`database-queries-stmt-close`.
 
 Model
 =====

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -90,6 +90,7 @@ The return value of  ``Validation::loadRuleGroup()`` has been changed ``null`` t
 Others
 ------
 
+- The return type of ``CodeIgniter\Database\BasePreparedQuery::close()`` has been changed to ``bool``.
 - The return type of ``CodeIgniter\Database\Database::loadForge()`` has been changed to ``Forge``.
 - The return type of ``CodeIgniter\Database\Database::loadUtils()`` has been changed to ``BaseUtils``.
 - Parameter ``$column`` has changed in ``Table::dropForeignKey()`` to ``$foreignName``.

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -232,6 +232,8 @@ Other Methods
 
 In addition to these two primary methods, the prepared query object also has the following methods:
 
+.. _database-queries-stmt-close:
+
 close()
 -------
 
@@ -239,6 +241,8 @@ While PHP does a pretty good job of closing all open statements with the databas
 close out the prepared statement when you're done with it:
 
 .. literalinclude:: queries/020.php
+
+.. note:: Since v4.3.0, the close() method deallocates the prepared statement in all DBMS. Previously, they were not deallocated in Postgre, SQLSRV and OCI8.
 
 getQueryString()
 ----------------

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -242,7 +242,7 @@ close out the prepared statement when you're done with it:
 
 .. literalinclude:: queries/020.php
 
-.. note:: Since v4.3.0, the close() method deallocates the prepared statement in all DBMS. Previously, they were not deallocated in Postgre, SQLSRV and OCI8.
+.. note:: Since v4.3.0, the ``close()`` method deallocates the prepared statement in all DBMS. Previously, they were not deallocated in Postgre, SQLSRV and OCI8.
 
 getQueryString()
 ----------------

--- a/user_guide_src/source/database/queries/020.php
+++ b/user_guide_src/source/database/queries/020.php
@@ -1,3 +1,7 @@
 <?php
 
-$bool = $pQuery->close();
+if ($pQuery->close()) {
+    echo 'Success!';
+} else {
+    echo 'Deallocation of prepared statements failed!';
+}

--- a/user_guide_src/source/database/queries/020.php
+++ b/user_guide_src/source/database/queries/020.php
@@ -1,3 +1,3 @@
 <?php
 
-$pQuery->close();
+$bool = $pQuery->close();


### PR DESCRIPTION
Fixes #1256

**Description**

Implement a common method in each database connector to destroy the prepared query when we're done with it

Cf Issue codeigniter4/CodeIgniter4#1256 : TODO Deallocate prepared statements

To closes a prepared statement :

- MySQLi have mysqli_stmt_close()
  https://www.php.net/manual/en/mysqli-stmt.close.php
- OCI8 have oci_free_statement()
  https://www.php.net/manual/en/function.oci-free-statement.php
- Postgre does not have a specific PHP function for deleting a prepared statement,
  the SQL DEALLOCATE statement can be used for that purpose :
  https://www.php.net/manual/en/function.pg-prepare.php
  https://www.postgresql.org/docs/8.1/sql-deallocate.html
- SQLite3 have SQLite3Stmt::close()
  https://www.php.net/manual/en/sqlite3stmt.close.php
- SQLSRV have sqlsrv_free_stmt()
  https://www.php.net/manual/en/function.sqlsrv-free-stmt.php

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
