### PR TITLE
bug: Supply mixin for TestResponse

### DIFF
--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\TestCase;
  * @no-final
  *
  * @internal
+ *
+ * @mixin DOMParser
  */
 class TestResponse extends TestCase
 {


### PR DESCRIPTION
**Description**
PHPStan is complaining about DOMParser methods that pass through. E.g.:
https://github.com/lonnieezell/myth-auth/actions/runs/3321152878/jobs/5488411025#step:9:82

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
