### PR TITLE
config: use Strict Validation Rules by default

### DIFF
--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -3,10 +3,10 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Validation\CreditCardRules;
-use CodeIgniter\Validation\FileRules;
-use CodeIgniter\Validation\FormatRules;
-use CodeIgniter\Validation\Rules;
+use CodeIgniter\Validation\StrictRules\CreditCardRules;
+use CodeIgniter\Validation\StrictRules\FileRules;
+use CodeIgniter\Validation\StrictRules\FormatRules;
+use CodeIgniter\Validation\StrictRules\Rules;
 
 class Validation extends BaseConfig
 {

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -262,6 +262,8 @@ Config
 - app/Config/Security.php
     - Changed the value of the property ``$redirect`` to ``false`` to prevent redirection when a CSRF
       check fails. This is to make it easier to recognize that it is a CSRF error.
+- app/Config/Validation.php
+    - The default Validation Rules have been changed to Strict Rules for better security. See :ref:`validation-traditional-and-strict-rules`.
 
 All Changes
 ===========

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -201,9 +201,16 @@ Config for Validation
 Traditional and Strict Rules
 ============================
 
-CI4 has two kinds of Validation rule classes.
-The default rule classes (**Traditional Rules**) have the namespace ``CodeIgniter\Validation``,
+CodeIgniter 4 has two kinds of Validation rule classes.
+The traditional rule classes (**Traditional Rules**) have the namespace ``CodeIgniter\Validation``,
 and the new classes (**Strict Rules**) have ``CodeIgniter\Validation\StrictRules``, which provide strict validation.
+
+.. note:: Since v4.3.0, **Strict Rules** are used by default for better security.
+
+Traditional Rules
+-----------------
+
+.. warning:: When validating data that contains non-string values, such as JSON data, it is recommended to use **Strict Rules**.
 
 The **Traditional Rules** implicitly assume that string values are validated,
 and the input value may be converted implicitly to a string value.
@@ -213,14 +220,17 @@ However, for example, if you use JSON input data, it may be a type of bool/null/
 When you validate the boolean ``true``, it is converted to string ``'1'`` with the Traditional rule classes.
 If you validate it with the ``integer`` rule, ``'1'`` passes the validation.
 
+Strict Rules
+------------
+
+.. versionadded:: 4.2.0
+
 The **Strict Rules** don't use implicit type conversion.
 
-.. warning:: When validating data that contains non-string values, such as JSON data, it is recommended to use **Strict Rules**.
+Using Traditional Rules
+-----------------------
 
-Using Strict Rules
-------------------
-
-If you want to use these rules, you need to change the rule classes in **app/Config/Validation.php**:
+If you want to use traditional rules, you need to change the rule classes in **app/Config/Validation.php**:
 
 .. literalinclude:: validation/003.php
 

--- a/user_guide_src/source/libraries/validation/003.php
+++ b/user_guide_src/source/libraries/validation/003.php
@@ -5,10 +5,10 @@ namespace Config;
 class Validation
 {
     public $ruleSets = [
-        \CodeIgniter\Validation\StrictRules\CreditCardRules::class,
-        \CodeIgniter\Validation\StrictRules\FileRules::class,
-        \CodeIgniter\Validation\StrictRules\FormatRules::class,
-        \CodeIgniter\Validation\StrictRules\Rules::class,
+        \CodeIgniter\Validation\CreditCardRules::class,
+        \CodeIgniter\Validation\FileRules::class,
+        \CodeIgniter\Validation\FormatRules::class,
+        \CodeIgniter\Validation\Rules::class,
     ];
 
     // ...


### PR DESCRIPTION
**Description**
Change the default Validation rules.
- The Traditional Rules cannot validate some non-string data correctly, or raise TypeError  #6489
- The controller `validate()` method validates JSON data automatically if a JSON request comes.
- This Config change is opt-in. The existing apps do not change.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
