### PR TITLE
Fix BaseBuilder setAlias() and RawSql use with key value pairs

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1969,6 +1969,7 @@ class BaseBuilder
     public function setAlias(string $alias): BaseBuilder
     {
         if ($alias !== '') {
+            $this->db->addTableAlias($alias);
             $this->QBOptions['alias'] = $this->db->protectIdentifiers($alias);
         }
 
@@ -2042,6 +2043,10 @@ class BaseBuilder
             foreach ($set as $key => $value) {
                 if (! ($value instanceof RawSql)) {
                     $value = $this->db->protectIdentifiers($value);
+                }
+
+                if (is_string($key)) {
+                    $key = $this->db->protectIdentifiers($key);
                 }
 
                 $this->QBOptions['constraints'][$key] = $value;
@@ -2462,9 +2467,20 @@ class BaseBuilder
             $sql .= 'WHERE ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key) => ($key instanceof RawSql ?
-                    $key :
-                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
+                    static fn ($key, $value) => (
+                        ($value instanceof RawSql && is_string($key))
+                        ?
+                        $table . '.' . $key . ' = ' . $value
+                        :
+                        (
+                            $value instanceof RawSql
+                            ?
+                            $value
+                            :
+                            $table . '.' . $value . ' = ' . $alias . '.' . $value
+                        )
+                    ),
+                    array_keys($constraints),
                     $constraints
                 )
             );

--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -90,9 +90,20 @@ class Builder extends BaseBuilder
             $sql .= 'ON ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key) => ($key instanceof RawSql ?
-                    $key :
-                    $table . '.' . $key . ' = ' . $alias . '.' . $key),
+                    static fn ($key, $value) => (
+                        ($value instanceof RawSql && is_string($key))
+                        ?
+                        $table . '.' . $key . ' = ' . $value
+                        :
+                        (
+                            $value instanceof RawSql
+                            ?
+                            $value
+                            :
+                            $table . '.' . $value . ' = ' . $alias . '.' . $value
+                        )
+                    ),
+                    array_keys($constraints),
                     $constraints
                 )
             ) . "\n";

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -364,6 +364,8 @@ class Builder extends BaseBuilder
                 }
             }
 
+            $alias = '"excluded"';
+
             $updateFields = $this->QBOptions['updateFields'] ?? $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ?? [];
 
             $sql = 'INSERT INTO ' . $table . ' (';
@@ -382,8 +384,8 @@ class Builder extends BaseBuilder
                 ",\n",
                 array_map(
                     static fn ($key, $value) => $key . ($value instanceof RawSql ?
-                        ' = ' . $value :
-                        ' = "excluded".' . $value),
+                    " = {$value}" :
+                    " = {$alias}.{$value}"),
                     array_keys($updateFields),
                     $updateFields
                 )

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -366,7 +366,7 @@ class Builder extends BaseBuilder
 
             $alias = $this->QBOptions['alias'] ?? '"excluded"';
 
-            if (strtolower($alias) !== '"excluded"' && $this->db->DBDebug) {
+            if (strtolower($alias) !== '"excluded"') {
                 throw new DatabaseException('Postgres alias is always named "excluded". A custom alias cannot be used.');
             }
 

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -364,7 +364,11 @@ class Builder extends BaseBuilder
                 }
             }
 
-            $alias = '"excluded"';
+            $alias = $this->QBOptions['alias'] ?? '"excluded"';
+
+            if (strtolower($alias) !== '"excluded"' && $this->db->DBDebug) {
+                throw new DatabaseException('Postgres alias is always named "excluded". A custom alias cannot be used.');
+            }
 
             $updateFields = $this->QBOptions['updateFields'] ?? $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ?? [];
 

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\InvalidArgumentException;
 use CodeIgniter\Database\RawSql;
 
 /**
@@ -367,7 +368,7 @@ class Builder extends BaseBuilder
             $alias = $this->QBOptions['alias'] ?? '"excluded"';
 
             if (strtolower($alias) !== '"excluded"') {
-                throw new DatabaseException('Postgres alias is always named "excluded". A custom alias cannot be used.');
+                throw new InvalidArgumentException('Postgres alias is always named "excluded". A custom alias cannot be used.');
             }
 
             $updateFields = $this->QBOptions['updateFields'] ?? $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ?? [];

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -13,8 +13,8 @@ namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\InvalidArgumentException;
 use CodeIgniter\Database\RawSql;
+use InvalidArgumentException;
 
 /**
  * Builder for Postgre

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\InvalidArgumentException;
+use CodeIgniter\Database\Exceptions\InvalidArgumentException;
 use CodeIgniter\Database\RawSql;
 
 /**

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -164,6 +164,8 @@ class Builder extends BaseBuilder
                 return ''; // @codeCoverageIgnore
             }
 
+            $alias = '`excluded`';
+
             $updateFields = $this->QBOptions['updateFields'] ??
                 $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ??
                 [];
@@ -184,8 +186,8 @@ class Builder extends BaseBuilder
                 ",\n",
                 array_map(
                     static fn ($key, $value) => $key . ($value instanceof RawSql ?
-                        ' = ' . $value :
-                        ' = `excluded`.' . $value),
+                        " = {$value}" :
+                        " = {$alias}.{$value}"),
                     array_keys($updateFields),
                     $updateFields
                 )

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\InvalidArgumentException;
+use CodeIgniter\Database\Exceptions\InvalidArgumentException;
 use CodeIgniter\Database\RawSql;
 
 /**

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\InvalidArgumentException;
 use CodeIgniter\Database\RawSql;
 
 /**
@@ -167,7 +168,7 @@ class Builder extends BaseBuilder
             $alias = $this->QBOptions['alias'] ?? '`excluded`';
 
             if (strtolower($alias) !== '`excluded`') {
-                throw new DatabaseException('SQLite alias is always named "excluded". A custom alias cannot be used.');
+                throw new InvalidArgumentException('SQLite alias is always named "excluded". A custom alias cannot be used.');
             }
 
             $updateFields = $this->QBOptions['updateFields'] ??

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -166,7 +166,7 @@ class Builder extends BaseBuilder
 
             $alias = $this->QBOptions['alias'] ?? '`excluded`';
 
-            if (strtolower($alias) !== '"excluded"' && $this->db->DBDebug) {
+            if (strtolower($alias) !== '`excluded`' && $this->db->DBDebug) {
                 throw new DatabaseException('SQLite alias is always named "excluded". A custom alias cannot be used.');
             }
 

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -166,7 +166,7 @@ class Builder extends BaseBuilder
 
             $alias = $this->QBOptions['alias'] ?? '`excluded`';
 
-            if (strtolower($alias) !== '`excluded`' && $this->db->DBDebug) {
+            if (strtolower($alias) !== '`excluded`') {
                 throw new DatabaseException('SQLite alias is always named "excluded". A custom alias cannot be used.');
             }
 

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -13,8 +13,8 @@ namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Database\Exceptions\InvalidArgumentException;
 use CodeIgniter\Database\RawSql;
+use InvalidArgumentException;
 
 /**
  * Builder for SQLite3

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -164,7 +164,11 @@ class Builder extends BaseBuilder
                 return ''; // @codeCoverageIgnore
             }
 
-            $alias = '`excluded`';
+            $alias = $this->QBOptions['alias'] ?? '`excluded`';
+
+            if (strtolower($alias) !== '"excluded"' && $this->db->DBDebug) {
+                throw new DatabaseException('SQLite alias is always named "excluded". A custom alias cannot be used.');
+            }
 
             $updateFields = $this->QBOptions['updateFields'] ??
                 $this->updateFields($keys, false, $constraints)->QBOptions['updateFields'] ??

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -475,9 +475,33 @@ final class UpdateTest extends CIUnitTestCase
 
         $builder = $this->db->table('user');
 
-        $builder->setData($data, true, 'db_myalias')
+        $builder->setData($data, true, 'myalias')
             ->updateFields('name, country')
             ->onConstraint(new RawSql($this->db->protectIdentifiers('user.email') . ' = ' . $this->db->protectIdentifiers('myalias.email')))
+            ->updateBatch();
+
+        $this->seeInDatabase('user', ['email' => 'derek@world.com', 'country' => 'Germany']);
+    }
+
+    public function testRawSqlConstraintWithKey()
+    {
+        if ($this->db->DBDriver === 'SQLite3' && ! (version_compare($this->db->getVersion(), '3.33.0') >= 0)) {
+            $this->markTestSkipped('Only SQLite 3.33 and newer can complete this test.');
+        }
+
+        $data = [
+            [
+                'name'    => 'Derek Jones',
+                'email'   => 'derek@world.com',
+                'country' => 'Germany',
+            ],
+        ];
+
+        $builder = $this->db->table('user');
+
+        $builder->setData($data, true, 'myalias')
+            ->updateFields('name, country')
+            ->onConstraint(['email' => new RawSql($this->db->protectIdentifiers('myalias.email'))])
             ->updateBatch();
 
         $this->seeInDatabase('user', ['email' => 'derek@world.com', 'country' => 'Germany']);


### PR DESCRIPTION
This fixes an issue when using an alias with setAlias() method. When using escape identifiers it was adding database prefix to alias. This was fixed.

Also, a small change to use of RawSql in constraints for updateBatch() and upsertBatch(). RawSql can be used for the entire expression or used as a key value pair. This is how I originally intended it but somehow it didn't get in correctly.

Can we expedite merging this? These fixes are needed for my other PRs.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
