### PR TITLE
fix: getGetPost() and getPostGet() when index is null

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -613,6 +613,9 @@ class IncomingRequest extends Request
      */
     public function getPostGet($index = null, $filter = null, $flags = null)
     {
+        if ($index === null) {
+            return array_merge($this->getGet($index, $filter, $flags), $this->getPost($index, $filter, $flags));
+        }
         // Use $_POST directly here, since filter_has_var only
         // checks the initial POST data, not anything that might
         // have been added since.
@@ -630,6 +633,9 @@ class IncomingRequest extends Request
      */
     public function getGetPost($index = null, $filter = null, $flags = null)
     {
+        if ($index === null) {
+            return array_merge($this->getPost($index, $filter, $flags), $this->getGet($index, $filter, $flags));
+        }
         // Use $_GET directly here, since filter_has_var only
         // checks the initial GET data, not anything that might
         // have been added since.

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -563,6 +563,26 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame($_GET, $this->request->getGetPost());
     }
 
+    public function testPostGetSecondStream()
+    {
+        $_GET['get'] = '3';
+        $this->assertSame($_GET, $this->request->getPostGet());
+    }
+
+    public function testGetPostSecondStream()
+    {
+        $_POST['post'] = '5';
+        $this->assertSame($_POST, $this->request->getGetPost());
+    }
+
+    public function testGetPostSecondStreams()
+    {
+        $_GET['get']   = '3';
+        $_POST['post'] = '5';
+        $this->assertSame(array_merge($_GET, $_POST), $this->request->getPostGet());
+        $this->assertSame(array_merge($_POST, $_GET), $this->request->getGetPost());
+    }
+
     public function testWithFalseBody()
     {
         // Use `false` here to simulate file_get_contents returning a false value

--- a/user_guide_src/source/changelogs/v4.2.8.rst
+++ b/user_guide_src/source/changelogs/v4.2.8.rst
@@ -36,6 +36,6 @@ none.
 Bugs Fixed
 **********
 
-none.
+- Fixed a bug when the ``CodeIgniter\HTTP\IncomingRequest::getPostGet()`` and ``CodeIgniter\HTTP\IncomingRequest::getGetPost()`` methods didn't return values from the other stream when ``index`` was set to ``null``.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -339,7 +339,8 @@ The methods provided by the parent classes that are available are:
                         found `here <https://www.php.net/manual/en/filter.filters.php>`__.
         :param  int     $flags: Flags to apply. A list of flags can be found
                         `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
-        :returns:       $_POST if no parameters supplied, otherwise the POST value if found, or null if not
+        :returns:       $_POST and $_GET combined if no parameters specified (prefer POST value on conflict),
+                        otherwise looks for POST value, if nothing found looks for GET value, if no value found returns null
         :rtype: mixed|null
 
         This method works pretty much the same way as ``getPost()`` and ``getGet()``, only combined.
@@ -348,6 +349,9 @@ The methods provided by the parent classes that are available are:
 
         .. literalinclude:: incomingrequest/032.php
 
+        If no index is specified, it will return both POST and GET streams combined.
+        Although POST data will be preferred in case of name conflict.
+
     .. php:method:: getGetPost([$index = null[, $filter = null[, $flags = null]]])
 
         :param  string  $index: The name of the variable/key to look for.
@@ -355,14 +359,18 @@ The methods provided by the parent classes that are available are:
                         found `here <https://www.php.net/manual/en/filter.filters.php>`__.
         :param  int     $flags: Flags to apply. A list of flags can be found
                         `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
-        :returns:       $_POST if no parameters supplied, otherwise the POST value if found, or null if not
+        :returns:       $_GET and $_POST combined if no parameters specified (prefer GET value on conflict),
+                        otherwise looks for GET value, if nothing found looks for POST value, if no value found returns null
         :rtype: mixed|null
 
         This method works pretty much the same way as ``getPost()`` and ``getGet()``, only combined.
-        It will search through both POST and GET streams for data, looking first in GET, and
+        It will search through both GET and POST streams for data, looking first in GET, and
         then in POST:
 
         .. literalinclude:: incomingrequest/033.php
+
+        If no index is specified, it will return both GET and POST streams combined.
+        Although GET data will be preferred in case of name conflict.
 
     .. php:method:: getCookie([$index = null[, $filter = null[, $flags = null]]])
         :noindex:


### PR DESCRIPTION
**Description**
This PR fixes the problem below:

```php
$_GET['foo'] = 'bar';
d(service('request')->getPostGet());
// returns an empty array
```

Basically, we return only one stream:
* for `getPostGet()` method - `POST` array
* and for `getGetPost()` method - `GET` array

And that's fine when the `index` is specified. 

But not when `index` is `null`. We should check both streams for values and return them all with priority for `GET` or `POST` values - depending on the used method.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
