### PR TITLE
docs: fix PHPDoc types in Factories

### DIFF
--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -31,7 +31,8 @@ class Factories
      * Store of component-specific options, usually
      * from CodeIgniter\Config\Factory.
      *
-     * @var array<string, array>
+     * @var array[]
+     * @phpstan-var array<string, array<string, string|bool|null>>
      */
     protected static $options = [];
 
@@ -39,7 +40,7 @@ class Factories
      * Explicit options for the Config
      * component to prevent logic loops.
      *
-     * @var array<string, mixed>
+     * @phpstan-var array<string, string|bool|null>
      */
     private static array $configOptions = [
         'component'  => 'config',
@@ -53,7 +54,8 @@ class Factories
      * Mapping of class basenames (no namespace) to
      * their instances.
      *
-     * @var array<string, string[]>
+     * @var array[]
+     * @phpstan-var array<string, array<string, class-string>>
      */
     protected static $basenames = [];
 
@@ -63,7 +65,8 @@ class Factories
      * A multi-dimensional array with components as
      * keys to the array of name-indexed instances.
      *
-     * @var array<string, array>
+     * @var array[]
+     * @phpstan-var  array<string, array<class-string, object>>
      */
     protected static $instances = [];
 
@@ -74,9 +77,10 @@ class Factories
      *
      * @template T of Model
      *
-     * @param class-string<T> $name
+     * @phpstan-param class-string<T> $name
      *
-     * @return T
+     * @return object
+     * @phpstan-return T
      */
     public static function models(string $name, array $options = [], ?ConnectionInterface &$conn = null)
     {
@@ -228,7 +232,7 @@ class Factories
      *
      * @param string $component Lowercase, plural component name
      *
-     * @return array<string, mixed>
+     * @phpstan-return array<string, string|null|bool>
      */
     public static function getOptions(string $component): array
     {
@@ -253,7 +257,8 @@ class Factories
      *
      * @param string $component Lowercase, plural component name
      *
-     * @return array<string, mixed> The result after applying defaults and normalization
+     * @return array The result after applying defaults and normalization
+     * @phpstan-return array<string, string|null|bool>
      */
     public static function setOptions(string $component, array $values): array
     {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -31,8 +31,7 @@ class Factories
      * Store of component-specific options, usually
      * from CodeIgniter\Config\Factory.
      *
-     * @var array[]
-     * @phpstan-var array<string, array<string, string|bool|null>>
+     * @var array<string, array<string, bool|string|null>>
      */
     protected static $options = [];
 
@@ -40,7 +39,7 @@ class Factories
      * Explicit options for the Config
      * component to prevent logic loops.
      *
-     * @phpstan-var array<string, string|bool|null>
+     * @var array<string, bool|string|null>
      */
     private static array $configOptions = [
         'component'  => 'config',
@@ -232,7 +231,7 @@ class Factories
      *
      * @param string $component Lowercase, plural component name
      *
-     * @phpstan-return array<string, string|null|bool>
+     * @return array<string, bool|string|null>
      */
     public static function getOptions(string $component): array
     {
@@ -257,8 +256,7 @@ class Factories
      *
      * @param string $component Lowercase, plural component name
      *
-     * @return array The result after applying defaults and normalization
-     * @phpstan-return array<string, string|null|bool>
+     * @return array<string, bool|string|null> The result after applying defaults and normalization
      */
     public static function setOptions(string $component, array $values): array
     {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -79,7 +79,7 @@ class Factories
      *
      * @phpstan-param class-string<T> $name
      *
-     * @return object
+     * @return Model
      * @phpstan-return T
      */
     public static function models(string $name, array $options = [], ?ConnectionInterface &$conn = null)

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -53,7 +53,7 @@ class Factories
      * Mapping of class basenames (no namespace) to
      * their instances.
      *
-     * @var array[]
+     * @var array<string, array<string, string>>
      * @phpstan-var array<string, array<string, class-string>>
      */
     protected static $basenames = [];
@@ -64,7 +64,7 @@ class Factories
      * A multi-dimensional array with components as
      * keys to the array of name-indexed instances.
      *
-     * @var array[]
+     * @var array<string, array<string, object>>
      * @phpstan-var  array<string, array<class-string, object>>
      */
     protected static $instances = [];


### PR DESCRIPTION
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

