### PR TITLE
fix: remove unnecessary global variables in rewrite.php

### DIFF
--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -29,11 +29,8 @@ $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 // All request handle by index.php file.
 $_SERVER['SCRIPT_NAME'] = '/index.php';
 
-// Front Controller path - expected to be in the default folder
-$fcpath = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR;
-
 // Full path
-$path = $fcpath . ltrim($uri, '/');
+$path = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . ltrim($uri, '/');
 
 // If $path is an existing file or folder within the public folder
 // then let the request handle it like normal.
@@ -41,7 +38,9 @@ if ($uri !== '/' && (is_file($path) || is_dir($path))) {
     return false;
 }
 
+unset($uri, $path);
+
 // Otherwise, we'll load the index file and let
 // the framework handle the request from here.
-require_once $fcpath . 'index.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'index.php';
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
**Description**
- remove unnecessary global variables

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
