### PR TITLE
fix: FileLocator::locateFile() bug with a similar namespace name

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -71,13 +71,9 @@ class FileLocator
         $namespaces = $this->autoloader->getNamespace();
 
         foreach (array_keys($namespaces) as $namespace) {
-            if (substr($file, 0, strlen($namespace)) === $namespace) {
+            if (substr($file, 0, strlen($namespace) + 1) === $namespace . '\\') {
                 $fileWithoutNamespace = substr($file, strlen($namespace));
-                // Check if this is really another sub-namespace,
-                // or just a namespace with a very similar name.
-                if ($fileWithoutNamespace[0] !== '\\') {
-                    continue;
-                }
+
                 // There may be sub-namespaces of the same vendor,
                 // so overwrite them with namespaces found later.
                 $paths    = $namespaces[$namespace];

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -72,12 +72,16 @@ class FileLocator
 
         foreach (array_keys($namespaces) as $namespace) {
             if (substr($file, 0, strlen($namespace)) === $namespace) {
+                $fileWithoutNamespace = substr($file, strlen($namespace));
+                // Check if this is really another sub-namespace,
+                // or just a namespace with a very similar name.
+                if ($fileWithoutNamespace[0] !== '\\') {
+                    continue;
+                }
                 // There may be sub-namespaces of the same vendor,
                 // so overwrite them with namespaces found later.
-                $paths = $namespaces[$namespace];
-
-                $fileWithoutNamespace = substr($file, strlen($namespace));
-                $filename             = ltrim(str_replace('\\', '/', $fileWithoutNamespace), '/');
+                $paths    = $namespaces[$namespace];
+                $filename = ltrim(str_replace('\\', '/', $fileWithoutNamespace), '/');
             }
         }
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -44,6 +44,8 @@ final class FileLocatorTest extends CIUnitTestCase
             'CodeIgniter\\Devkit' => [
                 TESTPATH . '_support/',
             ],
+            'Acme\SampleProject' => TESTPATH . '_support',
+            'Acme\Sample'        => TESTPATH . '_support/does/not/exists',
         ]);
 
         $this->locator = new FileLocator($autoloader);
@@ -149,6 +151,15 @@ final class FileLocatorTest extends CIUnitTestCase
         $file = '\Blogger\admin/posts.php';
 
         $this->assertFalse($this->locator->locateFile($file, 'Views'));
+    }
+
+    public function testLocateFileWithProperNamespace()
+    {
+        $file = 'Acme\SampleProject\View\Views\simple';
+
+        $expected = ROOTPATH . 'tests/_support/View/Views/simple.php';
+
+        $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
     public function testSearchSimple()

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.2.11
     v4.2.10
     v4.2.9
     v4.2.8

--- a/user_guide_src/source/changelogs/v4.2.11.rst
+++ b/user_guide_src/source/changelogs/v4.2.11.rst
@@ -1,0 +1,17 @@
+Version 4.2.11
+##############
+
+Release Date: Unreleased
+
+**4.2.11 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 2
+
+Bugs Fixed
+**********
+
+- Fixed a ``FileLocator::locateFile()`` bug where a similar namespace name could be replaced by another, causing a failure to find a file that exists.
+
+See the repo's `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_ for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
There is a bug in `FileLocator::locateFile()` when two namespaces are very similar.

Example:
```php
// app/Config/Autoload.php
public $psr4 = [
    APP_NAMESPACE => APPPATH, // For custom app namespace
    'Config'      => APPPATH . 'Config',
    'Acme\ProjectNameDemo' => APPPATH . 'Modules/project-name-demo',
    'Acme\ProjectName' => APPPATH . 'Modules/project-name',
];

// app/Config/Routes.php
$routes->get('demo', static function () {
    return view('Acme\ProjectNameDemo\Views\home');
});

```

In this scenario, the `FileLocator` will try to load a file from the namespace `Acme\ProjectName`.

If we switch the order of the `Acme` namespace in `Autoload.php`, then everything will work fine.

Bug proof of concept: https://github.com/michalsn/ci-filelocator-bug/commit/183d087ab36839ffb0cc8950e5a2265dae04971a


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
