### PR TITLE
fix: Model cannot insert when $useAutoIncrement is false

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -710,8 +710,13 @@ class Model extends BaseModel
 
         // Always grab the primary key otherwise updates will fail.
         if (
-            method_exists($data, 'toRawArray') && (! empty($properties) && ! empty($this->primaryKey) && ! in_array($this->primaryKey, $properties, true)
-            && ! empty($data->{$this->primaryKey}))
+            method_exists($data, 'toRawArray')
+            && (
+                ! empty($properties)
+                && ! empty($this->primaryKey)
+                && ! in_array($this->primaryKey, $properties, true)
+                && ! empty($data->{$this->primaryKey})
+            )
         ) {
             $properties[$this->primaryKey] = $data->{$this->primaryKey};
         }

--- a/system/Model.php
+++ b/system/Model.php
@@ -119,11 +119,11 @@ class Model extends BaseModel
     protected $escape = [];
 
     /**
-     * Primary Key data when inserting and useAutoIncrement is false.
+     * Primary Key value when inserting and useAutoIncrement is false.
      *
      * @var int|string|null
      */
-    private $tempPrimaryKeyData;
+    private $tempPrimaryKeyValue;
 
     /**
      * Builder method names that should not be used in the Model.
@@ -271,10 +271,10 @@ class Model extends BaseModel
         $this->escape = [];
 
         // If $useAutoIncrement is false, add the primary key data.
-        if ($this->useAutoIncrement === false && $this->tempPrimaryKeyData !== null) {
-            $data[$this->primaryKey] = $this->tempPrimaryKeyData;
+        if ($this->useAutoIncrement === false && $this->tempPrimaryKeyValue !== null) {
+            $data[$this->primaryKey] = $this->tempPrimaryKeyValue;
 
-            $this->tempPrimaryKeyData = null;
+            $this->tempPrimaryKeyValue = null;
         }
 
         // Require non-empty primaryKey when
@@ -676,7 +676,7 @@ class Model extends BaseModel
         }
 
         if ($this->useAutoIncrement === false && isset($data[$this->primaryKey])) {
-            $this->tempPrimaryKeyData = $data[$this->primaryKey];
+            $this->tempPrimaryKeyValue = $data[$this->primaryKey];
         }
 
         $this->escape   = $this->tempData['escape'] ?? [];

--- a/system/Model.php
+++ b/system/Model.php
@@ -119,6 +119,13 @@ class Model extends BaseModel
     protected $escape = [];
 
     /**
+     * Primary Key data when inserting and useAutoIncrement is false.
+     *
+     * @var int|string|null
+     */
+    private $tempPrimaryKeyData;
+
+    /**
      * Builder method names that should not be used in the Model.
      *
      * @var string[] method name
@@ -262,6 +269,13 @@ class Model extends BaseModel
     {
         $escape       = $this->escape;
         $this->escape = [];
+
+        // If $useAutoIncrement is false, add the primary key data.
+        if ($this->useAutoIncrement === false && $this->tempPrimaryKeyData !== null) {
+            $data[$this->primaryKey] = $this->tempPrimaryKeyData;
+
+            $this->tempPrimaryKeyData = null;
+        }
 
         // Require non-empty primaryKey when
         // not using auto-increment feature
@@ -659,6 +673,10 @@ class Model extends BaseModel
                 $data = $this->transformDataToArray($data, 'insert');
                 $data = array_merge($this->tempData['data'], $data);
             }
+        }
+
+        if ($this->useAutoIncrement === false && isset($data[$this->primaryKey])) {
+            $this->tempPrimaryKeyData = $data[$this->primaryKey];
         }
 
         $this->escape   = $this->tempData['escape'] ?? [];

--- a/tests/_support/Models/WithoutAutoIncrementModel.php
+++ b/tests/_support/Models/WithoutAutoIncrementModel.php
@@ -18,7 +18,6 @@ class WithoutAutoIncrementModel extends Model
     protected $table         = 'without_auto_increment';
     protected $primaryKey    = 'key';
     protected $allowedFields = [
-        'key',
         'value',
     ];
     protected $useAutoIncrement = false;


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=84733

- The `$primaryKey` field should never be an allowed field.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
