### PR TITLE
fix: Route placeholder `(:any)` does not pass the whole value to controller

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -419,8 +419,8 @@ class Router implements RouterInterface
 
             // Does the RegEx match?
             if (preg_match('#^' . $routeKey . '$#u', $uri, $matches)) {
-                $matchedPlaceholders = $matches;
-                unset($matchedPlaceholders[0]);
+                $placeholderValues = $matches;
+                unset($placeholderValues[0]);
 
                 // Is this route supposed to redirect to another?
                 if ($this->collection->isRedirect($routeKey)) {
@@ -462,7 +462,7 @@ class Router implements RouterInterface
                 if (! is_string($handler) && is_callable($handler)) {
                     $this->controller = $handler;
 
-                    $this->params = $matchedPlaceholders;
+                    $this->params = $placeholderValues;
 
                     $this->setMatchedRoute($matchedKey, $handler);
 
@@ -495,7 +495,7 @@ class Router implements RouterInterface
 
                     foreach ($params as $param) {
                         $i          = ltrim($param, '$');
-                        $segments[] = $matchedPlaceholders[$i];
+                        $segments[] = $placeholderValues[$i];
                     }
                 }
                 $this->setRequest($segments);

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -462,10 +462,7 @@ class Router implements RouterInterface
                 if (! is_string($handler) && is_callable($handler)) {
                     $this->controller = $handler;
 
-                    // Remove the original string from the matches array
-                    array_shift($matches);
-
-                    $this->params = $matches;
+                    $this->params = $matchedPlaceholders;
 
                     $this->setMatchedRoute($matchedKey, $handler);
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -55,7 +55,8 @@ class Router implements RouterInterface
      * An array of binds that were collected
      * so they can be sent to closure routes.
      *
-     * @var array
+     * @var array<int, string>
+     * @phpstan-var list<string>
      */
     protected $params = [];
 
@@ -155,6 +156,8 @@ class Router implements RouterInterface
     }
 
     /**
+     * @param string|null $uri The URI path (route)
+     *
      * @return Closure|string Controller classname or Closure
      *
      * @throws PageNotFoundException

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -406,7 +406,7 @@ final class RouterTest extends CIUnitTestCase
         $this->assertTrue($router->hasLocale());
         $this->assertSame('fr', $router->getLocale());
 
-        $router->handle('test/123/lang/bg');
+        $router->handle('test/123/456/lang/bg');
 
         $this->assertTrue($router->hasLocale());
         $this->assertSame('bg', $router->getLocale());

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -49,7 +49,7 @@ final class RouterTest extends CIUnitTestCase
             'books/(:num)/(:alpha)/(:num)'                    => 'Blog::show/$3/$1',
             'closure/(:num)/(:alpha)'                         => static fn ($num, $str) => $num . '-' . $str,
             '{locale}/pages'                                  => 'App\Pages::list_all',
-            'test/(:any)/lang/{locale}'                       => 'App\Pages::list_all',
+            'test/(:any)/lang/{locale}'                       => 'App\Pages::list_all/$1',
             'admin/admins'                                    => 'App\Admin\Admins::list_all',
             'admin/admins/edit/(:any)'                        => 'App/Admin/Admins::edit_show/$1',
             '/some/slash'                                     => 'App\Slash::index',
@@ -409,6 +409,19 @@ final class RouterTest extends CIUnitTestCase
         $router->handle('test/123/456/lang/bg');
 
         $this->assertTrue($router->hasLocale());
+        $this->assertSame('bg', $router->getLocale());
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/6947
+     */
+    public function testRouteParamAny()
+    {
+        $router = new Router($this->collection, $this->request);
+
+        $router->handle('test/123/456/lang/bg');
+
+        $this->assertSame(['123/456'], $router->params());
         $this->assertSame('bg', $router->getLocale());
     }
 

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -82,6 +82,7 @@ Others
 - **Database:** The data structure returned by :ref:`BaseConnection::getForeignKeyData() <metadata-getforeignkeydata>` has been changed.
 - **Database:** ``CodeIgniter\Database\BasePreparedQuery`` class returns now a bool value for write-type queries instead of the ``Result`` class object.
 - **Routing:** ``RouteCollection::resetRoutes()`` resets Auto-Discovery of Routes. Previously once discovered, RouteCollection never discover Routes files again even if ``RouteCollection::resetRoutes()`` is called.
+- **Routing:** When the placeholder ``(:any)`` matches a multiple URI segment string like ``abc/def``, now the controller takes ``abc/def`` as a parameter. Previously, it takes only ``abc`` as a parameter and ``def`` as the next parameter due to a bug. See :ref:`upgrade-430-route-placeholder-any`.
 
 .. _v430-interface-changes:
 

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -194,6 +194,17 @@ The data returned has the following structure::
      * ]
      */
 
+.. _upgrade-430-route-placeholder-any:
+
+Route placeholder (:any)
+=========================
+
+When the placeholder ``(:any)`` matches a multiple URI segment string like ``abc/def``, now the controller takes ``abc/def`` as a parameter. Previously, it takes only ``abc`` as a parameter and ``def`` as the next parameter due to a bug.
+
+.. literalinclude:: upgrade_430/001.php
+
+If your code depends on this bug, please fix it.
+
 Breaking Enhancements
 *********************
 

--- a/user_guide_src/source/installation/upgrade_430/001.php
+++ b/user_guide_src/source/installation/upgrade_430/001.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * When you have the route:
+ * $routes->get('(:any)', 'Pages::index/$1');
+ */
+
+namespace App\Controllers;
+
+class Pages extends BaseController
+{
+    public function index($page = 'home')
+    {
+        /*
+         * When navigating to `http://example.com/abc/def`,
+         * $page will be `abc/def`, not `abc`.
+         */
+
+        // ...
+    }
+}


### PR DESCRIPTION
**Description**
Fixes #6947

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
