### PR TITLE
Prep for 4.2.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v4.2.10](https://github.com/codeigniter4/CodeIgniter4/tree/v4.2.10) (2022-11-05)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.2.9...v4.2.10)
+
+### Fixed Bugs
+* docs: fix PHPDoc types in Session by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6796
+* fix: output "0" at the end of toolbar js when Kint::$enabled_mode is false by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6809
+
+### Refactoring
+* Refactor assertHeaderEmitted and assertHeaderNotEmitted by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/6806
+* fix: variable types for PHPStan 1.9.0 by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6810
+
 ## [v4.2.9](https://github.com/codeigniter4/CodeIgniter4/tree/v4.2.9) (2022-10-30)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.2.8...v4.2.9)
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -47,7 +47,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.2.8';
+    public const CI_VERSION = '4.2.10';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.2.10
     v4.2.9
     v4.2.8
     v4.2.7

--- a/user_guide_src/source/changelogs/v4.2.10.rst
+++ b/user_guide_src/source/changelogs/v4.2.10.rst
@@ -1,0 +1,17 @@
+Version 4.2.10
+##############
+
+Release Date: November 5, 2022
+
+**4.2.10 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 2
+
+Bugs Fixed
+**********
+
+- Fixed incorrect PHPDoc types in Session.
+
+See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2022 CodeIgniter Foundation'
 version = '4.2'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.2.8'
+release = '4.2.10'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_4210.rst
+++ b/user_guide_src/source/installation/upgrade_4210.rst
@@ -1,0 +1,26 @@
+##############################
+Upgrading from 4.2.9 to 4.2.10
+##############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+Project Files
+*************
+
+Version ``4.2.10`` did not alter any executable code in project files.
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+* composer.json

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -16,6 +16,7 @@ See also :doc:`./backward_compatibility_notes`.
 
     backward_compatibility_notes
 
+    upgrade_4210
     upgrade_428
     upgrade_427
     upgrade_426


### PR DESCRIPTION
**Description**
Updates changelog and version references for `4.2.10`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
