### PR TITLE
feat: disable BaseBuilder::setAlias()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1971,7 +1971,7 @@ class BaseBuilder
     /**
      * Set table alias for dataset sudo table.
      */
-    public function setAlias(string $alias): BaseBuilder
+    private function setAlias(string $alias): BaseBuilder
     {
         if ($alias !== '') {
             $this->db->addTableAlias($alias);

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -396,7 +396,7 @@ final class UpdateTest extends CIUnitTestCase
         $this->db->table('user')
             ->updateFields($updateFields)
             ->onConstraint(['email', new RawSql("{$esc}db_user{$esc}.{$esc}country{$esc} = {$esc}_update{$esc}.{$esc}country{$esc}")])
-            ->setAlias('_update')
+            ->setData($data, null, '_update')
             ->updateBatch($data);
 
         $result = $this->db->table('user')->get()->getResultArray();

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -397,7 +397,7 @@ final class UpdateTest extends CIUnitTestCase
             ->updateFields($updateFields)
             ->onConstraint(['email', new RawSql("{$esc}db_user{$esc}.{$esc}country{$esc} = {$esc}_update{$esc}.{$esc}country{$esc}")])
             ->setData($data, null, '_update')
-            ->updateBatch($data);
+            ->updateBatch();
 
         $result = $this->db->table('user')->get()->getResultArray();
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1842,16 +1842,6 @@ Class Reference
 
         Used for ``*Batch()`` methods to set data for insert, update, upsert.
 
-    .. php:method:: setAlias($alias)
-
-        :param string $alias: Alias for table
-        :returns:   ``BaseBuilder`` instance (method chaining)
-        :rtype:     ``BaseBuilder``
-
-        .. versionadded:: 4.3.0
-
-        This allows setting an alias for the psuedo table generated with ``setData()``.
-
     .. php:method:: setUpdateBatch($key[, $value = ''[, $escape = null]])
 
         :param mixed $key: Field name or an array of field/value pairs

--- a/user_guide_src/source/database/query_builder/092.php
+++ b/user_guide_src/source/database/query_builder/092.php
@@ -21,8 +21,7 @@ $builder->updateBatch($data, ['title', 'author']);
 $builder->setData($data)->onConstraint('title, author')->updateBatch();
 
 // OR
-$builder->setData($data)
-    ->setAlias('u')
+$builder->setData($data, null, 'u')
     ->onConstraint(['`mytable`.`title`' => '`u`.`title`', 'author' => new RawSql('`u`.`author`')])
     ->updateBatch();
 

--- a/user_guide_src/source/database/query_builder/110.php
+++ b/user_guide_src/source/database/query_builder/110.php
@@ -7,7 +7,7 @@ $data = [
     'country' => 'Afghanistan',
 ];
 
-$builder->updateFields('name, country')->setAlias('_upsert')->upsert($data);
+$builder->updateFields('name, country')->setData($data, null, '_upsert')->upsert($data);
 /* SQLSRV produces:
     MERGE INTO "test"."dbo"."db_user"
     USING (

--- a/user_guide_src/source/database/query_builder/110.php
+++ b/user_guide_src/source/database/query_builder/110.php
@@ -7,7 +7,7 @@ $data = [
     'country' => 'Afghanistan',
 ];
 
-$builder->updateFields('name, country')->setData($data, null, '_upsert')->upsert($data);
+$builder->updateFields('name, country')->setData($data, null, '_upsert')->upsert();
 /* SQLSRV produces:
     MERGE INTO "test"."dbo"."db_user"
     USING (


### PR DESCRIPTION
**Description**
Since there is not yet a consensus to make this method a public API, it will be disabled when v4.3.0 is released.

See https://github.com/codeigniter4/CodeIgniter4/pull/6734#discussion_r1013700177

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
