### PR TITLE
docs: fix PHPDoc in Header

### DIFF
--- a/system/HTTP/Header.php
+++ b/system/HTTP/Header.php
@@ -101,7 +101,7 @@ class Header
      * Appends a value to the list of values for this header. If the
      * header is a single value string, it will be converted to an array.
      *
-     * @param array<array<string>|string>|string|null $value
+     * @param array<string, string>|string|null $value
      *
      * @return $this
      */
@@ -126,7 +126,7 @@ class Header
      * Prepends a value to the list of values for this header. If the
      * header is a single value string, it will be converted to an array.
      *
-     * @param array<array<string>|string>|string|null $value
+     * @param array<string, string>|string|null $value
      *
      * @return $this
      */

--- a/system/HTTP/Header.php
+++ b/system/HTTP/Header.php
@@ -28,15 +28,23 @@ class Header
     /**
      * The value of the header. May have more than one
      * value. If so, will be an array of strings.
+     * E.g.,
+     *   [
+     *       'foo',
+     *       [
+     *           'bar' => 'fizz',
+     *       ],
+     *       'baz' => 'buzz',
+     *   ]
      *
-     * @var array<array<string>|string>|string
+     * @var array<int|string, array<string, string>|string>|string
      */
     protected $value;
 
     /**
      * Header constructor. name is mandatory, if a value is provided, it will be set.
      *
-     * @param array<array<string>|string>|string|null $value
+     * @param array<int|string, array<string, string>|string>|string|null $value
      */
     public function __construct(string $name, $value = null)
     {
@@ -56,7 +64,7 @@ class Header
      * Gets the raw value of the header. This may return either a string
      * of an array, depending on whether the header has multiple values or not.
      *
-     * @return array<array<string>|string>|string
+     * @return array<int|string, array<string, string>|string>|string
      */
     public function getValue()
     {
@@ -78,7 +86,7 @@ class Header
     /**
      * Sets the value of the header, overwriting any previous value(s).
      *
-     * @param array<array<string>|string>|string|null $value
+     * @param array<int|string, array<string, string>|string>|string|null $value
      *
      * @return $this
      */

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -80,6 +80,20 @@ final class HeaderTest extends CIUnitTestCase
         $this->assertSame($value, $header->getValue());
     }
 
+    public function testHeaderStoresArrayKeyValue()
+    {
+        $name  = 'foo';
+        $value = [
+            'key' => 'val',
+        ];
+
+        $header = new Header($name, $value);
+
+        $this->assertSame($name, $header->getName());
+        $this->assertSame($value, $header->getValue());
+        $this->assertSame('key=val', $header->getValueLine());
+    }
+
     public function testHeaderSetters()
     {
         $name  = 'foo';


### PR DESCRIPTION
**Description**
Follow-up: #6870

- fix PHPDoc in Header

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
