### PR TITLE
docs: fix tutorial placeholder `(:any)`

### DIFF
--- a/user_guide_src/source/tutorial/create_news_items/004.php
+++ b/user_guide_src/source/tutorial/create_news_items/004.php
@@ -6,6 +6,6 @@ $routes->match(['get', 'post'], 'news/create', 'News::create');
 $routes->get('news/(:segment)', 'News::view/$1');
 $routes->get('news', 'News::index');
 $routes->get('pages', 'Pages::index');
-$routes->get('(:any)', 'Pages::view/$1');
+$routes->get('(:segment)', 'Pages::view/$1');
 
 // ...

--- a/user_guide_src/source/tutorial/news_section/008.php
+++ b/user_guide_src/source/tutorial/news_section/008.php
@@ -5,6 +5,6 @@
 $routes->get('news/(:segment)', 'News::view/$1');
 $routes->get('news', 'News::index');
 $routes->get('pages', 'Pages::index');
-$routes->get('(:any)', 'Pages::view/$1');
+$routes->get('(:segment)', 'Pages::view/$1');
 
 // ...

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -151,8 +151,8 @@ More information about routing can be found in the URI Routing
 Here, the second rule in the ``$routes`` object matches GET request
 to the URI path ``/pages`` maps the ``index()`` method of the ``Pages`` class.
 
-The third rule in the ``$routes`` object matches GET request to **any** URI path
-using the wildcard string ``(:any)``, and passes the parameter to the
+The third rule in the ``$routes`` object matches a GET request to a URI segment
+using the placeholder ``(:segment)``, and passes the parameter to the
 ``view()`` method of the ``Pages`` class.
 
 Running the App

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -148,8 +148,8 @@ arguments.
 More information about routing can be found in the URI Routing
 :doc:`documentation </incoming/routing>`.
 
-Here, the second rule in the ``$routes`` object matches GET request
-to the URI path ``/pages`` maps the ``index()`` method of the ``Pages`` class.
+Here, the second rule in the ``$routes`` object matches a GET request
+to the URI path ``/pages``, and it maps to the ``index()`` method of the ``Pages`` class.
 
 The third rule in the ``$routes`` object matches a GET request to a URI segment
 using the placeholder ``(:segment)``, and passes the parameter to the

--- a/user_guide_src/source/tutorial/static_pages/004.php
+++ b/user_guide_src/source/tutorial/static_pages/004.php
@@ -1,4 +1,4 @@
 <?php
 
 $routes->get('pages', 'Pages::index');
-$routes->get('(:any)', 'Pages::view/$1');
+$routes->get('(:segment)', 'Pages::view/$1');


### PR DESCRIPTION
**Description**
See #6957

- replace `(:any)` with `(:segment)`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
