### PR TITLE
fix: support for assigning extra data for the view() method in controlled cells

### DIFF
--- a/system/View/Cells/Cell.php
+++ b/system/View/Cells/Cell.php
@@ -65,10 +65,11 @@ class Cell
      * current scope and captures the output buffer instead of
      * relying on the view service.
      */
-    final protected function view(?string $view): string
+    final protected function view(?string $view, array $data = []): string
     {
         $properties = $this->getPublicProperties();
         $properties = $this->includeComputedProperties($properties);
+        $properties = array_merge($properties, $data);
 
         // If no view is specified, we'll try to guess it based on the class name.
         if (empty($view)) {

--- a/tests/_support/View/Cells/RenderedExtraDataNotice.php
+++ b/tests/_support/View/Cells/RenderedExtraDataNotice.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\View\Cells;
+
+use CodeIgniter\View\Cells\Cell;
+
+class RenderedExtraDataNotice extends Cell
+{
+    public string $message = '4, 8, 15, 16, 23, 42';
+
+    public function render(): string
+    {
+        return $this->view('notice', ['message' => '42, 23, 16, 15, 8, 4']);
+    }
+}

--- a/tests/system/View/ControlledCellTest.php
+++ b/tests/system/View/ControlledCellTest.php
@@ -18,6 +18,7 @@ use Tests\Support\View\Cells\ColorsCell;
 use Tests\Support\View\Cells\GreetingCell;
 use Tests\Support\View\Cells\ListerCell;
 use Tests\Support\View\Cells\MultiplierCell;
+use Tests\Support\View\Cells\RenderedExtraDataNotice;
 use Tests\Support\View\Cells\RenderedNotice;
 use Tests\Support\View\Cells\SimpleNotice;
 
@@ -45,6 +46,13 @@ final class ControlledCellTest extends CIUnitTestCase
         $result = view_cell(RenderedNotice::class);
 
         $this->assertStringContainsString('4, 8, 15, 16, 23, 42', $result);
+    }
+
+    public function testCellThroughRenderMethodWithExtraData()
+    {
+        $result = view_cell(RenderedExtraDataNotice::class);
+
+        $this->assertStringContainsString('42, 23, 16, 15, 8, 4', $result);
     }
 
     public function testCellWithParameters()


### PR DESCRIPTION
**Description**
Follow-up #6620

This is related to the Controlled Cells.

According to the user guide, we should be able to assign extra variables to the `view()` method. But this function doesn't seem to be implemented. This PR fixes it.

Ref: https://github.com/codeigniter4/CodeIgniter4/blob/4.3/user_guide_src/source/outgoing/view_cells.rst#customize-the-rendering

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide