### PR TITLE
fix: CodeIgniter::run() doesn't respect $returnResponse

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -316,11 +316,11 @@ class CodeIgniter
         if ($this->request instanceof IncomingRequest && strtolower($this->request->getMethod()) === 'cli') {
             $this->response->setStatusCode(405)->setBody('Method Not Allowed');
 
-            if (! $this->returnResponse) {
-                $this->sendResponse();
-            } else {
+            if ($this->returnResponse) {
                 return $this->response;
             }
+
+            $this->sendResponse();
 
             return;
         }
@@ -357,11 +357,11 @@ class CodeIgniter
             // the exception with the $to as the message
             $this->response->redirect(base_url($e->getMessage()), 'auto', $e->getCode());
 
-            if (! $this->returnResponse) {
-                $this->sendResponse();
-            } else {
+            if ($this->returnResponse) {
                 return $this->response;
             }
+
+            $this->sendResponse();
 
             $this->callExit(EXIT_SUCCESS);
 
@@ -959,11 +959,11 @@ class CodeIgniter
 
             $cacheConfig = new Cache();
             $this->gatherOutput($cacheConfig, $returned);
-            if (! $this->returnResponse) {
-                $this->sendResponse();
-            } else {
+            if ($this->returnResponse) {
                 return $this->response;
             }
+
+            $this->sendResponse();
 
             return;
         }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -421,10 +421,12 @@ class CodeIgniter
      * @throws PageNotFoundException
      * @throws RedirectException
      *
-     * @deprecated $returnResponse is deprecated, and no longer used.
+     * @deprecated $returnResponse is deprecated.
      */
     protected function handleRequest(?RouteCollectionInterface $routes, Cache $cacheConfig, bool $returnResponse = false)
     {
+        $this->returnResponse = $returnResponse;
+
         $routeFilter = $this->tryToRouteIt($routes);
 
         $uri = $this->determinePath();

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -66,6 +66,16 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertStringContainsString('Welcome to CodeIgniter', $output);
     }
 
+    public function testRunEmptyDefaultRouteReturnResponse()
+    {
+        $_SERVER['argv'] = ['index.php'];
+        $_SERVER['argc'] = 1;
+
+        $response = $this->codeigniter->useSafeOutput(true)->run(null, true);
+
+        $this->assertStringContainsString('Welcome to CodeIgniter', $response->getBody());
+    }
+
     public function testRunClosureRoute()
     {
         $_SERVER['argv'] = ['index.php', 'pages/about'];
@@ -124,6 +134,23 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Oops', $output);
+    }
+
+    public function testRun404OverrideReturnResponse()
+    {
+        $_SERVER['argv'] = ['index.php', '/'];
+        $_SERVER['argc'] = 2;
+
+        // Inject mock router.
+        $routes = Services::routes();
+        $routes->setAutoRoute(false);
+        $routes->set404Override('Tests\Support\Controllers\Popcorn::pop');
+        $router = Services::router($routes, Services::incomingrequest());
+        Services::injectMock('router', $router);
+
+        $response = $this->codeigniter->useSafeOutput(true)->run($routes, true);
+
+        $this->assertStringContainsString('Oops', $response->getBody());
     }
 
     public function testRun404OverrideByClosure()

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -619,7 +619,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         // Clear Page cache
         command('cache:clear');
 
-        // Remove stream fliters
+        // Remove stream filters
         stream_filter_remove($outputStreamFilter);
         stream_filter_remove($errorStreamFilter);
     }
@@ -654,7 +654,7 @@ final class CodeIgniterTest extends CIUnitTestCase
             $_SERVER['REQUEST_URI'] = '/' . $testingUrl;
             $routes                 = Services::routes(true);
             $routes->add($testingUrl, static function () {
-                CodeIgniter::cache(0); // Dont cache the page in the run() function because CodeIgniter class will create default $cacheConfig and overwrite settings from the dataProvider
+                CodeIgniter::cache(0); // Don't cache the page in the run() function because CodeIgniter class will create default $cacheConfig and overwrite settings from the dataProvider
                 $response = Services::response();
                 $string   = 'This is a test page, to check cache configuration';
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -78,7 +78,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes->add('pages/(:segment)', static function ($segment) {
             echo 'You want to see "' . esc($segment) . '" page.';
         });
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -97,7 +97,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes = Services::routes();
         $routes->setAutoRoute(false);
         $routes->set404Override('Tests\Support\Controllers\Hello::index');
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -116,7 +116,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes = Services::routes();
         $routes->setAutoRoute(false);
         $routes->set404Override('Tests\Support\Controllers\Popcorn::pop');
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -137,7 +137,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes->set404Override(static function () {
             echo '404 Override by Closure.';
         });
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -157,7 +157,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         // Inject mock router.
         $routes = Services::routes();
         $routes->add('pages/(:segment)', static fn ($segment) => 'You want to see "' . esc($segment) . '" page.');
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -182,7 +182,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
             return $response->setBody($string);
         });
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -209,7 +209,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
             return $response->download('some.txt', 'some text', true);
         });
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -228,9 +228,9 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         // Inject mock router.
         $routes = Services::routes();
-        $routes->add('pages/about', static fn () => Services::request()->getBody(), ['filter' => Customfilter::class]);
+        $routes->add('pages/about', static fn () => Services::incomingrequest()->getBody(), ['filter' => Customfilter::class]);
 
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -258,7 +258,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $router = Services::router(null, Services::request(), false);
+        $router = Services::router(null, Services::incomingrequest(), false);
         Services::injectMock('router', $router);
 
         ob_start();
@@ -335,7 +335,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         }, ['as' => 'name']);
         $routes->addRedirect('example', 'name');
 
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -358,7 +358,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         });
         $routes->addRedirect('example', 'pages/uri');
 
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -382,7 +382,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes = Services::routes();
         $routes->addRedirect('example', 'pages/notset');
 
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -405,7 +405,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes = Services::routes();
         $routes->addRedirect('example', 'pages/notset', 301);
 
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -422,7 +422,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $router = Services::router(null, Services::request(), false);
+        $router = Services::router(null, Services::incomingrequest(), false);
         Services::injectMock('router', $router);
 
         ob_start();
@@ -446,7 +446,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes = Services::routes();
         $routes->addRedirect('example', 'pages/notset', 301);
 
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -470,7 +470,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
             return $response->setContentType('image/jpeg', '');
         });
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         ob_start();
@@ -537,7 +537,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
 
-        $this->assertSame('put', Services::request()->getMethod());
+        $this->assertSame('put', Services::incomingrequest()->getMethod());
     }
 
     public function testSpoofRequestMethodCannotUseGET()
@@ -561,7 +561,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->useSafeOutput(true)->run();
         ob_get_clean();
 
-        $this->assertSame('post', Services::request()->getMethod());
+        $this->assertSame('post', Services::incomingrequest()->getMethod());
     }
 
     /**
@@ -588,7 +588,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
             return $response->setBody($string);
         });
-        $router = Services::router($routes, Services::request());
+        $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
         /** @var Filters $filterConfig */
@@ -662,7 +662,7 @@ final class CodeIgniterTest extends CIUnitTestCase
             });
 
             // Inject router
-            $router = Services::router($routes, Services::request(null, false));
+            $router = Services::router($routes, Services::incomingrequest(null, false));
             Services::injectMock('router', $router);
 
             // Cache the page output using default caching function and $cacheConfig with value from the data provider

--- a/user_guide_src/source/changelogs/v4.2.8.rst
+++ b/user_guide_src/source/changelogs/v4.2.8.rst
@@ -31,7 +31,7 @@ none.
 Deprecations
 ************
 
-none.
+- The third parameter ``$returnResponse`` of ``CodeIgniter::handleRequest()`` is deprecated, and no longer used.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.2.8.rst
+++ b/user_guide_src/source/changelogs/v4.2.8.rst
@@ -31,7 +31,7 @@ none.
 Deprecations
 ************
 
-- The third parameter ``$returnResponse`` of ``CodeIgniter::handleRequest()`` is deprecated, and no longer used.
+- The third parameter ``$returnResponse`` of ``CodeIgniter::handleRequest()`` is deprecated.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
Fixes #6650

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
