### PR TITLE
[Rector] Update to Rector 0.15.1 and re-enable TypedPropertyFromAssignsRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpunit/phpcov": "^8.2",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1 || ^2.0",
-        "rector/rector": "0.15.0"
+        "rector/rector": "0.15.1"
     },
     "suggest": {
         "ext-curl": "If you use CURLRequest class",

--- a/rector.php
+++ b/rector.php
@@ -46,7 +46,6 @@ use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Rector\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Utils\Rector\PassStrictParameterToFunctionParameterRector;
 use Utils\Rector\RemoveErrorSuppressInTryCatchStmtsRector;
 use Utils\Rector\RemoveVarTagFromClassConstantRector;
@@ -111,9 +110,6 @@ return static function (RectorConfig $rectorConfig): void {
         GetMockBuilderGetMockToCreateMockRector::class => [
             __DIR__ . '/tests/system/Email/EmailTest.php',
         ],
-
-        // buggy on union mixed type, new class extends SomeClass marked as object in union, and false replaced with bool in Union
-        TypedPropertyFromAssignsRector::class,
     ]);
 
     // auto import fully qualified class names

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -39,11 +39,7 @@ use Tests\Support\Config\Validation;
 final class ControllerTest extends CIUnitTestCase
 {
     private App $config;
-
-    /**
-     * @var Controller|null
-     */
-    private $controller;
+    private ?Controller $controller = null;
 
     /**
      * Current request.

--- a/tests/system/View/DecoratorsTest.php
+++ b/tests/system/View/DecoratorsTest.php
@@ -28,7 +28,7 @@ final class DecoratorsTest extends CIUnitTestCase
 {
     private FileLocator $loader;
     private string $viewsDir;
-    private $config;
+    private ?\Config\View $config = null;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

@kenjis @paulbalandan Rector 0.15.1 just released and we can re-enable `TypedPropertyFromAssignsRector` that was buggy on `union mixed type, new class extends SomeClass marked as object in union, and false replaced with bool in Union` which currently resolved.

**Checklist:**
- [x] Securely signed commits