### PR TITLE
fix: [SQLSRV] _getResult() return object for preparedQuery class

### DIFF
--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -61,7 +61,7 @@ class PreparedQuery extends BasePreparedQuery
 
     /**
      * Takes a new set of data and runs it against the currently
-     * prepared query. Upon success, will return a Results object.
+     * prepared query.
      */
     public function _execute(array $data): bool
     {
@@ -77,7 +77,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Returns the result object for the prepared query.
+     * Returns the statement resource for the prepared query.
      *
      * @return mixed
      */

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -77,7 +77,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Returns the statement resource for the prepared query.
+     * Returns the statement resource for the prepared query or false when preparing failed.
      *
      * @return mixed
      */

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -28,13 +28,6 @@ class PreparedQuery extends BasePreparedQuery
     protected $parameters = [];
 
     /**
-     * The result boolean from a sqlsrv_execute.
-     *
-     * @var bool
-     */
-    protected $result;
-
-    /**
      * Prepares the query against the database, and saves the connection
      * info necessary to execute the query later.
      *
@@ -80,9 +73,7 @@ class PreparedQuery extends BasePreparedQuery
             $this->parameters[$key] = $value;
         }
 
-        $this->result = sqlsrv_execute($this->statement);
-
-        return (bool) $this->result;
+        return sqlsrv_execute($this->statement);
     }
 
     /**
@@ -92,7 +83,7 @@ class PreparedQuery extends BasePreparedQuery
      */
     public function _getResult()
     {
-        return $this->result;
+        return $this->statement;
     }
 
     /**

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -139,7 +139,7 @@ final class PreparedQueryTest extends CIUnitTestCase
     public function testExecuteSelectQueryAndCheckTypeAndResult()
     {
         $this->query = $this->db->prepare(static fn ($db) => $db->table('user')->select('id, name, email')->where([
-            'name' => 'foo'
+            'name' => 'foo',
         ])->get());
 
         $result = $this->query->execute('Derek Jones');

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -138,7 +138,7 @@ final class PreparedQueryTest extends CIUnitTestCase
 
     public function testExecuteSelectQueryAndCheckTypeAndResult()
     {
-        $this->query = $this->db->prepare(static fn ($db) => $db->table('user')->select(' name, email, country')->where([
+        $this->query = $this->db->prepare(static fn ($db) => $db->table('user')->select('name, email, country')->where([
             'name' => 'foo',
         ])->get());
 

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -138,7 +138,7 @@ final class PreparedQueryTest extends CIUnitTestCase
 
     public function testExecuteSelectQueryAndCheckTypeAndResult()
     {
-        $this->query = $this->db->prepare(static fn ($db) => $db->table('user')->select('id, name, email')->where([
+        $this->query = $this->db->prepare(static fn ($db) => $db->table('user')->select(' name, email, country')->where([
             'name' => 'foo',
         ])->get());
 
@@ -146,7 +146,7 @@ final class PreparedQueryTest extends CIUnitTestCase
 
         $this->assertInstanceOf(ResultInterface::class, $result);
 
-        $expectedRow = ['id' => 1, 'name' => 'Derek Jones', 'email' => 'derek@world.com'];
+        $expectedRow = ['name' => 'Derek Jones', 'email' => 'derek@world.com', 'country' => 'US'];
         $this->assertSame($expectedRow, $result->getRowArray());
     }
 }

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\BasePreparedQuery;
 use CodeIgniter\Database\Query;
+use CodeIgniter\Database\ResultInterface;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Tests\Support\Database\Seeds\CITestSeeder;
@@ -133,5 +134,19 @@ final class PreparedQueryTest extends CIUnitTestCase
 
         $this->seeInDatabase($this->db->DBPrefix . 'user', ['name' => 'foo', 'email' => 'foo@example.com']);
         $this->seeInDatabase($this->db->DBPrefix . 'user', ['name' => 'bar', 'email' => 'bar@example.com']);
+    }
+
+    public function testExecuteSelectQueryAndCheckTypeAndResult()
+    {
+        $this->query = $this->db->prepare(static fn ($db) => $db->table('user')->select('id, name, email')->where([
+            'name' => 'foo'
+        ])->get());
+
+        $result = $this->query->execute('Derek Jones');
+
+        $this->assertInstanceOf(ResultInterface::class, $result);
+
+        $expectedRow = ['id' => 1, 'name' => 'Derek Jones', 'email' => 'derek@world.com'];
+        $this->assertSame($expectedRow, $result->getRowArray());
     }
 }

--- a/user_guide_src/source/changelogs/v4.2.8.rst
+++ b/user_guide_src/source/changelogs/v4.2.8.rst
@@ -38,5 +38,6 @@ Bugs Fixed
 
 - Fixed a bug when the ``CodeIgniter\HTTP\IncomingRequest::getPostGet()`` and ``CodeIgniter\HTTP\IncomingRequest::getGetPost()`` methods didn't return values from the other stream when ``index`` was set to ``null``.
 - Fixed a bug when ``binds`` weren't cleaned properly when calling ``CodeIgniter\Database\Postgre::replace()`` multiple times in the context.
+- Fixed a bug when the ``CodeIgniter\Database\SQLSRV\PreparedQuery::_getResult()`` was returning the bool value instead of the resource.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
This PR fixes the result object for `CodeIgniter\Database\SQLSRV\PreparedQuery::_getResult()`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
