### PR TITLE
fix: [4.3] remove ignoreErrors item for PHPStan 1.9.0

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -51,11 +51,6 @@ parameters:
 			path: system/Cache/Handlers/RedisHandler.php
 
 		-
-			message: "#^Strict comparison using === between array<mixed, mixed> and array{} will always evaluate to false\\.$#"
-			count: 1
-			path: system/CLI/Console.php
-
-		-
 			message: "#^Call to an undefined method CodeIgniter\\\\HTTP\\\\Request\\:\\:getPost\\(\\)\\.$#"
 			count: 1
 			path: system/CodeIgniter.php


### PR DESCRIPTION
~~Needs #6810~~

**Description**
- PHPStan 1.9.0 reported errors.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
