### PR TITLE
fix: `TestCaseTest::testStreamFilter` fails on Windows

### DIFF
--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -59,7 +59,7 @@ final class TestCaseTest extends CIUnitTestCase
     public function testStreamFilter()
     {
         CLI::write('first.');
-        $expected = "\nfirst.\n";
+        $expected = PHP_EOL . 'first.' . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
     }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Code uses `PHP_EOL` but test uses `"\n"`, so it fails on Windows.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
