### PR TITLE
feat: add IncomingRequest::is() method

### DIFF
--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -304,4 +304,15 @@ class CLIRequest extends Request
     {
         return Locale::getDefault();
     }
+
+    /**
+     * Checks this request type.
+     *
+     * @param string $type HTTP verb or 'json' or 'ajax'
+     * @phpstan-param string|'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json'|'ajax' $type
+     */
+    public function is(string $type): bool
+    {
+        return false;
+    }
 }

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -376,14 +376,14 @@ class IncomingRequest extends Request
     }
 
     /**
-     * Checks if this request is.
+     * Checks this request type.
      *
-     * @param string $value HTTP verb or 'json' or 'ajax'
-     * @phpstan-param string|'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json'|'ajax' $value
+     * @param string $type HTTP verb or 'json' or 'ajax'
+     * @phpstan-param string|'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json'|'ajax' $type
      */
-    public function is(string $value): bool
+    public function is(string $type): bool
     {
-        $valueUpper = strtoupper($value);
+        $valueUpper = strtoupper($type);
 
         $httpMethods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH', 'OPTIONS'];
 
@@ -399,7 +399,7 @@ class IncomingRequest extends Request
             return $this->isAJAX();
         }
 
-        throw new InvalidArgumentException('Unknown value: ' . $value);
+        throw new InvalidArgumentException('Unknown type: ' . $type);
     }
 
     /**

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -383,19 +383,19 @@ class IncomingRequest extends Request
      */
     public function is(string $value): bool
     {
-        $value = strtolower($value);
+        $valueUpper = strtoupper($value);
 
-        $httpMethods = ['get', 'post', 'put', 'delete', 'head', 'patch', 'options'];
+        $httpMethods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH', 'OPTIONS'];
 
-        if (in_array($value, $httpMethods, true)) {
-            return strtolower($this->getMethod()) === $value;
+        if (in_array($valueUpper, $httpMethods, true)) {
+            return strtoupper($this->getMethod()) === $valueUpper;
         }
 
-        if ($value === 'json') {
+        if ($valueUpper === 'JSON') {
             return strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false;
         }
 
-        if ($value === 'ajax') {
+        if ($valueUpper === 'AJAX') {
             return $this->isAJAX();
         }
 

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -376,6 +376,30 @@ class IncomingRequest extends Request
     }
 
     /**
+     * Checks if this request is.
+     *
+     * @param string $value HTTP verb or 'json'
+     * @phpstan-param 'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json' $value
+     */
+    public function is(string $value): bool
+    {
+        $value = strtolower($value);
+
+        $httpMethods = ['get', 'post', 'put', 'delete', 'head', 'patch', 'options'];
+
+        if (in_array($value, $httpMethods, true)) {
+            return strtolower($this->getMethod()) === $value;
+        }
+
+        if ($value === 'json') {
+            return strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false;
+        }
+
+        // @phpstan-ignore-next-line
+        throw new InvalidArgumentException('Unknown value: ' . $value);
+    }
+
+    /**
      * Determines if this request was made from the command line (CLI).
      */
     public function isCLI(): bool

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -379,7 +379,7 @@ class IncomingRequest extends Request
      * Checks if this request is.
      *
      * @param string $value HTTP verb or 'json'
-     * @phpstan-param 'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json' $value
+     * @phpstan-param string|'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json' $value
      */
     public function is(string $value): bool
     {
@@ -395,7 +395,6 @@ class IncomingRequest extends Request
             return strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false;
         }
 
-        // @phpstan-ignore-next-line
         throw new InvalidArgumentException('Unknown value: ' . $value);
     }
 

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -378,8 +378,8 @@ class IncomingRequest extends Request
     /**
      * Checks if this request is.
      *
-     * @param string $value HTTP verb or 'json'
-     * @phpstan-param string|'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json' $value
+     * @param string $value HTTP verb or 'json' or 'ajax'
+     * @phpstan-param string|'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json'|'ajax' $value
      */
     public function is(string $value): bool
     {
@@ -393,6 +393,10 @@ class IncomingRequest extends Request
 
         if ($value === 'json') {
             return strpos($this->getHeaderLine('Content-Type'), 'application/json') !== false;
+        }
+
+        if ($value === 'ajax') {
+            return $this->isAJAX();
         }
 
         throw new InvalidArgumentException('Unknown value: ' . $value);

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -625,4 +625,9 @@ final class CLIRequestTest extends CIUnitTestCase
 
         $this->assertSame($this->request->getCookie(), []);
     }
+
+    public function testIs()
+    {
+        $this->assertFalse($this->request->is('get'));
+    }
 }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\Files\UploadedFile;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use Generator;
 use TypeError;
 
 /**
@@ -613,6 +614,46 @@ final class IncomingRequestTest extends CIUnitTestCase
         $request = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
 
         $this->assertSame($expected, $request->getRawInputVar($var, $filter, $flag));
+    }
+
+    /**
+     * @dataProvider provideIsHTTPMethods
+     */
+    public function testIsHTTPMethodLowerCase(string $value)
+    {
+        $request = $this->request->withMethod($value);
+
+        $this->assertTrue($request->is($value));
+    }
+
+    public function provideIsHTTPMethods(): Generator
+    {
+        yield from [
+            ['get'],
+            ['post'],
+            ['put'],
+            ['delete'],
+            ['head'],
+            ['patch'],
+            ['options'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIsHTTPMethods
+     */
+    public function testIsHTTPMethodUpperCase(string $value)
+    {
+        $request = $this->request->withMethod(strtoupper($value));
+
+        $this->assertTrue($request->is($value));
+    }
+
+    public function testIsJson()
+    {
+        $request = $this->request->setHeader('Content-Type', 'application/json');
+
+        $this->assertTrue($request->is('json'));
     }
 
     public function testIsCLI()

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -667,6 +667,13 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertTrue($request->is('json'));
     }
 
+    public function testIsWithAjax()
+    {
+        $request = $this->request->setHeader('X-Requested-With', 'XMLHttpRequest');
+
+        $this->assertTrue($request->is('ajax'));
+    }
+
     public function testIsCLI()
     {
         $this->assertFalse($this->request->isCLI());

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -624,19 +624,19 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $request = $this->request->withMethod($value);
 
-        $this->assertTrue($request->is($value));
+        $this->assertTrue($request->is(strtolower($value)));
     }
 
     public function provideIsHTTPMethods(): Generator
     {
         yield from [
-            ['get'],
-            ['post'],
-            ['put'],
-            ['delete'],
-            ['head'],
-            ['patch'],
-            ['options'],
+            ['GET'],
+            ['POST'],
+            ['PUT'],
+            ['DELETE'],
+            ['HEAD'],
+            ['PATCH'],
+            ['OPTIONS'],
         ];
     }
 
@@ -645,7 +645,7 @@ final class IncomingRequestTest extends CIUnitTestCase
      */
     public function testIsHTTPMethodUpperCase(string $value)
     {
-        $request = $this->request->withMethod(strtoupper($value));
+        $request = $this->request->withMethod($value);
 
         $this->assertTrue($request->is($value));
     }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -653,7 +653,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     public function testIsInvalidValue()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown value: invalid');
+        $this->expectExceptionMessage('Unknown type: invalid');
 
         $request = $this->request->withMethod('GET');
 

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\Files\UploadedFile;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Generator;
+use InvalidArgumentException;
 use TypeError;
 
 /**
@@ -647,6 +648,16 @@ final class IncomingRequestTest extends CIUnitTestCase
         $request = $this->request->withMethod(strtoupper($value));
 
         $this->assertTrue($request->is($value));
+    }
+
+    public function testIsInvalidValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown value: invalid');
+
+        $request = $this->request->withMethod('GET');
+
+        $request->is('invalid');
     }
 
     public function testIsJson()

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -323,7 +323,7 @@ Others
 - **Config:** Added ``Config\Session`` class to handle session configuration.
 - **Debug:** Kint has been updated to 5.0.1.
 - **Request:** Added new ``$request->getRawInputVar()`` method to return a specified variable from raw stream. See :ref:`Retrieving Raw data <incomingrequest-retrieving-raw-data>`.
-- **Request:** Added new ``$request->is()`` method to to query the request type.
+- **Request:** Added new ``$request->is()`` method to query the request type.
   See :ref:`Determining Request Type <incomingrequest-is>`.
 
 Message Changes

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -323,6 +323,8 @@ Others
 - **Config:** Added ``Config\Session`` class to handle session configuration.
 - **Debug:** Kint has been updated to 5.0.1.
 - **Request:** Added new ``$request->getRawInputVar()`` method to return a specified variable from raw stream. See :ref:`Retrieving Raw data <incomingrequest-retrieving-raw-data>`.
+- **Request:** Added new ``$request->is()`` method to to query the request type.
+  See :ref:`Determining Request Type <incomingrequest-is>`.
 
 Message Changes
 ***************

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -40,6 +40,20 @@ be checked with the ``isAJAX()`` and ``isCLI()`` methods:
     which in some cases is not sent by default in XHR requests via JavaScript (i.e., fetch).
     See the :doc:`AJAX Requests </general/ajax>` section on how to avoid this problem.
 
+.. _incomingrequest-is:
+
+is()
+====
+
+    .. versionadded:: 4.3.0
+
+Since v4.3.0, you can use the ``is()`` method. It returns boolean.
+
+.. literalinclude:: incomingrequest/040.php
+
+getMethod()
+===========
+
 You can check the HTTP method that this request represents with the ``getMethod()`` method:
 
 .. literalinclude:: incomingrequest/005.php

--- a/user_guide_src/source/incoming/incomingrequest/040.php
+++ b/user_guide_src/source/incoming/incomingrequest/040.php
@@ -1,0 +1,16 @@
+<?php
+
+// Checks HTTP methods. Returns boolean.
+$request->is('get');
+$request->is('post');
+$request->is('put');
+$request->is('delete');
+$request->is('head');
+$request->is('patch');
+$request->is('options');
+
+// Checks if it is an AJAX request.
+$request->is('ajax');
+
+// Checks if it is a JSON request.
+$request->is('json');

--- a/user_guide_src/source/incoming/incomingrequest/040.php
+++ b/user_guide_src/source/incoming/incomingrequest/040.php
@@ -9,7 +9,7 @@ $request->is('head');
 $request->is('patch');
 $request->is('options');
 
-// Checks if it is an AJAX request.
+// Checks if it is an AJAX request. The same as `$request->isAJAX()`.
 $request->is('ajax');
 
 // Checks if it is a JSON request.


### PR DESCRIPTION
**Description**
Writing code like `strtolower($this->request->getMethod()) !== 'post'` is a pain.

- add `IncomingRequest::is()`

```php
$request->is('get')
$request->is('post')
$request->is('put')
$request->is('delete')
$request->is('head')
$request->is('patch')
$request->is('options')
$request->is('json')
$request->is('ajax')
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
