### PR TITLE
fix: don't change the variable type and filter all values in JSON request

### DIFF
--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -185,6 +185,8 @@ Others
     - ``Debug\Exceptions::__construct()``
     - ``Services::exceptions()``
 
+- **Request:** The ``$index`` parameter of ``IncomingRequest::getJsonVar()`` now accepts an ``array``, ``string`` or ``null`` value.
+
 Enhancements
 ************
 
@@ -342,3 +344,5 @@ Bugs Fixed
 **********
 
 - Fixed a bug when all types of ``Prepared Queries`` were returning a ``Result`` object instead of a bool value for write-type queries.
+- Fixed a bug when not always all variables in a JSON request were filtered if filters were applied with ``IncomingRequest::getVar()`` or ``IncomingRequest::getJsonVar()`` methods.
+- Fixed a bug when variable type may be changed when using a specified index with ``IncomingRequest::getVar()`` or ``IncomingRequest::getJsonVar()`` methods.

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -344,5 +344,5 @@ Bugs Fixed
 **********
 
 - Fixed a bug when all types of ``Prepared Queries`` were returning a ``Result`` object instead of a bool value for write-type queries.
-- Fixed a bug when not always all variables in a JSON request were filtered if filters were applied with ``IncomingRequest::getVar()`` or ``IncomingRequest::getJsonVar()`` methods.
+- Fixed a bug with variable filtering in JSON requests using with ``IncomingRequest::getVar()`` or ``IncomingRequest::getJsonVar()`` methods.
 - Fixed a bug when variable type may be changed when using a specified index with ``IncomingRequest::getVar()`` or ``IncomingRequest::getJsonVar()`` methods.


### PR DESCRIPTION
**Description**
Fixes #6878

Current behavior is inconsistence.

1. `getVar(null)` will call `getJSON()` which will return all the data without filtering.
2. `getVar('index')` will be filtered, but... it seems like `getJsonVar()` doesn't perform filtering on nested values (arrays, objects), only on single variables.

This is very problematic:

* some variables may not be filtered at all (arrays etc.), even if we set a proper flag - it will be ignored
* if we call a single variable, it will be converted to a string due to the nature of the `filter_var()` function
* basically, we can get different variable types depending on how we ask for them

I targeted this PR to 4.3 because I'm changing the parameter signature in one method. This will make the code more consistent, and the functionality will be the same as we have with `getGet()`, etc. methods.

BC label is related to changing a signature for `$index` parameter in `IncomingRequest::getJsonVar()`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
