### PR TITLE
[PHPStan] Fix PHPStan notice on PHPStan 1.9.3

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -982,7 +982,7 @@ class CLI
             $table .= '| ' . implode(' | ', $tableRows[$row]) . ' |' . PHP_EOL;
 
             // Set the thead and table borders-bottom
-            if (isset($cols) && (($row === 0 && ! empty($thead)) || ($row + 1 === $totalRows))) {
+            if (($row === 0 && ! empty($thead)) || ($row + 1 === $totalRows)) {
                 $table .= $cols . PHP_EOL;
             }
         }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

Fix PHPStan notice on PHPStan 1.9.3:

```bash
Run vendor/bin/phpstan analyse
Note: Using configuration file /home/runner/work/CodeIgniter4/CodeIgniter4/phpstan.neon.dist.
   0/434 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
 360/434 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░]  82%
 434/434 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

Error: Variable $cols in isset() always exists and is not nullable.
 ------ -------------------------------------------------------------- 
  Line   system/CLI/CLI.php                                            
 ------ -------------------------------------------------------------- 
  985    Variable $cols in isset() always exists and is not nullable.  
```

Ref https://github.com/codeigniter4/CodeIgniter4/actions/runs/3686745072/jobs/6239400007#step:11:15

**Checklist:**
- [x] Securely signed commits
