### PR TITLE
refactor: make now() testable

### DIFF
--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -29,7 +29,16 @@ if (! function_exists('now')) {
         }
 
         $datetime = new DateTime('now', new DateTimeZone($timezone));
-        sscanf($datetime->format('j-n-Y G:i:s'), '%d-%d-%d %d:%d:%d', $day, $month, $year, $hour, $minute, $second);
+        sscanf(
+            $datetime->format('j-n-Y G:i:s'),
+            '%d-%d-%d %d:%d:%d',
+            $day,
+            $month,
+            $year,
+            $hour,
+            $minute,
+            $second
+        );
 
         return mktime($hour, $minute, $second, $month, $day, $year);
     }

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -18,8 +18,6 @@ if (! function_exists('now')) {
      * Returns time() based on the timezone parameter or on the
      * app_timezone() setting
      *
-     * @param string $timezone
-     *
      * @throws Exception
      */
     function now(?string $timezone = null): int

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -9,6 +9,8 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+use CodeIgniter\I18n\Time;
+
 // CodeIgniter Date Helpers
 
 if (! function_exists('now')) {
@@ -25,12 +27,14 @@ if (! function_exists('now')) {
         $timezone = empty($timezone) ? app_timezone() : $timezone;
 
         if ($timezone === 'local' || $timezone === date_default_timezone_get()) {
-            return time();
+            $time = Time::now();
+
+            return $time->getTimestamp();
         }
 
-        $datetime = new DateTime('now', new DateTimeZone($timezone));
+        $time = Time::now($timezone);
         sscanf(
-            $datetime->format('j-n-Y G:i:s'),
+            $time->format('j-n-Y G:i:s'),
             '%d-%d-%d %d:%d:%d',
             $day,
             $month,

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -33,7 +33,10 @@ final class DateHelperTest extends CIUnitTestCase
     public function testNowSpecific()
     {
         // Chicago should be two hours ahead of Vancouver
-        $this->assertCloseEnough(7200, now('America/Chicago') - now('America/Vancouver'));
+        $this->assertCloseEnough(
+            7200,
+            now('America/Chicago') - now('America/Vancouver')
+        );
     }
 
     public function testTimezoneSelectDefault()
@@ -66,7 +69,10 @@ final class DateHelperTest extends CIUnitTestCase
 
         $expected .= ("</select>\n");
 
-        $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion));
+        $this->assertSame(
+            $expected,
+            timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion)
+        );
     }
 
     public function testTimezoneSelectSingle()
@@ -84,6 +90,9 @@ final class DateHelperTest extends CIUnitTestCase
 
         $expected .= ("</select>\n");
 
-        $this->assertSame($expected, timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion, $country));
+        $this->assertSame(
+            $expected,
+            timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion, $country)
+        );
     }
 }

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Helpers;
 
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use DateTimeZone;
 
@@ -27,16 +28,24 @@ final class DateHelperTest extends CIUnitTestCase
 
     public function testNowDefault()
     {
-        $this->assertCloseEnough(now(), time());  // close enough
+        Time::setTestNow('June 20, 2022', 'America/Chicago');
+
+        $this->assertSame(now(), 1_655_701_200);
+
+        Time::setTestNow();
     }
 
     public function testNowSpecific()
     {
+        Time::setTestNow('June 20, 2022', 'America/Chicago');
+
         // Chicago should be two hours ahead of Vancouver
-        $this->assertCloseEnough(
+        $this->assertSame(
             7200,
             now('America/Chicago') - now('America/Vancouver')
         );
+
+        Time::setTestNow();
     }
 
     public function testTimezoneSelectDefault()


### PR DESCRIPTION
~~Needs #6752~~

**Description**
Fixes #5492 
Supersedes #6684

- refactor `now()`
- fix test code

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

