### PR TITLE
test: remove $request->uri and fix incorrect assertions

### DIFF
--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -863,56 +863,56 @@ final class URITest extends CIUnitTestCase
 
     public function testBasedNoIndex()
     {
-        $this->resetServices();
-
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/ci/v4/controller/method';
 
-        $config            = new App();
-        $config->baseURL   = 'http://example.com/ci/v4';
-        $config->indexPage = 'index.php';
-        $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/ci/v4/controller/method');
+        $this->resetServices();
 
+        $config            = new App();
+        $config->baseURL   = 'http://example.com/ci/v4/';
+        $config->indexPage = 'index.php';
+        Factories::injectMock('config', 'App', $config);
+
+        $request = Services::request($config);
         Services::injectMock('request', $request);
 
         // going through request
         $this->assertSame('http://example.com/ci/v4/controller/method', (string) $request->getUri());
-        $this->assertSame('/ci/v4/controller/method', $request->getUri()->getPath());
+        $this->assertSame('ci/v4/controller/method', $request->getUri()->getPath());
 
         // standalone
         $uri = new URI('http://example.com/ci/v4/controller/method');
         $this->assertSame('http://example.com/ci/v4/controller/method', (string) $uri);
         $this->assertSame('/ci/v4/controller/method', $uri->getPath());
 
-        $this->assertSame($uri->getPath(), $request->getUri()->getPath());
+        $this->assertSame($uri->getPath(), '/' . $request->getUri()->getPath());
     }
 
     public function testBasedWithIndex()
     {
-        $this->resetServices();
-
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/ci/v4/index.php/controller/method';
 
-        $config            = new App();
-        $config->baseURL   = 'http://example.com/ci/v4';
-        $config->indexPage = 'index.php';
-        $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/ci/v4/index.php/controller/method');
+        $this->resetServices();
 
+        $config            = new App();
+        $config->baseURL   = 'http://example.com/ci/v4/';
+        $config->indexPage = 'index.php';
+        Factories::injectMock('config', 'App', $config);
+
+        $request = Services::request($config);
         Services::injectMock('request', $request);
 
         // going through request
         $this->assertSame('http://example.com/ci/v4/index.php/controller/method', (string) $request->getUri());
-        $this->assertSame('/ci/v4/index.php/controller/method', $request->getUri()->getPath());
+        $this->assertSame('ci/v4/index.php/controller/method', $request->getUri()->getPath());
 
         // standalone
         $uri = new URI('http://example.com/ci/v4/index.php/controller/method');
         $this->assertSame('http://example.com/ci/v4/index.php/controller/method', (string) $uri);
         $this->assertSame('/ci/v4/index.php/controller/method', $uri->getPath());
 
-        $this->assertSame($uri->getPath(), $request->getUri()->getPath());
+        $this->assertSame($uri->getPath(), '/' . $request->getUri()->getPath());
     }
 
     public function testForceGlobalSecureRequests()

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -870,7 +870,7 @@ final class URITest extends CIUnitTestCase
 
         $config            = new App();
         $config->baseURL   = 'http://example.com/ci/v4/';
-        $config->indexPage = 'index.php';
+        $config->indexPage = '';
         Factories::injectMock('config', 'App', $config);
 
         $request = Services::request($config);

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -467,9 +467,9 @@ final class PagerTest extends CIUnitTestCase
         $config            = new App();
         $config->baseURL   = 'http://example.com/ci/v4/';
         $config->indexPage = 'fc.php';
-        $request           = Services::request($config);
-        $request->uri      = new URI('http://example.com/ci/v4/x/y');
+        Factories::injectMock('config', 'App', $config);
 
+        $request = Services::request($config);
         Services::injectMock('request', $request);
 
         $this->config = new PagerConfig();


### PR DESCRIPTION
**Description**
See #5344

- `IncomingRequest::$uri` will be protected.
- `$request->getUri()->getPath()` does not start with `/`. `IncomingRequest::$uri` is a bit different from a normal URI object.
https://github.com/codeigniter4/CodeIgniter4/blob/a3eedf4055c1a2895051b654c49311641dd2975f/system/HTTP/IncomingRequest.php#L60-L71

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

