### PR TITLE
Fix CreateDatabase leaving altered database config in connection

### DIFF
--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -148,8 +148,8 @@ class CreateDatabase extends BaseCommand
         } catch (Throwable $e) {
             $this->showError($e);
         } finally {
-            // Reset the altered config no matter what happens.
             Factories::reset('config');
+            Database::connect(null, false);
         }
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
When running `vendor/bin/phpunit --group DatabaseLive` either on GA or local, MigrationRunnerTest fails:

On GA:
```console
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.32
Configuration: /home/runner/work/CodeIgniter4/CodeIgniter4/phpunit.xml.dist

..S............................................................  63 / 516 ( 12%)
............S.S...S...........S................................ 126 / 516 ( 24%)
...................................................SSSSSSS..... 189 / 516 ( 36%)
............................................................... 252 / 516 ( 48%)
.............F................................................. 315 / 516 ( 61%)
............................................................... 378 / 516 ( 73%)
............................................................... 441 / 516 ( 85%)
..........SSSSSSSSSSSS......................................... 504 / 516 ( 97%)
............                                                    516 / 516 (100%)

Time: 00:[20](https://github.com/codeigniter4/CodeIgniter4/actions/runs/3456144117/jobs/5768709007#step:11:21).493, Memory: 102.00 MB

There was 1 failure:

1) CodeIgniter\Database\Migrations\MigrationRunnerTest::testLoadsDefaultDatabaseWhenNoneSpecified
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/home/runner/work/CodeIgniter4/CodeIgniter4/writable/database.db'
+'/home/runner/work/CodeIgniter4/CodeIgniter4/writable/foobar.db'

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Database/Migrations/MigrationRunnerTest.php:89
phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97
```

On local: (forgive the irrelevant failures)
```console
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.12
Configuration: C:\Users\P\Desktop\Web Dev\CodeIgniter4\phpunit.xml.dist

..S.....FFFF.FFFF..........................................................S.S...S...........S.................. 112 / 516 ( 21%)
.................................................................SSSSSSS........................................ 224 / 516 ( 43%)
.........................................F...................................................................... 336 / 516 ( 65%)
................................................................................................................ 448 / 516 ( 86%)
...SSSSSSSSSSSSSSSSSSS..............................................                                             516 / 516 (100%)

Nexus\PHPUnit\Extension\Tachycardia identified this sole slow test:
⚠  Took 1.86s from 0.50s limit to run CodeIgniter\\Database\\Live\\GroupTest::testOrNotHavingLike


Time: 01:20.643, Memory: 108.00 MB

There were 9 failures:

...

9) CodeIgniter\Database\Migrations\MigrationRunnerTest::testLoadsDefaultDatabaseWhenNoneSpecified
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-':memory:'
+'C:\Users\P\Desktop\Web Dev\CodeIgniter4\writable\foobar.db'
```

After this PR:
In local:
```console
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.12
Configuration: C:\Users\P\Desktop\Web Dev\CodeIgniter4\phpunit.xml.dist

..S.....FFFF.FFFF..........................................................S.S...S...........S.................. 112 / 516 ( 21%)
.................................................................SSSSSSS........................................ 224 / 516 ( 43%)
................................................................................................................ 336 / 516 ( 65%)
................................................................................................................ 448 / 516 ( 86%)
...SSSSSSSSSSSSSSSSSSS..............................................                                             516 / 516 (100%)

Time: 00:13.382, Memory: 108.00 MB
```

The reason for this is that all database live tests uses the shared DB connection (from `Database::connect()`). When `CreateDatabaseTest` runs for SQLite3, the tests alter the database to use `foobar.db` in the `Config\Database` instance. On cleanup, the altered config is reset. However, the protected `Database::$instances` array contains the shared DB connection which still uses the altered config. Running `Database::connect(null, false)` will effectively flush the old shared connection and create a new one using the fresh config.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
