### PR TITLE
Fix ShowTableInfoTest when migration records are numerous

### DIFF
--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -67,12 +67,8 @@ final class ShowTableInfoTest extends CIUnitTestCase
         $expected = 'Data of Table "db_migrations":';
         $this->assertStringContainsString($expected, $result);
 
-        $expected = <<<'EOL'
-            +----+----------------+--------------------+-------+---------------+------------+-------+
-            | id | version        | class              | group | namespace     | time       | batch |
-            +----+----------------+--------------------+-------+---------------+------------+-------+
-            EOL;
-        $this->assertStringContainsString($expected, $result);
+        $expectedPattern = '/\|\hid\h+\|\hversion\h+\|\hclass\h+\|\hgroup\h+\|\hnamespace\h+\|\htime\h+\|\hbatch\h\|/';
+        $this->assertMatchesRegularExpression($expectedPattern, $result);
     }
 
     public function testDbTableShow(): void

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -67,7 +67,7 @@ final class ShowTableInfoTest extends CIUnitTestCase
         $expected = 'Data of Table "db_migrations":';
         $this->assertStringContainsString($expected, $result);
 
-        $expectedPattern = '/\|\hid\h+\|\hversion\h+\|\hclass\h+\|\hgroup\h+\|\hnamespace\h+\|\htime\h+\|\hbatch\h\|/';
+        $expectedPattern = '/\| id[[:blank:]]+\| version[[:blank:]]+\| class[[:blank:]]+\| group[[:blank:]]+\| namespace[[:blank:]]+\| time[[:blank:]]+\| batch \|/';
         $this->assertMatchesRegularExpression($expectedPattern, $result);
     }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
When the migrations table has already recorded numerous migrations, there's a tendency that the id would be longer. The existing expected pattern only anticipates migrations run for the first time. However, repeated testing on local would accumulate the migration records. This PR instead resorted to regex matching.

Example failing message:
```console
3) CodeIgniter\Commands\Database\ShowTableInfoTest::testDbTable
Failed asserting that 'Data of Table "db_migrations":\n
\n
+-----+----------------+--------------------+-------+---------------+------------+-------+\n
| id  | version        | class              | group | namespace     | time       | batch |\n
+-----+----------------+--------------------+-------+---------------+------------+-------+\n
| 209 | 20160428212500 | Tests\Support\D... | tests | Tests\Support | 1668512072 | 1     |\n
+-----+----------------+--------------------+-------+---------------+------------+-------+\n
\n
' contains "+----+----------------+--------------------+-------+---------------+------------+-------+
| id | version        | class              | group | namespace     | time       | batch |
+----+----------------+--------------------+-------+---------------+------------+-------+".
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
