### PR TITLE
refactor: DOMParser::withString() for PHP 8.2

### DIFF
--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -61,9 +61,8 @@ class DOMParser
      */
     public function withString(string $content)
     {
-        // converts all special characters to HTML-Entities
-        $content = htmlentities($content);
-        $content = htmlspecialchars_decode($content);
+        // encode character to HTML numeric string reference
+        $content = mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0x1FFFFF], 'UTF-8');
 
         // turning off some errors
         libxml_use_internal_errors(true);

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -61,7 +61,10 @@ class DOMParser
      */
     public function withString(string $content)
     {
-        // encode character to HTML numeric string reference
+        // DOMDocument::loadHTML() will treat your string as being in ISO-8859-1
+        // (the HTTP/1.1 default character set) unless you tell it otherwise.
+        // https://stackoverflow.com/a/8218649
+        // So encode characters to HTML numeric string references.
         $content = mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0x1FFFFF], 'UTF-8');
 
         // turning off some errors

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -89,7 +89,7 @@ class DOMParser
      * Loads the contents of a file as a string
      * so that we can work with it.
      *
-     * @return DOMParser
+     * @return $this
      */
     public function withFile(string $path)
     {
@@ -184,7 +184,7 @@ class DOMParser
     /**
      * Search the DOM using an XPath expression.
      *
-     * @return DOMNodeList
+     * @return DOMNodeList|false
      */
     protected function doXPath(?string $search, string $element, array $paths = [])
     {

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -61,8 +61,9 @@ class DOMParser
      */
     public function withString(string $content)
     {
-        // converts all special characters to utf-8
-        $content = mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8');
+        // converts all special characters to HTML-Entities
+        $content = htmlentities($content);
+        $content = htmlspecialchars_decode($content);
 
         // turning off some errors
         libxml_use_internal_errors(true);

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -80,8 +80,9 @@ final class DOMParserTest extends CIUnitTestCase
     public function provideText()
     {
         return [
-            ['Hello World'],
-            ['Hellö Wörld'],
+            'en' => ['Hello World'],
+            'sv' => ['Hej, världen'],
+            'ja' => ['こんにちは、世界'],
         ];
     }
 


### PR DESCRIPTION
**Description**
See #6170
See https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated

- `mb_convert_encoding($str, 'HTML-Entities')` is deprecated in PHP 8.2.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

