### PR TITLE
Fix: Controller Test withBody()

### DIFF
--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -108,7 +108,7 @@ trait ControllerTestTrait
             $tempUri = Services::uri();
             Services::injectMock('uri', $this->uri);
 
-            $this->withRequest(Services::request($this->appConfig, false)->setBody($this->body));
+            $this->withRequest(Services::request($this->appConfig, false));
 
             // Restore the URI service
             Services::injectMock('uri', $tempUri);
@@ -156,6 +156,7 @@ trait ControllerTestTrait
         }
 
         $response = null;
+        $this->request->setBody($this->body);
 
         try {
             ob_start();

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -13,10 +13,12 @@ namespace CodeIgniter\Test;
 
 use App\Controllers\Home;
 use App\Controllers\NeverHeardOfIt;
+use CodeIgniter\Controller;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use Config\App;
 use Config\Services;
+use Exception;
 use Tests\Support\Controllers\Popcorn;
 
 /**
@@ -240,5 +242,21 @@ final class ControllerTestTraitTest extends CIUnitTestCase
         $result = $this->controller(Popcorn::class)
             ->execute('toindex');
         $this->assertTrue($result->isRedirect());
+    }
+
+    public function testUsesRequestBody()
+    {
+        $this->controller = new class () extends Controller {
+            public function throwsBody(): void
+            {
+                throw new Exception($this->request->getBody());
+            }
+        };
+        $this->controller->initController($this->request, $this->response, $this->logger);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('banana');
+
+        $this->withBody('banana')->execute('throwsBody');
     }
 }


### PR DESCRIPTION
**Description**
The `ControllerTestTrait` "with___" methods use local property references to apply their changes before execution. This doesn't work for `$body` however because it is a string and not passed by reference, so using `withBody()` has no effect.

This PR moves the application of the body to the `execute()` method so it is properly applied to the request prior to execution.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
