### PR TITLE
docs: add about removal of deprecated functionality

### DIFF
--- a/user_guide_src/source/installation/backward_compatibility_notes.rst
+++ b/user_guide_src/source/installation/backward_compatibility_notes.rst
@@ -7,7 +7,12 @@ We try to develop our products to be as backward compatible (BC) as possible.
 Only major releases (such as 4.0, 5.0 etc.) are allowed to break backward compatibility.
 Minor releases (such as 4.2, 4.3 etc.) may introduce new features, but must do so without breaking the existing API.
 
-However, the code is not mature and bug fixes may break compatibility in minor releases, or even in patch releases (such as 4.2.5). In that case, all the breaking changes are described in the :doc:`../changelogs/index`.
+However, the code is not mature and bug fixes may break compatibility in **minor** releases, or even in **patch** releases (such as 4.2.5).
+
+Deprecated functionality may be removed in the next **minor** version or later.
+Please discontinue use as soon as possible.
+
+In any case, all the breaking changes are described in the :doc:`../changelogs/index`.
 
 *****************************
 What are not Breaking Changes


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/7000#issuecomment-1364524729

- update `backward_compatibility_notes.rst`

At least `Autoloader::loadLegacy()` was removed in 4.1.0.
See https://codeigniter4.github.io/CodeIgniter4/installation/upgrade_410.html#breaking-changes

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
