### PR TITLE
fix: cast to string all values except arrays in Header class

### DIFF
--- a/system/HTTP/Header.php
+++ b/system/HTTP/Header.php
@@ -84,7 +84,7 @@ class Header
      */
     public function setValue($value = null)
     {
-        $this->value = $value ?? '';
+        $this->value = is_array($value) ? $value : (string) $value;
 
         return $this;
     }
@@ -108,7 +108,7 @@ class Header
         }
 
         if (! in_array($value, $this->value, true)) {
-            $this->value[] = $value;
+            $this->value[] = is_array($value) ? $value : (string) $value;
         }
 
         return $this;

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use Error;
 use stdClass;
 
 /**
@@ -43,6 +44,28 @@ final class HeaderTest extends CIUnitTestCase
         $this->assertSame('', $header->getValue());
     }
 
+    public function testHeaderStoresBasicWithInt()
+    {
+        $name  = 'foo';
+        $value = 123;
+
+        $header = new Header($name, $value);
+
+        $this->assertSame($name, $header->getName());
+        $this->assertSame((string) $value, $header->getValue());
+    }
+
+    public function testHeaderStoresBasicWithObject()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Object of class stdClass could not be converted to string');
+
+        $name  = 'foo';
+        $value = new stdClass();
+
+        $header = new Header($name, $value);
+    }
+
     public function testHeaderStoresArrayValues()
     {
         $name  = 'foo';
@@ -62,7 +85,7 @@ final class HeaderTest extends CIUnitTestCase
         $name  = 'foo';
         $value = [
             'bar',
-            'baz',
+            123,
         ];
 
         $header = new Header($name);
@@ -74,7 +97,7 @@ final class HeaderTest extends CIUnitTestCase
         $header->setName($name)->setValue($value);
         $this->assertSame($name, $header->getName());
         $this->assertSame($value, $header->getValue());
-        $this->assertSame($name . ': bar, baz', (string) $header);
+        $this->assertSame($name . ': bar, 123', (string) $header);
     }
 
     public function testHeaderAppendsValueSkippedForNull()
@@ -150,19 +173,6 @@ final class HeaderTest extends CIUnitTestCase
         ];
 
         $expected = 'bar, baz';
-
-        $header = new Header($name, $value);
-
-        $this->assertSame($name, $header->getName());
-        $this->assertSame($expected, $header->getValueLine());
-    }
-
-    public function testHeaderLineValueNotStringOrArray()
-    {
-        $name  = 'foo';
-        $value = new stdClass();
-
-        $expected = '';
 
         $header = new Header($name, $value);
 

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -63,7 +63,7 @@ final class HeaderTest extends CIUnitTestCase
         $name  = 'foo';
         $value = new stdClass();
 
-        $header = new Header($name, $value);
+        new Header($name, $value);
     }
 
     public function testHeaderStoresArrayValues()


### PR DESCRIPTION
**Description**
Fixes: #6842

I think that casting will be a better option than throwing an exception in this case.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
