### PR TITLE
chore: add `suggest` extensions in composer.json

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -34,6 +34,8 @@
         "ext-memcache": "If you use Cache class MemcachedHandler with Memcache",
         "ext-memcached": "If you use Cache class MemcachedHandler with Memcached",
         "ext-redis": "If you use Cache class RedisHandler",
+        "ext-dom": "If you use TestResponse",
+        "ext-libxml": "If you use TestResponse",
         "ext-fileinfo": "Improves mime type detection for files",
         "ext-readline": "Improves CLI::input() usability"
     },

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,8 @@
         "ext-memcache": "If you use Cache class MemcachedHandler with Memcache",
         "ext-memcached": "If you use Cache class MemcachedHandler with Memcached",
         "ext-redis": "If you use Cache class RedisHandler",
+        "ext-dom": "If you use TestResponse",
+        "ext-libxml": "If you use TestResponse",
         "ext-fileinfo": "Improves mime type detection for files",
         "ext-readline": "Improves CLI::input() usability"
     },


### PR DESCRIPTION
**Description**
There are two extensions used in `TestResponse`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

