### PR TITLE
feat: improve multiple domain support

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -25,6 +25,20 @@ class App extends BaseConfig
     public string $baseURL = 'http://localhost:8080/';
 
     /**
+     * Allowed Hostnames in the Site URL other than the hostname in the baseURL.
+     * If you want to accept multiple Hostnames, set this.
+     *
+     * E.g. When your site URL ($baseURL) is 'http://example.com/', and your site
+     *      also accepts 'http://media.example.com/' and
+     *      'http://accounts.example.com/':
+     *          ['media.example.com', 'accounts.example.com']
+     *
+     * @var string[]
+     * @phpstan-var list<string>
+     */
+    public array $allowedHostnames = [];
+
+    /**
      * --------------------------------------------------------------------------
      * Index File
      * --------------------------------------------------------------------------

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -196,6 +196,7 @@ class IncomingRequest extends Request
     protected function detectURI(string $protocol, string $baseURL)
     {
         // Passing the config is unnecessary but left for legacy purposes
+        // @TODO For what? Why clone?
         $config          = clone $this->config;
         $config->baseURL = $baseURL;
 

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -440,7 +440,7 @@ class IncomingRequest extends Request
         // Update host if it is valid.
         $httpHostPort = $this->getServer('HTTP_HOST');
         if ($httpHostPort !== null) {
-            $httpHost = explode(':', $httpHostPort)[0];
+            [$httpHost] = explode(':', $httpHostPort, 2);
 
             if (in_array($httpHost, $config->allowedHostnames, true)) {
                 $host = $httpHost;

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -251,7 +251,10 @@ class IncomingRequest extends Request
         $uri   = $parts['path'] ?? '';
 
         // Strip the SCRIPT_NAME path from the URI
-        if ($uri !== '' && isset($_SERVER['SCRIPT_NAME'][0]) && pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php') {
+        if (
+            $uri !== '' && isset($_SERVER['SCRIPT_NAME'][0])
+            && pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php'
+        ) {
             // Compare each segment, dropping them until there is no match
             $segments = $keep = explode('/', $uri);
 
@@ -356,7 +359,8 @@ class IncomingRequest extends Request
      */
     public function isAJAX(): bool
     {
-        return $this->hasHeader('X-Requested-With') && strtolower($this->header('X-Requested-With')->getValue()) === 'xmlhttprequest';
+        return $this->hasHeader('X-Requested-With')
+            && strtolower($this->header('X-Requested-With')->getValue()) === 'xmlhttprequest';
     }
 
     /**
@@ -512,7 +516,10 @@ class IncomingRequest extends Request
      */
     public function getVar($index = null, $filter = null, $flags = null)
     {
-        if (strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false && $this->body !== null) {
+        if (
+            strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false
+            && $this->body !== null
+        ) {
             if ($index === null) {
                 return $this->getJSON();
             }
@@ -649,7 +656,9 @@ class IncomingRequest extends Request
         // Use $_POST directly here, since filter_has_var only
         // checks the initial POST data, not anything that might
         // have been added since.
-        return isset($_POST[$index]) ? $this->getPost($index, $filter, $flags) : (isset($_GET[$index]) ? $this->getGet($index, $filter, $flags) : $this->getPost($index, $filter, $flags));
+        return isset($_POST[$index])
+            ? $this->getPost($index, $filter, $flags)
+            : (isset($_GET[$index]) ? $this->getGet($index, $filter, $flags) : $this->getPost($index, $filter, $flags));
     }
 
     /**
@@ -669,7 +678,9 @@ class IncomingRequest extends Request
         // Use $_GET directly here, since filter_has_var only
         // checks the initial GET data, not anything that might
         // have been added since.
-        return isset($_GET[$index]) ? $this->getGet($index, $filter, $flags) : (isset($_POST[$index]) ? $this->getPost($index, $filter, $flags) : $this->getGet($index, $filter, $flags));
+        return isset($_GET[$index])
+            ? $this->getGet($index, $filter, $flags)
+            : (isset($_POST[$index]) ? $this->getPost($index, $filter, $flags) : $this->getGet($index, $filter, $flags));
     }
 
     /**

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -396,9 +396,15 @@ class IncomingRequest extends Request
 
         $config ??= $this->config;
 
+        if ($config->baseURL === '') {
+            // @codeCoverageIgnoreStart
+            exit('You have an empty or invalid base URL. The baseURL value must be set in Config\App.php, or through the .env file.');
+            // @codeCoverageIgnoreEnd
+        }
+
         // It's possible the user forgot a trailing slash on their
         // baseURL, so let's help them out.
-        $baseURL = $config->baseURL === '' ? $config->baseURL : rtrim($config->baseURL, '/ ') . '/';
+        $baseURL = rtrim($config->baseURL, '/ ') . '/';
 
         // Based on our baseURL provided by the developer
         // set our current domain name, scheme
@@ -414,10 +420,6 @@ class IncomingRequest extends Request
             if ($config->forceGlobalSecureRequests && $this->uri->getScheme() === 'http') {
                 $this->uri->setScheme('https');
             }
-        } elseif (! is_cli()) {
-            // @codeCoverageIgnoreStart
-            exit('You have an empty or invalid base URL. The baseURL value must be set in Config\App.php, or through the .env file.');
-            // @codeCoverageIgnoreEnd
         }
 
         return $this;

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -433,13 +433,16 @@ class IncomingRequest extends Request
     {
         $host = parse_url($baseURL, PHP_URL_HOST);
 
+        if (empty($config->allowedHostnames)) {
+            return $host;
+        }
+
         // Update host if it is valid.
         $httpHostPort = $this->getServer('HTTP_HOST');
         if ($httpHostPort !== null) {
-            $httpHost         = explode(':', $httpHostPort)[0];
-            $allowedHostnames = $config->allowedHostnames ?? [];
+            $httpHost = explode(':', $httpHostPort)[0];
 
-            if (in_array($httpHost, $allowedHostnames, true)) {
+            if (in_array($httpHost, $config->allowedHostnames, true)) {
                 $host = $httpHost;
             }
         }

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -379,12 +379,13 @@ class IncomingRequest extends Request
 
     /**
      * Sets the relative path and updates the URI object.
+     *
      * Note: Since current_url() accesses the shared request
      * instance, this can be used to change the "current URL"
      * for testing.
      *
-     * @param string $path   URI path relative to SCRIPT_NAME
-     * @param App    $config Optional alternate config to use
+     * @param string   $path   URI path relative to SCRIPT_NAME
+     * @param App|null $config Optional alternate config to use
      *
      * @return $this
      */

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -145,9 +145,7 @@ class IncomingRequest extends Request
      * Constructor
      *
      * @param App         $config
-     * @param URI         $uri
      * @param string|null $body
-     * @param UserAgent   $userAgent
      */
     public function __construct($config, ?URI $uri = null, $body = 'php://input', ?UserAgent $userAgent = null)
     {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -407,25 +407,23 @@ class IncomingRequest extends Request
 
         $host = $this->determineHost($config, $baseURL);
 
-        // Based on our baseURL provided by the developer
-        // set our current domain name, scheme
-        if ($baseURL !== '') {
-            $this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
-            $this->uri->setHost($host);
-            $this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
+        // Based on $baseURL and $allowedHostnames provided by Config\App,
+        // set our current domain name, scheme.
+        $this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
+        $this->uri->setHost($host);
+        $this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
 
-            // Update Config\App::$baseURL
-            $uri = new URI($baseURL);
-            $uri->setHost($host);
-            $this->config->baseURL = $uri;
+        // Update Config\App::$baseURL
+        $uri = new URI($baseURL);
+        $uri->setHost($host);
+        $this->config->baseURL = $uri;
 
-            // Ensure we have any query vars
-            $this->uri->setQuery($_SERVER['QUERY_STRING'] ?? '');
+        // Ensure we have any query vars
+        $this->uri->setQuery($_SERVER['QUERY_STRING'] ?? '');
 
-            // Check if the baseURL scheme needs to be coerced into its secure version
-            if ($config->forceGlobalSecureRequests && $this->uri->getScheme() === 'http') {
-                $this->uri->setScheme('https');
-            }
+        // Check if the baseURL scheme needs to be coerced into its secure version
+        if ($config->forceGlobalSecureRequests && $this->uri->getScheme() === 'http') {
+            $this->uri->setScheme('https');
         }
 
         return $this;

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -39,7 +39,13 @@ if (! function_exists('_get_uri')) {
         // If a full URI was passed then convert it
         if (is_int(strpos($relativePath, '://'))) {
             $full         = new URI($relativePath);
-            $relativePath = URI::createURIString(null, null, $full->getPath(), $full->getQuery(), $full->getFragment());
+            $relativePath = URI::createURIString(
+                null,
+                null,
+                $full->getPath(),
+                $full->getQuery(),
+                $full->getFragment()
+            );
         }
 
         $relativePath = URI::removeDotSegments($relativePath);
@@ -86,7 +92,13 @@ if (! function_exists('site_url')) {
 
         $uri = _get_uri($relativePath, $config);
 
-        return URI::createURIString($scheme ?? $uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery(), $uri->getFragment());
+        return URI::createURIString(
+            $scheme ?? $uri->getScheme(),
+            $uri->getAuthority(),
+            $uri->getPath(),
+            $uri->getQuery(),
+            $uri->getFragment()
+        );
     }
 }
 

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -56,7 +56,9 @@ final class CurrentUrlTest extends CIUnitTestCase
 
     public function testCurrentURLReturnsBasicURL()
     {
-        // Since we're on a CLI, we must provide our own URI
+        $_SERVER['REQUEST_URI'] = '/public';
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php';
+
         $this->config->baseURL = 'http://example.com/public';
 
         $this->assertSame('http://example.com/public/index.php/', current_url());

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -64,6 +64,30 @@ final class CurrentUrlTest extends CIUnitTestCase
         $this->assertSame('http://example.com/public/index.php/', current_url());
     }
 
+    public function testCurrentURLReturnsAllowedHostname()
+    {
+        $_SERVER['HTTP_HOST']   = 'www.example.jp';
+        $_SERVER['REQUEST_URI'] = '/public';
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php';
+
+        $this->config->baseURL          = 'http://example.com/public';
+        $this->config->allowedHostnames = ['www.example.jp'];
+
+        $this->assertSame('http://www.example.jp/public/index.php/', current_url());
+    }
+
+    public function testCurrentURLReturnsBaseURLIfNotAllowedHostname()
+    {
+        $_SERVER['HTTP_HOST']   = 'invalid.example.org';
+        $_SERVER['REQUEST_URI'] = '/public';
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php';
+
+        $this->config->baseURL          = 'http://example.com/public';
+        $this->config->allowedHostnames = ['www.example.jp'];
+
+        $this->assertSame('http://example.com/public/index.php/', current_url());
+    }
+
     public function testCurrentURLReturnsObject()
     {
         // Since we're on a CLI, we must provide our own URI

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -261,10 +261,10 @@ final class SiteUrlTest extends CIUnitTestCase
      */
     public function testBaseURLDiscovery()
     {
-        $this->config->baseURL = 'http://example.com/';
-
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/test';
+
+        $this->config->baseURL = 'http://example.com/';
 
         $this->assertSame('http://example.com', base_url());
 
@@ -284,7 +284,8 @@ final class SiteUrlTest extends CIUnitTestCase
         Services::injectMock('uri', $uri);
 
         $this->config->baseURL = 'http://example.com/ci/v4/';
-        $request               = Services::request($this->config);
+
+        $request = Services::request($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame(

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -70,7 +70,8 @@ final class SiteUrlTest extends CIUnitTestCase
         $this->assertSame($expectedSiteUrl, site_url($path, $scheme, $this->config));
 
         // base_url is always the trimmed site_url without index page
-        $expectedBaseUrl = $indexPage === '' ? $expectedSiteUrl : str_replace('/' . $indexPage, '', $expectedSiteUrl);
+        $expectedBaseUrl = ($indexPage === '') ? $expectedSiteUrl
+            : str_replace('/' . $indexPage, '', $expectedSiteUrl);
         $expectedBaseUrl = rtrim($expectedBaseUrl, '/');
         $this->assertSame($expectedBaseUrl, base_url($path, $scheme));
     }
@@ -286,7 +287,13 @@ final class SiteUrlTest extends CIUnitTestCase
         $request               = Services::request($this->config);
         Services::injectMock('request', $request);
 
-        $this->assertSame('http://example.com/ci/v4/index.php/controller/method', site_url('controller/method', null, $this->config));
-        $this->assertSame('http://example.com/ci/v4/controller/method', base_url('controller/method', null));
+        $this->assertSame(
+            'http://example.com/ci/v4/index.php/controller/method',
+            site_url('controller/method', null, $this->config)
+        );
+        $this->assertSame(
+            'http://example.com/ci/v4/controller/method',
+            base_url('controller/method', null)
+        );
     }
 }

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -280,9 +280,6 @@ final class SiteUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/ci/v4/x/y';
 
-        $uri = new URI('http://example.com/ci/v4/x/y');
-        Services::injectMock('uri', $uri);
-
         $this->config->baseURL = 'http://example.com/ci/v4/';
 
         $request = Services::incomingrequest($this->config);

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -294,4 +294,42 @@ final class SiteUrlTest extends CIUnitTestCase
             base_url('controller/method', null)
         );
     }
+
+    public function testSiteURLWithAllowedHostname()
+    {
+        $_SERVER['HTTP_HOST']   = 'www.example.jp';
+        $_SERVER['REQUEST_URI'] = '/public';
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php';
+
+        $this->config->baseURL          = 'http://example.com/public/';
+        $this->config->allowedHostnames = ['www.example.jp'];
+
+        // URI object and Config\App::$baseURL are updated in IncomingRequest constructor.
+        $request = Services::incomingrequest($this->config);
+        Services::injectMock('request', $request);
+
+        $this->assertSame(
+            'http://www.example.jp/public/index.php/controller/method',
+            site_url('controller/method', null, $this->config)
+        );
+    }
+
+    public function testBaseURLWithAllowedHostname()
+    {
+        $_SERVER['HTTP_HOST']   = 'www.example.jp';
+        $_SERVER['REQUEST_URI'] = '/public';
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php';
+
+        $this->config->baseURL          = 'http://example.com/public/';
+        $this->config->allowedHostnames = ['www.example.jp'];
+
+        // URI object and Config\App::$baseURL are updated in IncomingRequest constructor.
+        $request = Services::incomingrequest($this->config);
+        Services::injectMock('request', $request);
+
+        $this->assertSame(
+            'http://www.example.jp/public/controller/method',
+            base_url('controller/method', null)
+        );
+    }
 }

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -285,7 +285,7 @@ final class SiteUrlTest extends CIUnitTestCase
 
         $this->config->baseURL = 'http://example.com/ci/v4/';
 
-        $request = Services::request($this->config);
+        $request = Services::incomingrequest($this->config);
         Services::injectMock('request', $request);
 
         $this->assertSame(


### PR DESCRIPTION
**Description**
Fixes #5807
Related #6746

- add `Config\App::$allowedHostnames`
- update `Config\App::$baseURL` in `IncomingRequest` if `HTTP_HOST` is an allowed hostname 

**Changes:**
- `current_url()`, `base_url()`, `site_url()` will return the URL with allowed `HTTP_HOST`
- `previous_url()` will return the site URL with allowed `HTTP_HOST` when cannot get it from session nor `HTTP_REFERER`

The following functions/methods are affected (There may be others):
- Using site_url()
  - form_open()
  - audio()
  - embed()
  - img()
  - link_tag()
  - object()
  - script_tag()
  - source()
  - video()
  - RedirectResponse::route()
  - RedirectResponse::to()
  - Toolbar::prepare()
  - Toolbar::respond()
  - anchor()
  - anchor_popup()
  - base_url()
  - previous_url()
  - url_to()
- Using base_url()
  - RedirectException in CodeIgnter.php L377
  - UserAgent::isReferral()
- Using current_url()
  - ChromeLoggerHandler::__construct()
  - CodeIgniter::storePreviousURL()
  - Pager::ensureGroup()
  - Toolbar::run()

Ref #4651

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
