### PR TITLE
docs: fix PHPDoc type mixed

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -416,7 +416,7 @@ abstract class BaseModel
      * through soft deletes (deleted = 1)
      * This methods works only with dbCalls
      *
-     * @return bool|string
+     * @return bool|string Returns a string if in test mode.
      */
     abstract protected function doPurgeDeleted();
 

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -416,7 +416,7 @@ abstract class BaseModel
      * through soft deletes (deleted = 1)
      * This methods works only with dbCalls
      *
-     * @return bool|mixed
+     * @return bool|string
      */
     abstract protected function doPurgeDeleted();
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -824,8 +824,9 @@ if (! function_exists('old')) {
      * Provides access to "old input" that was set in the session
      * during a redirect()->withInput().
      *
-     * @param string|null $default
-     * @param bool|string $escape
+     * @param string|null  $default
+     * @param false|string $escape
+     * @phpstan-param false|'attr'|'css'|'html'|'js'|'raw'|'url' $escape
      *
      * @return array|string|null
      */

--- a/system/Common.php
+++ b/system/Common.php
@@ -823,10 +823,10 @@ if (! function_exists('old')) {
      * Provides access to "old input" that was set in the session
      * during a redirect()->withInput().
      *
-     * @param null        $default
+     * @param string|null $default
      * @param bool|string $escape
      *
-     * @return mixed|null
+     * @return array|string|null
      */
     function old(string $key, $default = null, $escape = 'html')
     {
@@ -932,7 +932,7 @@ if (! function_exists('session')) {
      *
      * @param string $val
      *
-     * @return mixed|Session|null
+     * @return array|bool|float|int|object|Session|string|null
      */
     function session(?string $val = null)
     {

--- a/system/Common.php
+++ b/system/Common.php
@@ -415,7 +415,7 @@ if (! function_exists('esc')) {
      * 'value' of the key/value pairs.
      *
      * @param array|string $data
-     * @param string       $context  Valid context values: html, js, css, url, attr, raw
+     * @param 'html'|'js'|'css'|'url'|'attr'|'raw' $context
      * @param string|null  $encoding Current encoding for escaping.
      *                               If not UTF-8, we convert strings from this encoding
      *                               pre-escaping and back to this encoding post-escaping.

--- a/system/Common.php
+++ b/system/Common.php
@@ -414,10 +414,11 @@ if (! function_exists('esc')) {
      * If $data is an array, then it loops over it, escaping each
      * 'value' of the key/value pairs.
      *
-     * Valid context values: html, js, css, url, attr, raw
-     *
      * @param array|string $data
-     * @param string       $encoding
+     * @param string       $context  Valid context values: html, js, css, url, attr, raw
+     * @param string|null  $encoding Current encoding for escaping.
+     *                               If not UTF-8, we convert strings from this encoding
+     *                               pre-escaping and back to this encoding post-escaping.
      *
      * @return array|string
      *

--- a/system/Common.php
+++ b/system/Common.php
@@ -415,10 +415,10 @@ if (! function_exists('esc')) {
      * 'value' of the key/value pairs.
      *
      * @param array|string $data
-     * @param 'html'|'js'|'css'|'url'|'attr'|'raw' $context
-     * @param string|null  $encoding Current encoding for escaping.
-     *                               If not UTF-8, we convert strings from this encoding
-     *                               pre-escaping and back to this encoding post-escaping.
+     * @phpstan-param 'html'|'js'|'css'|'url'|'attr'|'raw' $context
+     * @param string|null $encoding Current encoding for escaping.
+     *                              If not UTF-8, we convert strings from this encoding
+     *                              pre-escaping and back to this encoding post-escaping.
      *
      * @return array|string
      *

--- a/system/Common.php
+++ b/system/Common.php
@@ -934,6 +934,7 @@ if (! function_exists('session')) {
      * @param string $val
      *
      * @return array|bool|float|int|object|Session|string|null
+     * @phpstan-return ($val is null ? Session : array|bool|float|int|object|string|null)
      */
     function session(?string $val = null)
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2350,7 +2350,7 @@ class BaseBuilder
      *
      * @param mixed $where
      *
-     * @return bool|string
+     * @return bool|string Returns a string if in test mode.
      *
      * @throws DatabaseException
      */

--- a/system/Format/XMLFormatter.php
+++ b/system/Format/XMLFormatter.php
@@ -25,7 +25,7 @@ class XMLFormatter implements FormatterInterface
      *
      * @param mixed $data
      *
-     * @return bool|string (XML string | false)
+     * @return false|string (XML string | false)
      */
     public function format($data)
     {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -671,7 +671,7 @@ class IncomingRequest extends Request
      * with redirect_with_input(). It first checks for the data in the old
      * POST data, then the old GET data and finally check for dot arrays
      *
-     * @return mixed
+     * @return array|string|null
      */
     public function getOldInput(string $key)
     {

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -202,7 +202,7 @@ interface ResponseInterface
     /**
      * Returns the current body, converted to JSON is it isn't already.
      *
-     * @return mixed|string
+     * @return string|null
      *
      * @throws InvalidArgumentException If the body property is not array.
      */

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -252,7 +252,7 @@ trait ResponseTrait
     /**
      * Returns the current body, converted to JSON is it isn't already.
      *
-     * @return mixed|string
+     * @return string|null
      *
      * @throws InvalidArgumentException If the body property is not array.
      */

--- a/system/Model.php
+++ b/system/Model.php
@@ -406,7 +406,7 @@ class Model extends BaseModel
      * through soft deletes (deleted = 1)
      * This methods works only with dbCalls
      *
-     * @return bool|string
+     * @return bool|string Returns a string if in test mode.
      */
     protected function doPurgeDeleted()
     {

--- a/system/Model.php
+++ b/system/Model.php
@@ -406,7 +406,7 @@ class Model extends BaseModel
      * through soft deletes (deleted = 1)
      * This methods works only with dbCalls
      *
-     * @return bool|mixed
+     * @return bool|string
      */
     protected function doPurgeDeleted()
     {

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -481,7 +481,7 @@ class Session implements SessionInterface
      *
      * @param string|null $key Identifier of the session property to retrieve
      *
-     * @return mixed The property value(s)
+     * @return array|bool|float|int|object|string|null The property value(s)
      */
     public function get(?string $key = null)
     {

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -147,7 +147,7 @@ abstract class CIUnitTestCase extends TestCase
     /**
      * Migration Runner instance.
      *
-     * @var MigrationRunner|mixed
+     * @var MigrationRunner|null
      */
     protected $migrations;
 

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -347,7 +347,7 @@ class TestResponse extends TestCase
     /**
      * Returns the response's body as JSON
      *
-     * @return false|mixed
+     * @return false|string|null
      */
     public function getJSON()
     {

--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -75,6 +75,7 @@ class Filters
      * Escapes the given value with our `esc()` helper function.
      *
      * @param string $value
+     * @phpstan-param 'html'|'js'|'css'|'url'|'attr'|'raw' $context
      */
     public static function esc($value, string $context = 'html'): string
     {

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -305,8 +305,9 @@ class View implements RendererInterface
     /**
      * Sets several pieces of view data at once.
      *
-     * @param string $context The context to escape it for: html, css, js, url
-     *                        If null, no escaping will happen
+     * @param string|null $context The context to escape it for: html, css, js, url
+     *                             If null, no escaping will happen
+     * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
      */
     public function setData(array $data = [], ?string $context = null): RendererInterface
     {
@@ -326,6 +327,7 @@ class View implements RendererInterface
      * @param mixed       $value
      * @param string|null $context The context to escape it for: html, css, js, url
      *                             If null, no escaping will happen
+     * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
      */
     public function setVar(string $name, $value = null, ?string $context = null): RendererInterface
     {


### PR DESCRIPTION
~~Needs #6722~~

**Description**
See #6310

- fix PHPDoc types
- ~~remove unneeded empty check~~

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

