### PR TITLE
test: add DB transaction tests

### DIFF
--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @group DatabaseLive
+ *
+ * @internal
+ */
+final class TransactionTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh = true;
+    protected $seed    = CITestSeeder::class;
+
+    protected function setUp(): void
+    {
+        // Reset connection instance.
+        $this->db = Database::connect($this->DBGroup, false);
+
+        parent::setUp();
+    }
+
+    /**
+     * Sets $DBDebug to false.
+     *
+     * WARNING: this value will persist! take care to roll it back.
+     */
+    protected function disableDBDebug(): void
+    {
+        $this->setPrivateProperty($this->db, 'DBDebug', false);
+    }
+
+    /**
+     * Sets $DBDebug to true.
+     */
+    protected function enableDBDebug(): void
+    {
+        $this->setPrivateProperty($this->db, 'DBDebug', true);
+    }
+
+    public function testTransStartDBDebugTrue()
+    {
+        $builder = $this->db->table('job');
+        $e       = null;
+
+        try {
+            $this->db->transStart();
+
+            $jobData = [
+                'name'        => 'Grocery Sales',
+                'description' => 'Discount!',
+            ];
+            $builder->insert($jobData);
+
+            // Duplicate entry '1' for key 'PRIMARY'
+            $jobData = [
+                'id'          => 1,
+                'name'        => 'Comedian',
+                'description' => 'Theres something in your teeth',
+            ];
+            $builder->insert($jobData);
+
+            $this->db->transComplete();
+        } catch (DatabaseException $e) {
+            // Do nothing.
+        }
+
+        $this->assertInstanceOf(DatabaseException::class, $e);
+        $this->dontSeeInDatabase('job', ['name' => 'Grocery Sales']);
+    }
+
+    public function testTransStartDBDebugFalse()
+    {
+        $this->disableDBDebug();
+
+        $builder = $this->db->table('job');
+
+        $this->db->transStart();
+
+        $jobData = [
+            'name'        => 'Grocery Sales',
+            'description' => 'Discount!',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertTrue($this->db->transStatus());
+
+        // Duplicate entry '1' for key 'PRIMARY'
+        $jobData = [
+            'id'          => 1,
+            'name'        => 'Comedian',
+            'description' => 'Theres something in your teeth',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertFalse($this->db->transStatus());
+
+        $this->db->transComplete();
+
+        $this->dontSeeInDatabase('job', ['name' => 'Grocery Sales']);
+
+        $this->enableDBDebug();
+    }
+
+    public function testTransStrictTrueAndDBDebugFalse()
+    {
+        $this->disableDBDebug();
+
+        $builder = $this->db->table('job');
+
+        // The first transaction group
+        $this->db->transStart();
+
+        $jobData = [
+            'name'        => 'Grocery Sales',
+            'description' => 'Discount!',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertTrue($this->db->transStatus());
+
+        // Duplicate entry '1' for key 'PRIMARY'
+        $jobData = [
+            'id'          => 1,
+            'name'        => 'Comedian',
+            'description' => 'Theres something in your teeth',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertFalse($this->db->transStatus());
+
+        $this->db->transComplete();
+
+        $this->dontSeeInDatabase('job', ['name' => 'Grocery Sales']);
+
+        // The second transaction group
+        $this->db->transStart();
+
+        $jobData = [
+            'name'        => 'Comedian',
+            'description' => 'Theres something in your teeth',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertFalse($this->db->transStatus());
+
+        $this->db->transComplete();
+
+        $this->dontSeeInDatabase('job', ['name' => 'Comedian']);
+
+        $this->enableDBDebug();
+    }
+
+    public function testTransStrictFalseAndDBDebugFalse()
+    {
+        $this->disableDBDebug();
+
+        $builder = $this->db->table('job');
+
+        $this->db->transStrict(false);
+
+        // The first transaction group
+        $this->db->transStart();
+
+        $jobData = [
+            'name'        => 'Grocery Sales',
+            'description' => 'Discount!',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertTrue($this->db->transStatus());
+
+        // Duplicate entry '1' for key 'PRIMARY'
+        $jobData = [
+            'id'          => 1,
+            'name'        => 'Comedian',
+            'description' => 'Theres something in your teeth',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertFalse($this->db->transStatus());
+
+        $this->db->transComplete();
+
+        $this->dontSeeInDatabase('job', ['name' => 'Grocery Sales']);
+
+        // The second transaction group
+        $this->db->transStart();
+
+        $jobData = [
+            'name'        => 'Comedian',
+            'description' => 'Theres something in your teeth',
+        ];
+        $builder->insert($jobData);
+
+        $this->assertTrue($this->db->transStatus());
+
+        $this->db->transComplete();
+
+        $this->seeInDatabase('job', ['name' => 'Comedian']);
+
+        $this->enableDBDebug();
+    }
+}

--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -11,10 +11,10 @@
 
 namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use Exception;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**
@@ -78,11 +78,28 @@ final class TransactionTest extends CIUnitTestCase
             $builder->insert($jobData);
 
             $this->db->transComplete();
-        } catch (DatabaseException $e) {
+        } catch (Exception $e) {
             // Do nothing.
+
+            // MySQLi
+            // mysqli_sql_exception: Duplicate entry '1' for key 'PRIMARY'
+
+            // SQLite3
+            // ErrorException: SQLite3::exec(): UNIQUE constraint failed: db_job.id
+
+            // Postgres
+            // ErrorException: pg_query(): Query failed: ERROR:  duplicate key value violates unique constraint "pk_db_job"
+            //   DETAIL:  Key (id)=(1) already exists.
+
+            // SQLSRV
+            // Exception: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Cannot insert explicit
+            //   value for identity column in table 'db_job' when IDENTITY_INSERT is set to OFF.
+
+            // OCI8
+            // ErrorException: oci_execute(): ORA-00001: unique constraint (ORACLE.pk_db_job) violated
         }
 
-        $this->assertInstanceOf(DatabaseException::class, $e);
+        $this->assertInstanceOf(Exception::class, $e);
         $this->dontSeeInDatabase('job', ['name' => 'Grocery Sales']);
     }
 


### PR DESCRIPTION
**Description**
This is tests for v4.2.

Related #6919, #6886

See https://github.com/codeigniter4/CodeIgniter4/actions/runs/3555886311/jobs/5972871727 to see Exception classes.

The current behaviors:
- All the current DB drivers throw an exception when a query error occurs.
- MySQLi driver sets `mysqli_report(MYSQLI_REPORT_ALL & ~MYSQLI_REPORT_INDEX)` that throws `mysqli_sql_exception`.
- SQLite3, Postgres and OCI8 drivers throw `ErrorException` because of Error Handler. 
- SQLSRV driver has different implementaion. It throws `Exception` when the query return value is false.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
