### PR TITLE
fix: Undefined constant "CodeIgniter\Debug\VENDORPATH"

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -174,6 +174,7 @@ class Exceptions
     {
         if (
             $severity === E_DEPRECATED
+            && defined('VENDORPATH')
             && strpos($file, VENDORPATH . 'fakerphp/faker/') !== false
             && $message === 'Use of "static" in callables is deprecated'
         ) {


### PR DESCRIPTION
**Description**
Reported at https://forum.codeigniter.com/showthread.php?tid=85882

- `VENDORPATH` may not defined.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
