### PR TITLE
docs: add background color for versionadded and deprecated

### DIFF
--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -265,10 +265,12 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 
 .versionadded {
     background: #dff0d8;
+    padding: 0 5px;
 }
 
-.deprecated {
+.deprecated:not(.versionmodified) {
     background: #f2dede;
+    padding: 0 5px;
 }
 
 /* Footer ------------------------------------------------------------------- */

--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -263,6 +263,14 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 	background: #dd4814;
 }
 
+.versionadded {
+    background: #dff0d8;
+}
+
+.deprecated {
+    background: #f2dede;
+}
+
 /* Footer ------------------------------------------------------------------- */
 
 .rst-footer-buttons {


### PR DESCRIPTION
**Description**
- add background color for versionadded and deprecated

![Screenshot 2022-12-25 9 18 22](https://user-images.githubusercontent.com/87955/209453802-516539b8-27c5-404a-8664-20ffd43c6b53.png)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
