### PR TITLE
chore: fix php-cs-fixer version to 3.13.0

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "codeigniter/coding-standard": "^1.5",
         "fakerphp/faker": "^1.9",
-        "friendsofphp/php-cs-fixer": "~3.13.0",
+        "friendsofphp/php-cs-fixer": "3.13.0",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
         "phpunit/phpunit": "^9.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "codeigniter/coding-standard": "^1.5",
         "fakerphp/faker": "^1.9",
-        "friendsofphp/php-cs-fixer": "~3.13.0",
+        "friendsofphp/php-cs-fixer": "3.13.0",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
         "nexusphp/tachycardia": "^1.0",


### PR DESCRIPTION
**Description**
This is a temporary situation.
See https://github.com/codeigniter4/CodeIgniter4/pull/6990#issuecomment-1359261950

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
