### PR TITLE
docs: make version notation consistent

### DIFF
--- a/user_guide_src/source/changelogs/v4.1.0.rst
+++ b/user_guide_src/source/changelogs/v4.1.0.rst
@@ -12,7 +12,7 @@ Release Date: January 31, 2021
 BREAKING
 ********
 
-- ``Autoloader::loadLegacy()`` method was previously used for migration of non-namespaced classes in transition to CodeIgniter v4. Since ``4.1.0``, this support was removed.
+- ``Autoloader::loadLegacy()`` method was previously used for migration of non-namespaced classes in transition to CodeIgniter v4. Since v4.1.0, this support was removed.
 
 Changes
 *******

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -96,7 +96,7 @@ The following functions are available:
 
         .. literalinclude:: url_helper/006.php
 
-.. important:: Prior to **4.1.2** this function had a bug causing it to ignore the configuration on ``App::$indexPage``.
+.. important:: Prior to v4.1.2, this function had a bug causing it to ignore the configuration on ``App::$indexPage``.
 
 .. php:function:: previous_url([$returnObject = false])
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -226,7 +226,7 @@ redirect and is recommended in most cases:
 
 .. literalinclude:: routing/022.php
 
-.. note:: Since v4.2.0 ``addRedirect()`` can use placeholders.
+.. note:: Since v4.2.0, ``addRedirect()`` can use placeholders.
 
 If a redirect route is matched during a page load, the user will be immediately redirected to the new page before a
 controller can be loaded.

--- a/user_guide_src/source/installation/upgrade_410.rst
+++ b/user_guide_src/source/installation/upgrade_410.rst
@@ -17,5 +17,5 @@ Breaking Changes
 
 **Legacy Autoloading**
 
-``Autoloader::loadLegacy()`` method was originally for transition to CodeIgniter v4. Since 4.1.0,
+``Autoloader::loadLegacy()`` method was originally for transition to CodeIgniter v4. Since v4.1.0,
 this support was removed. All classes must be namespaced.


### PR DESCRIPTION
**Description**
- Since v4.x.x, ...
- Prior to v4.x.x, ...

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
