### PR TITLE
Declared session in BaseController to avoid Creation of dynamic property in php 8.2

### DIFF
--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -38,7 +38,7 @@ abstract class BaseController extends Controller
     protected $helpers = [];
 
     /**
-     * Be sure to declare properties for anything you assign.
+     * Be sure to declare properties for any property fetch you initialized.
      * The creation of dynamic property is deprecated in PHP 8.2.
      */
     // protected $session;

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -42,7 +42,7 @@ abstract class BaseController extends Controller
      * initialization in the initController() method
      * See the Creation of dynamic property depreciation i php 8.2 
      */
-    public $session;
+    // public $session;
 
     /**
      * Constructor.

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -40,7 +40,7 @@ abstract class BaseController extends Controller
      /**
      * To declare the session propety to allow for global
      * initialization in the initController() method
-     * @var object
+     * See the Creation of dynamic property depreciation i php 8.2 
      */
     public $session;
 

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -37,12 +37,11 @@ abstract class BaseController extends Controller
      */
     protected $helpers = [];
 
-     /**
+    /**
      * Be sure to declare properties for anything you assign.
      * The creation of dynamic property is deprecated in PHP 8.2.
-     * 
-     * protected $session; 
      */
+    // protected $session;
 
     /**
      * Constructor.

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -37,6 +37,13 @@ abstract class BaseController extends Controller
      */
     protected $helpers = [];
 
+     /**
+     * To declare the session propety to allow for global
+     * initialization in the initController() method
+     * @var object
+     */
+    public $session;
+
     /**
      * Constructor.
      */

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -38,11 +38,11 @@ abstract class BaseController extends Controller
     protected $helpers = [];
 
      /**
-     * To declare the session propety to allow for global
-     * initialization in the initController() method
-     * See the Creation of dynamic property depreciation i php 8.2 
+     * Be sure to declare properties for anything you assign.
+     * The creation of dynamic property is deprecated in PHP 8.2.
+     * 
+     * protected $session; 
      */
-    // public $session;
 
     /**
      * Constructor.


### PR DESCRIPTION
Declared session property in the BaseController to avoid the depreciation of dynamic properties in PHP 8.2
