### PR TITLE
test: update failed DB session tests

### DIFF
--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -150,7 +150,7 @@ class CITestSeeder extends Seeder
 
         if ($this->db->DBDriver === 'MySQLi') {
             $data['ci_sessions'][] = [
-                'id'         => '1f5o06b43phsnnf8if6bo33b635e4p2o',
+                'id'         => 'ci_session:1f5o06b43phsnnf8if6bo33b635e4p2o',
                 'ip_address' => '127.0.0.1',
                 'timestamp'  => '2021-06-25 21:54:14',
                 'data'       => '__ci_last_regenerate|i:1624650854;_ci_previous_url|s:40:\"http://localhost/index.php/home/index\";',
@@ -159,7 +159,7 @@ class CITestSeeder extends Seeder
 
         if ($this->db->DBDriver === 'Postgre') {
             $data['ci_sessions'][] = [
-                'id'         => '1f5o06b43phsnnf8if6bo33b635e4p2o',
+                'id'         => 'ci_session:1f5o06b43phsnnf8if6bo33b635e4p2o',
                 'ip_address' => '127.0.0.1',
                 'timestamp'  => '2021-06-25 21:54:14.991403+02',
                 'data'       => '\x' . bin2hex('__ci_last_regenerate|i:1624650854;_ci_previous_url|s:40:\"http://localhost/index.php/home/index\";'),

--- a/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php
+++ b/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php
@@ -76,7 +76,7 @@ abstract class AbstractHandlerTestCase extends CIUnitTestCase
         $this->setPrivateProperty($handler, 'lock', false);
 
         $row = $this->db->table('ci_sessions')
-            ->getWhere(['id' => '555556b43phsnnf8if6bo33b635e4444'])
+            ->getWhere(['id' => 'ci_session:555556b43phsnnf8if6bo33b635e4444'])
             ->getRow();
 
         $this->assertGreaterThan(time() - 100, strtotime($row->timestamp));
@@ -100,7 +100,7 @@ abstract class AbstractHandlerTestCase extends CIUnitTestCase
         $releaseLock();
 
         $row = $this->db->table('ci_sessions')
-            ->getWhere(['id' => '1f5o06b43phsnnf8if6bo33b635e4p2o'])
+            ->getWhere(['id' => 'ci_session:1f5o06b43phsnnf8if6bo33b635e4p2o'])
             ->getRow();
 
         $this->assertGreaterThan(time() - 100, strtotime($row->timestamp));


### PR DESCRIPTION
**Description**
```
There was 1 error:

1) CodeIgniter\Session\Handlers\Database\MySQLiHandlerTest::testWriteInsert
ErrorException: Trying to get property 'timestamp' of non-object

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php:82
phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97

--

There were 2 failures:

1) CodeIgniter\Session\Handlers\Database\MySQLiHandlerTest::testReadSuccess
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'__ci_last_regenerate|i:1624650854;_ci_previous_url|s:40:\"http://localhost/index.php/home/index\";'
+''

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php:52
phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97

2) CodeIgniter\Session\Handlers\Database\MySQLiHandlerTest::testWriteUpdate
Failed asserting that 1624676054 is greater than 1671678533.

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php:106
phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/3754479040/jobs/6378889439

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
