### PR TITLE
fix: add missing ResultInterface::getNumRows()

### DIFF
--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -127,6 +127,11 @@ interface ResultInterface
     public function getPreviousRow(string $type = 'object');
 
     /**
+     * Returns number of rows in the result set.
+     */
+    public function getNumRows(): int;
+
+    /**
      * Returns an unbuffered row and move the pointer to the next row.
      *
      * @return mixed

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -62,6 +62,7 @@ Interface Changes
 - Now ``RequestInterface`` extends ``MessageInterface``.
 - Now ``ResponseInterface`` extends ``MessageInterface``.
 - Added missing ``ResponseInterface::getCSP()`` (and ``Response::getCSP()``), ``ResponseInterface::getReasonPhrase()`` and ``ResponseInterface::getCookieStore()`` methods.
+- Added missing ``CodeIgniter\Database\ResultInterface::getNumRows()`` method.
 - See also `Validation Changes`_.
 
 Method Signature Changes


### PR DESCRIPTION
**Description**
Fixes #6776
See #4356

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
