### PR TITLE
fix: `PHPStan` $cols not defined in `CLI`

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -965,6 +965,7 @@ class CLI
         }
 
         $table = '';
+        $cols  = '';
 
         // Joins columns and append the well formatted rows to the table
         for ($row = 0; $row < $totalRows; $row++) {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
```
------ --------------------------------------
  Line   system\CLI\CLI.php
 ------ --------------------------------------
  :987   Variable $cols might not be defined.
 ------ --------------------------------------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
