### PR TITLE
fix: bug that esc() accepts invalid context '0'

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -437,7 +437,7 @@ if (! function_exists('esc')) {
             // Provide a way to NOT escape data since
             // this could be called automatically by
             // the View library.
-            if (empty($context) || $context === 'raw') {
+            if ($context === 'raw') {
                 return $data;
             }
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -177,6 +177,12 @@ final class CommonFunctionsTest extends CIUnitTestCase
         esc(['width' => '800', 'height' => '600'], 'bogus');
     }
 
+    public function testEscapeBadContextZero()
+    {
+        $this->expectException('InvalidArgumentException');
+        esc('<script>', '0');
+    }
+
     /**
      * @runInSeparateProcess
      *


### PR DESCRIPTION
**Description**
- fix a bug that `esc()` accepts invalid context `'0'`

See https://github.com/codeigniter4/CodeIgniter4/pull/6715#discussion_r1000030058

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

