### PR TITLE
fix: HTML output

### DIFF
--- a/app/Views/welcome_message.php
+++ b/app/Views/welcome_message.php
@@ -5,7 +5,7 @@
     <title>Welcome to CodeIgniter 4!</title>
     <meta name="description" content="The small framework with powerful features">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" type="image/png" href="/favicon.ico"/>
+    <link rel="shortcut icon" type="image/png" href="/favicon.ico">
 
     <!-- STYLES -->
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -408,7 +408,7 @@ class Toolbar
                 . 'data-time="' . $time . '" '
                 . 'src="' . site_url() . '?debugbar"></script>'
                 . '<script ' . csp_script_nonce() . ' id="debugbar_dynamic_script"></script>'
-                . '<style type="text/css" ' . csp_style_nonce() . ' id="debugbar_dynamic_style"></style>'
+                . '<style ' . csp_style_nonce() . ' id="debugbar_dynamic_style"></style>'
                 . $kintScript
                 . PHP_EOL;
 

--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -18,7 +18,7 @@
  * @var \CodeIgniter\View\Parser   $parser
  */
 ?>
-<style type="text/css">
+<style>
     <?= preg_replace('#[\r\n\t ]+#', ' ', file_get_contents(__DIR__ . '/toolbar.css')) ?>
 </style>
 
@@ -264,7 +264,7 @@
         <?= $parser->setData($config)->render('_config.tpl') ?>
     </div>
 </div>
-<style type="text/css">
+<style>
 <?php foreach ($styles as $name => $style): ?>
 <?= sprintf(".%s { %s }\n", $name, $style) ?>
 <?php endforeach ?>

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -2147,7 +2147,7 @@ class Email
      */
     protected function setErrorMessage($msg)
     {
-        $this->debugMessage[]    = $msg . '<br />';
+        $this->debugMessage[]    = $msg . '<br>';
         $this->debugMessageRaw[] = $msg;
     }
 

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -287,7 +287,8 @@ class Typography
         $str = str_replace("\n\n", "</p>\n\n<p>", $str);
 
         // Convert single spaces to <br> tags
-        $str = preg_replace("/([^\n])(\n)([^\n])/", '\\1<br>\\2\\3', $str);
+        $br  = '<br' . _solidus() . '>';
+        $str = preg_replace("/([^\n])(\n)([^\n])/", '\\1' . $br . '\\2\\3', $str);
 
         // Wrap the whole enchilada in enclosing paragraphs
         if ($str !== "\n") {
@@ -323,7 +324,8 @@ class Typography
         $newstr = '';
 
         for ($ex = explode('pre>', $str), $ct = count($ex), $i = 0; $i < $ct; $i++) {
-            $newstr .= (($i % 2) === 0) ? nl2br($ex[$i], false) : $ex[$i];
+            $xhtml = ! (config('DocTypes')->html5 ?? false);
+            $newstr .= (($i % 2) === 0) ? nl2br($ex[$i], $xhtml) : $ex[$i];
 
             if ($ct - 1 !== $i) {
                 $newstr .= 'pre>';

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -24,7 +24,7 @@ class Typography
     public $blockElements = 'address|blockquote|div|dl|fieldset|form|h\d|hr|noscript|object|ol|p|pre|script|table|ul';
 
     /**
-     * Elements that should not have <p> and <br /> tags within them.
+     * Elements that should not have <p> and <br> tags within them.
      *
      * @var string
      */
@@ -63,7 +63,7 @@ class Typography
      *
      * This function converts text, making it typographically correct:
      *     - Converts double spaces into paragraphs.
-     *     - Converts single line breaks into <br /> tags
+     *     - Converts single line breaks into <br> tags
      *     - Converts single and double quotes into correctly facing curly quote entities.
      *     - Converts three dots into ellipsis.
      *     - Converts double dashes into em-dashes.
@@ -160,7 +160,7 @@ class Typography
                 $chunks[$i] .= "\n";
             }
 
-            // Convert Newlines into <p> and <br /> tags
+            // Convert Newlines into <p> and <br> tags
             $str .= $this->formatNewLines($chunks[$i]);
         }
 
@@ -275,7 +275,7 @@ class Typography
     /**
      * Format Newlines
      *
-     * Converts newline characters into either <p> tags or <br />
+     * Converts newline characters into either <p> tags or <br>
      */
     protected function formatNewLines(string $str): string
     {
@@ -286,8 +286,8 @@ class Typography
         // Convert two consecutive newlines to paragraphs
         $str = str_replace("\n\n", "</p>\n\n<p>", $str);
 
-        // Convert single spaces to <br /> tags
-        $str = preg_replace("/([^\n])(\n)([^\n])/", '\\1<br />\\2\\3', $str);
+        // Convert single spaces to <br> tags
+        $str = preg_replace("/([^\n])(\n)([^\n])/", '\\1<br>\\2\\3', $str);
 
         // Wrap the whole enchilada in enclosing paragraphs
         if ($str !== "\n") {
@@ -323,7 +323,7 @@ class Typography
         $newstr = '';
 
         for ($ex = explode('pre>', $str), $ct = count($ex), $i = 0; $i < $ct; $i++) {
-            $newstr .= (($i % 2) === 0) ? nl2br($ex[$i]) : $ex[$i];
+            $newstr .= (($i % 2) === 0) ? nl2br($ex[$i], false) : $ex[$i];
 
             if ($ct - 1 !== $i) {
                 $newstr .= 'pre>';

--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -182,7 +182,7 @@ class Filters
 
     /**
      * Returns a string with all instances of newline character (\n)
-     * converted to an HTML <br/> tag.
+     * converted to an HTML <br> tag.
      */
     public static function nl2br(string $value): string
     {

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -498,8 +498,8 @@ final class MiscUrlTest extends CIUnitTestCase
                 'This is my noreply@codeigniter.com test',
             ],
             'test03' => [
-                '<br />www.google.com',
-                '<br /><a href="http://www.google.com">www.google.com</a>',
+                '<br>www.google.com',
+                '<br><a href="http://www.google.com">www.google.com</a>',
             ],
             'test04' => [
                 'Download CodeIgniter at www.codeigniter.com. Period test.',
@@ -547,8 +547,8 @@ final class MiscUrlTest extends CIUnitTestCase
                 "This is my <script>var l=new Array();l[0] = '>';l[1] = 'a';l[2] = '/';l[3] = '<';l[4] = '|109';l[5] = '|111';l[6] = '|99';l[7] = '|46';l[8] = '|114';l[9] = '|101';l[10] = '|116';l[11] = '|105';l[12] = '|110';l[13] = '|103';l[14] = '|105';l[15] = '|101';l[16] = '|100';l[17] = '|111';l[18] = '|99';l[19] = '|64';l[20] = '|121';l[21] = '|108';l[22] = '|112';l[23] = '|101';l[24] = '|114';l[25] = '|111';l[26] = '|110';l[27] = '>';l[28] = '\"';l[29] = '|109';l[30] = '|111';l[31] = '|99';l[32] = '|46';l[33] = '|114';l[34] = '|101';l[35] = '|116';l[36] = '|105';l[37] = '|110';l[38] = '|103';l[39] = '|105';l[40] = '|101';l[41] = '|100';l[42] = '|111';l[43] = '|99';l[44] = '|64';l[45] = '|121';l[46] = '|108';l[47] = '|112';l[48] = '|101';l[49] = '|114';l[50] = '|111';l[51] = '|110';l[52] = ':';l[53] = 'o';l[54] = 't';l[55] = 'l';l[56] = 'i';l[57] = 'a';l[58] = 'm';l[59] = '\"';l[60] = '=';l[61] = 'f';l[62] = 'e';l[63] = 'r';l[64] = 'h';l[65] = ' ';l[66] = 'a';l[67] = '<';for (var i = l.length-1; i >= 0; i=i-1) {if (l[i].substring(0, 1) === '|') document.write(\"&#\"+unescape(l[i].substring(1))+\";\");else document.write(unescape(l[i]));}</script> test",
             ],
             'test03' => [
-                '<br />www.google.com',
-                '<br />www.google.com',
+                '<br>www.google.com',
+                '<br>www.google.com',
             ],
             'test04' => [
                 'Download CodeIgniter at www.codeigniter.com. Period test.',
@@ -596,8 +596,8 @@ final class MiscUrlTest extends CIUnitTestCase
                 "This is my <script>var l=new Array();l[0] = '>';l[1] = 'a';l[2] = '/';l[3] = '<';l[4] = '|109';l[5] = '|111';l[6] = '|99';l[7] = '|46';l[8] = '|114';l[9] = '|101';l[10] = '|116';l[11] = '|105';l[12] = '|110';l[13] = '|103';l[14] = '|105';l[15] = '|101';l[16] = '|100';l[17] = '|111';l[18] = '|99';l[19] = '|64';l[20] = '|121';l[21] = '|108';l[22] = '|112';l[23] = '|101';l[24] = '|114';l[25] = '|111';l[26] = '|110';l[27] = '>';l[28] = '\"';l[29] = '|109';l[30] = '|111';l[31] = '|99';l[32] = '|46';l[33] = '|114';l[34] = '|101';l[35] = '|116';l[36] = '|105';l[37] = '|110';l[38] = '|103';l[39] = '|105';l[40] = '|101';l[41] = '|100';l[42] = '|111';l[43] = '|99';l[44] = '|64';l[45] = '|121';l[46] = '|108';l[47] = '|112';l[48] = '|101';l[49] = '|114';l[50] = '|111';l[51] = '|110';l[52] = ':';l[53] = 'o';l[54] = 't';l[55] = 'l';l[56] = 'i';l[57] = 'a';l[58] = 'm';l[59] = '\"';l[60] = '=';l[61] = 'f';l[62] = 'e';l[63] = 'r';l[64] = 'h';l[65] = ' ';l[66] = 'a';l[67] = '<';for (var i = l.length-1; i >= 0; i=i-1) {if (l[i].substring(0, 1) === '|') document.write(\"&#\"+unescape(l[i].substring(1))+\";\");else document.write(unescape(l[i]));}</script> test",
             ],
             'test03' => [
-                '<br />www.google.com',
-                '<br /><a href="http://www.google.com">www.google.com</a>',
+                '<br>www.google.com',
+                '<br><a href="http://www.google.com">www.google.com</a>',
             ],
             'test04' => [
                 'Download CodeIgniter at www.codeigniter.com. Period test.',
@@ -645,8 +645,8 @@ final class MiscUrlTest extends CIUnitTestCase
                 'This is my noreply@codeigniter.com test',
             ],
             'test03' => [
-                '<br />www.google.com',
-                '<br /><a href="http://www.google.com" target="_blank">www.google.com</a>',
+                '<br>www.google.com',
+                '<br><a href="http://www.google.com" target="_blank">www.google.com</a>',
             ],
             'test04' => [
                 'Download CodeIgniter at www.codeigniter.com. Period test.',

--- a/tests/system/Typography/TypographyTest.php
+++ b/tests/system/Typography/TypographyTest.php
@@ -64,11 +64,11 @@ final class TypographyTest extends CIUnitTestCase
             "\n\n"                                 => "\n\n<p>&nbsp;</p>",
             "\n\n\n"                               => "\n\n<p>&nbsp;</p>",
             "Line One\n"                           => "<p>Line One</p>\n\n",
-            "Line One\nLine Two"                   => "<p>Line One<br />\nLine Two</p>",
+            "Line One\nLine Two"                   => "<p>Line One<br>\nLine Two</p>",
             "Line One\r\n"                         => "<p>Line One</p>\n\n",
-            "Line One\r\nLine Two"                 => "<p>Line One<br />\nLine Two</p>",
+            "Line One\r\nLine Two"                 => "<p>Line One<br>\nLine Two</p>",
             "Line One\r"                           => "<p>Line One</p>\n\n",
-            "Line One\rLine Two"                   => "<p>Line One<br />\nLine Two</p>",
+            "Line One\rLine Two"                   => "<p>Line One<br>\nLine Two</p>",
             "Line One\n\nLine Two\n\n\nLine Three" => "<p>Line One</p>\n\n<p>Line Two</p>\n\n<p>Line Three</p>",
         ];
 
@@ -84,12 +84,12 @@ final class TypographyTest extends CIUnitTestCase
             "\n\n"                                 => "\n\n",
             "\n\n\n"                               => "\n\n\n\n",
             "Line One\n"                           => "<p>Line One</p>\n\n",
-            "Line One\nLine Two"                   => "<p>Line One<br />\nLine Two</p>",
+            "Line One\nLine Two"                   => "<p>Line One<br>\nLine Two</p>",
             "Line One\r\n"                         => "<p>Line One</p>\n\n",
-            "Line One\r\nLine Two"                 => "<p>Line One<br />\nLine Two</p>",
+            "Line One\r\nLine Two"                 => "<p>Line One<br>\nLine Two</p>",
             "Line One\r"                           => "<p>Line One</p>\n\n",
-            "Line One\rLine Two"                   => "<p>Line One<br />\nLine Two</p>",
-            "Line One\n\nLine Two\n\n\nLine Three" => "<p>Line One</p>\n\n<p>Line Two</p>\n\n<p><br />\nLine Three</p>",
+            "Line One\rLine Two"                   => "<p>Line One<br>\nLine Two</p>",
+            "Line One\n\nLine Two\n\n\nLine Three" => "<p>Line One</p>\n\n<p>Line Two</p>\n\n<p><br>\nLine Three</p>",
         ];
 
         foreach ($strs as $str => $expect) {
@@ -141,9 +141,9 @@ final class TypographyTest extends CIUnitTestCase
     public function testNewlinesToHTMLLineBreaksExceptWithinPRE()
     {
         $strs = [
-            "Line One\nLine Two"            => "Line One<br />\nLine Two",
+            "Line One\nLine Two"            => "Line One<br>\nLine Two",
             "<pre>Line One\nLine Two</pre>" => "<pre>Line One\nLine Two</pre>",
-            "<div>Line One\nLine Two</div>" => "<div>Line One<br />\nLine Two</div>",
+            "<div>Line One\nLine Two</div>" => "<div>Line One<br>\nLine Two</div>",
         ];
 
         foreach ($strs as $str => $expect) {

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -250,7 +250,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $template = '{ value1|nl2br }';
 
         $parser->setData($data);
-        $this->assertSame("first<br />\nsecond", $parser->renderString($template));
+        $this->assertSame("first<br>\nsecond", $parser->renderString($template));
     }
 
     public function testNumberFormat()

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -227,21 +227,31 @@ Libraries
 - **Publisher:** Added methods ``replace()``, ``addLineAfter()`` and ``addLineBefore()`` to modify files in Publisher. See :ref:`Publisher <publisher-modifying-files>` for details.
 - **Encryption:** Now Encryption can decrypt data encrypted with CI3's Encryption. See :ref:`encryption-compatible-with-ci3`.
 - **CURLRequest:** Added option version HTTP2 in :ref:`CURLRequest <curlrequest-version>`.
-- **Typography:** Creation of ``br`` tag can be configured to exclude or not the solidus character (``/``)
-  before the right angle bracket (``>``) by setting the ``$html5`` property in
-  **app/Config/DocTypes.php** to ``true``.
-- **View:** The ``nl2br`` filter in ``Parser`` outputs ``<br>`` tag by setting the ``$html5`` property in
-  **app/Config/DocTypes.php** to ``true``.
 
 Helpers and Functions
 =====================
 
-- Creation of void HTML elements like ``<input>`` via ``form_helper``, ``html_helper`` or common functions can be configured to exclude or not the solidus character (``/``) before the right angle bracket (``>``) by setting the ``$html5`` property in **app/Config/DocTypes.php** to ``true``.
 - Now you can autoload helpers by **app/Config/Autoload.php**.
 - Added new Form helper function :php:func:`validation_errors()`, :php:func:`validation_list_errors()` and :php:func:`validation_show_error()` to display Validation Errors.
 - You can set the locale to :php:func:`route_to()` if you pass a locale value as the last parameter.
 - Added :php:func:`request()` and :php:func:`response()` functions.
 - Added :php:func:`decamelize()` function to convert camelCase to snake_case.
+
+HTML5 Compatibility
+===================
+
+Creation of void HTML elements like ``<input>`` can be configured to exclude or not the solidus character
+(``/``) before the right angle bracket (``>``) by setting the ``$html5`` property in
+**app/Config/DocTypes.php**. If you set it to ``true``, HTML5 compatible tags without ``/`` like ``<br>``
+will be output.
+
+The following items are affected:
+
+- Typography class: Creation of ``br`` tag
+- View Parser: The ``nl2br`` filter
+- Form helper
+- HTML helper
+- Common Functions
 
 Error Handling
 ==============

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -61,7 +61,6 @@ The following methods of the :doc:`Time <../libraries/time>` class had bugs that
 Others
 ------
 
-- **Helper:** Now ``form_helper``, ``html_helper`` and common functions that render HTML elements have been changed to make void HTML elements (e.g. ``<input>``) compatible with HTML5 by default.
 - **Helper:** :php:func:`script_tag()` and :php:func:`safe_mailto()` no longer output ``type="text/javascript"`` in ``<script>`` tag.
 - **CLI:** The ``spark`` file has been changed due to a change in the processing of Spark commands.
 - **CLI:** ``CITestStreamFilter::$buffer = ''`` no longer causes the filter to be registered to listen for streams. Now there

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -227,6 +227,11 @@ Libraries
 - **Publisher:** Added methods ``replace()``, ``addLineAfter()`` and ``addLineBefore()`` to modify files in Publisher. See :ref:`Publisher <publisher-modifying-files>` for details.
 - **Encryption:** Now Encryption can decrypt data encrypted with CI3's Encryption. See :ref:`encryption-compatible-with-ci3`.
 - **CURLRequest:** Added option version HTTP2 in :ref:`CURLRequest <curlrequest-version>`.
+- **Typography:** Creation of ``br`` tag can be configured to exclude or not the solidus character (``/``)
+  before the right angle bracket (``>``) by setting the ``$html5`` property in
+  **app/Config/DocTypes.php** to ``true``.
+- **View:** The ``nl2br`` filter in ``Parser`` outputs ``<br>`` tag by setting the ``$html5`` property in
+  **app/Config/DocTypes.php** to ``true``.
 
 Helpers and Functions
 =====================


### PR DESCRIPTION
**Description**
- remove trailing slash on void elements
- remove unnecessary type attributes
- `Typography` uses `Config\DocTypes::$html5` for `<br>` tag
 
Ref: #6298, #6789

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
