### PR TITLE
test: add `@var` in ExampleDatabaseTest

### DIFF
--- a/admin/starter/tests/database/ExampleDatabaseTest.php
+++ b/admin/starter/tests/database/ExampleDatabaseTest.php
@@ -31,6 +31,7 @@ final class ExampleDatabaseTest extends CIUnitTestCase
         $this->setPrivateProperty($model, 'useSoftDeletes', true);
         $this->setPrivateProperty($model, 'tempUseSoftDeletes', true);
 
+        /** @var stdClass $object */
         $object = $model->first();
         $model->delete($object->id);
 


### PR DESCRIPTION
**Description**
To prevent PHPStan from reporting errors.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
