### PR TITLE
fix: Time::now() does not respect timezone when using setTestNow()

### DIFF
--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -77,8 +77,13 @@ trait TimeTrait
 
         // If a test instance has been provided, use it instead.
         if ($time === '' && static::$testNow instanceof self) {
-            $timezone = $timezone ?: static::$testNow->getTimezone();
-            $time     = static::$testNow->format('Y-m-d H:i:s');
+            if ($timezone !== null) {
+                $testNow = static::$testNow->setTimezone($timezone);
+                $time    = $testNow->format('Y-m-d H:i:s');
+            } else {
+                $timezone = static::$testNow->getTimezone();
+                $time     = static::$testNow->format('Y-m-d H:i:s');
+            }
         }
 
         $timezone       = $timezone ?: date_default_timezone_get();

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -315,7 +315,7 @@ trait TimeTrait
 
     /**
      * Creates an instance of Time that will be returned during testing
-     * when calling 'Time::now' instead of the current time.
+     * when calling 'Time::now()' instead of the current time.
      *
      * @param DateTimeInterface|self|string|null $datetime
      * @param DateTimeZone|string|null           $timezone

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1132,6 +1132,15 @@ final class TimeTest extends CIUnitTestCase
         $this->assertNotSame($time1, $time2);
     }
 
+    public function testSetTestNowWithTimeZone()
+    {
+        Time::setTestNow('2017/03/10 12:00', 'Asia/Tokyo');
+
+        $now = Time::now('UTC');
+
+        $this->assertSame('2017-03-10T03:00:00+00:00', $now->format('c'));
+    }
+
     public function testSetTestNowWithFaLocale()
     {
         Locale::setDefault('fa');


### PR DESCRIPTION
**Description**
- fix bug 

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
