### PR TITLE
docs: fix upgrade_routing.rst

### DIFF
--- a/user_guide_src/source/installation/upgrade_routing.rst
+++ b/user_guide_src/source/installation/upgrade_routing.rst
@@ -22,10 +22,11 @@ Upgrade Guide
 =============
 
 1. If you use the Auto Routing in the same way as CI3, you need to enable :ref:`auto-routing`.
-2. You have to change the syntax of each routing line and append it in **app/Config/Routes.php**. For example:
+2. The placeholder ``(:any)`` in CI3 will be ``(:segment)`` in CI4.
+3. You have to change the syntax of each routing line and append it in **app/Config/Routes.php**. For example:
 
     - ``$route['journals'] = 'blogs';`` to ``$routes->add('journals', 'Blogs::index');``. This would map to the ``index()`` method in the ``Blogs`` controller.
-    - ``$route['product/(:any)'] = 'catalog/product_lookup';`` to ``$routes->add('product/(:any)', 'Catalog::productLookup');``
+    - ``$route['product/(:any)'] = 'catalog/product_lookup';`` to ``$routes->add('product/(:segment)', 'Catalog::productLookup');``
     - ``$route['login/(.+)'] = 'auth/login/$1';`` to ``$routes->add('login/(.+)', 'Auth::login/$1');``
 
 Code Example

--- a/user_guide_src/source/installation/upgrade_routing/001.php
+++ b/user_guide_src/source/installation/upgrade_routing/001.php
@@ -21,4 +21,4 @@ $routes->add('posts/create', 'Posts::create');
 $routes->add('posts/update', 'Posts::update');
 $routes->add('drivers/create', 'Drivers::create');
 $routes->add('drivers/update', 'Drivers::update');
-$routes->add('posts/(:any)', 'Posts::view/$1');
+$routes->add('posts/(:segment)', 'Posts::view/$1');

--- a/user_guide_src/source/installation/upgrade_routing/001.php
+++ b/user_guide_src/source/installation/upgrade_routing/001.php
@@ -2,14 +2,13 @@
 
 namespace Config;
 
-// Create a new instance of our RouteCollection class.
-$routes = Services::routes();
+// ...
 
-// Load the system's routing file first, so that the app and ENVIRONMENT
-// can override as needed.
-if (file_exists(SYSTEMPATH . 'Config/Routes.php')) {
-    require SYSTEMPATH . 'Config/Routes.php';
-}
+/*
+ * --------------------------------------------------------------------
+ * Route Definitions
+ * --------------------------------------------------------------------
+ */
 
 // ...
 
@@ -22,3 +21,5 @@ $routes->add('posts/update', 'Posts::update');
 $routes->add('drivers/create', 'Drivers::create');
 $routes->add('drivers/update', 'Drivers::update');
 $routes->add('posts/(:segment)', 'Posts::view/$1');
+
+// ...

--- a/user_guide_src/source/installation/upgrade_routing/ci3sample/001.php
+++ b/user_guide_src/source/installation/upgrade_routing/ci3sample/001.php
@@ -1,12 +1,14 @@
 <?php
 defined('BASEPATH') OR exit('No direct script access allowed');
 
-$route['posts/index'] = 'posts/index';
+// ...
+
+$route['posts/index']  = 'posts/index';
 $route['teams/create'] = 'teams/create';
 $route['teams/update'] = 'teams/update';
 
-$route['posts/create'] = 'posts/create';
-$route['posts/update'] = 'posts/update';
+$route['posts/create']   = 'posts/create';
+$route['posts/update']   = 'posts/update';
 $route['drivers/create'] = 'drivers/create';
 $route['drivers/update'] = 'drivers/update';
-$route['posts/(:any)'] = 'posts/view/$1';
+$route['posts/(:any)']   = 'posts/view/$1';


### PR DESCRIPTION
**Description**
The placeholder `(:any)` in CI3 is translated to `[^/]+`.  See http://codeigniter.com/userguide3/general/routing.html#wildcards
So it is `(:segment)` in CI4.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
