### PR TITLE
fix: output "0" at the end of toolbar js when Kint::$enabled_mode is false

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -405,6 +405,7 @@ class Toolbar
             $kintScript         = @Kint::dump('');
             Kint::$mode_default = $oldKintMode;
             $kintScript         = substr($kintScript, 0, strpos($kintScript, '</style>') + 8);
+            $kintScript         = ($kintScript === '0') ? '' : $kintScript;
 
             $script = PHP_EOL
                 . '<script type="text/javascript" ' . csp_script_nonce() . ' id="debugbar_loader" '


### PR DESCRIPTION
**Description**
The following controller outputs `0` if you enable debug toolbar.
`<script  id="debugbar_loader" data-time="1667373293.313775" src="[http://localhost:8080/index.php?debugbar](view-source:http://localhost:8080/index.php?debugbar)"></script><script  id="debugbar_dynamic_script"></script><style type="text/css"  id="debugbar_dynamic_style"></style>0`

```php
<?php

namespace App\Controllers;

use Kint;

class Home extends BaseController
{
    public function index()
    {
        Kint::$enabled_mode = false;

        return '';
    }
}
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
