### PR TITLE
Make Content Security Policy nonces optional

### DIFF
--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -185,4 +185,12 @@ class ContentSecurityPolicy extends BaseConfig
      * @var bool
      */
     public $autoNonce = true;
+    
+    /**
+     * When enabled will add nonce to script, style and headers.
+     *
+     * @var bool
+     */
+    public $nonceEnabled = true;
+    
 }

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -216,7 +216,7 @@ class ContentSecurityPolicy
      *
      * @var boolean
      */
-    protected $nounceEnabled = false;
+    protected $nonceEnabled = false;
 
     /**
      * An array of header info since we have
@@ -684,7 +684,7 @@ class ContentSecurityPolicy
         $body = preg_replace_callback($pattern, function ($match) {
             $nonce = $match[0] === $this->styleNonceTag ? $this->getStyleNonce() : $this->getScriptNonce();
 
-            return $this->nounceEnabled === false ? "" : "nonce=\"{$nonce}\"";
+            return $this->nonceEnabled === false ? "" : "nonce=\"{$nonce}\"";
         }, $body);
 
         $response->setBody($body);
@@ -795,7 +795,7 @@ class ContentSecurityPolicy
             }
 
             if (strpos($value, 'nonce-') === 0) {
-                if ($this->nounceEnabled === false) {
+                if ($this->nonceEnabled === false) {
                     $value = str_replace('nonce-', '', $value);
                 } else {
                     $value = "'{$value}'";

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -210,6 +210,13 @@ class ContentSecurityPolicy
      * @var bool
      */
     protected $autoNonce = true;
+    
+    /**
+     * When enabled will add nonce to script, style and headers otherwise nonces will be disabled.
+     *
+     * @var boolean
+     */
+    protected $nounceEnabled = false;
 
     /**
      * An array of header info since we have
@@ -677,7 +684,7 @@ class ContentSecurityPolicy
         $body = preg_replace_callback($pattern, function ($match) {
             $nonce = $match[0] === $this->styleNonceTag ? $this->getStyleNonce() : $this->getScriptNonce();
 
-            return "nonce=\"{$nonce}\"";
+            return $this->nounceEnabled === false ? "" : "nonce=\"{$nonce}\"";
         }, $body);
 
         $response->setBody($body);
@@ -788,7 +795,11 @@ class ContentSecurityPolicy
             }
 
             if (strpos($value, 'nonce-') === 0) {
-                $value = "'{$value}'";
+                if ($this->nounceEnabled === false) {
+                    $value = str_replace('nonce-', '', $value);
+                } else {
+                    $value = "'{$value}'";
+                }
             }
 
             if ($reportOnly === true) {


### PR DESCRIPTION
**Description**

Added a config option to make nonce optional.
There are many situations using third-party libs from google and others that doesn't work with nonces enabled as they inject new scripts or inline styles to their elements breaking their functionality.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Conforms to style guide
