### PR TITLE
chore: update test-deptrac.yml (Github API Rate Limit)

### DIFF
--- a/.github/workflows/test-deptrac.yml
+++ b/.github/workflows/test-deptrac.yml
@@ -73,3 +73,5 @@ jobs:
         run: |
             sudo phive --no-progress install --global qossmic/deptrac --trust-gpg-keys B8F640134AB1782E
             deptrac analyze --cache-file=build/deptrac.cache
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**
I'm not sure this really works.

- set GITHUB_AUTH_TOKEN for phive. See https://github.com/phar-io/phive/issues/127#issuecomment-354552572

```
Run sudo phive --no-progress install --global qossmic/deptrac --trust-gpg-keys B8F640134AB1782E
Phive 0.15.2 - Copyright (C) 2015-2022 by Arne Blankerts, Sebastian Heuer and Contributors
Downloading https://api.github.com/rate_limit
Warning:  Github API Rate Limit exceeded - cannot resolve "qossmic/deptrac"
Downloading https://gitlab.com/api/v4/projects/qossmic%2Fdeptrac/releases/
Fetching repository list
Downloading https://phar.io/data/repositories.xml
Error:    Could not resolve requested PHAR qossmic/deptrac

Error: Process completed with exit code 4.
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/3768833313/jobs/6407550006

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
