### PR TITLE
fix: remove CI_DEBUG check in Model

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -419,13 +419,9 @@ class Model extends BaseModel
 
         if ($this->useSoftDeletes && ! $purge) {
             if (empty($builder->getCompiledQBWhere())) {
-                if (CI_DEBUG) {
-                    throw new DatabaseException(
-                        'Deletes are not allowed unless they contain a "where" or "like" clause.'
-                    );
-                }
-
-                return false; // @codeCoverageIgnore
+                throw new DatabaseException(
+                    'Deletes are not allowed unless they contain a "where" or "like" clause.'
+                );
             }
 
             $builder->where($this->deletedField);

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -271,11 +271,12 @@ Changes
     - All atomic type properties in ``Config`` classes have been typed.
     - Changed the default setting to not redirect when a CSRF check fails so that it is easy to see that it is a CSRF error.
     - The default ``Config\App::$appTimezone`` has been changed to ``UTC`` to avoid being affected by daylight saving time.
-- DBDebug
+- DBDebug and CI_DEBUG
     - To be consistent in behavior regardless of environments, ``Config\Database::$default['DBDebug']`` and ``Config\Database::$tests['DBDebug']`` has been changed to ``true`` by default. With these settings, an exception is always thrown when a database error occurs.
     - Now ``DatabaseException`` thrown in ``BaseBuilder`` is thrown if ``$DBDebug`` is true. Previously, it is thrown if ``CI_DEBUG`` is true.
     - The default value of ``BaseConnection::$DBDebug`` has been changed to ``true``.
     - With these changes, ``DBDebug`` now means whether or not to throw an exception when an error occurs. Although unrelated to debugging, the name has not been changed.
+    - Now when you delete without WHERE clause in ``Model``, ``DatabaseException`` is thrown even if ``CI_DEBUG`` is false. Previously, it is thrown if ``CI_DEBUG`` is true.
 - Changed the processing of Spark commands:
     - The ``CodeIgniter\CodeIgniter`` no longer handles Spark commands.
     - The ``CodeIgniter::isSparked()`` method has been removed.


### PR DESCRIPTION
**Description**
It is not good if the behavior changes only in the production environment.
It is impossible to write tests for the production environment (CI_DEBUG is false).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
