### PR TITLE
fix: add missing property $context in PhpStreamWrapper

### DIFF
--- a/system/Test/PhpStreamWrapper.php
+++ b/system/Test/PhpStreamWrapper.php
@@ -20,6 +20,11 @@ namespace CodeIgniter\Test;
  */
 final class PhpStreamWrapper
 {
+    /**
+     * @var resource|null
+     */
+    public $context;
+
     private static string $content = '';
     private int $position          = 0;
 


### PR DESCRIPTION
**Description**
- add missing property $context
See https://www.php.net/manual/en/class.streamwrapper.php#streamwrapper.props

In PHP 8.2, the following error ocurrs:
> ErrorException: Creation of dynamic property CodeIgniter\Test\PhpStreamWrapper::$context is deprecated

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
