### PR TITLE
[Entity] Properly identify boolean when its a string

### DIFF
--- a/system/Entity/Cast/BooleanCast.php
+++ b/system/Entity/Cast/BooleanCast.php
@@ -23,4 +23,12 @@ class BooleanCast extends BaseCast
     {
         return (bool) $value;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function set($value, array $params = []): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
 }

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -348,6 +348,11 @@ final class EntityTest extends CIUnitTestCase
 
         $this->assertIsBool($entity->fifth);
         $this->assertFalse($entity->fifth);
+
+        $entity->fifth = 'false';
+
+        $this->assertIsBool($entity->fifth);
+        $this->assertFalse($entity->fifth);
     }
 
     public function testCastCSV()


### PR DESCRIPTION
**Description**
When passing a string to a value cast as boolean it would always set as true. In some cases, such as a value of false from the post array identify as strings and would be cast as true regardless.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
