### PR TITLE
docs: fix `@param` types in html/url helper

### DIFF
--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -22,7 +22,7 @@ if (! function_exists('ul')) {
      * Generates an HTML unordered list from an single or
      * multi-dimensional array.
      *
-     * @param mixed $attributes HTML attributes string, array, object
+     * @param array|object|string $attributes HTML attributes string, array, object
      */
     function ul(array $list, $attributes = ''): string
     {
@@ -36,7 +36,7 @@ if (! function_exists('ol')) {
      *
      * Generates an HTML ordered list from an single or multi-dimensional array.
      *
-     * @param mixed $attributes HTML attributes string, array, object
+     * @param array|object|string $attributes HTML attributes string, array, object
      */
     function ol(array $list, $attributes = ''): string
     {
@@ -50,8 +50,8 @@ if (! function_exists('_list')) {
      *
      * Generates an HTML ordered list from an single or multi-dimensional array.
      *
-     * @param mixed $list
-     * @param mixed $attributes string, array, object
+     * @param array               $list
+     * @param array|object|string $attributes string, array, object
      */
     function _list(string $type = 'ul', $list = [], $attributes = '', int $depth = 0): string
     {
@@ -224,8 +224,8 @@ if (! function_exists('link_tag')) {
      *
      * Generates link to a CSS file
      *
-     * @param mixed $href      Stylesheet href or an array
-     * @param bool  $indexPage should indexPage be added to the CSS path.
+     * @param array|string $href      Stylesheet href or an array
+     * @param bool         $indexPage should indexPage be added to the CSS path.
      */
     function link_tag($href = '', string $rel = 'stylesheet', string $type = 'text/css', string $title = '', string $media = '', bool $indexPage = false, string $hreflang = ''): string
     {
@@ -281,9 +281,9 @@ if (! function_exists('video')) {
      * Generates a video element to embed videos. The video element can
      * contain one or more video sources
      *
-     * @param mixed  $src                Either a source string or an array of sources
-     * @param string $unsupportedMessage The message to display if the media tag is not supported by the browser
-     * @param string $attributes         HTML attributes
+     * @param array|string $src                Either a source string or an array of sources
+     * @param string       $unsupportedMessage The message to display if the media tag is not supported by the browser
+     * @param string       $attributes         HTML attributes
      */
     function video($src, string $unsupportedMessage = '', string $attributes = '', array $tracks = [], bool $indexPage = false): string
     {
@@ -327,9 +327,9 @@ if (! function_exists('audio')) {
      *
      * Generates an audio element to embed sounds
      *
-     * @param mixed  $src                Either a source string or an array of sources
-     * @param string $unsupportedMessage The message to display if the media tag is not supported by the browser.
-     * @param string $attributes         HTML attributes
+     * @param array|string $src                Either a source string or an array of sources
+     * @param string       $unsupportedMessage The message to display if the media tag is not supported by the browser.
+     * @param string       $attributes         HTML attributes
      */
     function audio($src, string $unsupportedMessage = '', string $attributes = '', array $tracks = [], bool $indexPage = false): string
     {

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -96,7 +96,6 @@ if (! function_exists('base_url')) {
      * Base URLs are trimmed site URLs without the index page.
      *
      * @param array|string $relativePath URI string or array of URI segments
-     * @param string       $scheme
      */
     function base_url($relativePath = '', ?string $scheme = null): string
     {

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -95,8 +95,8 @@ if (! function_exists('base_url')) {
      * Returns the base URL as defined by the App config.
      * Base URLs are trimmed site URLs without the index page.
      *
-     * @param mixed  $relativePath URI string or array of URI segments
-     * @param string $scheme
+     * @param array|string $relativePath URI string or array of URI segments
+     * @param string       $scheme
      */
     function base_url($relativePath = '', ?string $scheme = null): string
     {
@@ -143,7 +143,7 @@ if (! function_exists('previous_url')) {
      * If that's not available, however, we'll use a sanitized url from $_SERVER['HTTP_REFERER']
      * which can be set by the user so is untrusted and not set by certain browsers/servers.
      *
-     * @return mixed|string|URI
+     * @return string|URI
      */
     function previous_url(bool $returnObject = false)
     {
@@ -197,10 +197,10 @@ if (! function_exists('anchor')) {
      *
      * Creates an anchor based on the local URL.
      *
-     * @param mixed    $uri        URI string or array of URI segments
-     * @param string   $title      The link title
-     * @param mixed    $attributes Any attributes
-     * @param App|null $altConfig  Alternate configuration to use
+     * @param array|string        $uri        URI string or array of URI segments
+     * @param string              $title      The link title
+     * @param array|object|string $attributes Any attributes
+     * @param App|null            $altConfig  Alternate configuration to use
      */
     function anchor($uri = '', string $title = '', $attributes = '', ?App $altConfig = null): string
     {
@@ -230,10 +230,10 @@ if (! function_exists('anchor_popup')) {
      * Creates an anchor based on the local URL. The link
      * opens a new window based on the attributes specified.
      *
-     * @param string   $uri        the URL
-     * @param string   $title      the link title
-     * @param mixed    $attributes any attributes
-     * @param App|null $altConfig  Alternate configuration to use
+     * @param string                    $uri        the URL
+     * @param string                    $title      the link title
+     * @param array|false|object|string $attributes any attributes
+     * @param App|null                  $altConfig  Alternate configuration to use
      */
     function anchor_popup($uri = '', string $title = '', $attributes = false, ?App $altConfig = null): string
     {
@@ -280,9 +280,9 @@ if (! function_exists('mailto')) {
     /**
      * Mailto Link
      *
-     * @param string $email      the email address
-     * @param string $title      the link title
-     * @param mixed  $attributes any attributes
+     * @param string              $email      the email address
+     * @param string              $title      the link title
+     * @param array|object|string $attributes any attributes
      */
     function mailto(string $email, string $title = '', $attributes = ''): string
     {
@@ -300,9 +300,9 @@ if (! function_exists('safe_mailto')) {
      *
      * Create a spam-protected mailto link written in Javascript
      *
-     * @param string $email      the email address
-     * @param string $title      the link title
-     * @param mixed  $attributes any attributes
+     * @param string              $email      the email address
+     * @param string              $title      the link title
+     * @param array|object|string $attributes any attributes
      */
     function safe_mailto(string $email, string $title = '', $attributes = ''): string
     {


### PR DESCRIPTION
**Description**
See #6310

- fix `@param` types

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
