### PR TITLE
fix: slack links

### DIFF
--- a/app/Views/welcome_message.php
+++ b/app/Views/welcome_message.php
@@ -270,7 +270,7 @@
         <p>CodeIgniter is a community-developed open source project, with several
              venues for the community members to gather and exchange ideas. View all
              the threads on <a href="https://forum.codeigniter.com/"
-             target="_blank">CodeIgniter's forum</a>, or <a href="https://codeigniterchat.slack.com/"
+             target="_blank">CodeIgniter's forum</a>, or <a href="https://join.slack.com/t/codeigniterchat/shared_invite/zt-rl30zw00-obL1Hr1q1ATvkzVkFp8S0Q"
              target="_blank">chat on Slack</a> !</p>
 
         <h2>

--- a/contributing/bug_report.md
+++ b/contributing/bug_report.md
@@ -20,7 +20,7 @@ Please note that GitHub is not for general support questions! If you are
 having trouble using a feature, you can:
 
 - Start a new thread on our [Forums](http://forum.codeigniter.com/)
-- Ask your questions on [Slack](https://codeigniterchat.slack.com/)
+- Ask your questions on [Slack](https://join.slack.com/t/codeigniterchat/shared_invite/zt-rl30zw00-obL1Hr1q1ATvkzVkFp8S0Q)
 
 If you are not sure whether you are using something correctly or if you
 have found a bug, again - please ask on the forums first.

--- a/user_guide_src/source/tutorial/conclusion.rst
+++ b/user_guide_src/source/tutorial/conclusion.rst
@@ -21,4 +21,4 @@ If you still have questions about the framework or your own CodeIgniter
 code, you can:
 
 -  Check out our `Forum <https://forum.codeigniter.com/>`_
--  Check out our `Slack <https://codeigniterchat.slack.com/>`_
+-  Check out our `Slack <https://join.slack.com/t/codeigniterchat/shared_invite/zt-rl30zw00-obL1Hr1q1ATvkzVkFp8S0Q>`_


### PR DESCRIPTION
**Description**
Use the invite link.

See https://github.com/codeigniter4projects/website/pull/337

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
