### PR TITLE
Enable `no_useless_concat_operator`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -38,7 +38,11 @@ $finder = Finder::create()
         __DIR__ . '/spark',
     ]);
 
-$overrides = [];
+$overrides = [
+    'no_useless_concat_operator' => [
+        'juggle_simple_strings' => true,
+    ],
+];
 
 $options = [
     'cacheFile'    => 'build/.php-cs-fixer.cache',

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -30,7 +30,11 @@ $finder = Finder::create()
         __DIR__ . '/admin/starter/builds',
     ]);
 
-$overrides = [];
+$overrides = [
+    'no_useless_concat_operator' => [
+        'juggle_simple_strings' => true,
+    ],
+];
 
 $options = [
     'cacheFile'    => 'build/.php-cs-fixer.no-header.cache',

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -33,6 +33,9 @@ $overrides = [
     'php_unit_internal_class'     => false,
     'no_unused_imports'           => false,
     'class_attributes_separation' => false,
+    'no_useless_concat_operator'  => [
+        'juggle_simple_strings' => true,
+    ],
 ];
 
 $options = [

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1179,7 +1179,7 @@ class BaseBuilder
      */
     protected function addUnionStatement($union, bool $all = false)
     {
-        $this->QBUnion[] = "\n" . 'UNION '
+        $this->QBUnion[] = "\nUNION "
             . ($all ? 'ALL ' : '')
             . 'SELECT * FROM '
             . $this->buildSubquery($union, true, 'uwrp' . (count($this->QBUnion) + 1));

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -360,7 +360,7 @@ class Connection extends BaseConnection
         // Escape LIKE condition wildcards
         return str_replace(
             [$this->likeEscapeChar, '%', '_'],
-            ['\\' . $this->likeEscapeChar, '\\' . '%', '\\' . '_'],
+            ['\\' . $this->likeEscapeChar, '\\%', '\\_'],
             $str
         );
     }

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -386,7 +386,7 @@ class Toolbar
                 mkdir(WRITEPATH . 'debugbar', 0777);
             }
 
-            write_file(WRITEPATH . 'debugbar/' . 'debugbar_' . $time . '.json', $data, 'w+');
+            write_file(WRITEPATH . 'debugbar/debugbar_' . $time . '.json', $data, 'w+');
 
             $format = $response->getHeaderLine('content-type');
 

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -484,13 +484,13 @@ if (! function_exists('form_datalist')) {
 
         $out = form_input($data) . "\n";
 
-        $out .= "<datalist id='" . $name . '_list' . "'>";
+        $out .= "<datalist id='" . $name . "_list'>";
 
         foreach ($options as $option) {
-            $out .= "<option value='{$option}'>" . "\n";
+            $out .= "<option value='{$option}'>\n";
         }
 
-        return $out . ('</datalist>' . "\n");
+        return $out . ("</datalist>\n");
     }
 }
 

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -277,7 +277,7 @@ class Parser extends View
         // have something to loop over.
         preg_match_all(
             '#' . $this->leftDelimiter . '\s*' . preg_quote($variable, '#') . '\s*' . $this->rightDelimiter . '(.+?)' .
-            $this->leftDelimiter . '\s*' . '/' . preg_quote($variable, '#') . '\s*' . $this->rightDelimiter . '#s',
+            $this->leftDelimiter . '\s*/' . preg_quote($variable, '#') . '\s*' . $this->rightDelimiter . '#s',
             $template,
             $matches,
             PREG_SET_ORDER

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -156,7 +156,7 @@ final class MessageTest extends CIUnitTestCase
 
         $this->message->appendBody('\n');
 
-        $this->assertSame('moo' . '\n', $this->message->getBody());
+        $this->assertSame('moo\n', $this->message->getBody());
     }
 
     public function testSetHeaderReplacingHeader()

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -413,7 +413,7 @@ final class GDHandlerTest extends CIUnitTestCase
     public function testImageReorientLandscape()
     {
         for ($i = 0; $i <= 8; $i++) {
-            $source = $this->origin . 'EXIFsamples/landscape_' . '' . $i . '.jpg';
+            $source = $this->origin . 'EXIFsamples/landscape_' . $i . '.jpg';
 
             $this->handler->withFile($source);
             $this->handler->reorient();
@@ -429,7 +429,7 @@ final class GDHandlerTest extends CIUnitTestCase
     public function testImageReorientPortrait()
     {
         for ($i = 0; $i <= 8; $i++) {
-            $source = $this->origin . 'EXIFsamples/portrait_' . '' . $i . '.jpg';
+            $source = $this->origin . 'EXIFsamples/portrait_' . $i . '.jpg';
 
             $this->handler->withFile($source);
             $this->handler->reorient();

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -408,7 +408,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     public function testImageReorientLandscape()
     {
         for ($i = 0; $i <= 8; $i++) {
-            $source = $this->origin . 'EXIFsamples/landscape_' . '' . $i . '.jpg';
+            $source = $this->origin . 'EXIFsamples/landscape_' . $i . '.jpg';
             $result = $this->root . 'landscape_' . $i . '_reoriented.jpg';
 
             $this->handler->withFile($source);
@@ -427,7 +427,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
     public function testImageReorientPortrait()
     {
         for ($i = 0; $i <= 8; $i++) {
-            $source = $this->origin . 'EXIFsamples/portrait_' . '' . $i . '.jpg';
+            $source = $this->origin . 'EXIFsamples/portrait_' . $i . '.jpg';
             $result = $this->root . 'portrait_' . $i . '_reoriented.jpg';
 
             $this->handler->withFile($source);

--- a/user_guide_src/source/testing/benchmark/007.php
+++ b/user_guide_src/source/testing/benchmark/007.php
@@ -4,7 +4,7 @@ $iterator = new \CodeIgniter\Debug\Iterator();
 
 // Add a new task
 $iterator->add('single_concat', static function () {
-    $str = 'Some basic' . 'little' . 'string concatenation test.';
+    $str = 'Some basiclittlestring concatenation test.';
 });
 
 // Add another task

--- a/user_guide_src/source/testing/benchmark/007.php
+++ b/user_guide_src/source/testing/benchmark/007.php
@@ -2,12 +2,6 @@
 
 $iterator = new \CodeIgniter\Debug\Iterator();
 
-// Add a new task
-$iterator->add('single_concat', static function () {
-    $str = 'Some basiclittlestring concatenation test.';
-});
-
-// Add another task
-$iterator->add('double', static function ($a = 'little') {
-    $str = "Some basic {$little} string test.";
+$iterator->add('double', static function ($word = 'little') {
+    "Some basic {$word} string test.";
 });


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Depends on #6674 

```console
$ vendor/bin/php-cs-fixer describe no_useless_concat_operator
Description of no_useless_concat_operator rule.
There should not be useless concat operations.

Fixer is configurable using following option:
* juggle_simple_strings (bool): allow for simple string quote juggling if it results in more concat-operations merges; defaults to false

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -$a = 'a'.'b';
   +$a = 'ab';

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['juggle_simple_strings' => true].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -$a = 'a'."b";
   +$a = "ab";

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
