### PR TITLE
test: fix Creation of dynamic property error in PHP 8.2

### DIFF
--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -229,7 +229,15 @@ final class GetTest extends CIUnitTestCase
 
     public function testGetRowWithCustomReturnType()
     {
-        $testClass = new class () {};
+        $testClass = new class () {
+            public $id;
+            public $name;
+            public $email;
+            public $country;
+            public $created_at;
+            public $updated_at;
+            public $deleted_at;
+        };
 
         $user = $this->db->table('user')->get()->getRow(0, get_class($testClass));
 


### PR DESCRIPTION
**Description**
See  #6170

```
1) CodeIgniter\Database\Live\GetTest::testGetRowWithCustomReturnType
ErrorException: Creation of dynamic property class@anonymous::$id is deprecated

/Users/kenji/work/codeigniter/official/CodeIgniter4/system/Database/SQLite3/Result.php:143
/Users/kenji/work/codeigniter/official/CodeIgniter4/system/Database/SQLite3/Result.php:147
/Users/kenji/work/codeigniter/official/CodeIgniter4/system/Database/BaseResult.php:149
/Users/kenji/work/codeigniter/official/CodeIgniter4/system/Database/BaseResult.php:286
/Users/kenji/work/codeigniter/official/CodeIgniter4/system/Database/BaseResult.php:273
/Users/kenji/work/codeigniter/official/CodeIgniter4/tests/system/Database/Live/GetTest.php:234
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide

