### PR TITLE
fix: add missing methods to BaseConnection

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -101,16 +101,6 @@ parameters:
 			path: system/Database/BaseBuilder.php
 
 		-
-			message: "#^Call to an undefined method CodeIgniter\\\\Database\\\\BaseConnection\\:\\:_disableForeignKeyChecks\\(\\)\\.$#"
-			count: 1
-			path: system/Database/BaseConnection.php
-
-		-
-			message: "#^Call to an undefined method CodeIgniter\\\\Database\\\\BaseConnection\\:\\:_enableForeignKeyChecks\\(\\)\\.$#"
-			count: 1
-			path: system/Database/BaseConnection.php
-
-		-
 			message: "#^Call to an undefined method CodeIgniter\\\\Database\\\\QueryInterface\\:\\:getOriginalQuery\\(\\)\\.$#"
 			count: 1
 			path: system/Database/BaseConnection.php

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1666,22 +1666,34 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * If this feature is not supported, return empty string.
      *
+     * @TODO This method should be abstract, but due to historical reasons,
+     *      it provides the default implementation.
+     *
      * @return string
      *
      * @see disableForeignKeyChecks()
      */
-    abstract protected function _disableForeignKeyChecks();
+    protected function _disableForeignKeyChecks()
+    {
+        return '';
+    }
 
     /**
      * Platform-specific SQL statement to enable foreign key checks.
      *
      * If this feature is not supported, return empty string.
      *
+     * @TODO This method should be abstract, but due to historical reasons,
+     *      it provides the default implementation.
+     *
      * @return string
      *
      * @see enableForeignKeyChecks()
      */
-    abstract protected function _enableForeignKeyChecks();
+    protected function _enableForeignKeyChecks()
+    {
+        return '';
+    }
 
     /**
      * Accessor for properties if they exist.

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1666,8 +1666,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * If this feature is not supported, return empty string.
      *
-     * @TODO This method should be abstract, but due to historical reasons,
-     *      it provides the default implementation.
+     * @TODO This method should be moved to an interface that represents foreign key support.
      *
      * @return string
      *
@@ -1683,8 +1682,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * If this feature is not supported, return empty string.
      *
-     * @TODO This method should be abstract, but due to historical reasons,
-     *      it provides the default implementation.
+     * @TODO This method should be moved to an interface that represents foreign key support.
      *
      * @return string
      *

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1538,20 +1538,34 @@ abstract class BaseConnection implements ConnectionInterface
 
     /**
      * Disables foreign key checks temporarily.
+     *
+     * @return bool
      */
     public function disableForeignKeyChecks()
     {
         $sql = $this->_disableForeignKeyChecks();
+
+        if ($sql === '') {
+            // The feature is not supported.
+            return false;
+        }
 
         return $this->query($sql);
     }
 
     /**
      * Enables foreign key checks temporarily.
+     *
+     * @return bool
      */
     public function enableForeignKeyChecks()
     {
         $sql = $this->_enableForeignKeyChecks();
+
+        if ($sql === '') {
+            // The feature is not supported.
+            return false;
+        }
 
         return $this->query($sql);
     }
@@ -1646,6 +1660,28 @@ abstract class BaseConnection implements ConnectionInterface
      * @see    getForeignKeyData()
      */
     abstract protected function _foreignKeyData(string $table): array;
+
+    /**
+     * Platform-specific SQL statement to disable foreign key checks.
+     *
+     * If this feature is not supported, return empty string.
+     *
+     * @return string
+     *
+     * @see disableForeignKeyChecks()
+     */
+    abstract protected function _disableForeignKeyChecks();
+
+    /**
+     * Platform-specific SQL statement to enable foreign key checks.
+     *
+     * If this feature is not supported, return empty string.
+     *
+     * @return string
+     *
+     * @see enableForeignKeyChecks()
+     */
+    abstract protected function _enableForeignKeyChecks();
 
     /**
      * Accessor for properties if they exist.

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -240,4 +240,14 @@ class MockConnection extends BaseConnection
     {
         return true;
     }
+
+    protected function _disableForeignKeyChecks()
+    {
+        return '';
+    }
+
+    protected function _enableForeignKeyChecks()
+    {
+        return '';
+    }
 }

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -240,14 +240,4 @@ class MockConnection extends BaseConnection
     {
         return true;
     }
-
-    protected function _disableForeignKeyChecks()
-    {
-        return '';
-    }
-
-    protected function _enableForeignKeyChecks()
-    {
-        return '';
-    }
 }


### PR DESCRIPTION
**Description**
- add missing methods `_disableForeignKeyChecks()` and `_ebleForeignKeyChecks()`
- fix a bug that `Forge::dropTable()` causes an error if an extended connection class does not have these methods

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
