### PR TITLE
fix: transaction exception test

### DIFF
--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -57,7 +57,9 @@ final class TransactionTest extends CIUnitTestCase
 
     public function testTransStartDBDebugTrue()
     {
-        $builder = $this->db->table('job');
+        $this->enableDBDebug();
+
+        $builder = $this->db->transException(true)->table('job');
         $e       = null;
 
         try {


### PR DESCRIPTION
**Description**
This PR fixes a `TransactionTest::testTransStartDBDebugTrue()`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
