### PR TITLE
refactor: remove unneeded code in form_helper

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -556,11 +556,6 @@ parameters:
 			path: system/Helpers/filesystem_helper.php
 
 		-
-			message: "#^Offset 'checked' on array\\{type\\: 'checkbox', name\\: mixed, value\\: string\\} in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: system/Helpers/form_helper.php
-
-		-
 			message: "#^Binary operation \"\\+\" between 0 and string results in an error\\.$#"
 			count: 1
 			path: system/Helpers/number_helper.php

--- a/system/Common.php
+++ b/system/Common.php
@@ -1054,7 +1054,7 @@ if (! function_exists('stringify_attributes')) {
      * Helper function used to convert a string, array, or object
      * of attributes to a string.
      *
-     * @param mixed $attributes string, array, object
+     * @param array|object|string $attributes string, array, object that can be cast to array
      */
     function stringify_attributes($attributes, bool $js = false): string
     {

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -353,6 +353,7 @@ if (! function_exists('form_checkbox')) {
 
         if (is_array($data) && array_key_exists('checked', $data)) {
             $checked = $data['checked'];
+
             if ($checked === false) {
                 unset($data['checked']);
             } else {
@@ -362,8 +363,6 @@ if (! function_exists('form_checkbox')) {
 
         if ($checked === true) {
             $defaults['checked'] = 'checked';
-        } elseif (isset($defaults['checked'])) {
-            unset($defaults['checked']);
         }
 
         return '<input ' . parse_form_attributes($data, $defaults) . stringify_attributes($extra) . " />\n";

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -137,8 +137,8 @@ if (! function_exists('form_input')) {
      * Text Input Field. If 'type' is passed in the $type field, it will be
      * used as the input type, for making 'email', 'phone', etc input fields.
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_input($data = '', string $value = '', $extra = '', string $type = 'text'): string
     {
@@ -158,8 +158,8 @@ if (! function_exists('form_password')) {
      *
      * Identical to the input function but adds the "password" type
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_password($data = '', string $value = '', $extra = ''): string
     {
@@ -178,8 +178,8 @@ if (! function_exists('form_upload')) {
      *
      * Identical to the input function but adds the "file" type
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_upload($data = '', string $value = '', $extra = ''): string
     {
@@ -202,8 +202,8 @@ if (! function_exists('form_textarea')) {
     /**
      * Textarea field
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_textarea($data = '', string $value = '', $extra = ''): string
     {
@@ -238,8 +238,8 @@ if (! function_exists('form_multiselect')) {
     /**
      * Multi-select menu
      *
-     * @param mixed $name
-     * @param mixed $extra
+     * @param array|string        $name
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_multiselect($name = '', array $options = [], array $selected = [], $extra = ''): string
     {
@@ -257,10 +257,10 @@ if (! function_exists('form_dropdown')) {
     /**
      * Drop-down Menu
      *
-     * @param mixed $data
-     * @param mixed $options
-     * @param mixed $selected
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|string        $options
+     * @param array|string        $selected
+     * @param array|object|string $extra    string, array, object that can be cast to array
      */
     function form_dropdown($data = '', $options = [], $selected = [], $extra = ''): string
     {
@@ -340,8 +340,8 @@ if (! function_exists('form_checkbox')) {
     /**
      * Checkbox Field
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_checkbox($data = '', string $value = '', bool $checked = false, $extra = ''): string
     {
@@ -374,8 +374,8 @@ if (! function_exists('form_radio')) {
     /**
      * Radio Button
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_radio($data = '', string $value = '', bool $checked = false, $extra = ''): string
     {
@@ -392,8 +392,8 @@ if (! function_exists('form_submit')) {
     /**
      * Submit Button
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_submit($data = '', string $value = '', $extra = ''): string
     {
@@ -405,8 +405,8 @@ if (! function_exists('form_reset')) {
     /**
      * Reset Button
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_reset($data = '', string $value = '', $extra = ''): string
     {
@@ -418,8 +418,8 @@ if (! function_exists('form_button')) {
     /**
      * Form Button
      *
-     * @param mixed $data
-     * @param mixed $extra
+     * @param array|string        $data
+     * @param array|object|string $extra string, array, object that can be cast to array
      */
     function form_button($data = '', string $content = '', $extra = ''): string
     {


### PR DESCRIPTION
**Description**
- fix PHPDoc types. See #6310
- remove unneeded code

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
