### PR TITLE
refactor: replace deprecated getHeaders() with headers()

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -270,7 +270,7 @@
 
                 <?php endif; ?>
 
-                <?php $headers = $request->getHeaders(); ?>
+                <?php $headers = $request->headers(); ?>
                 <?php if (! empty($headers)) : ?>
 
                     <h3>Headers</h3>
@@ -318,7 +318,7 @@
                     </tr>
                 </table>
 
-                <?php $headers = $response->getHeaders(); ?>
+                <?php $headers = $response->headers(); ?>
                 <?php if (! empty($headers)) : ?>
                     <?php natsort($headers) ?>
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -471,7 +471,7 @@ trait ResponseTrait
         header(sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->getStatusCode(), $this->getReasonPhrase()), true, $this->getStatusCode());
 
         // Send all of our headers
-        foreach (array_keys($this->getHeaders()) as $name) {
+        foreach (array_keys($this->headers()) as $name) {
             header($name . ': ' . $this->getHeaderLine($name), false, $this->getStatusCode());
         }
 

--- a/user_guide_src/source/libraries/curlrequest/006.php
+++ b/user_guide_src/source/libraries/curlrequest/006.php
@@ -2,5 +2,5 @@
 
 echo $response->getStatusCode();
 echo $response->getBody();
-echo $response->getHeader('Content-Type');
+echo $response->header('Content-Type');
 $language = $response->negotiateLanguage(['en', 'fr']);

--- a/user_guide_src/source/libraries/curlrequest/010.php
+++ b/user_guide_src/source/libraries/curlrequest/010.php
@@ -4,6 +4,6 @@
 echo $response->getHeaderLine('Content-Type');
 
 // Get all headers
-foreach ($response->getHeaders() as $name => $value) {
+foreach ($response->headers() as $name => $value) {
     echo $name . ': ' . $response->getHeaderLine($name) . "\n";
 }

--- a/user_guide_src/source/libraries/curlrequest/012.php
+++ b/user_guide_src/source/libraries/curlrequest/012.php
@@ -1,5 +1,5 @@
 <?php
 
-if (strpos($response->getHeader('content-type'), 'application/json') !== false) {
+if (strpos($response->header('content-type'), 'application/json') !== false) {
     $body = json_decode($body);
 }


### PR DESCRIPTION
**Description**
- replace deprecated getHeaders() with headers()
- replace deprecated getHeader() with header()

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
