### PR TITLE
fix: add missing getProtocolVersion() in MessageInterface

### DIFF
--- a/system/HTTP/MessageInterface.php
+++ b/system/HTTP/MessageInterface.php
@@ -14,10 +14,19 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 
 /**
- * Expected behavior of an HTTP request
+ * Expected behavior of an HTTP messages
  */
 interface MessageInterface
 {
+    /**
+     * Retrieves the HTTP protocol version as a string.
+     *
+     * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
+     *
+     * @return string HTTP protocol version.
+     */
+    public function getProtocolVersion(): string;
+
     /**
      * Sets the body of the current message.
      *

--- a/system/HTTP/MessageInterface.php
+++ b/system/HTTP/MessageInterface.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 
 /**
- * Expected behavior of an HTTP messages
+ * Expected behavior of an HTTP message
  */
 interface MessageInterface
 {

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -53,7 +53,7 @@ Others
 Interface Changes
 =================
 
-- Added missing ``getBody()``, ``hasHeader()`` and ``getHeaderLine()`` method in ``MessageInterface``.
+- Added missing ``getProtocolVersion()``, ``getBody()``, ``hasHeader()`` and ``getHeaderLine()`` method in ``MessageInterface``.
 - Now ``RequestInterface`` extends ``MessageInterface``.
 - Now ``ResponseInterface`` extends ``MessageInterface``.
 - Added missing ``ResponseInterface::getCSP()`` (and ``Response::getCSP()``), ``ResponseInterface::getReasonPhrase()`` and ``ResponseInterface::getCookieStore()`` methods.


### PR DESCRIPTION
**Description**
- add missing getProtocolVersion()
  - PSR-7 has the method

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
