### PR TITLE
refactor: to fix psalm error

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -252,7 +252,9 @@ class Language
         }
 
         if (isset($strings[1])) {
-            $strings = array_replace_recursive(...$strings);
+            $string = array_shift($strings);
+
+            $strings = array_replace_recursive($string, ...$strings);
         } elseif (isset($strings[0])) {
             $strings = $strings[0];
         }


### PR DESCRIPTION
**Description**

```
ERROR: TooFewArguments - system/Language/Language.php:255:24 - Too few arguments for array_replace_recursive - expecting array to be passed (see https://psalm.dev/025)
            $strings = array_replace_recursive(...$strings);
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/3745997494/jobs/6360957133

See https://www.php.net/manual/en/function.array-replace-recursive.php

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
