### PR TITLE
docs: add missing `\` for consistency

### DIFF
--- a/user_guide_src/source/libraries/images/002.php
+++ b/user_guide_src/source/libraries/images/002.php
@@ -1,3 +1,3 @@
 <?php
 
-$image = Config\Services::image('imagick');
+$image = \Config\Services::image('imagick');

--- a/user_guide_src/source/testing/controllers/005.php
+++ b/user_guide_src/source/testing/controllers/005.php
@@ -1,6 +1,6 @@
 <?php
 
-$config              = new Config\App();
+$config              = new \Config\App();
 $config->appTimezone = 'America/Chicago';
 
 $results = $this->withConfig($config)


### PR DESCRIPTION
**Description**
- add missing `\`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

