### PR TITLE
refactor: valid_date does not work in PHP 8.2

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -344,6 +344,15 @@ class FormatRules
         $date   = DateTime::createFromFormat($format, $str);
         $errors = DateTime::getLastErrors();
 
-        return $date !== false && $errors !== false && $errors['warning_count'] === 0 && $errors['error_count'] === 0;
+        if ($date === false) {
+            return false;
+        }
+
+        // PHP 8.2 or later.
+        if ($errors === false) {
+            return true;
+        }
+
+        return $errors['warning_count'] === 0 && $errors['error_count'] === 0;
     }
 }


### PR DESCRIPTION
**Description**
See #6170
See https://github.com/codeigniter4/CodeIgniter4/pull/6172#issuecomment-1275496541

```console
bash-3.2$ ./phpunit tests/system/Validation/FormatRulesTest.php
PHPUnit 9.5.25 #StandWithUkraine

Runtime:       PHP 8.2.0-dev
Configuration: /Users/kenji/work/codeigniter/official/CodeIgniter4/phpunit.xml

...............................................................  63 / 193 ( 32%)
............................................................... 126 / 193 ( 65%)
............................................................... 189 / 193 ( 97%)
....                                                            193 / 193 (100%)

Time: 00:00.325, Memory: 14.00 MB

OK (193 tests, 193 assertions)
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

