### PR TITLE
Turn on logging for deprecation notices by default

### DIFF
--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -60,7 +60,7 @@ class Exceptions extends BaseConfig
      * Use this option to temporarily cease the warnings and instead log those.
      * This option also works for user deprecations.
      */
-    public bool $logDeprecationsOnly = false;
+    public bool $logDeprecationsOnly = true;
 
     /**
      * --------------------------------------------------------------------------

--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -60,13 +60,13 @@ class Exceptions extends BaseConfig
      * Use this option to temporarily cease the warnings and instead log those.
      * This option also works for user deprecations.
      */
-    public bool $logDeprecationsOnly = true;
+    public bool $logDeprecations = true;
 
     /**
      * --------------------------------------------------------------------------
      * LOG LEVEL THRESHOLD FOR DEPRECATIONS
      * --------------------------------------------------------------------------
-     * If `$logDeprecationsOnly` is set to `true`, this sets the log level
+     * If `$logDeprecations` is set to `true`, this sets the log level
      * to which the deprecation will be logged. This should be one of the log
      * levels recognized by PSR-3.
      *

--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -38,7 +38,7 @@ class Logger extends BaseConfig
      *
      * @var array|int
      */
-    public $threshold = 4;
+    public $threshold = (ENVIRONMENT === 'production') ? 4 : 9;
 
     /**
      * --------------------------------------------------------------------------

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -71,6 +71,7 @@
 
     <php>
         <server name="app.baseURL" value="http://example.com/"/>
+        <server name="CODEIGNITER_SCREAM_DEPRECATIONS" value="1"/>
         <!-- Directory containing phpunit.xml -->
         <const name="HOMEPATH" value="./"/>
         <!-- Directory containing the Paths config file -->

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -83,8 +83,8 @@ class Exceptions
         if (! isset($this->config->sensitiveDataInTrace)) {
             $this->config->sensitiveDataInTrace = [];
         }
-        if (! isset($this->config->logDeprecationsOnly, $this->config->deprecationLogLevel)) {
-            $this->config->logDeprecationsOnly = false;
+        if (! isset($this->config->logDeprecations, $this->config->deprecationLogLevel)) {
+            $this->config->logDeprecations     = false;
             $this->config->deprecationLogLevel = LogLevel::WARNING;
         }
     }
@@ -164,7 +164,7 @@ class Exceptions
                 return true;
             }
 
-            if (! $this->config->logDeprecationsOnly || (bool) env('CODEIGNITER_SCREAM_DEPRECATIONS')) {
+            if (! $this->config->logDeprecations || (bool) env('CODEIGNITER_SCREAM_DEPRECATIONS')) {
                 throw new ErrorException($message, 0, $severity, $file, $line);
             }
 

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -158,7 +158,11 @@ class Exceptions
      */
     public function errorHandler(int $severity, string $message, ?string $file = null, ?int $line = null)
     {
-        if ($this->isDeprecationError($severity) && $this->config->logDeprecationsOnly) {
+        if ($this->isDeprecationError($severity)) {
+            if (! $this->config->logDeprecationsOnly || (bool) env('CODEIGNITER_SCREAM_DEPRECATIONS')) {
+                throw new ErrorException($message, 0, $severity, $file, $line);
+            }
+
             return $this->handleDeprecationError($message, $file, $line);
         }
 

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -159,6 +159,11 @@ class Exceptions
     public function errorHandler(int $severity, string $message, ?string $file = null, ?int $line = null)
     {
         if ($this->isDeprecationError($severity)) {
+            // @TODO Remove if Faker is fixed.
+            if ($this->isFakerDeprecationError($message, $file, $line)) {
+                return true;
+            }
+
             if (! $this->config->logDeprecationsOnly || (bool) env('CODEIGNITER_SCREAM_DEPRECATIONS')) {
                 throw new ErrorException($message, 0, $severity, $file, $line);
             }
@@ -167,12 +172,6 @@ class Exceptions
         }
 
         if (error_reporting() & $severity) {
-            // @TODO Remove if Faker is fixed.
-            if ($this->isFakerDeprecationError($severity, $message, $file, $line)) {
-                // Ignore the error.
-                return true;
-            }
-
             throw new ErrorException($message, 0, $severity, $file, $line);
         }
 
@@ -184,11 +183,10 @@ class Exceptions
      *
      * @see https://github.com/FakerPHP/Faker/issues/479
      */
-    private function isFakerDeprecationError(int $severity, string $message, ?string $file = null, ?int $line = null)
+    private function isFakerDeprecationError(string $message, ?string $file = null, ?int $line = null)
     {
         if (
-            $severity === E_DEPRECATED
-            && strpos($file, VENDORPATH . 'fakerphp/faker/') !== false
+            strpos($file, VENDORPATH . 'fakerphp/faker/') !== false
             && $message === 'Use of "static" in callables is deprecated'
         ) {
             log_message(

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -31,6 +31,20 @@ final class ExceptionsTest extends CIUnitTestCase
 
     private \CodeIgniter\Debug\Exceptions $exception;
 
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        unset($_SERVER['CODEIGNITER_SCREAM_DEPRECATIONS']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        $_SERVER['CODEIGNITER_SCREAM_DEPRECATIONS'] = '1';
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -59,7 +59,7 @@ final class ExceptionsTest extends CIUnitTestCase
     {
         $config = new ExceptionsConfig();
 
-        $config->logDeprecationsOnly = true;
+        $config->logDeprecations     = true;
         $config->deprecationLogLevel = 'error';
 
         $this->exception = new Exceptions($config, Services::request(), Services::response());
@@ -83,7 +83,7 @@ final class ExceptionsTest extends CIUnitTestCase
     {
         $config = new ExceptionsConfig();
 
-        $config->logDeprecationsOnly = true;
+        $config->logDeprecations     = true;
         $config->deprecationLogLevel = 'error';
 
         $this->exception = new Exceptions($config, Services::request(), Services::response());

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -221,7 +221,9 @@ Helpers and Functions
 Error Handling
 ==============
 
-- You can now log deprecation errors instead of throwing them. See :ref:`logging_deprecation_errors` for details.
+- You can now log deprecation warnings instead of throwing exceptions. See :ref:`logging_deprecation_warnings` for details.
+- Logging of deprecations is turned on by default.
+- To *temporarily* enable throwing of deprecations, set the environment variable ``CODEIGNITER_SCREAM_DEPRECATIONS`` to a truthy value.
 
 Others
 ======

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -224,6 +224,7 @@ Error Handling
 - You can now log deprecation warnings instead of throwing exceptions. See :ref:`logging_deprecation_warnings` for details.
 - Logging of deprecations is turned on by default.
 - To *temporarily* enable throwing of deprecations, set the environment variable ``CODEIGNITER_SCREAM_DEPRECATIONS`` to a truthy value.
+- ``Config\Logger::$threshold`` is now, by default, environment-specific. For production environment, default threshold is still ``4`` but changed to ``9`` for other environments.
 
 Others
 ======
@@ -272,4 +273,3 @@ Bugs Fixed
 **********
 
 - Fixed a bug when all types of ``Prepared Queries`` were returning a ``Result`` object instead of a bool value for write-type queries.
-

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -134,10 +134,10 @@ Since v4.3.0, you can specify the exit code for your Exception class to implemen
 
 When an exception implementing ``HasExitCodeInterface`` is caught by CodeIgniter's exception handler, the code returned from the ``getExitCode()`` method will become the exit code.
 
-.. _logging_deprecation_errors:
+.. _logging_deprecation_warnings:
 
-Logging Deprecation Errors
-==========================
+Logging Deprecation Warnings
+============================
 
 .. versionadded:: 4.3.0
 
@@ -161,3 +161,6 @@ After that, subsequent deprecations will be logged instead of thrown.
 This feature also works with user deprecations:
 
 .. literalinclude:: errors/014.php
+
+For testing your application you may want to always throw on deprecations. You may configure this by
+setting the environment variable ``CODEIGNITER_SCREAM_DEPRECATIONS`` to a truthy value.

--- a/user_guide_src/source/general/errors/012.php
+++ b/user_guide_src/source/general/errors/012.php
@@ -9,6 +9,6 @@ class Exceptions extends BaseConfig
 {
     // ... other properties
 
-    public bool $logDeprecationsOnly   = true;
+    public bool $logDeprecations       = true;
     public string $deprecationLogLevel = LogLevel::WARNING; // this should be one of the log levels supported by PSR-3
 }

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -178,7 +178,7 @@ The following files received significant changes (including deprecations or visu
 and it is recommended that you merge the updated versions with your application:
 
 * ``app/Config/Exceptions.php``
-    * Two additional public properties were added: ``$logDeprecationsOnly`` and ``$deprecationLogLevel``.
+    * Two additional public properties were added: ``$logDeprecations`` and ``$deprecationLogLevel``.
 * ``app/Config/Routes.php``
     * Due to the fact that the approach to running Spark Commands has changed, there is no longer a need to load the internal routes of the framework.
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Following up on #6705 , this turns on the feature by default.

Deprecation notices should not halt execution. These notices are here to _notify_ the users that something will not work in the _future_. They should not be forced to fix it now.

This PR changes the following:
- Turns on deprecation logging
- Raise logger reporting threshold to `5`
- Use the env variable `CODEIGNITER_SCREAM_DEPRECATIONS` to temporarily throw deprecations in tests (for convenience rather than changing the config).

Related: #6764

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
