### PR TITLE
[Rector] Enable skipped StringClassNameToClassConstantRector on namespaced string

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -98,15 +98,6 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/system/Session/Handlers',
         ],
 
-        StringClassNameToClassConstantRector::class => [
-            // may cause load view files directly when detecting namespaced string
-            // due to internal PHPStan issue
-            __DIR__ . '/app/Config/Pager.php',
-            __DIR__ . '/app/Config/Validation.php',
-            __DIR__ . '/tests/system/Validation/StrictRules/ValidationTest.php',
-            __DIR__ . '/tests/system/Validation/ValidationTest.php',
-        ],
-
         // sometime too detail
         CountOnNullRector::class,
 


### PR DESCRIPTION
**Description**

There was internal PHPStan error by enabling `StringClassNameToClassConstantRector` on namespaced string, it seems resolved now so the skipped `StringClassNameToClassConstantRector` can be enabled again.

**Checklist:**
- [x] Securely signed commits
