### PR TITLE
docs: fix `@return` type in FormatterInterface

### DIFF
--- a/system/Format/FormatterInterface.php
+++ b/system/Format/FormatterInterface.php
@@ -21,7 +21,7 @@ interface FormatterInterface
      *
      * @param array|string $data
      *
-     * @return bool|string
+     * @return false|string
      */
     public function format($data);
 }


### PR DESCRIPTION
**Description**
- fix `@return` type

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

