### PR TITLE
docs: fix Config file paths

### DIFF
--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -96,7 +96,7 @@ rule and message array formats, as well as available rules:
 .. literalinclude:: controllers/004.php
 
 If you find it simpler to keep the rules in the configuration file, you can replace
-the ``$rules`` array with the name of the group as defined in ``Config\Validation.php``:
+the ``$rules`` array with the name of the group as defined in **app/Config/Validation.php**:
 
 .. literalinclude:: controllers/005.php
 

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -54,7 +54,7 @@ for details.
 withConfig($config)
 -------------------
 
-Allows you to pass in a modified version of **Config\App.php** to test with different settings:
+Allows you to pass in a modified version of **app/Config/App.php** to test with different settings:
 
 .. literalinclude:: controllers/005.php
 


### PR DESCRIPTION
**Description**
- fix Config file paths

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
