### PR TITLE
fix: MessageInterface inheritance

### DIFF
--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -16,7 +16,7 @@ use CodeIgniter\Validation\FormatRules;
 /**
  * Representation of an HTTP request.
  */
-class Request extends Message implements MessageInterface, RequestInterface
+class Request extends Message implements RequestInterface
 {
     use RequestTrait;
 

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\HTTP;
 /**
  * Expected behavior of an HTTP request
  */
-interface RequestInterface
+interface RequestInterface extends MessageInterface
 {
     /**
      * Gets the user's IP address.

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -29,7 +29,7 @@ use Config\Services;
  * - Headers
  * - Message body
  */
-class Response extends Message implements MessageInterface, ResponseInterface
+class Response extends Message implements ResponseInterface
 {
     use ResponseTrait;
 

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -54,6 +54,7 @@ Interface Changes
 =================
 
 - Added missing ``getBody()``, ``hasHeader()`` and ``getHeaderLine()`` method in ``MessageInterface``.
+- Now ``RequestInterface`` extends ``MessageInterface``.
 - Now ``ResponseInterface`` extends ``MessageInterface``.
 - Added missing ``ResponseInterface::getCSP()`` (and ``Response::getCSP()``), ``ResponseInterface::getReasonPhrase()`` and ``ResponseInterface::getCookieStore()`` methods.
 


### PR DESCRIPTION
**Description**
A parallel change to https://github.com/codeigniter4/CodeIgniter4/pull/6556 this gives our HTTP Request objects their expected methods.

Ref #6573

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
