### PR TITLE
refactor: Database connect()

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -64,6 +64,7 @@ abstract class BaseModel
      * should be instantiated.
      *
      * @var string
+     * @phpstan-var non-empty-string
      */
     protected $DBGroup;
 

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -65,18 +65,12 @@ class Config extends BaseConfig
             if (! isset($dbConfig->{$group})) {
                 throw new InvalidArgumentException($group . ' is not a valid database connection group.');
             }
+
+            $config = $dbConfig->{$group};
         }
 
         if ($getShared && isset(static::$instances[$group])) {
             return static::$instances[$group];
-        }
-
-        if (isset($dbConfig->{$group})) {
-            $config = $dbConfig->{$group};
-        }
-
-        if (! isset($config)) {
-            throw new InvalidArgumentException('There is no valid database config.');
         }
 
         static::ensureFactory();

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -59,7 +59,7 @@ class Config extends BaseConfig
         /** @var DbConfig $dbConfig */
         $dbConfig = config('Database');
 
-        if (empty($group)) {
+        if ($group === null) {
             $group = ENVIRONMENT === 'testing' ? 'tests' : $dbConfig->defaultGroup;
         }
 

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -60,7 +60,7 @@ class Config extends BaseConfig
         $dbConfig = config('Database');
 
         if ($group === null) {
-            $group = ENVIRONMENT === 'testing' ? 'tests' : $dbConfig->defaultGroup;
+            $group = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
         }
 
         if (is_string($group) && ! isset($dbConfig->{$group}) && strpos($group, 'custom-') !== 0) {

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database;
 
 use CodeIgniter\Config\BaseConfig;
+use Config\Database as DbConfig;
 use InvalidArgumentException;
 
 /**
@@ -55,13 +56,14 @@ class Config extends BaseConfig
             $group  = 'custom-' . md5(json_encode($config));
         }
 
-        $config ??= config('Database');
+        /** @var DbConfig $dbConfig */
+        $dbConfig = config('Database');
 
         if (empty($group)) {
-            $group = ENVIRONMENT === 'testing' ? 'tests' : $config->defaultGroup;
+            $group = ENVIRONMENT === 'testing' ? 'tests' : $dbConfig->defaultGroup;
         }
 
-        if (is_string($group) && ! isset($config->{$group}) && strpos($group, 'custom-') !== 0) {
+        if (is_string($group) && ! isset($dbConfig->{$group}) && strpos($group, 'custom-') !== 0) {
             throw new InvalidArgumentException($group . ' is not a valid database connection group.');
         }
 
@@ -71,8 +73,12 @@ class Config extends BaseConfig
 
         static::ensureFactory();
 
-        if (isset($config->{$group})) {
-            $config = $config->{$group};
+        if (isset($dbConfig->{$group})) {
+            $config = $dbConfig->{$group};
+        }
+
+        if (! isset($config)) {
+            throw new InvalidArgumentException('There is no valid database config.');
         }
 
         $connection = static::$factory->load($config, $group);

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -62,6 +62,8 @@ class Config extends BaseConfig
                 $group = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
             }
 
+            assert(is_string($group));
+
             if (! isset($dbConfig->{$group})) {
                 throw new InvalidArgumentException($group . ' is not a valid database connection group.');
             }

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -62,7 +62,7 @@ class Config extends BaseConfig
                 $group = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
             }
 
-            if (is_string($group) && ! isset($dbConfig->{$group}) && strpos($group, 'custom-') !== 0) {
+            if (! isset($dbConfig->{$group})) {
                 throw new InvalidArgumentException($group . ' is not a valid database connection group.');
             }
         }

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -54,17 +54,17 @@ class Config extends BaseConfig
         if (is_array($group)) {
             $config = $group;
             $group  = 'custom-' . md5(json_encode($config));
-        }
+        } else {
+            /** @var DbConfig $dbConfig */
+            $dbConfig = config('Database');
 
-        /** @var DbConfig $dbConfig */
-        $dbConfig = config('Database');
+            if ($group === null) {
+                $group = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
+            }
 
-        if ($group === null) {
-            $group = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
-        }
-
-        if (is_string($group) && ! isset($dbConfig->{$group}) && strpos($group, 'custom-') !== 0) {
-            throw new InvalidArgumentException($group . ' is not a valid database connection group.');
+            if (is_string($group) && ! isset($dbConfig->{$group}) && strpos($group, 'custom-') !== 0) {
+                throw new InvalidArgumentException($group . ' is not a valid database connection group.');
+            }
         }
 
         if ($getShared && isset(static::$instances[$group])) {

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -71,8 +71,6 @@ class Config extends BaseConfig
             return static::$instances[$group];
         }
 
-        static::ensureFactory();
-
         if (isset($dbConfig->{$group})) {
             $config = $dbConfig->{$group};
         }
@@ -80,6 +78,8 @@ class Config extends BaseConfig
         if (! isset($config)) {
             throw new InvalidArgumentException('There is no valid database config.');
         }
+
+        static::ensureFactory();
 
         $connection = static::$factory->load($config, $group);
 

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -39,9 +39,10 @@ class Config extends BaseConfig
     /**
      * Creates the default
      *
-     * @param array|BaseConnection|string|null $group     The name of the connection group to use,
-     *                                                    or an array of configuration settings.
-     * @param bool                             $getShared Whether to return a shared instance of the connection.
+     * @param array|BaseConnection|string|null $group The name of the connection group to use,
+     *                                                or an array of configuration settings.
+     * @phpstan-param array|BaseConnection|non-empty-string|null $group
+     * @param bool $getShared Whether to return a shared instance of the connection.
      *
      * @return BaseConnection
      */
@@ -124,6 +125,8 @@ class Config extends BaseConfig
 
     /**
      * Returns a new instance of the Database Seeder.
+     *
+     * @phpstan-param null|non-empty-string $group
      *
      * @return Seeder
      */

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -39,8 +39,9 @@ class Config extends BaseConfig
     /**
      * Creates the default
      *
-     * @param array|string $group     The name of the connection group to use, or an array of configuration settings.
-     * @param bool         $getShared Whether to return a shared instance of the connection.
+     * @param array|BaseConnection|string|null $group     The name of the connection group to use,
+     *                                                    or an array of configuration settings.
+     * @param bool                             $getShared Whether to return a shared instance of the connection.
      *
      * @return BaseConnection
      */

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -80,7 +80,7 @@ class Config extends BaseConfig
 
         $connection = static::$factory->load($config, $group);
 
-        static::$instances[$group] = &$connection;
+        static::$instances[$group] = $connection;
 
         return $connection;
     }

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -26,6 +26,7 @@ class Seeder
      * The name of the database group to use.
      *
      * @var string
+     * @phpstan-var non-empty-string
      */
     protected $DBGroup;
 

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -134,6 +134,7 @@ abstract class CIUnitTestCase extends TestCase
      * If not present, will use the defaultGroup.
      *
      * @var string
+     * @phpstan-var non-empty-string
      */
     protected $DBGroup = 'tests';
 


### PR DESCRIPTION
**Description**
Reduce the complexity of the method.

- refactor
- remove `&`
- fix PHPDoc

```console
$ phploc system/Database/Config.php
```
Before:
```
Cyclomatic Complexity
  Average Complexity per LLOC                     0.52
  Average Complexity per Class                   13.00
    Minimum Class Complexity                     13.00
    Maximum Class Complexity                     13.00
  Average Complexity per Method                   3.00
    Minimum Method Complexity                     1.00
    Maximum Method Complexity                    11.00
```
After:
```
Cyclomatic Complexity
  Average Complexity per LLOC                     0.38
  Average Complexity per Class                   10.00
    Minimum Class Complexity                     10.00
    Maximum Class Complexity                     10.00
  Average Complexity per Method                   2.50
    Minimum Method Complexity                     1.00
    Maximum Method Complexity                     8.00
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

