### PR TITLE
Enable xdebug regardless of coverage option

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl
-          extensions: imagick, sqlsrv, gd, sqlite3, redis, memcached, oci8, pgsql
+          extensions: imagick, sqlsrv, gd, sqlite3, redis, memcached, oci8, pgsql, xdebug
           coverage: ${{ env.COVERAGE_DRIVER }}
         env:
           update: true
@@ -200,7 +200,8 @@ jobs:
         with:
           php-version: ${{ env.COVERAGE_PHP_VERSION }}
           tools: composer
-          coverage: xdebug
+          extensions: xdebug
+          coverage: none
         env:
           update: true
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Apparently, `CIUnitTestCase::assertHeaderEmitted()` and `CIUnitTestCase::assertHeaderNotEmitted()` requires `xdebug_get_headers()` but we disabled `xdebug` on PHP_VERSION !== '8.1'.

Not sure if this would work. 🤞 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
