### PR TITLE
test: make test case in MessageTest a bit more realistic

### DIFF
--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -154,9 +154,9 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->message->setBody('moo');
 
-        $this->message->appendBody('\n');
+        $this->message->appendBody("\n");
 
-        $this->assertSame('moo\n', $this->message->getBody());
+        $this->assertSame("moo\n", $this->message->getBody());
     }
 
     public function testSetHeaderReplacingHeader()


### PR DESCRIPTION
**Description**
- adding string `\n` does  not make sense

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

