### PR TITLE
feat: Check logs against parts of the message only

### DIFF
--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -349,8 +349,6 @@ abstract class CIUnitTestCase extends TestCase
      * @param string|null $expectedMessage
      *
      * @return bool
-     *
-     * @throws Exception
      */
     public function assertLogged(string $level, $expectedMessage = null)
     {
@@ -363,6 +361,21 @@ abstract class CIUnitTestCase extends TestCase
         ));
 
         return $result;
+    }
+
+    /**
+     * Asserts that there is a log record that contains `$logMessage` in the message.
+     */
+    public function assertLogContains(string $level, string $logMessage, string $message = ''): void
+    {
+        $this->assertTrue(
+            TestLogger::didLog($level, $logMessage, false),
+            $message ?: sprintf(
+                'Failed asserting that logs have a record of message containing "%s" with level "%s".',
+                $logMessage,
+                $level
+            )
+        );
     }
 
     /**

--- a/system/Test/TestLogger.php
+++ b/system/Test/TestLogger.php
@@ -59,10 +59,24 @@ class TestLogger extends Logger
      *
      * @return bool
      */
-    public static function didLog(string $level, $message)
+    public static function didLog(string $level, $message, bool $useExactComparison = true)
     {
+        $lowerLevel = strtolower($level);
+
         foreach (self::$op_logs as $log) {
-            if (strtolower($log['level']) === strtolower($level) && $message === $log['message']) {
+            if (strtolower($log['level']) !== $lowerLevel) {
+                continue;
+            }
+
+            if ($useExactComparison) {
+                if ($log['message'] === $message) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (strpos($log['message'], $message) !== false) {
                 return true;
             }
         }

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -45,6 +45,12 @@ final class TestCaseTest extends CIUnitTestCase
         $this->assertLogged('error', 'Some variable did not contain a value.');
     }
 
+    public function testAssertLogContains()
+    {
+        log_message('error', 'Some variable did not contain a value.');
+        $this->assertLogContains('error', 'variable did not');
+    }
+
     public function testEventTriggering()
     {
         Events::on('foo', static function ($arg) use (&$result) {

--- a/tests/system/Test/TestLoggerTest.php
+++ b/tests/system/Test/TestLoggerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Test;
+
+use Config\Logger;
+
+/**
+ * @internal
+ */
+final class TestLoggerTest extends CIUnitTestCase
+{
+    /**
+     * @dataProvider provideDidLogCases
+     */
+    public function testDidLogMethod(bool $expected, string $level, string $message, bool $exact): void
+    {
+        (new TestLogger(new Logger()))->log('error', 'Some variable did not contain a value.');
+
+        $this->assertSame(
+            $expected,
+            TestLogger::didLog($level, $message, $exact),
+        );
+    }
+
+    public function provideDidLogCases(): iterable
+    {
+        yield 'exact' => [
+            true,
+            'error',
+            'Some variable did not contain a value.',
+            true,
+        ];
+
+        yield 'wrong level' => [
+            false,
+            'warning',
+            'Some variable did not contain a value.',
+            true,
+        ];
+
+        yield 'wrong message' => [
+            false,
+            'error',
+            'Some variables did not contain a value.',
+            true,
+        ];
+
+        yield 'approximate' => [
+            true,
+            'error',
+            'Some variable did not',
+            false,
+        ];
+
+        yield 'approximate but wrong level' => [
+            false,
+            'warning',
+            'Some variable did not',
+            false,
+        ];
+    }
+}

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -128,6 +128,8 @@ Testing
 - The CITestStreamFilter filter class now implements methods for adding a filter to streams. See :ref:`testing-cli-output`.
 - Added the ``PhpStreamWrapper`` to make it easier to work with setting data to ``php://stdin``. See :ref:`testing-cli-input`.
 - Added method :ref:`benchmark-timer-record` to measure performance in a callable. Also enhanced common function ``timer()`` to accept optional callable.
+- A boolean third parameter ``$useExactComparison`` is added to ``TestLogger::didLog()`` which sets whether log messages are checked verbatim. This defaults to ``true``.
+- Added method ``CIUnitTestCase::assertLogContains()`` which compares log messages by parts instead of the whole of the message.
 
 Database
 ========

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -126,7 +126,12 @@ Additional Assertions
 assertLogged($level, $expectedMessage)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Ensure that something you expected to be logged actually was:
+Ensure that something you expected to be logged was actually logged:
+
+assertLogContains($level, $logMessage)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ensure that there's a record in the logs which contains a message part.
 
 .. literalinclude:: overview/007.php
 

--- a/user_guide_src/source/testing/overview/007.php
+++ b/user_guide_src/source/testing/overview/007.php
@@ -1,9 +1,13 @@
 <?php
 
-$config = new LoggerConfig();
-$logger = new Logger($config);
+$config = new Config\Logger();
+$logger = new CodeIgniter\Log\Logger($config);
 
-// ... do something that you expect a log entry from
+// check verbatim the log message
 $logger->log('error', "That's no moon");
-
 $this->assertLogged('error', "That's no moon");
+
+// check that a portion of the message is found in the logs
+$exception = new RuntimeException('Hello world.');
+$logger->log('error', $exception->getTraceAsString());
+$this->assertLogContains('error', '{main}');


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Currently, `CIUnitTestCase::assertLogged()` matches the logged message verbatim. For simple messages this is no problem but for complex, hard-to-build, or volatile messages, it may be hard to come up with the exact message. This PR adds the capability for the `assertLogged` method to compare only parts of the message instead of the whole.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
