### PR TITLE
fix: BasePreparedQuery class to return boolean values for write-type queries

### DIFF
--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -111,7 +111,9 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
      *
-     * @return ResultInterface
+     * @return bool|ResultInterface
+     *
+     * @throws DatabaseException
      */
     public function execute(...$data)
     {
@@ -119,19 +121,63 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
         $startTime = microtime(true);
 
         try {
-            $this->_execute($data);
-        } catch (ArgumentCountError|ErrorException $e) {
-            throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+            $exception = null;
+            $result = $this->_execute($data);
+        } catch (ArgumentCountError|ErrorException $exception) {
+            $result = false;
         }
 
         // Update our query object
         $query = clone $this->query;
         $query->setBinds($data);
 
+        if ($result === false) {
+            $query->setDuration($startTime, $startTime);
+
+            // This will trigger a rollback if transactions are being used
+            if ($this->db->transDepth !== 0) {
+                $this->db->transStatus = false;
+            }
+
+            if ($this->db->DBDebug) {
+                // We call this function in order to roll-back queries
+                // if transactions are enabled. If we don't call this here
+                // the error message will trigger an exit, causing the
+                // transactions to remain in limbo.
+                while ($this->db->transDepth !== 0) {
+                    $transDepth = $this->db->transDepth;
+                    $this->db->transComplete();
+
+                    if ($transDepth === $this->db->transDepth) {
+                        log_message('error', 'Database: Failure during an automated transaction commit/rollback!');
+                        break;
+                    }
+                }
+
+                // Let others do something with this query.
+                Events::trigger('DBQuery', $query);
+
+                if ($exception !== null) {
+                    throw new DatabaseException($exception->getMessage(), $exception->getCode(), $exception);
+                }
+
+                return false;
+            }
+
+            // Let others do something with this query.
+            Events::trigger('DBQuery', $query);
+
+            return false;
+        }
+
         $query->setDuration($startTime);
 
         // Let others do something with this query
         Events::trigger('DBQuery', $query);
+
+        if ($this->db->isWriteType($query)) {
+            return true;
+        }
 
         // Return a result object
         $resultClass = str_replace('PreparedQuery', 'Result', static::class);

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -122,7 +122,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
 
         try {
             $exception = null;
-            $result = $this->_execute($data);
+            $result    = $this->_execute($data);
         } catch (ArgumentCountError|ErrorException $exception) {
             $result = false;
         }

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -15,6 +15,7 @@ use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use mysqli;
+use mysqli_sql_exception;
 use mysqli_stmt;
 
 /**
@@ -79,7 +80,15 @@ class PreparedQuery extends BasePreparedQuery
         // Bind it
         $this->statement->bind_param($bindTypes, ...$data);
 
-        return $this->statement->execute();
+        try {
+            return $this->statement->execute();
+        } catch (mysqli_sql_exception $e) {
+            if ($this->db->DBDebug) {
+                throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+            }
+
+            return false;
+        }
     }
 
     /**

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -34,9 +34,9 @@ class PreparedQuery extends BasePreparedQuery
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
      *
-     * @return mixed
+     * @throws DatabaseException
      */
-    public function _prepare(string $sql, array $options = [])
+    public function _prepare(string $sql, array $options = []): PreparedQuery
     {
         // Mysqli driver doesn't like statements
         // with terminating semicolons.
@@ -85,7 +85,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Returns the result object for the prepared query.
+     * Returns the result object for the prepared query or false on failure.
      *
      * @return mixed
      */

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -93,7 +93,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Deallocate prepared statements
+     * Deallocate prepared statements.
      */
     protected function _close(): bool
     {

--- a/system/Database/MySQLi/PreparedQuery.php
+++ b/system/Database/MySQLi/PreparedQuery.php
@@ -33,8 +33,6 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
-     *
-     * @throws DatabaseException
      */
     public function _prepare(string $sql, array $options = []): PreparedQuery
     {

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -85,7 +85,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Returns the statement resource for the prepared query or false when preparing failed
+     * Returns the statement resource for the prepared query or false when preparing failed.
      *
      * @return mixed
      */
@@ -95,7 +95,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Deallocate prepared statements
+     * Deallocate prepared statements.
      */
     protected function _close(): bool
     {

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -44,9 +44,9 @@ class PreparedQuery extends BasePreparedQuery
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the OCI8 driver.
      *
-     * @return mixed
+     * @throws DatabaseException
      */
-    public function _prepare(string $sql, array $options = [])
+    public function _prepare(string $sql, array $options = []): PreparedQuery
     {
         if (! $this->statement = oci_parse($this->db->connID, $this->parameterize($sql))) {
             $error             = oci_error($this->db->connID);
@@ -73,11 +73,8 @@ class PreparedQuery extends BasePreparedQuery
             throw new BadMethodCallException('You must call prepare before trying to execute a prepared statement.');
         }
 
-        $lastKey = 0;
-
         foreach (array_keys($data) as $key) {
             oci_bind_by_name($this->statement, ':' . $key, $data[$key]);
-            $lastKey = $key;
         }
 
         $result = oci_execute($this->statement, $this->db->commitMode);
@@ -90,7 +87,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Returns the result object for the prepared query.
+     * Returns the statement resource for the prepared query or false when preparing failed
      *
      * @return mixed
      */

--- a/system/Database/OCI8/PreparedQuery.php
+++ b/system/Database/OCI8/PreparedQuery.php
@@ -43,8 +43,6 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the OCI8 driver.
-     *
-     * @throws DatabaseException
      */
     public function _prepare(string $sql, array $options = []): PreparedQuery
     {

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -51,11 +51,9 @@ class PreparedQuery extends BasePreparedQuery
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
      *
-     * @return mixed
-     *
-     * @throws Exception
+     * @throws DatabaseException
      */
-    public function _prepare(string $sql, array $options = [])
+    public function _prepare(string $sql, array $options = []): PreparedQuery
     {
         $this->name = (string) random_int(1, 10_000_000_000_000_000);
 
@@ -93,7 +91,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Returns the result object for the prepared query.
+     * Returns the result object for the prepared query or false on failure.
      *
      * @return mixed
      */

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -101,7 +101,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Deallocate prepared statements
+     * Deallocate prepared statements.
      */
     protected function _close(): bool
     {

--- a/system/Database/Postgre/PreparedQuery.php
+++ b/system/Database/Postgre/PreparedQuery.php
@@ -51,7 +51,7 @@ class PreparedQuery extends BasePreparedQuery
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
      *
-     * @throws DatabaseException
+     * @throws Exception
      */
     public function _prepare(string $sql, array $options = []): PreparedQuery
     {

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -25,7 +25,7 @@ interface PreparedQueryInterface
      * Takes a new set of data and runs it against the currently
      * prepared query. Upon success, will return a Results object.
      *
-     * @return ResultInterface
+     * @return bool|ResultInterface
      */
     public function execute(...$data);
 

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -50,7 +50,7 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $options Options takes an associative array;
      *
-     * @throws DatabaseException
+     * @throws Exception
      */
     public function _prepare(string $sql, array $options = []): PreparedQuery
     {

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -50,7 +50,7 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $options Options takes an associative array;
      *
-     * @throws Exception
+     * @throws DatabaseException
      */
     public function _prepare(string $sql, array $options = []): PreparedQuery
     {

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -14,7 +14,6 @@ namespace CodeIgniter\Database\SQLSRV;
 use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use Exception;
 
 /**
  * Prepared query for Postgre
@@ -51,11 +50,9 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $options Options takes an associative array;
      *
-     * @return mixed
-     *
-     * @throws Exception
+     * @throws DatabaseException
      */
-    public function _prepare(string $sql, array $options = [])
+    public function _prepare(string $sql, array $options = []): PreparedQuery
     {
         // Prepare parameters for the query
         $queryString = $this->getQueryString();

--- a/system/Database/SQLSRV/PreparedQuery.php
+++ b/system/Database/SQLSRV/PreparedQuery.php
@@ -109,7 +109,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Deallocate prepared statements
+     * Deallocate prepared statements.
      */
     protected function _close(): bool
     {
@@ -117,7 +117,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Handle parameters
+     * Handle parameters.
      */
     protected function parameterize(string $queryString): array
     {

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -41,9 +41,9 @@ class PreparedQuery extends BasePreparedQuery
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
      *
-     * @return $this
+     * @throws DatabaseException
      */
-    public function _prepare(string $sql, array $options = [])
+    public function _prepare(string $sql, array $options = []): PreparedQuery
     {
         if (! ($this->statement = $this->db->connID->prepare($sql))) {
             $this->errorCode   = $this->db->connID->lastErrorCode();
@@ -87,7 +87,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Returns the result object for the prepared query.
+     * Returns the result object for the prepared query or false on failure.
      *
      * @return mixed
      */

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -95,7 +95,7 @@ class PreparedQuery extends BasePreparedQuery
     }
 
     /**
-     * Deallocate prepared statements
+     * Deallocate prepared statements.
      */
     protected function _close(): bool
     {

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -40,8 +40,6 @@ class PreparedQuery extends BasePreparedQuery
      *
      * @param array $options Passed to the connection's prepare statement.
      *                       Unused in the MySQLi driver.
-     *
-     * @throws DatabaseException
      */
     public function _prepare(string $sql, array $options = []): PreparedQuery
     {

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -52,6 +52,7 @@ Others
 - ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there
   is a ``CITestStreamFilter::registration()`` method for this. See :ref:`upgrade-430-stream-filter` for details.
 - :php:func:`script_tag()` and :php:func:`safe_mailto()` no longer output ``type="text/javascript"`` in ``<script>`` tag.
+- ``CodeIgniter\Database\BasePreparedQuery`` class returns now a bool value for write-type queries instead of the ``Result`` class object.
 
 .. _v430-interface-changes:
 
@@ -252,4 +253,5 @@ Deprecations
 Bugs Fixed
 **********
 
-none.
+- Fixed a bug when all types of ``Prepared Queries`` were returning a ``Result`` object instead of a bool value for write-type queries.
+

--- a/user_guide_src/source/database/queries.rst
+++ b/user_guide_src/source/database/queries.rst
@@ -227,7 +227,8 @@ query:
 
 .. literalinclude:: queries/019.php
 
-This returns a standard :doc:`result set </database/results>`.
+For queries of type "write" it returns true or false, indicating the success or failure of the query.
+For queries of type "read" it returns a standard :doc:`result set </database/results>`.
 
 Other Methods
 =============


### PR DESCRIPTION
**Description**
Fixes #4342

This PR fixes the behavior of Prepared Queries, which always return a `Result` object.

Some time ago, we fixed the regular query: #4176, but somehow Prepared Queries were forgotten.

Desired behavior is the same as for regular queries, return:
* `Result` object for "read" queries
* `bool` value for "write" queries

Potentially this is a breaking change, but we should treat it as a bug fix.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
