### PR TITLE
new make:cell command 

### DIFF
--- a/system/Commands/Generators/CellGenerator.php
+++ b/system/Commands/Generators/CellGenerator.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Generators;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\GeneratorTrait;
+
+/**
+ * Generates a skeleton Cell and its view.
+ */
+class CellGenerator extends BaseCommand
+{
+    use GeneratorTrait;
+
+    /**
+     * The Command's Group
+     *
+     * @var string
+     */
+    protected $group = 'Generators';
+
+    /**
+     * The Command's Name
+     *
+     * @var string
+     */
+    protected $name = 'make:cell';
+
+    /**
+     * The Command's Description
+     *
+     * @var string
+     */
+    protected $description = 'Generates a new Cell file and its view.';
+
+    /**
+     * The Command's Usage
+     *
+     * @var string
+     */
+    protected $usage = 'make:cell <name> [options]';
+
+    /**
+     * The Command's Arguments
+     *
+     * @var array
+     */
+    protected $arguments = [
+        'name' => 'The entity class name.',
+    ];
+
+    /**
+     * The Command's Options
+     *
+     * @var array
+     */
+    protected $options = [
+        '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',
+        '--suffix'    => 'Append the component title to the class name (e.g. User => UserCell).',
+        '--force'     => 'Force overwrite existing file.',
+    ];
+
+    /**
+     * Actually execute a command.
+     */
+    public function run(array $params)
+    {
+        // Generate the Class first
+        $this->component     = 'Cell';
+        $this->directory     = 'Cells';
+        $this->template      = 'cell.tpl.php';
+        $this->classNameLang = 'CLI.generator.className.cell';
+
+        $this->generateClass($params);
+
+        // Generate the View
+
+        // Form the view name
+        $segments = explode('\\', $this->qualifyClassName());
+
+        $view = array_pop($segments);
+        $view = str_replace('Cell', '', decamelize($view));
+        if (strpos($view, '_cell') === false) {
+            $view .= '_cell';
+        }
+        $segments[] = $view;
+        $view       = implode('\\', $segments);
+
+        $this->template = 'cell_view.tpl.php';
+
+        $this->generateView($view, $params);
+    }
+}

--- a/system/Commands/Generators/Views/cell.tpl.php
+++ b/system/Commands/Generators/Views/cell.tpl.php
@@ -1,0 +1,10 @@
+<@php
+
+namespace {namespace};
+
+use CodeIgniter\View\Cells\Cell;
+
+class {class} extends Cell
+{
+    //
+}

--- a/system/Commands/Generators/Views/cell_view.tpl.php
+++ b/system/Commands/Generators/Views/cell_view.tpl.php
@@ -1,0 +1,3 @@
+<div>
+    <!-- Your HTML here -->
+</div>

--- a/tests/system/Commands/CellGeneratorTest.php
+++ b/tests/system/Commands/CellGeneratorTest.php
@@ -62,7 +62,7 @@ final class CellGeneratorTest extends CIUnitTestCase
         // Check the view was generated
         $file = APPPATH . 'Cells/recent_cell.php';
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
-        $this->assertFileExists(APPPATH . 'Cells/recent_cell.php');
+        $this->assertFileExists($file);
     }
 
     /**
@@ -81,7 +81,7 @@ final class CellGeneratorTest extends CIUnitTestCase
         // Check the view was generated
         $file = APPPATH . 'Cells/another_cell.php';
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
-        $this->assertFileExists(APPPATH . 'Cells/another_cell.php');
+        $this->assertFileExists($file);
     }
 
     private function cleanUp()

--- a/tests/system/Commands/CellGeneratorTest.php
+++ b/tests/system/Commands/CellGeneratorTest.php
@@ -16,6 +16,8 @@ use CodeIgniter\Test\StreamFilterTrait;
 
 /**
  * @internal
+ *
+ * @group Others
  */
 final class CellGeneratorTest extends CIUnitTestCase
 {

--- a/tests/system/Commands/CellGeneratorTest.php
+++ b/tests/system/Commands/CellGeneratorTest.php
@@ -44,6 +44,9 @@ final class CellGeneratorTest extends CIUnitTestCase
         return file_get_contents($filepath) ?: '';
     }
 
+    /**
+     * @group Others
+     */
     public function testGenerateCell()
     {
         command('make:cell RecentCell');
@@ -60,6 +63,9 @@ final class CellGeneratorTest extends CIUnitTestCase
         $this->assertFileExists(APPPATH . 'Cells/recent_cell.php');
     }
 
+    /**
+     * @group Others
+     */
     public function testGenerateCellSimpleName()
     {
         command('make:cell Another');

--- a/tests/system/Commands/CellGeneratorTest.php
+++ b/tests/system/Commands/CellGeneratorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\StreamFilterTrait;
+
+/**
+ * @internal
+ */
+final class CellGeneratorTest extends CIUnitTestCase
+{
+    use StreamFilterTrait;
+
+    protected function tearDown(): void
+    {
+        $dirName = APPPATH . DIRECTORY_SEPARATOR . 'Cells';
+        // remove dir
+        if (is_dir($dirName)) {
+            $files = array_diff(scandir($dirName), ['.', '..']);
+
+            foreach ($files as $file) {
+                (is_dir("{$dirName}/{$file}")) ? rmdir("{$dirName}/{$file}") : unlink("{$dirName}/{$file}");
+            }
+            rmdir($dirName);
+        }
+    }
+
+    protected function getFileContents(string $filepath): string
+    {
+        if (! is_file($filepath)) {
+            return '';
+        }
+
+        return file_get_contents($filepath) ?: '';
+    }
+
+    public function testGenerateCell()
+    {
+        command('make:cell RecentCell');
+
+        // Check the class was generated
+        $file = APPPATH . 'Cells/RecentCell.php';
+        $this->assertFileExists($file);
+        $contents = $this->getFileContents($file);
+        $this->assertStringContainsString('class RecentCell extends Cell', $contents);
+
+        // Check the view was generated
+        $file = APPPATH . 'Cells/recent_cell.php';
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
+        $this->assertFileExists(APPPATH . 'Cells/recent_cell.php');
+    }
+
+    public function testGenerateCellSimpleName()
+    {
+        command('make:cell Another');
+
+        // Check the class was generated
+        $file = APPPATH . 'Cells/Another.php';
+        $this->assertFileExists($file);
+        $contents = $this->getFileContents($file);
+        $this->assertStringContainsString('class Another extends Cell', $contents);
+
+        // Check the view was generated
+        $file = APPPATH . 'Cells/another_cell.php';
+        $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
+        $this->assertFileExists(APPPATH . 'Cells/another_cell.php');
+    }
+
+    private function cleanUp()
+    {
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
+        $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
+        $dir    = dirname($file);
+
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($dir) && strpos($dir, 'Cells') !== false) {
+            rmdir($dir);
+        }
+    }
+}

--- a/tests/system/Commands/CellGeneratorTest.php
+++ b/tests/system/Commands/CellGeneratorTest.php
@@ -46,9 +46,6 @@ final class CellGeneratorTest extends CIUnitTestCase
         return file_get_contents($filepath) ?: '';
     }
 
-    /**
-     * @group Others
-     */
     public function testGenerateCell()
     {
         command('make:cell RecentCell');
@@ -65,9 +62,6 @@ final class CellGeneratorTest extends CIUnitTestCase
         $this->assertFileExists($file);
     }
 
-    /**
-     * @group Others
-     */
     public function testGenerateCellSimpleName()
     {
         command('make:cell Another');
@@ -82,19 +76,5 @@ final class CellGeneratorTest extends CIUnitTestCase
         $file = APPPATH . 'Cells/another_cell.php';
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
-    }
-
-    private function cleanUp()
-    {
-        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', $this->getStreamFilterBuffer());
-        $file   = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
-        $dir    = dirname($file);
-
-        if (is_file($file)) {
-            unlink($file);
-        }
-        if (is_dir($dir) && strpos($dir, 'Cells') !== false) {
-            rmdir($dir);
-        }
     }
 }

--- a/user_guide_src/source/outgoing/view_cells.rst
+++ b/user_guide_src/source/outgoing/view_cells.rst
@@ -98,6 +98,15 @@ At the most basic level, all you need to implement within the class are public p
         <?= $message; ?>
     </div>
 
+Generating Cell via Command
+===========================
+
+You can also create a controlled cell via a built in command from the CLI. The command is ``php spark make:cell``. It takes one argument, the name of the cell to create. The name should be in PascalCase, and the class will be created in the ``app/Cells`` directory. The view file will also be created in the ``app/Views/cells`` directory.
+
+```console
+php spark make:cell AlertMessage
+```
+
 Using a Different View
 ======================
 


### PR DESCRIPTION
Provides a new `make:cell` command to generate a controlled cell and its accompanying view. 

This includes a refactor on the GeneratorTrait to split out file creation to `generateClass` and `generateView`. The first working much like the existing `execute()` method which has been refactored to use the `generateClass` method.