### PR TITLE
Bug: ResponseTest::testSetLastModifiedWithDateTimeObject depends on time

### DIFF
--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -243,9 +243,10 @@ final class ResponseTest extends CIUnitTestCase
     {
         $response = new Response(new App());
 
-        $response->setLastModified(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
+        $datetime = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $response->setLastModified($datetime);
 
-        $date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
+        $date = clone $datetime;
         $date->setTimezone(new DateTimeZone('UTC'));
 
         $header = $response->getHeaderLine('Last-Modified');


### PR DESCRIPTION
Fixes #5428

**Description**

In the `testSetLastModifiedWithDateTimeObject()` method, there are two `DateTime::createFromFormat` calls

When they are performed close to the beginning of a new second, the difference between the two dates is (sometimes) one second

To reproduce, just add a delay between the two date calls

```diff
@@ -244,6 +244,7 @@ final class ResponseTest extends CIUnitTestCase
         $response = new Response(new App());
 
         $response->setLastModified(DateTime::createFromFormat('Y-m-d', '2000-03-10'));
+        sleep(1);
 
         $date = DateTime::createFromFormat('Y-m-d', '2000-03-10');
         $date->setTimezone(new DateTimeZone('UTC'));
```

The fix, attached in this PR, is to use the same date object

**Checklist:**

- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
