### PR TITLE
Remove testing of deprecated methods in CookieStore

### DIFF
--- a/tests/system/Cookie/CookieStoreTest.php
+++ b/tests/system/Cookie/CookieStoreTest.php
@@ -14,7 +14,6 @@ namespace CodeIgniter\Cookie;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\Test\CIUnitTestCase;
 use DateTimeImmutable;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @internal
@@ -94,29 +93,6 @@ final class CookieStoreTest extends CIUnitTestCase
         $this->assertTrue($bottle->has('test'));
         $this->assertTrue($store->has('dev'));
         $this->assertFalse($jar->has('dev'));
-    }
-
-    public function testCookieDispatching(): void
-    {
-        $cookies = [
-            'dev'  => new Cookie('dev', 'cookie'),
-            'prod' => new Cookie('prod', 'cookie', ['raw' => true]),
-        ];
-
-        $dev  = $cookies['dev']->getOptions();
-        $prod = $cookies['prod']->getOptions();
-
-        /**
-         * @var CookieStore&MockObject $store
-         */
-        $store = $this->getMockBuilder(CookieStore::class)
-            ->setConstructorArgs([$cookies])
-            ->onlyMethods(['setRawCookie', 'setCookie'])
-            ->getMock();
-
-        $store->expects($this->once())->method('setRawCookie')->with('prod', 'cookie', $prod);
-        $store->expects($this->once())->method('setCookie')->with('dev', 'cookie', $dev);
-        $store->dispatch();
     }
 
     public function testCookiesFunction(): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Found in #6773 
Since the deprecated methods have `@codeCoverageIgnore` already, no testing is needed to cover those methods.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide

<!--

**Notes**
- Pull requests must be in English
- If the PR solves an issue, reference it with a suitable verb and the issue number
(e.g. fixes <hash>12345)
- Unsolicited pull requests will be considered, but there is no guarantee of acceptance
- Pull requests should be from a feature branch in the contributor's fork of the repository
  to the develop branch of the project repository

-->
