### PR TITLE
docs: remove `/` before right `>` in void HTML elements

### DIFF
--- a/user_guide_src/source/installation/upgrade_security/ci3sample/002.php
+++ b/user_guide_src/source/installation/upgrade_security/ci3sample/002.php
@@ -12,6 +12,6 @@ $csrf = array(
     <input name="email" type="text">
     <input name="password" type="password">
 
-    <input type="hidden" name="<?= $csrf['name'] ?>" value="<?= $csrf['hash'] ?>" />
+    <input type="hidden" name="<?= $csrf['name'] ?>" value="<?= $csrf['hash'] ?>">
     <input type="submit" value="Save">
 </form>

--- a/user_guide_src/source/libraries/caching/001.php
+++ b/user_guide_src/source/libraries/caching/001.php
@@ -1,7 +1,7 @@
 <?php
 
 if (! $foo = cache('foo')) {
-    echo 'Saving to the cache!<br />';
+    echo 'Saving to the cache!<br>';
     $foo = 'foobarbaz!';
 
     // Save into the cache for 5 minutes

--- a/user_guide_src/source/libraries/email/022.php
+++ b/user_guide_src/source/libraries/email/022.php
@@ -6,6 +6,6 @@ $email->attach($filename);
 foreach ($list as $address) {
     $email->setTo($address);
     $cid = $email->setAttachmentCID($filename);
-    $email->setMessage('<img src="cid:' . $cid . '" alt="photo1" />');
+    $email->setMessage('<img src="cid:' . $cid . '" alt="photo1">');
     $email->send();
 }

--- a/user_guide_src/source/libraries/uploaded_files/001.php
+++ b/user_guide_src/source/libraries/uploaded_files/001.php
@@ -10,13 +10,9 @@
 <?php endforeach ?>
 
 <?= form_open_multipart('upload/upload') ?>
-
-<input type="file" name="userfile" size="20" />
-
-<br /><br />
-
-<input type="submit" value="upload" />
-
+    <input type="file" name="userfile" size="20">
+    <br><br>
+    <input type="submit" value="upload">
 </form>
 
 </body>


### PR DESCRIPTION
**Description**
HTML5 compatible.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
