### PR TITLE
Add BaseBuilder::deleteBatch()

### DIFF
--- a/.github/workflows/test-phpcpd.yml
+++ b/.github/workflows/test-phpcpd.yml
@@ -43,4 +43,12 @@ jobs:
           extensions: dom, mbstring
 
       - name: Detect code duplication
-        run: phpcpd --exclude system/Test --exclude system/ThirdParty --exclude system/Database/SQLSRV/Builder.php --exclude system/Database/SQLSRV/Forge.php --exclude system/Database/MySQLi/Builder.php --exclude system/Database/OCI8/Builder.php -- app/ public/ system/
+        run: phpcpd
+            --exclude system/Test
+            --exclude system/ThirdParty
+            --exclude system/Database/SQLSRV/Builder.php
+            --exclude system/Database/SQLSRV/Forge.php
+            --exclude system/Database/MySQLi/Builder.php
+            --exclude system/Database/OCI8/Builder.php
+            --exclude system/Database/Postgre/Builder.php
+            -- app/ public/ system/

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2704,12 +2704,12 @@ class BaseBuilder
                 array_map(
                     static fn ($key, $value) => (
                         $value instanceof RawSql ?
-                    $value :
-                    (
-                        is_string($key) ?
-                    $table . '.' . $key . ' = ' . $alias . '.' . $value :
-                    $table . '.' . $value . ' = ' . $alias . '.' . $value
-                    )
+                        $value :
+                        (
+                            is_string($key) ?
+                            $table . '.' . $key . ' = ' . $alias . '.' . $value :
+                            $table . '.' . $value . ' = ' . $alias . '.' . $value
+                        )
                     ),
                     array_keys($constraints),
                     $constraints

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2702,18 +2702,17 @@ class BaseBuilder
             $sql .= 'ON ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key, $value, $id) => (
+                    static fn ($key, $value) => (
                         $value instanceof RawSql ?
                     $value :
                     (
                         is_string($key) ?
-                    $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :
+                    $table . '.' . $key . ' = ' . $alias . '.' . $value :
                     $table . '.' . $value . ' = ' . $alias . '.' . $value
                     )
                     ),
                     array_keys($constraints),
-                    $constraints,
-                    array_fill(0, count($constraints), $this->db->escapeChar)
+                    $constraints
                 )
             );
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2704,7 +2704,7 @@ class BaseBuilder
                 array_map(
                     static fn ($key, $value, $id) => (
                         $value instanceof RawSql ?
-                    $key :
+                    $value :
                     (
                         is_string($key) ?
                     $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2656,7 +2656,7 @@ class BaseBuilder
     /**
      * Sets data and calls batchExecute to run queries
      *
-     * @param array|object|null        $set         a dataset or select query
+     * @param array|object|null $set         a dataset or select query
      * @param array|RawSql|null $constraints
      *
      * @return false|int|string[] Number of rows affected or FALSE on failure, SQL array when testMode

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2691,10 +2691,6 @@ class BaseBuilder
                 return ''; // @codeCoverageIgnore
             }
 
-            $updateFields = $this->QBOptions['updateFields'] ??
-                $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ??
-                [];
-
             $alias = $this->QBOptions['alias'] ?? '_u';
 
             $sql = 'DELETE ' . $table . ' FROM ' . $table . "\n";

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2657,7 +2657,7 @@ class BaseBuilder
      * Sets data and calls batchExecute to run queries
      *
      * @param array|object|null        $set         a dataset or select query
-     * @param array|RawSql|string|null $constraints
+     * @param array|RawSql|null $constraints
      *
      * @return false|int|string[] Number of rows affected or FALSE on failure, SQL array when testMode
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2702,10 +2702,18 @@ class BaseBuilder
             $sql .= 'ON ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key) => ($key instanceof RawSql ?
+                    static fn ($key, $value, $id) => (
+                        $value instanceof RawSql ?
                     $key :
-                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
-                    $constraints
+                    (
+                        is_string($key) ?
+                    $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :
+                    $table . '.' . $value . ' = ' . $alias . '.' . $value
+                    )
+                    ),
+                    array_keys($constraints),
+                    $constraints,
+                    array_fill(0, count($constraints), $this->db->escapeChar)
                 )
             );
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1969,7 +1969,7 @@ class BaseBuilder
     }
 
     /**
-     * Set table alias for dataset sudo table.
+     * Set table alias for dataset pseudo table.
      */
     private function setAlias(string $alias): BaseBuilder
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2723,14 +2723,9 @@ class BaseBuilder
                 }
             }
 
-            // remove database prefix from alias in where
-            $sql .= ' ' . str_replace(
-                $this->db->DBPrefix . trim($alias, $this->db->escapeChar),
-                trim($alias, $this->db->escapeChar),
-                $this->compileWhereHaving('QBWhere')
-            );
+            $sql .= ' ' . $this->compileWhereHaving('QBWhere');
 
-            $this->QBOptions['sql'] = $sql;
+            $this->QBOptions['sql'] = trim($sql);
         }
 
         if (isset($this->QBOptions['fromQuery'])) {

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -434,4 +434,81 @@ class Builder extends BaseBuilder
 
         return str_replace('{:_table_:}', $data, $sql);
     }
+
+    /**
+     * Generates a platform-specific batch update string from the supplied data
+     */
+    protected function _deleteBatch(string $table, array $keys, array $values): string
+    {
+        $sql = $this->QBOptions['sql'] ?? '';
+
+        // if this is the first iteration of batch then we need to build skeleton sql
+        if ($sql === '') {
+            $constraints = $this->QBOptions['constraints'] ?? [];
+
+            if ($constraints === []) {
+                if ($this->db->DBDebug) {
+                    throw new DatabaseException('You must specify a constraint to match on for batch deletes.'); // @codeCoverageIgnore
+                }
+
+                return ''; // @codeCoverageIgnore
+            }
+
+            $alias = $this->QBOptions['alias'] ?? '_u';
+
+            $sql = 'DELETE ' . $table . "\n";
+
+            $sql .= "WHERE EXISTS (SELECT * FROM (\n{:_table_:}";
+
+            $sql .= ') ' . $alias . "\n";
+
+            $sql .= 'WHERE ' . implode(
+                ' AND ',
+                array_map(
+                    static fn ($key) => ($key instanceof RawSql ?
+                    $key :
+                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
+                    $constraints
+                )
+            );
+
+            // convert binds in where
+            foreach ($this->QBWhere as $key => $where) {
+                foreach ($this->binds as $field => $bind) {
+                    $this->QBWhere[$key]['condition'] = str_replace(':' . $field . ':', $bind[0], $where['condition']);
+                }
+            }
+
+            // remove database prefix from alias in where
+            $sql .= ' ' . str_replace(
+                'WHERE ',
+                'AND ',
+                str_replace(
+                    $this->db->DBPrefix . trim($alias, $this->db->escapeChar),
+                    trim($alias, $this->db->escapeChar),
+                    $this->compileWhereHaving('QBWhere')
+                )
+            ) . ')';
+
+            $this->QBOptions['sql'] = $sql;
+        }
+
+        if (isset($this->QBOptions['fromQuery'])) {
+            $data = $this->QBOptions['fromQuery'];
+        } else {
+            $data = implode(
+                " FROM DUAL UNION ALL\n",
+                array_map(
+                    static fn ($value) => 'SELECT ' . implode(', ', array_map(
+                        static fn ($key, $index) => $index . ' ' . $key,
+                        $keys,
+                        $value
+                    )),
+                    $values
+                )
+            ) . " FROM DUAL\n";
+        }
+
+        return str_replace('{:_table_:}', $data, $sql);
+    }
 }

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -465,18 +465,17 @@ class Builder extends BaseBuilder
             $sql .= 'WHERE ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key, $value, $id) => (
+                    static fn ($key, $value) => (
                         $value instanceof RawSql ?
                     $value :
                     (
                         is_string($key) ?
-                    $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :
+                    $table . '.' . $key . ' = ' . $alias . '.' . $value :
                     $table . '.' . $value . ' = ' . $alias . '.' . $value
                     )
                     ),
                     array_keys($constraints),
-                    $constraints,
-                    array_fill(0, count($constraints), $this->db->escapeChar)
+                    $constraints
                 )
             );
 

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -465,10 +465,18 @@ class Builder extends BaseBuilder
             $sql .= 'WHERE ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key) => ($key instanceof RawSql ?
+                    static fn ($key, $value, $id) => (
+                        $value instanceof RawSql ?
                     $key :
-                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
-                    $constraints
+                    (
+                        is_string($key) ?
+                    $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :
+                    $table . '.' . $value . ' = ' . $alias . '.' . $value
+                    )
+                    ),
+                    array_keys($constraints),
+                    $constraints,
+                    array_fill(0, count($constraints), $this->db->escapeChar)
                 )
             );
 

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -467,12 +467,12 @@ class Builder extends BaseBuilder
                 array_map(
                     static fn ($key, $value) => (
                         $value instanceof RawSql ?
-                    $value :
-                    (
-                        is_string($key) ?
-                    $table . '.' . $key . ' = ' . $alias . '.' . $value :
-                    $table . '.' . $value . ' = ' . $alias . '.' . $value
-                    )
+                        $value :
+                        (
+                            is_string($key) ?
+                            $table . '.' . $key . ' = ' . $alias . '.' . $value :
+                            $table . '.' . $value . ' = ' . $alias . '.' . $value
+                        )
                     ),
                     array_keys($constraints),
                     $constraints

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -467,7 +467,7 @@ class Builder extends BaseBuilder
                 array_map(
                     static fn ($key, $value, $id) => (
                         $value instanceof RawSql ?
-                    $key :
+                    $value :
                     (
                         is_string($key) ?
                     $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -486,15 +486,10 @@ class Builder extends BaseBuilder
                 }
             }
 
-            // remove database prefix from alias in where
             $sql .= ' ' . str_replace(
                 'WHERE ',
                 'AND ',
-                str_replace(
-                    $this->db->DBPrefix . trim($alias, $this->db->escapeChar),
-                    trim($alias, $this->db->escapeChar),
-                    $this->compileWhereHaving('QBWhere')
-                )
+                $this->compileWhereHaving('QBWhere')
             ) . ')';
 
             $this->QBOptions['sql'] = $sql;

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -441,7 +441,7 @@ class Builder extends BaseBuilder
                 array_map(
                     static fn ($key, $value, $id) => (
                         $value instanceof RawSql ?
-                    $key :
+                    $value :
                     (
                         is_string($key) ?
                     $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -441,12 +441,12 @@ class Builder extends BaseBuilder
                 array_map(
                     static fn ($key, $value) => (
                         $value instanceof RawSql ?
-                    $value :
-                    (
-                        is_string($key) ?
-                    $table . '.' . $key . ' = ' . $alias . '.' . $value :
-                    $table . '.' . $value . ' = ' . $alias . '.' . $value
-                    )
+                        $value :
+                        (
+                            is_string($key) ?
+                            $table . '.' . $key . ' = ' . $alias . '.' . $value :
+                            $table . '.' . $value . ' = ' . $alias . '.' . $value
+                        )
                     ),
                     array_keys($constraints),
                     $constraints

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -408,4 +408,85 @@ class Builder extends BaseBuilder
 
         return str_replace('{:_table_:}', $data, $sql);
     }
+
+    /**
+     * Generates a platform-specific batch update string from the supplied data
+     */
+    protected function _deleteBatch(string $table, array $keys, array $values): string
+    {
+        $sql = $this->QBOptions['sql'] ?? '';
+
+        // if this is the first iteration of batch then we need to build skeleton sql
+        if ($sql === '') {
+            $constraints = $this->QBOptions['constraints'] ?? [];
+
+            if ($constraints === []) {
+                if ($this->db->DBDebug) {
+                    throw new DatabaseException('You must specify a constraint to match on for batch deletes.'); // @codeCoverageIgnore
+                }
+
+                return ''; // @codeCoverageIgnore
+            }
+
+            $updateFields = $this->QBOptions['updateFields'] ??
+                $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ??
+                [];
+
+            $alias = $this->QBOptions['alias'] ?? '_u';
+
+            $sql = 'DELETE FROM ' . $table . "\n";
+
+            $sql .= "USING (\n{:_table_:}";
+
+            $sql .= ') ' . $alias . "\n";
+
+            $sql .= 'WHERE ' . implode(
+                ' AND ',
+                array_map(
+                    static fn ($key) => ($key instanceof RawSql ?
+                    $key :
+                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
+                    $constraints
+                )
+            );
+
+            // convert binds in where
+            foreach ($this->QBWhere as $key => $where) {
+                foreach ($this->binds as $field => $bind) {
+                    $this->QBWhere[$key]['condition'] = str_replace(':' . $field . ':', $bind[0], $where['condition']);
+                }
+            }
+
+            // remove database prefix from alias in where
+            $sql .= ' ' . str_replace(
+                'WHERE ',
+                ' AND ',
+                str_replace(
+                    $this->db->DBPrefix . trim($alias, $this->db->escapeChar),
+                    trim($alias, $this->db->escapeChar),
+                    $this->compileWhereHaving('QBWhere')
+                )
+            );
+
+            $this->QBOptions['sql'] = $sql;
+        }
+
+        if (isset($this->QBOptions['fromQuery'])) {
+            $data = $this->QBOptions['fromQuery'];
+        } else {
+            $data = implode(
+                " UNION ALL\n",
+                array_map(
+                    static fn ($value) => 'SELECT ' . implode(', ', array_map(
+                        static fn ($key, $index) => $index . ' ' . $key,
+                        $keys,
+                        $value
+                    )),
+                    $values
+                )
+            ) . "\n";
+        }
+
+        return str_replace('{:_table_:}', $data, $sql);
+    }
 }

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -428,10 +428,6 @@ class Builder extends BaseBuilder
                 return ''; // @codeCoverageIgnore
             }
 
-            $updateFields = $this->QBOptions['updateFields'] ??
-                $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ??
-                [];
-
             $alias = $this->QBOptions['alias'] ?? '_u';
 
             $sql = 'DELETE FROM ' . $table . "\n";

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -460,15 +460,10 @@ class Builder extends BaseBuilder
                 }
             }
 
-            // remove database prefix from alias in where
             $sql .= ' ' . str_replace(
                 'WHERE ',
                 'AND ',
-                str_replace(
-                    $this->db->DBPrefix . trim($alias, $this->db->escapeChar),
-                    trim($alias, $this->db->escapeChar),
-                    $this->compileWhereHaving('QBWhere')
-                )
+                $this->compileWhereHaving('QBWhere')
             );
 
             $this->QBOptions['sql'] = $sql;

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -439,18 +439,17 @@ class Builder extends BaseBuilder
             $sql .= 'WHERE ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key, $value, $id) => (
+                    static fn ($key, $value) => (
                         $value instanceof RawSql ?
                     $value :
                     (
                         is_string($key) ?
-                    $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :
+                    $table . '.' . $key . ' = ' . $alias . '.' . $value :
                     $table . '.' . $value . ' = ' . $alias . '.' . $value
                     )
                     ),
                     array_keys($constraints),
-                    $constraints,
-                    array_fill(0, count($constraints), $this->db->escapeChar)
+                    $constraints
                 )
             );
 

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -439,10 +439,18 @@ class Builder extends BaseBuilder
             $sql .= 'WHERE ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key) => ($key instanceof RawSql ?
+                    static fn ($key, $value, $id) => (
+                        $value instanceof RawSql ?
                     $key :
-                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
-                    $constraints
+                    (
+                        is_string($key) ?
+                    $table . '.' . $id . $key . $id . ' = ' . $alias . '.' . $value :
+                    $table . '.' . $value . ' = ' . $alias . '.' . $value
+                    )
+                    ),
+                    array_keys($constraints),
+                    $constraints,
+                    array_fill(0, count($constraints), $this->db->escapeChar)
                 )
             );
 

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -456,7 +456,7 @@ class Builder extends BaseBuilder
             // remove database prefix from alias in where
             $sql .= ' ' . str_replace(
                 'WHERE ',
-                ' AND ',
+                'AND ',
                 str_replace(
                     $this->db->DBPrefix . trim($alias, $this->db->escapeChar),
                     trim($alias, $this->db->escapeChar),

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -231,14 +231,11 @@ class Builder extends BaseBuilder
                 return ''; // @codeCoverageIgnore
             }
 
-            $alias = $this->QBOptions['alias'] ?? '_u';
-
             $sql = 'DELETE FROM ' . $table . "\n";
 
-            if (current($constraints) instanceof RawSql) {
-                if ($this->db->DBDebug) {
-                    throw new DatabaseException('You cannot use RawSql for constraint in SQLite.'); // @codeCoverageIgnore
-                }
+            if (current($constraints) instanceof RawSql && $this->db->DBDebug) {
+                throw new DatabaseException('You cannot use RawSql for constraint in SQLite.');
+                // @codeCoverageIgnore
             }
 
             if (is_string(current(array_keys($constraints)))) {
@@ -252,10 +249,9 @@ class Builder extends BaseBuilder
             $sql .= "WHERE {$concat1} IN (SELECT {$concat2} FROM (\n{:_table_:}))";
 
             // where is not supported
-            if ($this->QBWhere !== []) {
-                if ($this->db->DBDebug) {
-                    throw new DatabaseException('You cannot use WHERE with SQLite.'); // @codeCoverageIgnore
-                }
+            if ($this->QBWhere !== [] && $this->db->DBDebug) {
+                throw new DatabaseException('You cannot use WHERE with SQLite.');
+                // @codeCoverageIgnore
             }
 
             $this->QBOptions['sql'] = $sql;

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -67,4 +67,22 @@ final class DeleteTest extends CIUnitTestCase
 
         $this->seeNumRecords(1, 'user', ['country' => 'US']);
     }
+
+    public function testDeleteBatch()
+    {
+        $data = [
+            ['userid' => 1, 'username' => 'Derek J', 'unused' => 'You can have fields you dont use'],
+            ['userid' => 2, 'username' => 'Ahmadinejad', 'unused' => 'You can have fields you dont use'],
+        ];
+
+        $this->db->table('user')
+            ->setAlias('data')
+            ->setData($data)
+            ->onConstraint(['id' => 'userid', 'name' => 'username'])
+            ->deleteBatch();
+
+        $this->seeInDatabase('user', ['email' => 'derek@world.com', 'name' => 'Derek Jones']);
+
+        $this->dontSeeInDatabase('user', ['email' => 'ahmadinejad@world.com', 'name' => 'Ahmadinejad']);
+    }
 }

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -75,10 +75,16 @@ final class DeleteTest extends CIUnitTestCase
             ['userid' => 2, 'username' => 'Ahmadinejad', 'unused' => 'You can have fields you dont use'],
         ];
 
-        $this->db->table('user')
+        $builder = $this->db->table('user')
             ->setData($data, null, 'data')
-            ->onConstraint(['id' => 'userid', 'name' => 'username'])
-            ->deleteBatch();
+            ->onConstraint(['id' => 'userid', 'name' => 'username']);
+
+        // SQLite does not support where for batch deletes
+        if ($this->db->DBDriver !== 'SQLite3') {
+            $builder->where('data.userid > 0');
+        }
+
+        $builder->deleteBatch();
 
         $this->seeInDatabase('user', ['email' => 'derek@world.com', 'name' => 'Derek Jones']);
 

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -76,8 +76,7 @@ final class DeleteTest extends CIUnitTestCase
         ];
 
         $this->db->table('user')
-            ->setAlias('data')
-            ->setData($data)
+            ->setData($data, null, 'data')
             ->onConstraint(['id' => 'userid', 'name' => 'username'])
             ->deleteBatch();
 

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -193,6 +193,7 @@ Query Builder
 - Improved the SQL structure for ``Builder::updateBatch()``. See :ref:`update-batch` for the details.
 - Added ``when()`` and ``whenNot()`` methods to conditionally add clauses to the query. See :ref:`BaseBuilder::when() <db-builder-when>` for details.
 - Added ``upsert()`` and ``upsertBatch()`` methods to QueryBuilder. See :ref:`upsert-data`.
+- Added ``deleteBatch()`` methods to QueryBuilder. See :ref:`delete-batch`.
 
 Forge
 -----

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1110,7 +1110,7 @@ method, or ``emptyTable()``.
 .. _delete-batch:
 
 $builder->deleteBatch()
-------------------
+-----------------------
 
 Generates a batch **DELETE** statement based on a set of data.
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1118,6 +1118,8 @@ Generates a batch **DELETE** statement based on a set of data.
 
 This method may be especially useful when deleting data in a table with a composite primary key.
 
+.. note:: SQLite does not support the use of ``where()``.
+
 $builder->emptyTable()
 ----------------------
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1107,6 +1107,17 @@ the data to the first parameter of the method:
 If you want to delete all data from a table, you can use the ``truncate()``
 method, or ``emptyTable()``.
 
+.. _delete-batch:
+
+$builder->deleteBatch()
+------------------
+
+Generates a batch **DELETE** statement based on a set of data.
+
+.. literalinclude:: query_builder/118.php
+
+This method may be especially useful when deleting data in a table with a composite primary key.
+
 $builder->emptyTable()
 ----------------------
 
@@ -1871,6 +1882,16 @@ Class Reference
         :rtype:     ``BaseBuilder|false``
 
         Compiles and executes a ``DELETE`` query.
+
+    .. php:method:: deleteBatch([$set = null[, $constraints = null[, $batchSize = 100]]])
+
+        :param array|object|null $set: Field name, or an associative array of field/value pairs
+        :param array|RawSql|string|null $constraints: The field or fields used as keys to delete on.
+        :param int $batchSize: Count of conditions to group in a single query
+        :returns:   Number of rows deleted or ``false`` on failure
+        :rtype:     int|false
+
+        Compiles and executes batch ``DELETE`` query.
 
     .. php:method:: increment($column[, $value = 1])
 

--- a/user_guide_src/source/database/query_builder/118.php
+++ b/user_guide_src/source/database/query_builder/118.php
@@ -2,19 +2,19 @@
 
 $data = [
     [
-        'order' => 48372,
+        'order'   => 48372,
         'line'    => 3,
         'product' => 'Keyboard',
         'qty'     => 1,
     ],
     [
-        'order' => 48372,
+        'order'   => 48372,
         'line'    => 4,
         'product' => 'Mouse',
         'qty'     => 1,
     ],
     [
-        'order' => 48372,
+        'order'   => 48372,
         'line'    => 5,
         'product' => 'Monitor',
         'qty'     => 2,

--- a/user_guide_src/source/database/query_builder/118.php
+++ b/user_guide_src/source/database/query_builder/118.php
@@ -21,13 +21,13 @@ $data = [
     ],
 ];
 
-$builder->setAlias('del')->where('order_line.qty >', 1)->deleteBatch($data, 'order, line');
+$builder->setAlias('del')->where('del.qty >', 1)->deleteBatch($data, 'order, line');
 
 // OR
 $builder
     ->setData($data, true, 'del')
     ->onConstraint('order, line')
-    ->where('order_line.qty >', 1)
+    ->where('del.qty >', 1)
     ->deleteBatch();
 
 /*
@@ -39,5 +39,5 @@ $builder
  * SELECT 48372 `order`, 5 `line`, 'Monitor'  `product`, 2 `qty`
  * ) `del`
  * ON `order_line`.`order` = `del`.`order` AND `order_line`.`line` = `del`.`line`
- * WHERE `order_line`.`qty` > 1
+ * WHERE `del`.`qty` > 1
  */

--- a/user_guide_src/source/database/query_builder/118.php
+++ b/user_guide_src/source/database/query_builder/118.php
@@ -30,9 +30,9 @@ $builder->setData($data, true, 'del')
  * MySQL Produces:
  * DELETE `order_line` FROM `order_line`
  * INNER JOIN (
- * SELECT 48372 `order`, 3 `line`, 'Keyboard' `product`, 1 `qty` UNION ALL
- * SELECT 48372 `order`, 4 `line`, 'Mouse'    `product`, 1 `qty` UNION ALL
- * SELECT 48372 `order`, 5 `line`, 'Monitor'  `product`, 2 `qty`
+ * SELECT 3 `line`, 48372 `order`, 'Keyboard' `product`, 1 `qty` UNION ALL
+ * SELECT 4 `line`, 48372 `order`, 'Mouse'    `product`, 1 `qty` UNION ALL
+ * SELECT 5 `line`, 48372 `order`, 'Monitor'  `product`, 2 `qty`
  * ) `del`
  * ON `order_line`.`order` = `del`.`order` AND `order_line`.`line` = `del`.`line`
  * WHERE `del`.`qty` > 1

--- a/user_guide_src/source/database/query_builder/118.php
+++ b/user_guide_src/source/database/query_builder/118.php
@@ -1,0 +1,43 @@
+<?php
+
+$data = [
+    [
+        'order' => 48372,
+        'line'    => 3,
+        'product' => 'Keyboard',
+        'qty'     => 1,
+    ],
+    [
+        'order' => 48372,
+        'line'    => 4,
+        'product' => 'Mouse',
+        'qty'     => 1,
+    ],
+    [
+        'order' => 48372,
+        'line'    => 5,
+        'product' => 'Monitor',
+        'qty'     => 2,
+    ],
+];
+
+$builder->setAlias('del')->where('order_line.qty >', 1)->deleteBatch($data, 'order, line');
+
+// OR
+$builder
+    ->setData($data, true, 'del')
+    ->onConstraint('order, line')
+    ->where('order_line.qty >', 1)
+    ->deleteBatch();
+
+/*
+ * MySQL Produces:
+ * DELETE `order_line` FROM `order_line`
+ * INNER JOIN (
+ * SELECT 48372 `order`, 3 `line`, 'Keyboard' `product`, 1 `qty` UNION ALL
+ * SELECT 48372 `order`, 4 `line`, 'Mouse'    `product`, 1 `qty` UNION ALL
+ * SELECT 48372 `order`, 5 `line`, 'Monitor'  `product`, 2 `qty`
+ * ) `del`
+ * ON `order_line`.`order` = `del`.`order` AND `order_line`.`line` = `del`.`line`
+ * WHERE `order_line`.`qty` > 1
+ */

--- a/user_guide_src/source/database/query_builder/118.php
+++ b/user_guide_src/source/database/query_builder/118.php
@@ -21,11 +21,7 @@ $data = [
     ],
 ];
 
-$builder->setAlias('del')->where('del.qty >', 1)->deleteBatch($data, 'order, line');
-
-// OR
-$builder
-    ->setData($data, true, 'del')
+$builder->setData($data, true, 'del')
     ->onConstraint('order, line')
     ->where('del.qty >', 1)
     ->deleteBatch();


### PR DESCRIPTION
~~Needs #6741~~

The *Batch() saga continues..

This adds deleteBatch() to Builder. This allows using a set of data to selectively delete items from a table.

```php
$data = [
    ['userid' => 1, 'username' => 'Derek Does Not Match', 'unused' => 'You can have fields you dont use'],
    ['userid' => 2, 'username' => 'Ahmadinejad', 'unused' => 'You can have fields you dont use'],
];

$this->db->table('user')
    ->setData($data)
    ->onConstraint(['id' => 'userid', 'name' => 'username'])
    ->deleteBatch();

$this->seeInDatabase('user', ['email' => 'derek@world.com', 'name' => 'Derek Jones']);

$this->dontSeeInDatabase('user', ['email' => 'ahmadinejad@world.com', 'name' => 'Ahmadinejad']);
```
You can also use where() for additional conditions except with SQLite.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
