### PR TITLE
docs: fix ResponseTrait::getJSON() `@return` type

### DIFF
--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -254,7 +254,7 @@ trait ResponseTrait
     /**
      * Returns the current body, converted to JSON is it isn't already.
      *
-     * @return bool|string|null
+     * @return string|null
      *
      * @throws InvalidArgumentException If the body property is not array.
      */


### PR DESCRIPTION
**Description**
This is merge mistake. When `$body` is false, it will be null in the end.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
