### PR TITLE
Fixed several grammar errors and typos

### DIFF
--- a/user_guide_src/README.rst
+++ b/user_guide_src/README.rst
@@ -75,7 +75,7 @@ Installation
 
 Now we need to install Sphinx and it's dependencies. Choose ``pip`` or ``pip3``
 depending on operative system. After this step you need to restart your Terminal
-window as Python won't find all applications we just installed othervise.
+window as Python won't find all applications we just installed otherwise.
 
 .. code-block:: bash
 

--- a/user_guide_src/source/_static/js/citheme.js
+++ b/user_guide_src/source/_static/js/citheme.js
@@ -23,8 +23,8 @@ window.onload = function() {
 		var chapter = sanitizeClass(index[1]);
 		var subject = sanitizeClass(index[2]);
 
-		// Documentation are generated into an html-folder for developers.
-		// This aren't a valid chapter. We are on documentation index.
+		// Documentation is generated into an html-folder for developers.
+		// This isn't a valid chapter. We are on documentation index.
 		if (chapter === 'html')
 		{
 			index = null;

--- a/user_guide_src/source/changelogs/v4.0.0-beta.3.rst
+++ b/user_guide_src/source/changelogs/v4.0.0-beta.3.rst
@@ -179,7 +179,7 @@ PRs merged
 - #1943 Model, Entity, Exception & Migration test cases
 - #1939 Remove section that prevents hotlinking
 - #1938 Database typos changes
-- #1936 Docs: improce app testing writeup
+- #1936 Docs: improve app testing writeup
 - #1935 Update phpunit.xml scripts. Fixes #1932
 - #1933 having (Is NULL deletion)
 - #1931 Toolbar IE11 fix

--- a/user_guide_src/source/dbmgmt/db_commands.rst
+++ b/user_guide_src/source/dbmgmt/db_commands.rst
@@ -2,7 +2,7 @@
 Database Commands
 #################
 
-CodeIgniter provides some simple commands for databse management.
+CodeIgniter provides some simple commands for database management.
 
 .. contents::
     :local:

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -134,7 +134,7 @@ prefix followed by a dot (.), and then the variable name itself.
 Namespace Separator
 -------------------
 
-Some environments, e.g., Docker, CloudFormation, do not permit variable name with dots (``.``). In such case, since v4.1.5, you could also use underscores (``_``) as a seperator.
+Some environments, e.g., Docker, CloudFormation, do not permit variable name with dots (``.``). In such case, since v4.1.5, you could also use underscores (``_``) as a separator.
 
 ::
 

--- a/user_guide_src/source/helpers/html_helper.rst
+++ b/user_guide_src/source/helpers/html_helper.rst
@@ -165,10 +165,10 @@ The following functions are available:
             <li>shapes
                 <ul>
                     <li>round</li>
-                    <li>suare</li>
+                    <li>square</li>
                     <li>circles
                         <ul>
-                            <li>elipse</li>
+                            <li>ellipse</li>
                             <li>oval</li>
                             <li>sphere</li>
                         </ul>

--- a/user_guide_src/source/incoming/content_negotiation.rst
+++ b/user_guide_src/source/incoming/content_negotiation.rst
@@ -40,7 +40,7 @@ Media
 
 The first aspect to look at is handling 'media' negotiations. These are provided by the ``Accept`` header and
 is one of the most complex headers available. A common example is the client telling the server what format it
-wants the data in. This is especially common in API's. For example, a client might request JSON formatted data
+wants the data in. This is especially common in APIs. For example, a client might request JSON formatted data
 from an API endpoint::
 
     GET /foo HTTP/1.1

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -461,7 +461,7 @@ Offsetting the Matched Parameters
 You can offset the matched parameters in your route by any numeric value with the ``offset`` option, with the
 value being the number of segments to offset.
 
-This can be beneficial when developing API's with the first URI segment being the version number. It can also
+This can be beneficial when developing APIs with the first URI segment being the version number. It can also
 be used when the first parameter is a language string:
 
 .. literalinclude:: routing/042.php

--- a/user_guide_src/source/installation/repositories.rst
+++ b/user_guide_src/source/installation/repositories.rst
@@ -28,7 +28,7 @@ There are several development repositories, of interest to potential contributor
 +------------------+--------------+-----------------------------------------------------------------+
 | shield           | developers   | Authentication and Authorization Library for CodeIgniter 4      |
 +------------------+--------------+-----------------------------------------------------------------+
-| tasks            | developers   | Task Scheduler for CodeIgnter 4                                 |
+| tasks            | developers   | Task Scheduler for CodeIgniter 4                                 |
 +------------------+--------------+-----------------------------------------------------------------+
 | cache            | developers   | PSR-6 and PSR-16 Cache Adapters for CodeIgniter 4               |
 +------------------+--------------+-----------------------------------------------------------------+

--- a/user_guide_src/source/installation/repositories.rst
+++ b/user_guide_src/source/installation/repositories.rst
@@ -28,7 +28,7 @@ There are several development repositories, of interest to potential contributor
 +------------------+--------------+-----------------------------------------------------------------+
 | shield           | developers   | Authentication and Authorization Library for CodeIgniter 4      |
 +------------------+--------------+-----------------------------------------------------------------+
-| tasks            | developers   | Task Scheduler for CodeIgniter 4                                 |
+| tasks            | developers   | Task Scheduler for CodeIgniter 4                                |
 +------------------+--------------+-----------------------------------------------------------------+
 | cache            | developers   | PSR-6 and PSR-16 Cache Adapters for CodeIgniter 4               |
 +------------------+--------------+-----------------------------------------------------------------+

--- a/user_guide_src/source/installation/upgrade_sessions.rst
+++ b/user_guide_src/source/installation/upgrade_sessions.rst
@@ -23,7 +23,7 @@ Upgrade Guide
     - To access session data use the syntax ``$session->item`` or ``$session->get('item')`` instead of the CI3 syntax ``$this->session->name``.
     - To set data use ``$session->set($array);`` instead of ``$this->session->set_userdata($array);``.
     - To remove data use ``unset($_SESSION['some_name']);`` or ``$session->remove('some_name');`` instead of ``$this->session->unset_userdata('some_name');``.
-    - To mark session data as flasdata, which will only be available for the next request, use ``$session->markAsFlashdata('item');`` instead of ``$this->session->mark_as_flash('item');```
+    - To mark session data as flashdata, which will only be available for the next request, use ``$session->markAsFlashdata('item');`` instead of ``$this->session->mark_as_flash('item');```
 
 Code Example
 ============

--- a/user_guide_src/source/libraries/official_packages.rst
+++ b/user_guide_src/source/libraries/official_packages.rst
@@ -20,7 +20,7 @@ Shield
 `CodeIgniter Shield <https://github.com/codeigniter4/shield>`_ is an authentication
 and authorization framework for CodeIgniter 4. It is designed to be secure, flexible,
 and easily extendable to meet the needs of many different types of websites.
-Among the many featues, it includes:
+Among the many features, it includes:
 
 * Session-based authentication
 * Personal access token authentication
@@ -56,7 +56,7 @@ DevKit
 
 `CodeIgniter DevKit <https://github.com/codeigniter4/devkit>`_ provides all of the
 development tools that CodeIgniter uses to help ensure quality code, including
-our coding standard, static analysys tools and rules, unit testing, data generation,
+our coding standard, static analysis tools and rules, unit testing, data generation,
 file-system mocking, security advisories, and more. This can be used in any of
 your personal projects or libraries to get you rapidly setup with 17 different tools.
 

--- a/user_guide_src/source/libraries/pagination.rst
+++ b/user_guide_src/source/libraries/pagination.rst
@@ -78,7 +78,7 @@ Setting Page Manually
 =====================
 
 If you need to specify which page of results to return you can specify the page as the 3rd argument. This can be
-handy when you have a different manner than the default ``$_GET`` varibable to control which page to show.
+handy when you have a different manner than the default ``$_GET`` variable to control which page to show.
 
 .. literalinclude:: pagination/005.php
 

--- a/user_guide_src/source/libraries/throttler.rst
+++ b/user_guide_src/source/libraries/throttler.rst
@@ -7,7 +7,7 @@ Throttler
     :depth: 2
 
 The Throttler class provides a very simple way to limit an activity to be performed to a certain number of attempts
-within a set period of time. This is most often used for performing rate limiting on API's, or restricting the number
+within a set period of time. This is most often used for performing rate limiting on APIs, or restricting the number
 of attempts a user can make against a form to help prevent brute force attacks. The class itself can be used
 for anything that you need to throttle based on actions within a set time interval.
 

--- a/user_guide_src/source/libraries/uploaded_files.rst
+++ b/user_guide_src/source/libraries/uploaded_files.rst
@@ -59,9 +59,9 @@ place this code and save it to your **app/Views/** directory::
     <h3>Your file was successfully uploaded!</h3>
 
     <ul>
-        <li>name: <?= esc($uploaded_flleinfo->getBasename()) ?></li>
-        <li>size: <?= esc($uploaded_flleinfo->getSizeByUnit('kb')) ?> KB</li>
-        <li>extension: <?= esc($uploaded_flleinfo->guessExtension()) ?></li>
+        <li>name: <?= esc($uploaded_fileinfo->getBasename()) ?></li>
+        <li>size: <?= esc($uploaded_fileinfo->getSizeByUnit('kb')) ?> KB</li>
+        <li>extension: <?= esc($uploaded_fileinfo->guessExtension()) ?></li>
     </ul>
 
     <p><?= anchor('upload', 'Upload Another File!') ?></p>

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -118,7 +118,7 @@ The host portion of the URI is typically the domain name of the URL. This can be
 Port
 ----
 
-The port is an integer number between 0 and 65535. Each sheme has a default value associated with it.
+The port is an integer number between 0 and 65535. Each scheme has a default value associated with it.
 
 .. literalinclude:: uri/015.php
 
@@ -174,7 +174,7 @@ you can use the ``stripQuery()`` and ``keepQuery()`` methods to change the actua
 Fragment
 --------
 
-Fragments are the portion at the end of the URL, preceded by the pound-sign (#). In HTML URL's these are links
+Fragments are the portion at the end of the URL, preceded by the pound-sign (#). In HTML URLs these are links
 to an on-page anchor. Media URI's can make use of them in various other ways.
 
 .. literalinclude:: uri/022.php

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -311,12 +311,12 @@ Saving Data
 insert()
 --------
 
-The first parametre is an associative array of data to create a new row of data in the database. 
+The first parameter is an associative array of data to create a new row of data in the database.
 If an object is passed instead of an array, it will attempt to convert it to an array.
 
 The array's keys must match the name of the columns in the ``$table``, while the array's values are the values to save for that key.
 
-The optional second parameter is of type boolean, and if it is set to false, the method will return a boolean value, 
+The optional second parameter is of type boolean, and if it is set to false, the method will return a boolean value,
 which indicates the success or failure of the query.
 
 You can retrieve the last inserted row's primary key using the ``getInsertID()`` method.
@@ -593,7 +593,7 @@ Returns data from the next **find*()** method as associative arrays:
 asObject()
 ----------
 
-Returns data from the next **find*()** method as standard objects or custom class intances:
+Returns data from the next **find*()** method as standard objects or custom class instances:
 
 .. literalinclude:: model/048.php
 

--- a/user_guide_src/source/models/model/001.php
+++ b/user_guide_src/source/models/model/001.php
@@ -11,6 +11,6 @@ $userModel = model('App\Models\UserModel');
 
 // Create shared instance with a supplied database connection
 // When no namespace is given, it will search through all namespaces
-// the system knows about and attempt to located the UserModel class.
+// the system knows about and attempts to locate the UserModel class.
 $db        = db_connect('custom');
 $userModel = model('UserModel', true, $db);

--- a/user_guide_src/source/outgoing/api_responses.rst
+++ b/user_guide_src/source/outgoing/api_responses.rst
@@ -2,7 +2,7 @@
 API Response Trait
 ##################
 
-Much of modern PHP development requires building API's, whether simply to provide data for a javascript-heavy
+Much of modern PHP development requires building APIs, whether simply to provide data for a javascript-heavy
 single page application, or as a standalone product. CodeIgniter provides an API Response trait that can be
 used with any controller to make common response types simple, with no need to remember which HTTP status code
 should be returned for which response types.

--- a/user_guide_src/source/testing/benchmark.rst
+++ b/user_guide_src/source/testing/benchmark.rst
@@ -52,7 +52,7 @@ the only parameter. The default value is 4 numbers behind the decimal point:
 
 .. literalinclude:: benchmark/005.php
 
-The timers are automatically displayed in the :doc:`Debub Toolbar </testing/debugging>`.
+The timers are automatically displayed in the :doc:`Debug Toolbar </testing/debugging>`.
 
 Displaying Execution Time
 =========================

--- a/user_guide_src/source/testing/fabricator.rst
+++ b/user_guide_src/source/testing/fabricator.rst
@@ -156,7 +156,7 @@ example:
 
 Your project has users and groups. In your test case you want to create various scenarios
 with groups of different sizes, so you use ``Fabricator`` to create a bunch of groups.
-Now you want to create fake users but don't want to assign them to a non-existant group ID.
+Now you want to create fake users but don't want to assign them to a non-existent group ID.
 Your model's fake method could look like this:
 
 .. literalinclude:: fabricator/021.php

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -80,7 +80,7 @@ Formatting The Request
 You can set the format of your request's body using the ``withBodyFormat()`` method. Currently this supports either
 `json` or `xml`. This will take the parameters passed into ``call()``, ``post()``, ``get()``... and assign them to the
 body of the request in the given format. This will also set the `Content-Type` header for your request accordingly.
-This is useful when testing JSON or XML API's so that you can set the request in the form that the controller will expect.
+This is useful when testing JSON or XML APIs so that you can set the request in the form that the controller will expect.
 
 .. literalinclude:: feature/008.php
 
@@ -88,7 +88,7 @@ Setting the Body
 ----------------
 
 You can set the body of your request with the ``withBody()`` method. This allows you to format the body how you want
-to format it. It is recommended that you use this if you have more complicated xml's to test. This will also not set
+to format it. It is recommended that you use this if you have more complicated XMLs to test. This will also not set
 the Content-Type header for you so if you need that, you can set it with the ``withHeaders()`` method.
 
 Checking the Response

--- a/user_guide_src/source/testing/response/018.php
+++ b/user_guide_src/source/testing/response/018.php
@@ -7,4 +7,4 @@ $results->see('Hello World', 'h1');
 // Check that "Hello World" is within an element with the "notice" class
 $results->see('Hello World', '.notice');
 // Check that "Hello World" is within an element with id of "title"
-$results->see('Hellow World', '#title');
+$results->see('Hello World', '#title');

--- a/user_guide_src/source/testing/response/024.php
+++ b/user_guide_src/source/testing/response/024.php
@@ -7,4 +7,4 @@ $result->assertSee('Hello World', 'h1');
 // Check that "Hello World" is within an element with the "notice" class
 $result->assertSee('Hello World', '.notice');
 // Check that "Hello World" is within an element with id of "title"
-$result->assertSee('Hellow World', '#title');
+$result->assertSee('Hello World', '#title');

--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -53,7 +53,7 @@ Enjoy your exploration of the CodeIgniter framework.
 Getting Up and Running
 **********************
 
-Installing CodeIgnier
+Installing CodeIgniter
 =====================
 
 You can download a release manually from the site, but for this tutorial we will

--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -54,7 +54,7 @@ Getting Up and Running
 **********************
 
 Installing CodeIgniter
-=====================
+======================
 
 You can download a release manually from the site, but for this tutorial we will
 use the recommended way and install the AppStarter package through Composer.


### PR DESCRIPTION
**Description**
I found some grammar errors and typos in the documentation and have fixed them. Maintaining documentation is something that's important to me :-)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
