### PR TITLE
Add `is_windows()` global function

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -518,10 +518,12 @@ class CLI
 
     /**
      * if operating system === windows
+     *
+     * @deprecated v4.3 Use `is_windows()` instead
      */
     public static function isWindows(): bool
     {
-        return PHP_OS_FAMILY === 'Windows';
+        return is_windows();
     }
 
     /**
@@ -544,7 +546,7 @@ class CLI
     {
         // Unix systems, and Windows with VT100 Terminal support (i.e. Win10)
         // can handle CSI sequences. For lower than Win10 we just shove in 40 new lines.
-        static::isWindows() && ! static::streamSupports('sapi_windows_vt100_support', STDOUT)
+        is_windows() && ! static::streamSupports('sapi_windows_vt100_support', STDOUT)
             ? static::newLine(40)
             : static::fwrite(STDOUT, "\033[H\033[2J");
     }
@@ -691,7 +693,7 @@ class CLI
             return true;
         }
 
-        if (static::isWindows()) {
+        if (is_windows()) {
             // @codeCoverageIgnoreStart
             return static::streamSupports('sapi_windows_vt100_support', $resource)
                 || isset($_SERVER['ANSICON'])
@@ -736,7 +738,7 @@ class CLI
     public static function generateDimensions()
     {
         try {
-            if (static::isWindows()) {
+            if (is_windows()) {
                 // Shells such as `Cygwin` and `Git bash` returns incorrect values
                 // when executing `mode CON`, so we use `tput` instead
                 if (getenv('TERM') || (($shell = getenv('SHELL')) && preg_match('/(?:bash|zsh)(?:\.exe)?$/', $shell))) {

--- a/system/Common.php
+++ b/system/Common.php
@@ -725,8 +725,18 @@ if (! function_exists('is_windows')) {
     /**
      * Detect if platform is running in Windows.
      */
-    function is_windows(): bool
+    function is_windows(?bool $mock = null): bool
     {
+        static $mocked;
+
+        if (func_num_args() === 1) {
+            $mocked = $mock;
+        }
+
+        if (isset($mocked)) {
+            return $mocked;
+        }
+
         return DIRECTORY_SEPARATOR === '\\';
     }
 }

--- a/system/Common.php
+++ b/system/Common.php
@@ -721,6 +721,16 @@ if (! function_exists('is_really_writable')) {
     }
 }
 
+if (! function_exists('is_windows')) {
+    /**
+     * Detect if platform is running in Windows.
+     */
+    function is_windows(): bool
+    {
+        return DIRECTORY_SEPARATOR === '\\';
+    }
+}
+
 if (! function_exists('lang')) {
     /**
      * A convenience method to translate a string or array of them and format

--- a/system/Common.php
+++ b/system/Common.php
@@ -691,7 +691,7 @@ if (! function_exists('is_really_writable')) {
     function is_really_writable(string $file): bool
     {
         // If we're on a Unix server we call is_writable
-        if (DIRECTORY_SEPARATOR === '/') {
+        if (! is_windows()) {
             return is_writable($file);
         }
 

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -112,12 +112,6 @@ final class CLITest extends CIUnitTestCase
         PhpStreamWrapper::restore();
     }
 
-    public function testIsWindows()
-    {
-        $this->assertSame(('\\' === DIRECTORY_SEPARATOR), CLI::isWindows());
-        $this->assertSame(defined('PHP_WINDOWS_VERSION_MAJOR'), CLI::isWindows());
-    }
-
     public function testNewLine()
     {
         $this->expectOutputString('');

--- a/tests/system/Commands/GeneratorsTest.php
+++ b/tests/system/Commands/GeneratorsTest.php
@@ -61,7 +61,7 @@ final class GeneratorsTest extends CIUnitTestCase
 
     public function testGenerateFileFailsOnUnwritableDirectory()
     {
-        if ('\\' === DIRECTORY_SEPARATOR) {
+        if (is_windows()) {
             $this->markTestSkipped('chmod does not work as expected on Windows');
         }
 

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -700,4 +700,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         $this->resetServices();
     }
+
+    public function testIsWindows()
+    {
+        $this->assertSame(strpos(php_uname(), 'Windows') !== false, is_windows());
+        $this->assertSame(defined('PHP_WINDOWS_VERSION_MAJOR'), is_windows());
+    }
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -706,4 +706,19 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->assertSame(strpos(php_uname(), 'Windows') !== false, is_windows());
         $this->assertSame(defined('PHP_WINDOWS_VERSION_MAJOR'), is_windows());
     }
+
+    public function testIsWindowsUsingMock()
+    {
+        is_windows(true);
+        $this->assertTrue(is_windows());
+        $this->assertNotFalse(is_windows());
+
+        is_windows(false);
+        $this->assertFalse(is_windows());
+        $this->assertNotTrue(is_windows());
+
+        is_windows(null);
+        $this->assertSame(strpos(php_uname(), 'Windows') !== false, is_windows());
+        $this->assertSame(defined('PHP_WINDOWS_VERSION_MAJOR'), is_windows());
+    }
 }

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -237,6 +237,7 @@ Helpers and Functions
 - You can set the locale to :php:func:`route_to()` if you pass a locale value as the last parameter.
 - Added :php:func:`request()` and :php:func:`response()` functions.
 - Added :php:func:`decamelize()` function to convert camelCase to snake_case.
+- Added :php:func:`is_windows()` global function to detect Windows platforms.
 
 Error Handling
 ==============

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -299,6 +299,7 @@ Deprecations
 - ``CodeIgniter::$path`` and ``CodeIgniter::setPath()`` are deprecated. No longer used.
 - The public property ``IncomingRequest::$uri`` is deprecated. It will be protected. Use ``IncomingRequest::getUri()`` instead.
 - The public property ``IncomingRequest::$config`` is deprecated. It will be protected.
+- The method ``CLI::isWindows()`` is deprecated. Use ``is_windows()`` instead.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -281,6 +281,12 @@ Miscellaneous Functions
     :returns: true if you can write to the file, false otherwise.
     :rtype: bool
 
+.. php:function:: is_windows()
+
+    :rtype: bool
+
+    Detect if platform is running in Windows.
+
 .. php:function:: log_message($level, $message [, $context])
 
     :param   string   $level: The level of severity

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -281,11 +281,18 @@ Miscellaneous Functions
     :returns: true if you can write to the file, false otherwise.
     :rtype: bool
 
-.. php:function:: is_windows()
+.. php:function:: is_windows([$mock = null])
 
+    :param bool|null $mock: If given and is a boolean then it will be used as the return value.
     :rtype: bool
 
     Detect if platform is running in Windows.
+
+    .. note:: The boolean value provided to $mock will persist in subsequent calls. To reset this
+        mock value, the user must pass an explicit ``null`` to the function call. This will
+        refresh the function to use auto-detection.
+
+    .. literalinclude:: common_functions/012.php
 
 .. php:function:: log_message($level, $message [, $context])
 

--- a/user_guide_src/source/general/common_functions/012.php
+++ b/user_guide_src/source/general/common_functions/012.php
@@ -1,0 +1,11 @@
+<?php
+
+is_windows(true);
+
+// some code ...
+
+if (is_windows()) {
+    // do something ..
+}
+
+is_windows(null); // reset


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
- Adds `is_windows()` global function, for uniform detection of Windows platform
- Deprecate `CLI::isWindows()`, as platform detection is not limited to console
- Normalize platform detection

Related: #6882 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
