### PR TITLE
Fix CreateDatabaseTest to not leave database

### DIFF
--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -31,21 +31,23 @@ final class CreateDatabaseTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         CITestStreamFilter::$buffer = '';
 
         $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
         $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
         $this->connection   = Database::connect();
 
-        parent::setUp();
         $this->dropDatabase();
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         stream_filter_remove($this->streamFilter);
 
-        parent::tearDown();
         $this->dropDatabase();
     }
 

--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -38,7 +38,24 @@ final class CreateDatabaseTest extends CIUnitTestCase
         $this->connection   = Database::connect();
 
         parent::setUp();
+        $this->dropDatabase();
+    }
 
+    protected function tearDown(): void
+    {
+        stream_filter_remove($this->streamFilter);
+
+        parent::tearDown();
+        $this->dropDatabase();
+    }
+
+    protected function getBuffer()
+    {
+        return CITestStreamFilter::$buffer;
+    }
+
+    private function dropDatabase(): void
+    {
         if ($this->connection instanceof SQLite3Connection) {
             $file = WRITEPATH . 'foobar.db';
             if (is_file($file)) {
@@ -51,18 +68,6 @@ final class CreateDatabaseTest extends CIUnitTestCase
                 Database::forge()->dropDatabase('foobar');
             }
         }
-    }
-
-    protected function tearDown(): void
-    {
-        stream_filter_remove($this->streamFilter);
-
-        parent::tearDown();
-    }
-
-    protected function getBuffer()
-    {
-        return CITestStreamFilter::$buffer;
     }
 
     public function testCreateDatabase()


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
The last test would leave the `foobar` database not dropped.

Follow up to #6856 and #6858 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
