### PR TITLE
chore: update PHPStan PHP version to 8.1

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -33,8 +33,6 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix:
-        php-versions: ['8.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -42,7 +40,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.1'
           extensions: intl
 
       - name: Use latest Composer

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -301,7 +301,7 @@ parameters:
 			path: system/Database/MySQLi/Result.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
+			message: "#^Strict comparison using \\=\\=\\= between array<string, int|string|null> and false will always evaluate to false\\.$#"
 			count: 1
 			path: system/Database/Postgre/Connection.php
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,7 +16,7 @@ includes:
 	- phpstan-baseline.neon.dist
 
 parameters:
-	phpVersion: 80000
+	phpVersion: 80100
 	tmpDir: build/phpstan
 	level: 5
 	paths:


### PR DESCRIPTION
**Description**
PHP 8.1 is the most used version with Composer.

![Screenshot 2022-10-12 8 15 14](https://user-images.githubusercontent.com/87955/195215958-4ff4d1d8-4863-4e40-8bc4-453b08c2436f.png)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide

