### PR TITLE
fix: required PHP extentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Made with [contrib.rocks](https://contrib.rocks).
 PHP version 7.4 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
-- [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)
 
 Additionally, make sure that the following extensions are enabled in your PHP:
@@ -95,6 +94,7 @@ Additionally, make sure that the following extensions are enabled in your PHP:
 - json (enabled by default - don't turn it off)
 - xml (enabled by default - don't turn it off)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
+- [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
 
 ## Running CodeIgniter Tests
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ PHP version 7.4 or higher is required, with the following extensions installed:
 Additionally, make sure that the following extensions are enabled in your PHP:
 
 - json (enabled by default - don't turn it off)
-- xml (enabled by default - don't turn it off)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
 

--- a/admin/framework/README.md
+++ b/admin/framework/README.md
@@ -45,7 +45,6 @@ Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/
 PHP version 7.4 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
-- [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)
 
 Additionally, make sure that the following extensions are enabled in your PHP:
@@ -53,3 +52,4 @@ Additionally, make sure that the following extensions are enabled in your PHP:
 - json (enabled by default - don't turn it off)
 - xml (enabled by default - don't turn it off)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
+- [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library

--- a/admin/framework/README.md
+++ b/admin/framework/README.md
@@ -50,6 +50,5 @@ PHP version 7.4 or higher is required, with the following extensions installed:
 Additionally, make sure that the following extensions are enabled in your PHP:
 
 - json (enabled by default - don't turn it off)
-- xml (enabled by default - don't turn it off)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -6,7 +6,6 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "ext-curl": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -24,6 +23,7 @@
         "predis/predis": "^1.1 || ^2.0"
     },
     "suggest": {
+        "ext-curl": "If you use CURLRequest class",
         "ext-imagick": "If you use Image class ImageMagickHandler",
         "ext-gd": "If you use Image class GDHandler",
         "ext-exif": "If you run Image class tests",

--- a/admin/starter/README.md
+++ b/admin/starter/README.md
@@ -58,6 +58,5 @@ PHP version 7.4 or higher is required, with the following extensions installed:
 Additionally, make sure that the following extensions are enabled in your PHP:
 
 - json (enabled by default - don't turn it off)
-- xml (enabled by default - don't turn it off)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library

--- a/admin/starter/README.md
+++ b/admin/starter/README.md
@@ -53,7 +53,6 @@ Problems with it can be raised on our forum, or as issues in the main repository
 PHP version 7.4 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
-- [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)
 
 Additionally, make sure that the following extensions are enabled in your PHP:
@@ -61,3 +60,4 @@ Additionally, make sure that the following extensions are enabled in your PHP:
 - json (enabled by default - don't turn it off)
 - xml (enabled by default - don't turn it off)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
+- [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "ext-curl": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -29,6 +28,7 @@
         "rector/rector": "0.14.8"
     },
     "suggest": {
+        "ext-curl": "If you use CURLRequest class",
         "ext-imagick": "If you use Image class ImageMagickHandler",
         "ext-gd": "If you use Image class GDHandler",
         "ext-exif": "If you run Image class tests",

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -205,11 +205,9 @@ class CodeIgniter
     protected function resolvePlatformExtensions()
     {
         $requiredExtensions = [
-            'curl',
             'intl',
             'json',
             'mbstring',
-            'xml',
         ];
 
         $missingExtensions = [];

--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -2,18 +2,31 @@
 Server Requirements
 ###################
 
-`PHP <https://www.php.net/>`_ version 7.4 or newer is required, with the
-`*intl* extension <https://www.php.net/manual/en/intl.requirements.php>`_ and `*mbstring* extension <https://www.php.net/manual/en/mbstring.requirements.php>`_
-installed.
+`PHP <https://www.php.net/>`_ version 7.4 or newer is required, with the following PHP extensions are enabled:
+
+  - `intl <https://www.php.net/manual/en/intl.requirements.php>`_
+  - `mbstring <https://www.php.net/manual/en/mbstring.requirements.php>`_
+  - `json <https://www.php.net/manual/en/json.requirements.php>`_
 
 The following PHP extensions should be enabled on your server:
 
-  - ``php-json``
-  - ``php-mysqlnd`` (if you use MySQL)
-  - ``php-xml``
+  - `mysqlnd <https://www.php.net/manual/en/mysqlnd.install.php>`_ (if you use MySQL)
+  - `curl <https://www.php.net/manual/en/curl.requirements.php>`_ (if you use :doc:`CURLRequest </libraries/curlrequest>`)
+  - `imagick <https://www.php.net/manual/en/imagick.requirements.php>`_ (if you use :doc:`Image </libraries/images>` class ImageMagickHandler)
+  - `gd <https://www.php.net/manual/en/image.requirements.php>`_ (if you use :doc:`Image </libraries/images>` class GDHandler)
+  - `simplexml <https://www.php.net/manual/en/simplexml.requirements.php>`_ (if you format XML)
 
-In order to use the :doc:`CURLRequest </libraries/curlrequest>`, you will need
-`libcurl <https://www.php.net/manual/en/curl.requirements.php>`_ installed.
+The following PHP extensions are required when you use a Cache server:
+
+  - `memcache <https://www.php.net/manual/en/memcache.requirements.php>`_ (if you use :doc:`Cache </libraries/caching>` class MemcachedHandler with Memcache)
+  - `memcached <https://www.php.net/manual/en/memcached.requirements.php>`_ (if you use :doc:`Cache </libraries/caching>` class MemcachedHandler with Memcached)
+  - `redis <https://github.com/phpredis/phpredis>`_ (if you use :doc:`Cache </libraries/caching>` class RedisHandler)
+
+The following PHP extensions are required when you use PHPUnit:
+
+   - `dom <https://www.php.net/manual/en/dom.requirements.php>`_ (if you use :doc:`TestResponse </testing/response>` class)
+   - `libxml <https://www.php.net/manual/en/libxml.requirements.php>`_ (if you use :doc:`TestResponse </testing/response>` class)
+   - `xdebug <https://xdebug.org/docs/install>`_ (if you use ``CIUnitTestCase::assertHeaderEmitted()``)
 
 A database is required for most web application programming.
 Currently supported databases are:


### PR DESCRIPTION
**Description**
- update the docs
- remove `curl` and `xml` from required PHP extension check in `CodeIgniter`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
