### PR TITLE
Add `@group Others` to all other tests

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -24,6 +24,8 @@ use stdClass;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ResponseTraitTest extends CIUnitTestCase
 {

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -20,6 +20,8 @@ use UnnamespacedClass;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class AutoloaderTest extends CIUnitTestCase
 {

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -18,6 +18,8 @@ use Config\Modules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileLocatorTest extends CIUnitTestCase
 {

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -18,6 +18,8 @@ use RuntimeException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CLITest extends CIUnitTestCase
 {

--- a/tests/system/CLI/CommandRunnerTest.php
+++ b/tests/system/CLI/CommandRunnerTest.php
@@ -18,6 +18,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CommandRunnerTest extends CIUnitTestCase
 {

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -21,6 +21,8 @@ use CodeIgniter\Test\Mock\MockCodeIgniter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ConsoleTest extends CIUnitTestCase
 {

--- a/tests/system/Cache/CacheFactoryTest.php
+++ b/tests/system/Cache/CacheFactoryTest.php
@@ -18,6 +18,8 @@ use Config\Cache;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CacheFactoryTest extends CIUnitTestCase
 {

--- a/tests/system/Cache/CacheMockTest.php
+++ b/tests/system/Cache/CacheMockTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockCache;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CacheMockTest extends CIUnitTestCase
 {

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -17,6 +17,8 @@ use Tests\Support\Cache\RestrictiveHandler;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class BaseHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DummyHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -17,6 +17,8 @@ use Config\Cache;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileHandlerTest extends AbstractHandlerTest
 {

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -27,6 +27,8 @@ use Tests\Support\Filters\Customfilter;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class CodeIgniterTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -17,6 +17,8 @@ use Tests\Support\Commands\AppInfo;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class BaseCommandTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -18,6 +18,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ClearCacheTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ClearDebugbarTest.php
+++ b/tests/system/Commands/ClearDebugbarTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ClearDebugbarTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ClearLogsTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/CommandGeneratorTest.php
+++ b/tests/system/Commands/CommandGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CommandGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -18,6 +18,8 @@ use Tests\Support\Commands\ParamsReveal;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CommandTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ConfigGeneratorTest.php
+++ b/tests/system/Commands/ConfigGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ConfigGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ConfigurableSortImportsTest.php
+++ b/tests/system/Commands/ConfigurableSortImportsTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ConfigurableSortImportsTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ControllerGeneratorTest.php
+++ b/tests/system/Commands/ControllerGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ControllerGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/EntityGeneratorTest.php
+++ b/tests/system/Commands/EntityGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class EntityGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/EnvironmentCommandTest.php
+++ b/tests/system/Commands/EnvironmentCommandTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class EnvironmentCommandTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/FilterGeneratorTest.php
+++ b/tests/system/Commands/FilterGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FilterGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/GeneratorsTest.php
+++ b/tests/system/Commands/GeneratorsTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class GeneratorsTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class HelpCommandTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -18,6 +18,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class InfoCacheTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/MigrationGeneratorTest.php
+++ b/tests/system/Commands/MigrationGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class MigrationGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ModelGeneratorTest.php
+++ b/tests/system/Commands/ModelGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ModelGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/PublishCommandTest.php
+++ b/tests/system/Commands/PublishCommandTest.php
@@ -17,6 +17,8 @@ use Tests\Support\Publishers\TestPublisher;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class PublishCommandTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -17,6 +17,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class RoutesTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/ScaffoldGeneratorTest.php
@@ -19,6 +19,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ScaffoldGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/SeederGeneratorTest.php
+++ b/tests/system/Commands/SeederGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SeederGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/AutoRouteCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouteCollectorTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class AutoRouteCollectorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
@@ -17,6 +17,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class AutoRouteCollectorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -17,6 +17,8 @@ use Tests\Support\Controllers\Remap;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ControllerMethodReaderTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/ControllerFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/ControllerFinderTest.php
@@ -16,6 +16,8 @@ use Tests\Support\Controllers\Hello;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ControllerFinderTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/ControllerMethodReaderTest.php
@@ -17,6 +17,8 @@ use Tests\Support\Controllers\Remap;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ControllerMethodReaderTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -16,6 +16,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FilterCollectorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -28,6 +28,8 @@ use Config\Modules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FilterFinderTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -17,6 +17,8 @@ use Generator;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SampleURIGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/ValidationGeneratorTest.php
+++ b/tests/system/Commands/ValidationGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ValidationGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/CommonHelperTest.php
+++ b/tests/system/CommonHelperTest.php
@@ -21,6 +21,8 @@ use Tests\Support\Autoloader\FatalLocator;
 /**
  * @internal
  *
+ * @group Others
+ *
  * @covers ::helper
  */
 final class CommonHelperTest extends CIUnitTestCase

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -21,6 +21,8 @@ use ReflectionMethod;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CommonSingleServiceTest extends CIUnitTestCase
 {

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -20,6 +20,8 @@ use Tests\Support\Widgets\SomeWidget;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FactoriesTest extends CIUnitTestCase
 {

--- a/tests/system/Config/MimesTest.php
+++ b/tests/system/Config/MimesTest.php
@@ -16,6 +16,8 @@ use Config\Mimes;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class MimesTest extends CIUnitTestCase
 {

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -33,6 +33,8 @@ use Tests\Support\Config\Validation;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class ControllerTest extends CIUnitTestCase
 {

--- a/tests/system/Cookie/CookieStoreTest.php
+++ b/tests/system/Cookie/CookieStoreTest.php
@@ -17,6 +17,8 @@ use DateTimeImmutable;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CookieStoreTest extends CIUnitTestCase
 {

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -21,6 +21,8 @@ use LogicException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CookieTest extends CIUnitTestCase
 {

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -19,6 +19,8 @@ use Throwable;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class BaseConnectionTest extends CIUnitTestCase
 {

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class BaseQueryTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class AliasTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class BaseTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CountTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DeleteTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/DistinctTest.php
+++ b/tests/system/Database/Builder/DistinctTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DistinctTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class EmptyTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FromTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class GetTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class GroupTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class InsertTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -20,6 +20,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class JoinTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class LikeTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/LimitTest.php
+++ b/tests/system/Database/Builder/LimitTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class LimitTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class OrderTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class PrefixTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/ReplaceTest.php
+++ b/tests/system/Database/Builder/ReplaceTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ReplaceTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -20,6 +20,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SelectTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/TruncateTest.php
+++ b/tests/system/Database/Builder/TruncateTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TruncateTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/UnionTest.php
+++ b/tests/system/Database/Builder/UnionTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class UnionTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -19,6 +19,8 @@ use CodeIgniter\Test\Mock\MockQuery;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class UpdateTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -22,6 +22,8 @@ use stdClass;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class WhereTest extends CIUnitTestCase
 {

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\ReflectionHelper;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ConfigTest extends CIUnitTestCase
 {

--- a/tests/system/Database/DatabaseSeederTest.php
+++ b/tests/system/Database/DatabaseSeederTest.php
@@ -17,6 +17,8 @@ use Faker\Generator;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DatabaseSeederTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Forge/CreateTableTest.php
+++ b/tests/system/Database/Forge/CreateTableTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CreateTableTest extends CIUnitTestCase
 {

--- a/tests/system/Database/Forge/DropForeignKeyTest.php
+++ b/tests/system/Database/Forge/DropForeignKeyTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DropForeignKeyTest extends CIUnitTestCase
 {

--- a/tests/system/Database/RawSqlTest.php
+++ b/tests/system/Database/RawSqlTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class RawSqlTest extends CIUnitTestCase
 {

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -23,6 +23,8 @@ use RuntimeException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ExceptionsTest extends CIUnitTestCase
 {

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TimerTest extends CIUnitTestCase
 {

--- a/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DatabaseTest extends CIUnitTestCase
 {
@@ -37,7 +39,7 @@ final class DatabaseTest extends CIUnitTestCase
 
         $this->assertSame('1234.56 ms', $queries[0]['duration']);
         $this->assertSame('<strong>SHOW</strong> TABLES;', $queries[0]['sql']);
-        $this->assertSame(clean_path(__FILE__) . ':33', $queries[0]['trace-file']);
+        $this->assertSame(clean_path(__FILE__) . ':' . (__LINE__ - 7), $queries[0]['trace-file']);
 
         foreach ($queries[0]['trace'] as $i => $trace) {
             // since we added the index numbering

--- a/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
@@ -17,6 +17,8 @@ use DateTime;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class HistoryTest extends CIUnitTestCase
 {

--- a/tests/system/DebugTraceableTraitTest.php
+++ b/tests/system/DebugTraceableTraitTest.php
@@ -18,19 +18,21 @@ use CodeIgniter\Test\CIUnitTestCase;
 /**
  * @internal
  *
+ * @group Others
+ *
  * @covers \CodeIgniter\Exceptions\DebugTraceableTrait
  */
 final class DebugTraceableTraitTest extends CIUnitTestCase
 {
     public function testFactoryInstanceReturnsWhereItIsRaised(): void
     {
-        $e1 = new FrameworkException('I am on line 27.');
+        $e1 = new FrameworkException('Hello.');
         $e2 = FrameworkException::forEnabledZlibOutputCompression();
 
         $this->assertContainsEquals(DebugTraceableTrait::class, class_uses(FrameworkException::class));
-        $this->assertSame(27, $e1->getLine());
+        $this->assertSame(__LINE__ - 4, $e1->getLine());
         $this->assertSame(__FILE__, $e1->getFile());
-        $this->assertSame(28, $e2->getLine());
+        $this->assertSame(__LINE__ - 5, $e2->getLine());
         $this->assertSame(__FILE__, $e2->getFile());
     }
 }

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -18,6 +18,8 @@ use ErrorException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class EmailTest extends CIUnitTestCase
 {

--- a/tests/system/Encryption/EncryptionTest.php
+++ b/tests/system/Encryption/EncryptionTest.php
@@ -18,6 +18,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class EncryptionTest extends CIUnitTestCase
 {

--- a/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
+++ b/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
@@ -18,6 +18,8 @@ use Config\Encryption as EncryptionConfig;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class OpenSSLHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Encryption/Handlers/SodiumHandlerTest.php
+++ b/tests/system/Encryption/Handlers/SodiumHandlerTest.php
@@ -18,6 +18,8 @@ use Config\Encryption as EncryptionConfig;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SodiumHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -26,6 +26,8 @@ use Tests\Support\SomeEntity;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class EntityTest extends CIUnitTestCase
 {

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileCollectionTest extends CIUnitTestCase
 {

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -17,6 +17,8 @@ use ZipArchive;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileTest extends CIUnitTestCase
 {

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -16,6 +16,8 @@ use org\bovigo\vfs\vfsStream;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileWithVfsTest extends CIUnitTestCase
 {

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\Test\CIUnitTestCase;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class CSRFTest extends CIUnitTestCase
 {

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -19,6 +19,8 @@ use Config\Filters as FilterConfig;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class DebugToolbarTest extends CIUnitTestCase
 {

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -41,6 +41,8 @@ require_once __DIR__ . '/fixtures/Role.php';
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class FiltersTest extends CIUnitTestCase
 {

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -21,6 +21,8 @@ use CodeIgniter\Test\Mock\MockAppConfig;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class InvalidCharsTest extends CIUnitTestCase
 {

--- a/tests/system/Filters/SecureHeadersTest.php
+++ b/tests/system/Filters/SecureHeadersTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SecureHeadersTest extends CIUnitTestCase
 {

--- a/tests/system/Format/FormatTest.php
+++ b/tests/system/Format/FormatTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FormatTest extends CIUnitTestCase
 {

--- a/tests/system/Format/JSONFormatterTest.php
+++ b/tests/system/Format/JSONFormatterTest.php
@@ -16,6 +16,8 @@ use RuntimeException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class JSONFormatterTest extends CIUnitTestCase
 {

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -16,6 +16,8 @@ use DOMDocument;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class XMLFormatterTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -21,6 +21,8 @@ use Config\App;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class CLIRequestTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -22,6 +22,8 @@ use CURLFile;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -22,6 +22,8 @@ use CURLFile;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CURLRequestTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -16,6 +16,8 @@ use Config\Mimes;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileCollectionTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -18,6 +18,8 @@ use org\bovigo\vfs\vfsStreamDirectory;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileMovingTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -16,6 +16,8 @@ use stdClass;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class HeaderTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -18,6 +18,8 @@ use Config\App;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class IncomingRequestDetectingTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class MessageTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -17,6 +17,8 @@ use Config\App;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class NegotiateTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -18,6 +18,8 @@ use Config\App;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class RequestTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -21,6 +21,8 @@ use Config\Cookie as CookieConfig;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ResponseCookieTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -23,6 +23,8 @@ use DateTimeZone;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ResponseTest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -21,6 +21,8 @@ use Config\App;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class URITest extends CIUnitTestCase
 {

--- a/tests/system/HTTP/UserAgentTest.php
+++ b/tests/system/HTTP/UserAgentTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class UserAgentTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -17,6 +17,8 @@ use ValueError;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ArrayHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -26,6 +26,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CookieHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -16,6 +16,8 @@ use DateTimeZone;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DateHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -17,6 +17,8 @@ use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FilesystemHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -18,6 +18,8 @@ use Config\App;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class HTMLHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class InflectorHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class NumberHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/SecurityHelperTest.php
+++ b/tests/system/Helpers/SecurityHelperTest.php
@@ -18,6 +18,8 @@ use Tests\Support\Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SecurityHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -16,6 +16,8 @@ use InvalidArgumentException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TextHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -25,6 +25,8 @@ use Config\App;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class CurrentUrlTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -22,6 +22,8 @@ use Config\App;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class MiscUrlTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -25,6 +25,8 @@ use Config\App;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class SiteUrlTest extends CIUnitTestCase
 {

--- a/tests/system/Helpers/XMLHelperTest.php
+++ b/tests/system/Helpers/XMLHelperTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class XMLHelperTest extends CIUnitTestCase
 {

--- a/tests/system/HomeTest.php
+++ b/tests/system/HomeTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\TestResponse;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class HomeTest extends CIUnitTestCase
 {

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -20,6 +20,8 @@ use CodeIgniter\Test\CIUnitTestCase;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class HoneypotTest extends CIUnitTestCase
 {

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -16,6 +16,8 @@ use Locale;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TimeDifferenceTest extends CIUnitTestCase
 {

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -23,6 +23,8 @@ use Locale;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TimeTest extends CIUnitTestCase
 {

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -28,6 +28,8 @@ use org\bovigo\vfs\vfsStreamDirectory;
  * testing saving only.
  *
  * @internal
+ *
+ * @group Others
  */
 final class BaseHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -28,6 +28,8 @@ use org\bovigo\vfs\vfsStreamDirectory;
  * Was unable to test fontPath & related logic.
  *
  * @internal
+ *
+ * @group Others
  */
 final class GDHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -28,6 +28,8 @@ use Imagick;
  * Was unable to test fontPath & related logic.
  *
  * @internal
+ *
+ * @group Others
  */
 final class ImageMagickHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Images/ImageTest.php
+++ b/tests/system/Images/ImageTest.php
@@ -18,6 +18,8 @@ use org\bovigo\vfs\vfsStreamDirectory;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ImageTest extends CIUnitTestCase
 {

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -19,6 +19,8 @@ use Tests\Support\Language\SecondMockLanguage;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class LanguageTest extends CIUnitTestCase
 {

--- a/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
@@ -20,6 +20,8 @@ use stdClass;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ChromeLoggerHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Log/Handlers/ErrorlogHandlerTest.php
+++ b/tests/system/Log/Handlers/ErrorlogHandlerTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ErrorlogHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Log/Handlers/FileHandlerTest.php
+++ b/tests/system/Log/Handlers/FileHandlerTest.php
@@ -20,6 +20,8 @@ use Tests\Support\Log\Handlers\TestHandler;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileHandlerTest extends CIUnitTestCase
 {

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -20,6 +20,8 @@ use Tests\Support\Log\Handlers\TestHandler;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class LoggerTest extends CIUnitTestCase
 {

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -23,6 +23,8 @@ use Tests\Support\Models\UserModel;
  * features without requiring a database connection.
  *
  * @internal
+ *
+ * @group Others
  */
 final class GeneralModelTest extends CIUnitTestCase
 {

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class PagerRendererTest extends CIUnitTestCase
 {

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -25,6 +25,8 @@ use Config\Services;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class PagerTest extends CIUnitTestCase
 {

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class PublisherInputTest extends CIUnitTestCase
 {

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -17,6 +17,8 @@ use org\bovigo\vfs\vfsStreamDirectory;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class PublisherOutputTest extends CIUnitTestCase
 {

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -21,6 +21,8 @@ use CodeIgniter\Test\CIUnitTestCase;
  * file properly prevent disallowed actions.
  *
  * @internal
+ *
+ * @group Others
  */
 final class PublisherRestrictionsTest extends CIUnitTestCase
 {

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -17,6 +17,8 @@ use Tests\Support\Publishers\TestPublisher;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class PublisherSupportTest extends CIUnitTestCase
 {

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -22,6 +22,8 @@ use Config\Modules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class AutoRouterImprovedTest extends CIUnitTestCase
 {

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -19,6 +19,8 @@ use Generator;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class RouteCollectionReverseRouteTest extends CIUnitTestCase
 {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -18,6 +18,8 @@ use Tests\Support\Controllers\Hello;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class RouteCollectionTest extends CIUnitTestCase
 {

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -22,6 +22,8 @@ use Tests\Support\Filters\Customfilter;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class RouterTest extends CIUnitTestCase
 {

--- a/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
@@ -23,6 +23,8 @@ use Config\Security as SecurityConfig;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SecurityCSRFCookieRandomizeTokenTest extends CIUnitTestCase
 {

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -27,6 +27,8 @@ use Config\Services;
  * @backupGlobals enabled
  *
  * @internal
+ *
+ * @group Others
  */
 final class SecurityTest extends CIUnitTestCase
 {

--- a/tests/system/SparkTest.php
+++ b/tests/system/SparkTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class SparkTest extends CIUnitTestCase
 {

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -22,6 +22,8 @@ namespace CodeIgniter\Test;
  * from correctFCPATH();
  *
  * @internal
+ *
+ * @group Others
  */
 final class BootstrapFCPATHTest extends CIUnitTestCase
 {

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -13,6 +13,8 @@ namespace CodeIgniter\Test;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DOMParserTest extends CIUnitTestCase
 {

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -20,6 +20,8 @@ use Tests\Support\Models\UserModel;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FabricatorTest extends CIUnitTestCase
 {

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -25,6 +25,8 @@ use Tests\Support\Filters\Customfilter;
  *  - class: \Tests\Support\Filters\Customfilter::class
  *
  * @internal
+ *
+ * @group Others
  */
 final class FilterTestTraitTest extends CIUnitTestCase
 {

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -13,6 +13,8 @@ namespace CodeIgniter\Test;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ReflectionHelperTest extends CIUnitTestCase
 {

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -19,6 +19,8 @@ use Config\App;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TestCaseTest extends CIUnitTestCase
 {

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\AssertionFailedError;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TestResponseTest extends CIUnitTestCase
 {

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -17,6 +17,8 @@ use CodeIgniter\Test\Mock\MockCache;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ThrottleTest extends CIUnitTestCase
 {

--- a/tests/system/Typography/TypographyTest.php
+++ b/tests/system/Typography/TypographyTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TypographyTest extends CIUnitTestCase
 {

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -18,6 +18,8 @@ use Tests\Support\Validation\TestRules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CreditCardRulesTest extends CIUnitTestCase
 {

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -18,6 +18,8 @@ use Tests\Support\Validation\TestRules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileRulesTest extends CIUnitTestCase
 {

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -19,6 +19,8 @@ use Tests\Support\Validation\TestRules;
 /**
  * @internal
  *
+ * @group Others
+ *
  * @no-final
  */
 class FormatRulesTest extends CIUnitTestCase

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -20,6 +20,8 @@ use Tests\Support\Validation\TestRules;
 /**
  * @internal
  *
+ * @group Others
+ *
  * @no-final
  */
 class RulesTest extends CIUnitTestCase

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -19,6 +19,8 @@ use Tests\Support\Validation\TestRules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CreditCardRulesTest extends CIUnitTestCase
 {

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -19,6 +19,8 @@ use Tests\Support\Validation\TestRules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FileRulesTest extends CIUnitTestCase
 {

--- a/tests/system/Validation/StrictRules/FormatRulesTest.php
+++ b/tests/system/Validation/StrictRules/FormatRulesTest.php
@@ -17,6 +17,8 @@ use Tests\Support\Validation\TestRules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class FormatRulesTest extends TraditionalFormatRulesTest
 {

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -18,6 +18,8 @@ use Tests\Support\Validation\TestRules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class RulesTest extends TraditionalRulesTest
 {

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -16,6 +16,8 @@ use Tests\Support\Validation\TestRules;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ValidationTest extends TraditionalValidationTest
 {

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -26,6 +26,8 @@ use TypeError;
 /**
  * @internal
  *
+ * @group Others
+ *
  * @no-final
  */
 class ValidationTest extends CIUnitTestCase

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -18,6 +18,8 @@ use CodeIgniter\View\Exceptions\ViewException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CellTest extends CIUnitTestCase
 {

--- a/tests/system/View/DecoratorsTest.php
+++ b/tests/system/View/DecoratorsTest.php
@@ -20,6 +20,8 @@ use Tests\Support\View\WorldDecorator;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class DecoratorsTest extends CIUnitTestCase
 {

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -17,6 +17,8 @@ use Config\View;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ParserFilterTest extends CIUnitTestCase
 {

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -17,6 +17,8 @@ use Config\Services;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ParserPluginTest extends CIUnitTestCase
 {

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -21,6 +21,8 @@ use stdClass;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ParserTest extends CIUnitTestCase
 {

--- a/tests/system/View/TableTest.php
+++ b/tests/system/View/TableTest.php
@@ -18,6 +18,8 @@ use stdClass;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class TableTest extends CIUnitTestCase
 {

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -19,6 +19,8 @@ use RuntimeException;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class ViewTest extends CIUnitTestCase
 {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Since we have `DatabaseLive`, `CacheLive`, `SeparateProcess`, `AutoReview` groups already, I think we need a catch-all group for the others for consistency.

Use case: Since there are existing groups already for tests, I find that useful for my refactoring of the phpunit tests to be more efficient. The drawback is that not all tests have groups, which would unnecessarily add logic of excluding _groups_ instead of adding _group_.

If you have a better term for the other group, I'm all ears.

In a separate PR, I'll add an autoreview test to enforce groups.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
