### PR TITLE
fix: `spark namespaces` cannot show a namespace with mutilple paths

### DIFF
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -38,7 +38,8 @@ class Autoload extends AutoloadConfig
      *   ];
      *```
      *
-     * @var array<string, string>
+     * @var array<string, array<int, string>|string>
+     * @phpstan-var array<string, string|list<string>>
      */
     public $psr4 = [
         APP_NAMESPACE => APPPATH, // For custom app namespace

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -21,11 +21,6 @@ parameters:
 			path: system/Autoloader/Autoloader.php
 
 		-
-			message: "#^Property Config\\\\Autoload\\:\\:\\$psr4 \\(array\\<string, string\\>\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Autoloader/Autoloader.php
-
-		-
 			message: "#^Property Config\\\\Cache\\:\\:\\$backupHandler \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: system/Cache/CacheFactory.php

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -11,16 +11,6 @@ parameters:
 			path: system/Autoloader/Autoloader.php
 
 		-
-			message: "#^Property Config\\\\Autoload\\:\\:\\$classmap \\(array\\<string, string\\>\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Autoloader/Autoloader.php
-
-		-
-			message: "#^Property Config\\\\Autoload\\:\\:\\$files \\(array\\<int, string\\>\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Autoloader/Autoloader.php
-
-		-
 			message: "#^Property Config\\\\Cache\\:\\:\\$backupHandler \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: system/Cache/CacheFactory.php

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -88,19 +88,19 @@ class Autoloader
 
         // We have to have one or the other, though we don't enforce the need
         // to have both present in order to work.
-        if (empty($config->psr4) && empty($config->classmap)) {
+        if ($config->psr4 === [] && $config->classmap === []) {
             throw new InvalidArgumentException('Config array must contain either the \'psr4\' key or the \'classmap\' key.');
         }
 
-        if (isset($config->psr4)) {
+        if ($config->psr4 !== []) {
             $this->addNamespace($config->psr4);
         }
 
-        if (isset($config->classmap)) {
+        if ($config->classmap !== []) {
             $this->classmap = $config->classmap;
         }
 
-        if (isset($config->files)) {
+        if ($config->files !== []) {
             $this->files = $config->files;
         }
 
@@ -148,7 +148,8 @@ class Autoloader
     /**
      * Registers namespaces with the autoloader.
      *
-     * @param array|string $namespace
+     * @param array<string, array<int, string>|string>|string $namespace
+     * @phpstan-param array<string, list<string>|string>|string $namespace
      *
      * @return $this
      */

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -74,14 +74,20 @@ class Namespaces extends BaseCommand
 
         $tbody = [];
 
-        foreach ($config->psr4 as $ns => $path) {
-            $path = realpath($path) ?: $path;
+        foreach ($config->psr4 as $ns => $paths) {
+            if (is_string($paths)) {
+                $paths = [$paths];
+            }
 
-            $tbody[] = [
-                $ns,
-                realpath($path) ?: $path,
-                is_dir($path) ? 'Yes' : 'MISSING',
-            ];
+            foreach ($paths as $path) {
+                $path = realpath($path) ?: $path;
+
+                $tbody[] = [
+                    $ns,
+                    realpath($path) ?: $path,
+                    is_dir($path) ? 'Yes' : 'MISSING',
+                ];
+            }
         }
 
         $thead = [

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -80,7 +80,7 @@ class Namespaces extends BaseCommand
 
                 $tbody[] = [
                     $ns,
-                    realpath($path) ?: $path,
+                    $path,
                     is_dir($path) ? 'Yes' : 'MISSING',
                 ];
             }

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -75,11 +75,7 @@ class Namespaces extends BaseCommand
         $tbody = [];
 
         foreach ($config->psr4 as $ns => $paths) {
-            if (is_string($paths)) {
-                $paths = [$paths];
-            }
-
-            foreach ($paths as $path) {
+            foreach ((array) $paths as $path) {
                 $path = realpath($path) ?: $path;
 
                 $tbody[] = [

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -73,6 +73,7 @@ class AutoloadConfig
      * or for loading functions.
      *
      * @var array<int, string>
+     * @phpstan-var list<string>
      */
     public $files = [];
 

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -45,7 +45,8 @@ class AutoloadConfig
      * but this should be done prior to creating any namespaced classes,
      * else you will need to modify all of those classes for this to work.
      *
-     * @var array<string, string>
+     * @var array<string, array<int, string>|string>
+     * @phpstan-var array<string, string|list<string>>
      */
     public $psr4 = [];
 


### PR DESCRIPTION
**Description**
Autoloader supports a psr4 namespace with multiple paths.
See https://github.com/codeigniter4/CodeIgniter4/blob/ce64c72c06fe5a45c2ba56dfcbae2f7837447901/tests/system/Autoloader/AutoloaderTest.php#L149
But `spark namespaces` cannot show it.

```diff
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -43,6 +43,7 @@ class Autoload extends AutoloadConfig
     public $psr4 = [
         APP_NAMESPACE => APPPATH, // For custom app namespace
         'Config'      => APPPATH . 'Config',
+        'Test'        => [ROOTPATH . 'modules/Test/src', ROOTPATH . 'modules/Test/tests'],
     ];
 
     /**
```

Before:
```
[TypeError]

realpath(): Argument #1 ($path) must be of type string, array given

at SYSTEMPATH/Commands/Utilities/Namespaces.php:78

Backtrace:
  1    SYSTEMPATH/Commands/Utilities/Namespaces.php:78
       realpath([...])

  2    SYSTEMPATH/CLI/Commands.php:63
       CodeIgniter\Commands\Utilities\Namespaces()->run([])

  3    SYSTEMPATH/CLI/CommandRunner.php:65
       CodeIgniter\CLI\Commands()->run('namespaces', [])

  4    SYSTEMPATH/CLI/CommandRunner.php:51
       CodeIgniter\CLI\CommandRunner()->index([])

  5    SYSTEMPATH/CodeIgniter.php:918
       CodeIgniter\CLI\CommandRunner()->_remap('index', [...])

  6    SYSTEMPATH/CodeIgniter.php:480
       CodeIgniter\CodeIgniter()->runController(Object(CodeIgniter\CLI\CommandRunner))

  7    SYSTEMPATH/CodeIgniter.php:345
       CodeIgniter\CodeIgniter()->handleRequest(null, Object(Config\Cache), false)

  8    SYSTEMPATH/CLI/Console.php:48
       CodeIgniter\CodeIgniter()->run()

  9    ROOTPATH/spark:98
       CodeIgniter\CLI\Console()->run()
```

After:
```
+-------------+------------------------------------------------------------------------+---------+
| Namespace   | Path                                                                   | Found?  |
+-------------+------------------------------------------------------------------------+---------+
| CodeIgniter | /Users/kenji/work/codeigniter/official/CodeIgniter4/system             | Yes     |
| App         | /Users/kenji/work/codeigniter/official/CodeIgniter4/app                | Yes     |
| Config      | /Users/kenji/work/codeigniter/official/CodeIgniter4/app/Config         | Yes     |
| Test        | /Users/kenji/work/codeigniter/official/CodeIgniter4/modules/Test/src   | MISSING |
| Test        | /Users/kenji/work/codeigniter/official/CodeIgniter4/modules/Test/tests | MISSING |
+-------------+------------------------------------------------------------------------+---------+
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
