### PR TITLE
fix: workaround for Faker deprecation errors in PHP 8.2

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -152,6 +152,18 @@ class Exceptions
     public function errorHandler(int $severity, string $message, ?string $file = null, ?int $line = null)
     {
         if (error_reporting() & $severity) {
+            // Workaround for Faker deprecation errors in PHP 8.2.
+            // See https://github.com/FakerPHP/Faker/issues/479
+            // @TODO Remove if Faker is fixed.
+            if (
+                $severity === E_DEPRECATED
+                && strpos($file, VENDORPATH . 'fakerphp/faker/') !== false
+                && $message === 'Use of "static" in callables is deprecated'
+            ) {
+                // Ignore the error.
+                return true;
+            }
+
             throw new ErrorException($message, 0, $severity, $file, $line);
         }
 

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -20,6 +20,7 @@ use CodeIgniter\HTTP\Response;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Paths;
 use ErrorException;
+use Psr\Log\LogLevel;
 use Throwable;
 
 /**
@@ -160,6 +161,16 @@ class Exceptions
                 && strpos($file, VENDORPATH . 'fakerphp/faker/') !== false
                 && $message === 'Use of "static" in callables is deprecated'
             ) {
+                log_message(
+                    LogLevel::WARNING,
+                    '[DEPRECATED] {message} in {errFile} on line {errLine}.',
+                    [
+                        'message' => $message,
+                        'errFile' => clean_path($file ?? ''),
+                        'errLine' => $line ?? 0,
+                    ]
+                );
+
                 // Ignore the error.
                 return true;
             }


### PR DESCRIPTION
**Description**
See #6170 

Suppress the following error in PHP 8.2.
This error prevents our app and library developments to support 8.2. See https://github.com/codeigniter4/CodeIgniter4/pull/6172#issuecomment-1288302674

```
1) CodeIgniter\Test\FabricatorTest::testMakeArrayReturnsArray
ErrorException: Use of "static" in callables is deprecated

/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Provider/Base.php:374
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Provider/Base.php:432
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Provider/Base.php:449
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Provider/Internet.php:118
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Generator.php:696
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Generator.php:744
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Generator.php:747
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Provider/Internet.php:51
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Generator.php:696
/Users/kenji/work/codeigniter/official/CodeIgniter4/vendor/fakerphp/faker/src/Faker/Generator.php:952
/Users/kenji/work/codeigniter/official/CodeIgniter4/system/Test/Fabricator.php:377
/Users/kenji/work/codeigniter/official/CodeIgniter4/tests/system/Test/FabricatorTest.php:254
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
