### PR TITLE
feat: add IncomingRequest::getRawInputVar() method

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -609,6 +609,60 @@ class IncomingRequest extends Request
     }
 
     /**
+     * Gets a specific variable from raw input stream (send method in PUT, PATCH, DELETE).
+     *
+     * @param array|string|null $index  The variable that you want which can use dot syntax for getting specific values.
+     * @param int|null          $filter Filter Constant
+     * @param array|int|null    $flags  Option
+     *
+     * @return mixed
+     */
+    public function getRawInputVar($index = null, ?int $filter = null, $flags = null)
+    {
+        helper('array');
+
+        parse_str($this->body ?? '', $output);
+
+        if (is_string($index)) {
+            $output = dot_array_search($index, $output);
+        } elseif (is_array($index)) {
+            $data = [];
+
+            foreach ($index as $key) {
+                $data[$key] = dot_array_search($key, $output);
+            }
+
+            [$output, $data] = [$data, null];
+        }
+
+        $filter ??= FILTER_DEFAULT;
+        $flags = is_array($flags) ? $flags : (is_numeric($flags) ? (int) $flags : 0);
+
+        if (is_array($output)
+            && (
+                $filter !== FILTER_DEFAULT
+                || (
+                    (is_numeric($flags) && $flags !== 0)
+                    || is_array($flags) && $flags !== []
+                )
+            )
+        ) {
+            // Iterate over array and append filter and flags
+            array_walk_recursive($output, static function (&$val) use ($filter, $flags) {
+                $val = filter_var($val, $filter, $flags);
+            });
+
+            return $output;
+        }
+
+        if (is_string($output)) {
+            return filter_var($output, $filter, $flags);
+        }
+
+        return $output;
+    }
+
+    /**
      * Fetch an item from GET data.
      *
      * @param array|string|null $index  Index for item to fetch from $_GET.

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -295,6 +295,7 @@ Others
 - **View:** Added ``Controlled Cells`` that provide more structure and flexibility to your View Cells. See :ref:`View Cells <controlled-cells>` for details.
 - **Config:** Now you can specify Composer packages to auto-discover manually. See :ref:`Code Modules <modules-specify-composer-packages>`.
 - **Debug:** Kint has been updated to 5.0.1.
+- **Request:** Added new ``$request->getRawInputVar()`` method to return a specified variable from raw stream. See :ref:`Retrieving Raw data <incomingrequest-retrieving-raw-data>`.
 
 Message Changes
 ***************

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -155,6 +155,10 @@ This will retrieve data and convert it to an array. Like this:
 
 .. literalinclude:: incomingrequest/013.php
 
+You can also use ``getRawInputVar()``, to get the specified variable from raw stream and filter it.
+
+.. literalinclude:: incomingrequest/039.php
+
 Filtering Input Data
 ====================
 
@@ -168,7 +172,7 @@ Filtering a POST variable would look like this:
 .. literalinclude:: incomingrequest/014.php
 
 All of the methods mentioned above support the filter type passed in as the second parameter, with the
-exception of ``getJSON()``.
+exception of ``getJSON()`` and ``getRawInput()``.
 
 Retrieving Headers
 ******************

--- a/user_guide_src/source/incoming/incomingrequest/039.php
+++ b/user_guide_src/source/incoming/incomingrequest/039.php
@@ -1,6 +1,6 @@
 <?php
 
-// foo=one&bar=two&baz[]=10&baz[]=20
+// When the request body is 'foo=one&bar=two&baz[]=10&baz[]=20'
 var_dump($request->getRawInputVar('bar'));
 
 // Outputs: two
@@ -22,8 +22,8 @@ var_dump($request->getRawInputVar('baz'));
 /*
  * Outputs:
  * [
- *      10,
- *      20
+ *      '10',
+ *      '20'
  * ]
  */
 

--- a/user_guide_src/source/incoming/incomingrequest/039.php
+++ b/user_guide_src/source/incoming/incomingrequest/039.php
@@ -1,0 +1,33 @@
+<?php
+
+// foo=one&bar=two&baz[]=10&baz[]=20
+var_dump($request->getRawInputVar('bar'));
+
+// Outputs: two
+
+// foo=one&bar=two&baz[]=10&baz[]=20
+var_dump($request->getRawInputVar(['foo', 'bar']));
+
+/*
+ * Outputs:
+ * [
+ *      'foo' => 'one',
+ *      'bar' => 'two'
+ * ]
+ */
+
+// foo=one&bar=two&baz[]=10&baz[]=20
+var_dump($request->getRawInputVar('baz'));
+
+/*
+ * Outputs:
+ * [
+ *      10,
+ *      20
+ * ]
+ */
+
+// foo=one&bar=two&baz[]=10&baz[]=20
+var_dump($request->getRawInputVar('baz.0'));
+
+// Outputs: 10

--- a/user_guide_src/source/incoming/incomingrequest/039.php
+++ b/user_guide_src/source/incoming/incomingrequest/039.php
@@ -2,12 +2,10 @@
 
 // When the request body is 'foo=one&bar=two&baz[]=10&baz[]=20'
 var_dump($request->getRawInputVar('bar'));
-
 // Outputs: two
 
 // foo=one&bar=two&baz[]=10&baz[]=20
 var_dump($request->getRawInputVar(['foo', 'bar']));
-
 /*
  * Outputs:
  * [
@@ -18,7 +16,6 @@ var_dump($request->getRawInputVar(['foo', 'bar']));
 
 // foo=one&bar=two&baz[]=10&baz[]=20
 var_dump($request->getRawInputVar('baz'));
-
 /*
  * Outputs:
  * [
@@ -29,5 +26,4 @@ var_dump($request->getRawInputVar('baz'));
 
 // foo=one&bar=two&baz[]=10&baz[]=20
 var_dump($request->getRawInputVar('baz.0'));
-
 // Outputs: 10


### PR DESCRIPTION
**Description**
Working with raw input data should be as easy as in other cases. `getRawInputVar()` adds missing features that are available for other methods, like retrieving specified indexes and filtering data.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
