### PR TITLE
fix: Config property type

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -148,11 +148,9 @@ class App extends BaseConfig
      * - `CodeIgniter\Session\Handlers\MemcachedHandler`
      * - `CodeIgniter\Session\Handlers\RedisHandler`
      *
-     * @var string
-     *
      * @deprecated use Config\Session::$driver instead.
      */
-    public $sessionDriver = FileHandler::class;
+    public string $sessionDriver = FileHandler::class;
 
     /**
      * --------------------------------------------------------------------------
@@ -345,7 +343,7 @@ class App extends BaseConfig
      *
      * @var array<string, string>
      */
-    public $proxyIPs = [];
+    public array $proxyIPs = [];
 
     /**
      * --------------------------------------------------------------------------

--- a/system/Test/Mock/MockAppConfig.php
+++ b/system/Test/Mock/MockAppConfig.php
@@ -23,7 +23,7 @@ class MockAppConfig extends App
     public bool $cookieSecure      = false;
     public bool $cookieHTTPOnly    = false;
     public ?string $cookieSameSite = 'Lax';
-    public $proxyIPs               = [];
+    public array $proxyIPs         = [];
     public string $CSRFTokenName   = 'csrf_test_name';
     public string $CSRFHeaderName  = 'X-CSRF-TOKEN';
     public string $CSRFCookieName  = 'csrf_cookie_name';

--- a/system/Test/Mock/MockCLIConfig.php
+++ b/system/Test/Mock/MockCLIConfig.php
@@ -23,7 +23,7 @@ class MockCLIConfig extends App
     public bool $cookieSecure      = false;
     public bool $cookieHTTPOnly    = false;
     public ?string $cookieSameSite = 'Lax';
-    public $proxyIPs               = [];
+    public array $proxyIPs         = [];
     public string $CSRFTokenName   = 'csrf_test_name';
     public string $CSRFCookieName  = 'csrf_cookie_name';
     public int $CSRFExpire         = 7200;

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\Files\UploadedFile;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use TypeError;
 
 /**
  * @backupGlobals enabled
@@ -1072,10 +1073,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
     public function testGetIPAddressThruProxyInvalidConfigString()
     {
-        $this->expectException(ConfigException::class);
-        $this->expectExceptionMessage(
-            'You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.'
-        );
+        $this->expectException(TypeError::class);
 
         $config           = new App();
         $config->proxyIPs = '192.168.5.0/28';

--- a/user_guide_src/source/installation/troubleshooting/001.php
+++ b/user_guide_src/source/installation/troubleshooting/001.php
@@ -8,7 +8,7 @@ class App extends BaseConfig
 {
     // ...
 
-    public $indexPage = 'index.php';
+    public string $indexPage = 'index.php';
 
     // ...
 }

--- a/user_guide_src/source/installation/troubleshooting/002.php
+++ b/user_guide_src/source/installation/troubleshooting/002.php
@@ -8,7 +8,7 @@ class App extends BaseConfig
 {
     // ...
 
-    public $indexPage = 'index.php?';
+    public string $indexPage = 'index.php?';
 
     // ...
 }

--- a/user_guide_src/source/installation/upgrade_localization/001.php
+++ b/user_guide_src/source/installation/upgrade_localization/001.php
@@ -8,7 +8,7 @@ class App extends BaseConfig
 {
     // ...
 
-    public $defaultLocale = 'en';
+    public string $defaultLocale = 'en';
 
     // ...
 }

--- a/user_guide_src/source/outgoing/localization/001.php
+++ b/user_guide_src/source/outgoing/localization/001.php
@@ -6,7 +6,7 @@ use CodeIgniter\Config\BaseConfig;
 
 class App extends BaseConfig
 {
-    public $defaultLocale = 'en';
+    public string $defaultLocale = 'en';
 
     // ...
 }

--- a/user_guide_src/source/outgoing/localization/002.php
+++ b/user_guide_src/source/outgoing/localization/002.php
@@ -6,7 +6,7 @@ use CodeIgniter\Config\BaseConfig;
 
 class App extends BaseConfig
 {
-    public $negotiateLocale = true;
+    public bool $negotiateLocale = true;
 
     // ...
 }

--- a/user_guide_src/source/outgoing/localization/003.php
+++ b/user_guide_src/source/outgoing/localization/003.php
@@ -6,7 +6,7 @@ use CodeIgniter\Config\BaseConfig;
 
 class App extends BaseConfig
 {
-    public $supportedLocales = ['en', 'es', 'fr-FR'];
+    public array $supportedLocales = ['en', 'es', 'fr-FR'];
 
     // ...
 }

--- a/user_guide_src/source/outgoing/response/011.php
+++ b/user_guide_src/source/outgoing/response/011.php
@@ -6,7 +6,7 @@ use CodeIgniter\Config\BaseConfig;
 
 class App extends BaseConfig
 {
-    public $CSPEnabled = true;
+    public bool $CSPEnabled = true;
 
     // ...
 }


### PR DESCRIPTION
**Description**
All atomic type properties in Config classes have been typed in 4.3.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
