### PR TITLE
fix: variable types for PHPStan 1.9.0

### DIFF
--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -141,7 +141,7 @@ class Connection extends BaseConnection
         $errors = [];
 
         foreach (sqlsrv_errors(SQLSRV_ERR_ERRORS) as $error) {
-            $errors[] = preg_replace('/(\[.+\]\[.+\](?:\[.+\])?)(.+)/', '$2', $error['message']);
+            $errors[] = (string) preg_replace('/(\[.+\]\[.+\](?:\[.+\])?)(.+)/', '$2', $error['message']);
         }
 
         throw new DatabaseException(implode("\n", $errors));

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -474,7 +474,7 @@ class CURLRequest extends Request
                 }
 
                 if (isset($matches[2])) {
-                    $this->response->setStatusCode($matches[2], $matches[3] ?? null);
+                    $this->response->setStatusCode((int) $matches[2], $matches[3] ?? null);
                 }
             }
         }

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -598,7 +598,7 @@ if (! function_exists('increment_string')) {
     {
         preg_match('/(.+)' . preg_quote($separator, '/') . '([0-9]+)$/', $str, $match);
 
-        return isset($match[2]) ? $match[1] . $separator . ($match[2] + 1) : $str . $separator . $first;
+        return isset($match[2]) ? $match[1] . $separator . ((int) $match[2] + 1) : $str . $separator . $first;
     }
 }
 

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -103,7 +103,7 @@ class MemcachedHandler extends BaseHandler
                 continue;
             }
 
-            if (! $this->memcached->addServer($match[1], $match[2], $match[3] ?? 0)) {
+            if (! $this->memcached->addServer($match[1], (int) $match[2], $match[3] ?? 0)) {
                 $this->logger->error('Could not add ' . $match[1] . ':' . $match[2] . ' to Memcached server pool.');
             } else {
                 $serverList[] = $match[1] . ':' . $match[2];


### PR DESCRIPTION
**Description**
- PHPStan 1.9.0 reported errors.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
