### PR TITLE
Fix error handler callback

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -147,17 +147,19 @@ class Exceptions
      *
      * This seems to be primarily when a user triggers it with trigger_error().
      *
+     * @return bool
+     *
      * @throws ErrorException
      *
      * @codeCoverageIgnore
      */
     public function errorHandler(int $severity, string $message, ?string $file = null, ?int $line = null)
     {
-        if (! (error_reporting() & $severity)) {
-            return;
+        if (error_reporting() & $severity) {
+            throw new ErrorException($message, 0, $severity, $file, $line);
         }
 
-        throw new ErrorException($message, 0, $severity, $file, $line);
+        return false; // return false to propagate the error to PHP standard error handler
     }
 
     /**

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -141,11 +141,7 @@ class Exceptions
     }
 
     /**
-     * Even in PHP7, some errors make it through to the errorHandler, so
-     * convert these to Exceptions and let the exception handler log it and
-     * display it.
-     *
-     * This seems to be primarily when a user triggers it with trigger_error().
+     * The callback to be registered to `set_error_handler()`.
      *
      * @return bool
      *

--- a/user_guide_src/source/changelogs/v4.2.8.rst
+++ b/user_guide_src/source/changelogs/v4.2.8.rst
@@ -39,5 +39,6 @@ Bugs Fixed
 - Fixed a bug when the ``CodeIgniter\HTTP\IncomingRequest::getPostGet()`` and ``CodeIgniter\HTTP\IncomingRequest::getGetPost()`` methods didn't return values from the other stream when ``index`` was set to ``null``.
 - Fixed a bug when ``binds`` weren't cleaned properly when calling ``CodeIgniter\Database\Postgre::replace()`` multiple times in the context.
 - Fixed a bug when the ``CodeIgniter\Database\SQLSRV\PreparedQuery::_getResult()`` was returning the bool value instead of the resource.
+- Fixed a bug in the error handler where in cases the callback cannot process the error level it does not pass the error to PHP's standard error handler.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
The callback to `set_error_handler` expects to return a `bool`:
https://www.php.net/manual/en/function.set-error-handler.php

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
