### PR TITLE
docs: DB Config `strictOn` is MySQLi only

### DIFF
--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -141,7 +141,7 @@ Explanation of Values:
                 * ``ssl_verify`` - true/false; Whether to verify the server certificate or not (``MySQLi`` only)
 **compress**    Whether or not to use client compression (``MySQLi`` only).
 **strictOn**    true/false (boolean) - Whether to force "Strict Mode" connections, good for ensuring strict SQL
-                while developing an application.
+                while developing an application (``MySQLi`` only).
 **port**        The database port number.
 **foreignKeys** true/false (boolean) - Whether or not to enable Foreign Key constraint (``SQLite3`` only).
 


### PR DESCRIPTION
**Description**
strictOn is MySQLi only.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
