### PR TITLE
Add Forge::processIndexes() to create indexes on existing table

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1040,7 +1040,7 @@ class Forge
         }
     }
 
-    protected function _processPrimaryKeys(string $table): string
+    protected function _processPrimaryKeys(string $table, bool $asQuery = false): string
     {
         $sql = '';
 
@@ -1053,7 +1053,12 @@ class Forge
         }
 
         if (isset($this->primaryKeys['fields']) && $this->primaryKeys['fields'] !== []) {
-            $sql .= ",\n\tCONSTRAINT " . $this->db->escapeIdentifiers(($this->primaryKeys['keyName'] === '' ?
+            if ($asQuery === true) {
+                $sql .= 'ALTER TABLE ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $table) . ' ADD ';
+            } else {
+                $sql .= ",\n\t";
+            }
+            $sql .= "CONSTRAINT " . $this->db->escapeIdentifiers(($this->primaryKeys['keyName'] === '' ?
                 'pk_' . $table :
                 $this->primaryKeys['keyName']))
                     . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys['fields'])) . ')';

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1166,6 +1166,8 @@ class Forge
         foreach ($this->foreignKeys as $index => $fkey) {
             if ($asQuery === false) {
                 $index = 0;
+            } else {
+                $sqls[$index] = '';
             }
 
             $nameIndex = $fkey['fkName'] !== '' ?
@@ -1176,8 +1178,6 @@ class Forge
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
             $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
             $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
-
-            $sqls[$index] = '';
 
             if ($asQuery === true) {
                 $sqls[$index] .= 'ALTER TABLE ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $table) . ' ADD ';

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1161,9 +1161,8 @@ class Forge
             throw new DatabaseException(lang('Database.fieldNotExists', $errorNames));
         }
 
-        $sqls    = [];
+        $sqls    = [''];
         $index   = 0;
-        $sqls[0] = '';
         $i       = 0;
 
         foreach ($this->foreignKeys as $fkey) {

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1072,7 +1072,7 @@ class Forge
         $fields = $this->fields;
 
         if (! empty($this->keys)) {
-            $sqls = array_merge($sqls, $this->_processIndexes($this->db->DBPrefix . $table, true));
+            $sqls = $this->_processIndexes($this->db->DBPrefix . $table, true);
 
             $pk = $this->_processPrimaryKeys($table, true);
 
@@ -1088,8 +1088,8 @@ class Forge
             $sqls = array_merge($sqls, $this->_processForeignKeys($table, true));
         }
 
-        for ($i = 0, $sqls, $c = count($sqls); $i < $c; $i++) {
-            if ($this->db->query($sqls[$i]) === false) {
+        foreach ($sqls as $sql) {
+            if ($this->db->query($sql) === false) {
                 return false;
             }
         }
@@ -1161,12 +1161,9 @@ class Forge
             throw new DatabaseException(lang('Database.fieldNotExists', $errorNames));
         }
 
-        $sqls    = [''];
-        $index   = 0;
-        $i       = 0;
+        $sqls = [''];
 
-        foreach ($this->foreignKeys as $fkey) {
-            $index = $i;
+        foreach ($this->foreignKeys as $index => $fkey) {
             if ($asQuery === false) {
                 $index = 0;
             }
@@ -1183,23 +1180,21 @@ class Forge
             $sqls[$index] = '';
 
             if ($asQuery === true) {
-                $sqls[$i] .= 'ALTER TABLE ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $table) . ' ADD ';
+                $sqls[$index] .= 'ALTER TABLE ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $table) . ' ADD ';
             } else {
-                $sqls[$i] .= ",\n\t";
+                $sqls[$index] .= ",\n\t";
             }
 
             $formatSql = 'CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s)';
-            $sqls[$i] .= sprintf($formatSql, $nameIndexFilled, $foreignKeyFilled, $referenceTableFilled, $referenceFieldFilled);
+            $sqls[$index] .= sprintf($formatSql, $nameIndexFilled, $foreignKeyFilled, $referenceTableFilled, $referenceFieldFilled);
 
             if ($fkey['onDelete'] !== false && in_array($fkey['onDelete'], $this->fkAllowActions, true)) {
-                $sqls[$i] .= ' ON DELETE ' . $fkey['onDelete'];
+                $sqls[$index] .= ' ON DELETE ' . $fkey['onDelete'];
             }
 
             if ($this->db->DBDriver !== 'OCI8' && $fkey['onUpdate'] !== false && in_array($fkey['onUpdate'], $this->fkAllowActions, true)) {
-                $sqls[$i] .= ' ON UPDATE ' . $fkey['onUpdate'];
+                $sqls[$index] .= ' ON UPDATE ' . $fkey['onUpdate'];
             }
-
-            $i++;
         }
 
         return $sqls;

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1156,7 +1156,7 @@ class Forge
         }
 
         if ($errorNames !== []) {
-            $errorNames[0] = implode(', ', $errorNames);
+            $errorNames = [implode(', ', $errorNames)];
 
             throw new DatabaseException(lang('Database.fieldNotExists', $errorNames));
         }

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1027,6 +1027,11 @@ class Forge
         }
     }
 
+    /**
+     * Generates SQL to add primary key
+     *
+     * @param bool $asQuery When true returns stand alone SQL, else partial SQL used with CREATE TABLE
+     */
     protected function _processPrimaryKeys(string $table, bool $asQuery = false): string
     {
         $sql = '';
@@ -1099,6 +1104,11 @@ class Forge
         return true;
     }
 
+    /**
+     * Generates SQL to add indexes
+     *
+     * @param bool $asQuery When true returns stand alone SQL, else partial SQL used with CREATE TABLE
+     */
     protected function _processIndexes(string $table, bool $asQuery = false): array
     {
         $sqls = [];
@@ -1141,7 +1151,9 @@ class Forge
     }
 
     /**
-     * Generates SQL to process foreign keys
+     * Generates SQL to add foreign keys
+     *
+     * @param bool $asQuery When true returns stand alone SQL, else partial SQL used with CREATE TABLE
      */
     protected function _processForeignKeys(string $table, bool $asQuery = false): array
     {

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -594,7 +594,7 @@ class Forge
         $columns .= $this->_processForeignKeys($table);
 
         if ($this->createTableKeys === true) {
-            $indexes = $this->_processIndexes($table);
+            $indexes = current($this->_processIndexes($table));
             if (is_string($indexes)) {
                 $columns .= $indexes;
             }
@@ -1062,7 +1062,7 @@ class Forge
         return $sql;
     }
 
-    protected function _processIndexes(string $table)
+    protected function _processIndexes(string $table, bool $asQuery = false): array
     {
         $sqls = [];
 

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -183,9 +183,9 @@ class Forge extends BaseForge
     }
 
     /**
-     * Process indexes
+     * Generates SQL to add indexes
      *
-     * @param string $table (ignored)
+     * @param bool $asQuery When true returns stand alone SQL, else partial SQL used with CREATE TABLE
      */
     protected function _processIndexes(string $table, bool $asQuery = false): array
     {

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -187,11 +187,18 @@ class Forge extends BaseForge
      *
      * @param string $table (ignored)
      */
-    protected function _processIndexes(string $table): string
+    protected function _processIndexes(string $table, bool $asQuery = false): array
     {
-        $sql = '';
+        $sqls    = [];
+        $index   = 0;
+        $sqls[0] = '';
 
         for ($i = 0, $c = count($this->keys); $i < $c; $i++) {
+            $index = $i;
+            if ($asQuery === false) {
+                $index = 0;
+            }
+
             if (isset($this->keys[$i]['fields'])) {
                 for ($i2 = 0, $c2 = count($this->keys[$i]['fields']); $i2 < $c2; $i2++) {
                     if (! isset($this->fields[$this->keys[$i]['fields'][$i2]])) {
@@ -211,14 +218,20 @@ class Forge extends BaseForge
             $keyName = $this->db->escapeIdentifiers(($this->keys[$i]['keyName'] === '') ?
                 implode('_', $this->keys[$i]['fields']) :
                 $this->keys[$i]['keyName']);
-
-            $sql .= ",\n\t{$unique}KEY " . $keyName
+                
+            if ($asQuery === true) {
+                $sqls[$index] = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table) . " ADD {$unique}KEY "
+                    . $keyName
+                    . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ')';
+            } else {
+                $sqls[$index] .= ",\n\t{$unique}KEY " . $keyName
                 . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i]['fields'])) . ')';
+            }
         }
 
         $this->keys = [];
 
-        return $sql;
+        return $sqls;
     }
 
     /**

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -218,11 +218,11 @@ class Forge extends BaseForge
             $keyName = $this->db->escapeIdentifiers(($this->keys[$i]['keyName'] === '') ?
                 implode('_', $this->keys[$i]['fields']) :
                 $this->keys[$i]['keyName']);
-                
+
             if ($asQuery === true) {
                 $sqls[$index] = 'ALTER TABLE ' . $this->db->escapeIdentifiers($table) . " ADD {$unique}KEY "
                     . $keyName
-                    . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i])) . ')';
+                    . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i]['fields'])) . ')';
             } else {
                 $sqls[$index] .= ",\n\t{$unique}KEY " . $keyName
                 . ' (' . implode(', ', $this->db->escapeIdentifiers($this->keys[$i]['fields'])) . ')';

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -189,8 +189,8 @@ class Forge extends BaseForge
      */
     protected function _processIndexes(string $table, bool $asQuery = false): array
     {
-        $sqls    = [''];
-        $index   = 0;
+        $sqls  = [''];
+        $index = 0;
 
         for ($i = 0, $c = count($this->keys); $i < $c; $i++) {
             $index = $i;

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -189,9 +189,8 @@ class Forge extends BaseForge
      */
     protected function _processIndexes(string $table, bool $asQuery = false): array
     {
-        $sqls    = [];
+        $sqls    = [''];
         $index   = 0;
-        $sqls[0] = '';
 
         for ($i = 0, $c = count($this->keys); $i < $c; $i++) {
             $index = $i;

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -243,9 +243,9 @@ class Forge extends BaseForge
     /**
      * Process indexes
      *
-     * @return array|string
+     * @return array
      */
-    protected function _processIndexes(string $table)
+    protected function _processIndexes(string $table, bool $asQuery = false): array
     {
         $sqls = [];
 

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -241,7 +241,9 @@ class Forge extends BaseForge
     }
 
     /**
-     * Process indexes
+     * Generates SQL to add indexes
+     *
+     * @param bool $asQuery When true returns stand alone SQL, else partial SQL used with CREATE TABLE
      */
     protected function _processIndexes(string $table, bool $asQuery = false): array
     {

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -298,31 +298,6 @@ class Forge extends BaseForge
     }
 
     /**
-     * Process primary keys
-     */
-    protected function _processPrimaryKeys(string $table): string
-    {
-        if (isset($this->primaryKeys['fields'])) {
-            for ($i = 0, $c = count($this->primaryKeys['fields']); $i < $c; $i++) {
-                if (! isset($this->fields[$this->primaryKeys['fields'][$i]])) {
-                    unset($this->primaryKeys['fields'][$i]);
-                }
-            }
-
-            if ($this->primaryKeys['fields'] !== []) {
-                $sql = ",\n\tCONSTRAINT " . $this->db->escapeIdentifiers(
-                    ($this->primaryKeys['keyName'] === '' ?
-                    'pk_' . $table :
-                    $this->primaryKeys['keyName'])
-                )
-                    . ' PRIMARY KEY(' . implode(', ', $this->db->escapeIdentifiers($this->primaryKeys['fields'])) . ')';
-            }
-        }
-
-        return $sql ?? '';
-    }
-
-    /**
      * Performs a data type mapping between different databases.
      */
     protected function _attributeType(array &$attributes)

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -242,8 +242,6 @@ class Forge extends BaseForge
 
     /**
      * Process indexes
-     *
-     * @return array
      */
     protected function _processIndexes(string $table, bool $asQuery = false): array
     {

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -269,7 +269,7 @@ class Forge extends BaseForge
         }
 
         if ($errorNames !== []) {
-            $errorNames[0] = implode(', ', $errorNames);
+            $errorNames = [implode(', ', $errorNames)];
 
             throw new DatabaseException(lang('Database.fieldNotExists', $errorNames));
         }

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -237,6 +237,11 @@ class Forge extends BaseForge
         throw new DatabaseException('SQLite does not support foreign key names. CodeIgniter will refer to them in the format: prefix_table_column_referencecolumn_foreign');
     }
 
+    /**
+     * Generates SQL to add primary key
+     *
+     * @param bool $asQuery When true recreates table with key, else partial SQL used with CREATE TABLE
+     */
     protected function _processPrimaryKeys(string $table, bool $asQuery = false): string
     {
         if ($asQuery === false) {
@@ -252,6 +257,11 @@ class Forge extends BaseForge
         return '';
     }
 
+    /**
+     * Generates SQL to add foreign keys
+     *
+     * @param bool $asQuery When true recreates table with key, else partial SQL used with CREATE TABLE
+     */
     protected function _processForeignKeys(string $table, bool $asQuery = false): array
     {
         if ($asQuery === false) {

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -241,8 +241,9 @@ class Table
         }
 
         // add array to keys of fields
-        $pk = ['fields' => $fields['fields'],
-            'type'      => 'primary',
+        $pk = [
+            'fields' => $fields['fields'],
+            'type'   => 'primary',
         ];
 
         $this->keys['primary'] = $pk;

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\Exceptions\DataException;
+use stdclass;
 
 /**
  * Class Table
@@ -228,6 +229,54 @@ class Table
     }
 
     /**
+     * Adds primary key
+     */
+    public function addPrimaryKey(array $fields): Table
+    {
+        $primaryIndexes = array_filter($this->keys, static fn ($index) => strtolower($index['type']) === 'primary');
+
+        // if primary key already exists we can't add another one
+        if ($primaryIndexes !== []) {
+            return $this;
+        }
+
+        // add array to keys of fields
+        $pk = ['fields' => $fields['fields'],
+            'type'      => 'primary',
+        ];
+
+        $this->keys['primary'] = $pk;
+
+        return $this;
+    }
+
+    /**
+     * Add a foreign key
+     *
+     * @return Table
+     */
+    public function addForeignKey(array $foreignKeys)
+    {
+        $fk = [];
+
+        // convert to object
+        foreach ($foreignKeys as $row) {
+            $obj                      = new stdClass();
+            $obj->column_name         = $row['field'];
+            $obj->foreign_table_name  = $row['referenceTable'];
+            $obj->foreign_column_name = $row['referenceField'];
+            $obj->on_delete           = $row['onDelete'];
+            $obj->on_update           = $row['onUpdate'];
+
+            $fk[] = $obj;
+        }
+
+        $this->foreignKeys = array_merge($this->foreignKeys, $fk);
+
+        return $this;
+    }
+
+    /**
      * Creates the new table based on our current fields.
      *
      * @return mixed
@@ -276,6 +325,14 @@ class Table
                         break;
                 }
             }
+        }
+
+        foreach ($this->foreignKeys as $foreignKey) {
+            $this->forge->addForeignKey(
+                $foreignKey->column_name,
+                trim($foreignKey->foreign_table_name, $this->db->DBPrefix),
+                $foreignKey->foreign_column_name
+            );
         }
 
         return $this->forge->createTable($this->tableName);

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -254,7 +254,7 @@ class Table
     /**
      * Add a foreign key
      *
-     * @return Table
+     * @return $this
      */
     public function addForeignKey(array $foreignKeys)
     {

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1516,11 +1516,11 @@ final class ForgeTest extends CIUnitTestCase
             ],
         ];
 
-        foreach ($data as $table => $dummy_data) {
+        foreach ($data as $table => $dummyData) {
             $this->db->table($table)->truncate();
 
-            foreach ($dummy_data as $single_dummy_data) {
-                $this->db->table($table)->insert($single_dummy_data);
+            foreach ($dummyData as $singleDummyData) {
+                $this->db->table($table)->insert($singleDummyData);
             }
         }
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1482,53 +1482,9 @@ final class ForgeTest extends CIUnitTestCase
         $this->forge->dropTable('actions', true);
         $this->forge->dropTable('user2', true);
 
-        // create user2 table
-        $this->forge->addField([
-            'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
-            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
-            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
-            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
-            'created_at' => ['type' => 'DATETIME', 'null' => true],
-            'updated_at' => ['type' => 'DATETIME', 'null' => true],
-            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
-        ])->addKey('id', true)->addUniqueKey('email')->addKey('country')->createTable('user2', true);
-
-        // populate user2 table
-        $data = [
-            [
-                'name'    => 'Derek Jones2',
-                'email'   => 'derek@world.com',
-                'country' => 'France',
-            ],
-            [
-                'name'    => 'Ahmadinejad2',
-                'email'   => 'ahmadinejad@world.com',
-                'country' => 'Greece',
-            ],
-            [
-                'name'    => 'Richard A Causey2',
-                'email'   => 'richard@world.com',
-                'country' => 'France',
-            ],
-            [
-                'name'    => 'Chris Martin2',
-                'email'   => 'chris@world.com',
-                'country' => 'Greece',
-            ],
-        ];
-        $this->db->table('user2')->insertBatch($data);
-
-        // create actions table
-        $fields = [
-            'id'       => ['type' => 'int', 'constraint' => 9],
-            'userid'   => ['type' => 'int', 'constraint' => 9],
-            'userid2'  => ['type' => 'int', 'constraint' => 9],
-            'category' => ['type' => 'varchar', 'constraint' => 63],
-            'name'     => ['type' => 'varchar', 'constraint' => 63],
-        ];
-
-        $this->forge->addField($fields);
-        $this->forge->createTable('actions');
+        $this->createUser2TableWithKeys();
+        $this->populateUser2Table();
+        $this->createActionsTable();
 
         // define indexes, primary key, and foreign keys on existing table
         $this->forge->addKey('name', false, false, 'db_actions_name');
@@ -1577,6 +1533,73 @@ final class ForgeTest extends CIUnitTestCase
         $this->assertCount(2, $this->db->getForeignKeyData('actions'));
 
         // test inserting data
+        $this->insertDataTest();
+
+        // drop tables to avoid any future conflicts
+        $this->forge->dropTable('actions', true);
+        $this->forge->dropTable('user2', true);
+    }
+
+    private function createUser2TableWithKeys()
+    {
+        $fields = [
+            'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
+            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
+            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
+            'created_at' => ['type' => 'DATETIME', 'null' => true],
+            'updated_at' => ['type' => 'DATETIME', 'null' => true],
+            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
+        ];
+        $this->forge->addField($fields)
+            ->addKey('id', true)
+            ->addUniqueKey('email')
+            ->addKey('country')
+            ->createTable('user2', true);
+    }
+
+    private function populateUser2Table()
+    {
+        $data = [
+            [
+                'name'    => 'Derek Jones2',
+                'email'   => 'derek@world.com',
+                'country' => 'France',
+            ],
+            [
+                'name'    => 'Ahmadinejad2',
+                'email'   => 'ahmadinejad@world.com',
+                'country' => 'Greece',
+            ],
+            [
+                'name'    => 'Richard A Causey2',
+                'email'   => 'richard@world.com',
+                'country' => 'France',
+            ],
+            [
+                'name'    => 'Chris Martin2',
+                'email'   => 'chris@world.com',
+                'country' => 'Greece',
+            ],
+        ];
+        $this->db->table('user2')->insertBatch($data);
+    }
+
+    private function createActionsTable()
+    {
+        $fields = [
+            'id'       => ['type' => 'int', 'constraint' => 9],
+            'userid'   => ['type' => 'int', 'constraint' => 9],
+            'userid2'  => ['type' => 'int', 'constraint' => 9],
+            'category' => ['type' => 'varchar', 'constraint' => 63],
+            'name'     => ['type' => 'varchar', 'constraint' => 63],
+        ];
+        $this->forge->addField($fields);
+        $this->forge->createTable('actions');
+    }
+
+    private function insertDataTest()
+    {
         $data = [
             [
                 'id'       => 1,
@@ -1610,9 +1633,5 @@ final class ForgeTest extends CIUnitTestCase
             'userid'  => '2',
             'userid2' => '2',
         ]);
-
-        // drop tables to avoid any future conflicts
-        $this->forge->dropTable('actions', true);
-        $this->forge->dropTable('user2', true);
     }
 }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1479,9 +1479,54 @@ final class ForgeTest extends CIUnitTestCase
     public function testProcessIndexes()
     {
         $this->forge->dropTable('actions', true);
+        $this->forge->dropTable('user2', true);
+
+        $this->forge->addField([
+            'id'         => ['type' => 'INTEGER', 'constraint' => 3, 'auto_increment' => true],
+            'name'       => ['type' => 'VARCHAR', 'constraint' => 80],
+            'email'      => ['type' => 'VARCHAR', 'constraint' => 100],
+            'country'    => ['type' => 'VARCHAR', 'constraint' => 40],
+            'created_at' => ['type' => 'DATETIME', 'null' => true],
+            'updated_at' => ['type' => 'DATETIME', 'null' => true],
+            'deleted_at' => ['type' => 'DATETIME', 'null' => true],
+        ])->addKey('id', true)->addUniqueKey('email')->addKey('country')->createTable('user2', true);
+
+        $data = [
+            'user2' => [
+                [
+                    'name'    => 'Derek Jones2',
+                    'email'   => 'derek@world.com',
+                    'country' => 'France',
+                ],
+                [
+                    'name'    => 'Ahmadinejad2',
+                    'email'   => 'ahmadinejad@world.com',
+                    'country' => 'Greece',
+                ],
+                [
+                    'name'    => 'Richard A Causey2',
+                    'email'   => 'richard@world.com',
+                    'country' => 'France',
+                ],
+                [
+                    'name'    => 'Chris Martin2',
+                    'email'   => 'chris@world.com',
+                    'country' => 'Greece',
+                ],
+            ],
+        ];
+
+        foreach ($data as $table => $dummy_data) {
+            $this->db->table($table)->truncate();
+
+            foreach ($dummy_data as $single_dummy_data) {
+                $this->db->table($table)->insert($single_dummy_data);
+            }
+        }
 
         $fields = [
             'userid'      => ['type' => 'int', 'constraint' => 9],
+            'userid2'     => ['type' => 'int', 'constraint' => 9],
             'category'    => ['type' => 'varchar', 'constraint' => 63],
             'name'        => ['type' => 'varchar', 'constraint' => 63],
             'uid'         => ['type' => 'varchar', 'constraint' => 63],
@@ -1507,8 +1552,10 @@ final class ForgeTest extends CIUnitTestCase
 
         if ($this->db->DBDriver === 'SQLite3') {
             $this->forge->addForeignKey('userid', 'user', 'id');
+            $this->forge->addForeignKey('userid2', 'user2', 'id');
         } else {
             $this->forge->addForeignKey('userid', 'user', 'id', '', '', 'db_actions_userid_foreign');
+            $this->forge->addForeignKey('userid2', 'user2', 'id', '', '', 'db_actions_userid2_foreign');
         }
 
         $this->forge->createTable('actions');
@@ -1524,6 +1571,7 @@ final class ForgeTest extends CIUnitTestCase
         $this->assertCount(0, $indexes);
 
         $this->forge->dropForeignKey('actions', 'db_actions_userid_foreign');
+        $this->forge->dropForeignKey('actions', 'db_actions_userid2_foreign');
 
         $this->assertCount(0, $this->db->getForeignKeyData('actions'));
 
@@ -1572,8 +1620,10 @@ final class ForgeTest extends CIUnitTestCase
         // SQLite does not support custom foreign key name
         if ($this->db->DBDriver === 'SQLite3') {
             $this->forge->addForeignKey('userid', 'user', 'id');
+            $this->forge->addForeignKey('userid2', 'user2', 'id');
         } else {
             $this->forge->addForeignKey('userid', 'user', 'id', '', '', 'db_actions_userid_foreign');
+            $this->forge->addForeignKey('userid2', 'user2', 'id', '', '', 'db_actions_userid2_foreign');
         }
 
         $this->forge->processIndexes('actions');
@@ -1585,7 +1635,7 @@ final class ForgeTest extends CIUnitTestCase
         );
         $this->assertCount(1, $indexes);
 
-        $this->assertCount(1, $this->db->getForeignKeyData('actions'));
+        $this->assertCount(2, $this->db->getForeignKeyData('actions'));
 
         $indexes = array_filter(
             $this->db->getIndexData('actions'),
@@ -1613,12 +1663,14 @@ final class ForgeTest extends CIUnitTestCase
                 'uid'      => 't',
                 'category' => 'cat',
                 'userid'   => 1,
+                'userid2'  => 1,
             ],
             [
                 'name'     => 'another name',
                 'uid'      => 't',
                 'category' => 'cat',
                 'userid'   => 1,
+                'userid2'  => 1,
             ],
         ];
         $this->db->table('actions')->insertBatch($data);
@@ -1636,5 +1688,6 @@ final class ForgeTest extends CIUnitTestCase
         ]);
 
         $this->forge->dropTable('actions', true);
+        $this->forge->dropTable('user2', true);
     }
 }

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -144,6 +144,7 @@ Database
 - Fixed ``Forge::dropKey()`` to allow droping unique indexes. This required the ``DROP CONSTRAINT`` SQL command.
 - Added ``upsert()`` and ``upsertBatch()`` methods to QueryBuilder. See :ref:`upsert-data`.
 - ``BasePreparedQuery::close()`` now deallocates the prepared statement in all DBMS. Previously, they were not deallocated in Postgre, SQLSRV and OCI8. See :ref:`database-queries-stmt-close`.
+- Added ``Forge::processIndexes()`` allowing the creation of indexes on an existing table. See :ref:`adding-keys` for the details.
 
 Model
 =====

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -107,6 +107,11 @@ Others
 - The method signature of ``Forge::addKey()`` has changed. An additional optional parameter ``$keyName`` has been added.
 - The method signature of ``Forge::addPrimaryKey()`` has changed. An additional optional parameter ``$keyName`` has been added.
 - The method signature of ``Forge::addUniqueKey()`` has changed. An additional optional parameter ``$keyName`` has been added.
+- The following method has an additional ``$asQuery`` parameter. When set to ``true`` the method returns a stand alone SQL query.
+    - ``CodeIgniter\Database\Forge::_processPrimaryKeys()``
+- In addition to the added ``$asQuery`` parameter above the following methods also now return an array.
+    - ``CodeIgniter\Database\Forge::_processIndexes()``
+    - ``CodeIgniter\Database\Forge::_processForeignKeys()``
 
 Enhancements
 ************

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -150,6 +150,8 @@ Primary Key.
 
 .. literalinclude:: forge/009.php
 
+.. _adding-keys:
+
 Adding Keys
 ===========
 
@@ -158,7 +160,8 @@ accomplished with ``$forge->addKey('field')``. The optional second
 parameter set to true will make it a primary key and the third
 parameter set to true will make it a unique key. You may specify a name
 with the fourth parameter. Note that ``addKey()`` must be followed by a
-call to ``createTable()``.
+call to ``createTable()`` or ``processIndexes()`` when the table already
+exists.
 
 Multiple column non-primary keys must be sent as an array. Sample output
 below is for MySQL.
@@ -171,6 +174,10 @@ and unique keys with specific methods:
 .. literalinclude:: forge/011.php
 
 .. note:: When you add a primary key, MySQL and SQLite will assume the name ``PRIMARY`` even if a name is provided.
+
+You may add keys to an existing table by using ``processIndexes()``:
+
+.. literalinclude:: forge/029.php
 
 .. _adding-foreign-keys:
 
@@ -447,6 +454,15 @@ Class Reference
         :rtype:    bool
 
         Drops a table. Usage:  See `Dropping a Table`_.
+
+    .. php:method:: processIndexes($table)
+
+        :param    string    $table: Name of the table to add indexes to
+        :returns:    true on success, false on failure
+        :rtype:    bool
+
+        Used following ``addKey()``, ``addPrimaryKey()``, ``addUniqueKey()``,
+        and ``addForeignKey()`` to add indexes to an existing table.
 
     .. php:method:: modifyColumn($table, $field)
 

--- a/user_guide_src/source/dbmgmt/forge/029.php
+++ b/user_guide_src/source/dbmgmt/forge/029.php
@@ -1,0 +1,11 @@
+<?php
+
+$this->forge->addKey(['category', 'name'], false, false, 'category_name');
+$this->forge->addPrimaryKey('id', 'pk_actions');
+$this->forge->addForeignKey('userid', 'user', 'id', '', '', 'userid_fk');
+$this->forge->processIndexes('actions');
+/* gives:
+ALTER TABLE `actions` ADD KEY `category_name` (`category`, `name`);
+ALTER TABLE `actions` ADD CONSTRAINT `pk_actions` PRIMARY KEY(`id`);
+ALTER TABLE `actions` ADD CONSTRAINT `userid_fk` FOREIGN KEY (`userid`) REFERENCES `user`(`id`);
+*/


### PR DESCRIPTION
Closes #4814

This PR allows creating indexes on an existing table. 

It is used following ``addKey()``, ``addPrimaryKey()``, ``addUniqueKey()``, and ``addForeignKey()`` to add indexes to an existing table. It is used instead of or in place of  ``createTable()``.

This is the last part of https://github.com/codeigniter4/CodeIgniter4/pull/6430

Fixes #6453

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
