### PR TITLE
Bug: DateHelperTest::testNowSpecific depends on time

### DIFF
--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -32,8 +32,8 @@ final class DateHelperTest extends CIUnitTestCase
 
     public function testNowSpecific()
     {
-        // Chicago should be two hours ahead of Vancouver
-        $this->assertCloseEnough(7200, now('America/Chicago') - now('America/Vancouver'));
+        // Chicago should be two hours ahead of Vancouver (+- 10 sec)
+        $this->assertCloseEnough(7200, now('America/Chicago') - now('America/Vancouver'), '', 10);
     }
 
     public function testTimezoneSelectDefault()


### PR DESCRIPTION
Fixes #5492

**Description**

In the `testNowSpecific()` method, there are two different `now()` calls

There may be sometimes a latency between the two calls, and by default `assertCloseEnough` test if the difference is lower than 1 second.

To reproduce, just add a delay `sleep(n)` inside the `now()` function

A solution may be to increase the tolerance threshold to an acceptable level (eg 10 sec for 2 hours should be sufficient)

**Checklist:**

- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide