### PR TITLE
Use Services for the FeatureTestTrait request.

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -15,7 +15,6 @@ use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\URI;
-use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\RouteCollection;
 use Config\App;
@@ -292,7 +291,7 @@ trait FeatureTestTrait
     {
         $path    = URI::removeDotSegments($path);
         $config  = config(App::class);
-        $request = new IncomingRequest($config, new URI(), null, new UserAgent());
+        $request = Services::request($config, true);
 
         // $path may have a query in it
         $parts                   = explode('?', $path);


### PR DESCRIPTION
Replaces #6958 

When using a custom extension of the IncomingRequest class, running Feature tests would fail with a TypeError. The problem is that FeatureTestTrait would directly create an instance of the framework's IncomingRequest instead of grabbing it from the Services class.

This changes that to use it from the Service class instead.