### PR TITLE
fix: [Postgres] reset binds when replace() method is called multiple times in the context

### DIFF
--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -179,6 +179,7 @@ class Builder extends BaseBuilder
 
         unset($builder);
         $this->resetWrite();
+        $this->binds = [];
 
         return $result;
     }

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -92,6 +92,9 @@ final class InsertTest extends CIUnitTestCase
         $this->assertSame('Cab Driver', $row->name);
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6726
+     */
     public function testReplaceTwice()
     {
         $builder = $this->db->table('job');

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -92,6 +92,35 @@ final class InsertTest extends CIUnitTestCase
         $this->assertSame('Cab Driver', $row->name);
     }
 
+    public function testReplaceTwice()
+    {
+        $builder = $this->db->table('job');
+
+        $data = [
+            'id'          => 1,
+            'name'        => 'John Smith',
+            'description' => 'American',
+        ];
+        $builder->replace($data);
+
+        $row = $this->db->table('job')
+            ->getwhere(['id' => 1])
+            ->getRow();
+        $this->assertSame('John Smith', $row->name);
+
+        $data = [
+            'id'          => 2,
+            'name'        => 'Hans Schmidt',
+            'description' => 'German',
+        ];
+        $builder->replace($data);
+
+        $row = $this->db->table('job')
+            ->getwhere(['id' => 2])
+            ->getRow();
+        $this->assertSame('Hans Schmidt', $row->name);
+    }
+
     public function testBug302()
     {
         $code = "my code \\'CodeIgniter\\Autoloader\\'";

--- a/user_guide_src/source/changelogs/v4.2.8.rst
+++ b/user_guide_src/source/changelogs/v4.2.8.rst
@@ -37,5 +37,6 @@ Bugs Fixed
 **********
 
 - Fixed a bug when the ``CodeIgniter\HTTP\IncomingRequest::getPostGet()`` and ``CodeIgniter\HTTP\IncomingRequest::getGetPost()`` methods didn't return values from the other stream when ``index`` was set to ``null``.
+- Fixed a bug when ``binds`` weren't cleaned properly when calling ``CodeIgniter\Database\Postgre::replace()`` multiple times in the context.
 
 See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
Fixes #6726

Code provided by kenjis. Thanks!

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide