### PR TITLE
docs: change "Custom Exceptions" to "Framework Exceptions"

### DIFF
--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -64,10 +64,10 @@ To ignore logging on other status codes, you can set the status code to ignore i
 .. note:: It is possible that logging still will not happen for exceptions if your current Log settings
     are not set up to log **critical** errors, which all exceptions are logged as.
 
-Custom Exceptions
-=================
+Framework Exceptions
+====================
 
-The following custom exceptions are available:
+The following framework exceptions are available:
 
 PageNotFoundException
 ---------------------


### PR DESCRIPTION
**Description**
"Custom Exceptions" feels a little different.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide

