### PR TITLE
fix: empty paths for `rewrite.php`

### DIFF
--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -25,7 +25,7 @@ if (PHP_SAPI === 'cli') {
 }
 
 $uri = urldecode(
-    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
+    parse_url('http://ci4.dev' . $_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
 );
 
 // All request handle by index.php file.

--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -24,7 +24,9 @@ if (PHP_SAPI === 'cli') {
     return;
 }
 
-$uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+$uri = urldecode(
+    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
+);
 
 // All request handle by index.php file.
 $_SERVER['SCRIPT_NAME'] = '/index.php';

--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -25,7 +25,7 @@ if (PHP_SAPI === 'cli') {
 }
 
 $uri = urldecode(
-    parse_url('http://ci4.dev' . $_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
+    parse_url('https://codeigniter.com' . $_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
 );
 
 // All request handle by index.php file.


### PR DESCRIPTION

![Screenshot 2022-12-19 063650](https://user-images.githubusercontent.com/9530214/208340126-307846c3-f5ac-4407-97a1-f3360060526d.jpg)
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
This PR fixes an issue where an url has an empty path segment and a non-trailing slash ending. 
```
Deprecated: urldecode(): Passing null to parameter #1 ($string) of type string is deprecated in P:\Bug\project-root\vendor\codeigniter4\framework\system\Commands\Server\rewrite.php on line 28
```
Instead, what we'll do is pass an empty string if that happens. Since the url couldn't be parsed, we give an empty string, which is an url that will definitely not exist (root is /) and it will properly show the **404 page**.

**PHP: 8.1.5**
see: http://localhost:8080//any




**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
