### PR TITLE
docs: fix about foreignKeys in changelog

### DIFF
--- a/user_guide_src/source/changelogs/v4.2.0.rst
+++ b/user_guide_src/source/changelogs/v4.2.0.rst
@@ -93,7 +93,7 @@ Database
     - Added the class ``CodeIgniter\Database\RawSql`` which expresses raw SQL strings.
     - :ref:`select() <query-builder-select-rawsql>`, :ref:`where() <query-builder-where-rawsql>`, :ref:`like() <query-builder-like-rawsql>`, :ref:`join() <query-builder-join-rawsql>` accept the ``CodeIgniter\Database\RawSql`` instance.
     - ``DBForge::addField()`` default value raw SQL string support. See :ref:`forge-addfield-default-value-rawsql`.
-- SQLite3 has a new Config property ``$foreignKeys`` that enables foreign key constraints.
+- SQLite3 has a new Config item ``foreignKeys`` that enables foreign key constraints.
 
 Helpers and Functions
 =====================


### PR DESCRIPTION
**Description**
Follow-up #6940

`foreignKeys` is not a property but an array key.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
