### PR TITLE
docs: use lower case for view file path

### DIFF
--- a/user_guide_src/source/concepts/mvc.rst
+++ b/user_guide_src/source/concepts/mvc.rst
@@ -51,7 +51,7 @@ Views are generally stored in **app/Views**, but can quickly become unwieldy if 
 CodeIgniter does not enforce any type of organization, but a good rule of thumb would be to create a new directory in
 the **Views** directory for each controller. Then, name views by the method name. This makes them very easy to find later
 on. For example, a user's profile might be displayed in a controller named ``User``, and a method named ``profile``.
-You might store the view file for this method in **app/Views/User/Profile.php**.
+You might store the view file for this method in **app/Views/user/profile.php**.
 
 That type of organization works great as a base habit to get into. At times you might need to organize it differently.
 That's not a problem. As long as CodeIgniter can find the file, it can display it.


### PR DESCRIPTION
**Description**
Use lower case for view file path example. It is our convention.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
