### PR TITLE
docs: fix sub section level in caching.rst

### DIFF
--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -23,33 +23,34 @@ You can grab an instance of the cache engine directly through the Services class
 
 .. literalinclude:: caching/002.php
 
+*********************
 Configuring the Cache
-=====================
+*********************
 
 All configuration for the cache engine is done in **app/Config/Cache.php**. In that file,
 the following items are available.
 
 $handler
---------
+========
 
 The is the name of the handler that should be used as the primary handler when starting up the engine.
 Available names are: dummy, file, memcached, redis, predis, wincache.
 
 $backupHandler
---------------
+==============
 
 In the case that the first choice ``$handler`` is not available, this is the next cache handler to load.
 This is commonly the ``File`` handler since the file system is always available, but may not fit
 more complex, multi-server setups.
 
 $prefix
--------
+=======
 
 If you have more than one application using the same cache storage, you can add a custom prefix
 string here that is prepended to all key names.
 
 $ttl
-----
+====
 
 The default number of seconds to save items when none is specified.
 
@@ -57,17 +58,17 @@ WARNING: This is not used by framework handlers where 60 seconds is hard-coded, 
 to projects and modules. This will replace the hard-coded value in a future release.
 
 $file
------
+=====
 
 This is an array of settings specific to the  ``File`` handler to determine how it should save the cache files.
 
 $memcached
-----------
+==========
 
 This is an array of servers that will be used when using the ``Memcache(d)`` handler.
 
 $redis
-------
+======
 
 The settings for the Redis server that you wish to use when using the ``Redis`` and ``Predis`` handler.
 


### PR DESCRIPTION
**Description**
Before:
![Screenshot 2022-10-30 9 13 08](https://user-images.githubusercontent.com/87955/198857049-6b40b1ac-4606-4314-b5b0-1c1aa0c0db91.png)

After:
![Screenshot 2022-10-30 9 13 15](https://user-images.githubusercontent.com/87955/198857056-f24b26cc-7932-4801-8092-4e912f510a10.png)


**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

