### PR TITLE
fix: BaseBuilder::getOperator() doesn't recognize LIKE operator in array expression

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -749,7 +749,7 @@ class BaseBuilder
                 $k  = '';
                 $op = '';
             } elseif ($v !== null) {
-                $op = $this->getOperator($k, true);
+                $op = $this->getOperatorFromWhereKey($k);
 
                 if (! empty($op)) {
                     $k = trim($k);
@@ -3385,6 +3385,35 @@ class BaseBuilder
             $str,
             $match
         ) ? ($list ? $match[0] : $match[0][0]) : false;
+    }
+
+    /**
+     * Returns the SQL string operator from where key
+     *
+     * @return array<int, string>|false
+     * @phpstan-return list<string>|false
+     */
+    private function getOperatorFromWhereKey(string $whereKey)
+    {
+        $whereKey = trim($whereKey);
+
+        if ($this->pregOperators === []) {
+            $this->pregOperators = [
+                '\s*(?:<|>|!)?=', // =, <=, >=, !=
+                '\s*<>?',         // <, <>
+                '\s*>',           // >
+                '\s+IS NULL',     // IS NULL
+                '\s+IS NOT NULL', // IS NOT NULL
+                '\s+LIKE',        // LIKE
+                '\s+NOT LIKE',    // NOT LIKE
+            ];
+        }
+
+        return preg_match_all(
+            '/' . implode('|', $this->pregOperators) . '/i',
+            $whereKey,
+            $match
+        ) ? $match[0] : false;
     }
 
     /**

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3397,20 +3397,18 @@ class BaseBuilder
     {
         $whereKey = trim($whereKey);
 
-        if ($this->pregOperators === []) {
-            $this->pregOperators = [
-                '\s*(?:<|>|!)?=', // =, <=, >=, !=
-                '\s*<>?',         // <, <>
-                '\s*>',           // >
-                '\s+IS NULL',     // IS NULL
-                '\s+IS NOT NULL', // IS NOT NULL
-                '\s+LIKE',        // LIKE
-                '\s+NOT LIKE',    // NOT LIKE
-            ];
-        }
+        $pregOperators = [
+            '\s*(?:<|>|!)?=', // =, <=, >=, !=
+            '\s*<>?',         // <, <>
+            '\s*>',           // >
+            '\s+IS NULL',     // IS NULL
+            '\s+IS NOT NULL', // IS NOT NULL
+            '\s+LIKE',        // LIKE
+            '\s+NOT LIKE',    // NOT LIKE
+        ];
 
         return preg_match_all(
-            '/' . implode('|', $this->pregOperators) . '/i',
+            '/' . implode('|', $pregOperators) . '/i',
             $whereKey,
             $match
         ) ? $match[0] : false;

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -132,6 +132,20 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
+    public function testWhereLikeInAssociateArray()
+    {
+        $builder = $this->db->table('user');
+
+        $where = [
+            'id <'      => 100,
+            'col1 LIKE' => '%gmail%',
+        ];
+        $builder->where($where);
+
+        $expectedSQL = 'SELECT * FROM "user" WHERE "id" < 100 AND "col1" LIKE \'%gmail%\'';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
     public function testWhereCustomString()
     {
         $builder = $this->db->table('jobs');


### PR DESCRIPTION
**Description**
Fixes #4347

- no longer use `getOperator()` in `where()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
