### PR TITLE
fix: `link_tag()` missing `type="application/rss+xml"`

### DIFF
--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -222,13 +222,20 @@ if (! function_exists('link_tag')) {
     /**
      * Link
      *
-     * Generates link to a CSS file
+     * Generates link tag
      *
-     * @param array|string $href      Stylesheet href or an array
-     * @param bool         $indexPage should indexPage be added to the CSS path.
+     * @param array<string, bool|string>|string $href      Stylesheet href or an array
+     * @param bool                              $indexPage should indexPage be added to the CSS path.
      */
-    function link_tag($href = '', string $rel = 'stylesheet', string $type = 'text/css', string $title = '', string $media = '', bool $indexPage = false, string $hreflang = ''): string
-    {
+    function link_tag(
+        $href = '',
+        string $rel = 'stylesheet',
+        string $type = 'text/css',
+        string $title = '',
+        string $media = '',
+        bool $indexPage = false,
+        string $hreflang = ''
+    ): string {
         $link = '<link ';
 
         // extract fields if needed
@@ -258,7 +265,7 @@ if (! function_exists('link_tag')) {
 
         $link .= 'rel="' . $rel . '" ';
 
-        if (! in_array($rel, ['alternate', 'canonical'], true)) {
+        if ($type !== '' && $rel !== 'canonical') {
             $link .= 'type="' . $type . '" ';
         }
 

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -265,7 +265,7 @@ if (! function_exists('link_tag')) {
 
         $link .= 'rel="' . $rel . '" ';
 
-        if ($type !== '' && $rel !== 'canonical' && $hreflang === '') {
+        if ($type !== '' && $rel !== 'canonical' && $hreflang === '' && ! ($rel === 'alternate' && $media !== '')) {
             $link .= 'type="' . $type . '" ';
         }
 

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -265,7 +265,7 @@ if (! function_exists('link_tag')) {
 
         $link .= 'rel="' . $rel . '" ';
 
-        if ($type !== '' && $rel !== 'canonical') {
+        if ($type !== '' && $rel !== 'canonical' && $hreflang === '') {
             $link .= 'type="' . $type . '" ';
         }
 

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -367,6 +367,18 @@ final class HTMLHelperTest extends CIUnitTestCase
         $this->assertSame($expected, link_tag($parms));
     }
 
+    public function testLinkTagArrayHreflang()
+    {
+        $tag = link_tag([
+            'href'     => 'https://example.com/en',
+            'rel'      => 'alternate',
+            'hreflang' => 'x-default',
+        ]);
+
+        $expected = '<link href="https://example.com/en" hreflang="x-default" rel="alternate" />';
+        $this->assertSame($expected, $tag);
+    }
+
     public function testDocType()
     {
         $target   = 'html4-strict';

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -319,6 +319,44 @@ final class HTMLHelperTest extends CIUnitTestCase
         $this->assertSame($expected, link_tag($target, 'banana', 'fruit', 'Go away', 'VHS'));
     }
 
+    public function testLinkTagFavicon()
+    {
+        $tag = link_tag('favicon.ico', 'shortcut icon', 'image/ico');
+
+        $expected = '<link href="http://example.com/favicon.ico" rel="shortcut icon" type="image/ico" />';
+        $this->assertSame($expected, $tag);
+    }
+
+    public function testLinkTagRss()
+    {
+        $tag = link_tag('feed', 'alternate', 'application/rss+xml', 'My RSS Feed');
+
+        $expected = '<link href="http://example.com/feed" rel="alternate" type="application/rss+xml" title="My RSS Feed" />';
+        $this->assertSame($expected, $tag);
+    }
+
+    public function testLinkTagAlternate()
+    {
+        $tag = link_tag(
+            'http://sp.example.com/',
+            'alternate',
+            '',
+            '',
+            'only screen and (max-width: 640px)'
+        );
+
+        $expected = '<link href="http://sp.example.com/" rel="alternate" media="only screen and (max-width: 640px)" />';
+        $this->assertSame($expected, $tag);
+    }
+
+    public function testLinkTagCanonical()
+    {
+        $tag = link_tag('http://www.example.com/', 'canonical');
+
+        $expected = '<link href="http://www.example.com/" rel="canonical" />';
+        $this->assertSame($expected, $tag);
+    }
+
     public function testLinkTagArray()
     {
         $parms = [

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -312,11 +312,21 @@ final class HTMLHelperTest extends CIUnitTestCase
         $this->assertSame($expected, link_tag($target));
     }
 
-    public function testLinkTagComplete()
+    public function testLinkTagMedia()
     {
-        $target   = 'https://styles.com/css/mystyles.css';
-        $expected = '<link href="https://styles.com/css/mystyles.css" rel="banana" type="fruit" media="VHS" title="Go away" />';
-        $this->assertSame($expected, link_tag($target, 'banana', 'fruit', 'Go away', 'VHS'));
+        $target = 'https://styles.com/css/mystyles.css';
+        $tag    = link_tag($target, 'stylesheet', 'text/css', '', 'print');
+
+        $expected = '<link href="https://styles.com/css/mystyles.css" rel="stylesheet" type="text/css" media="print" />';
+        $this->assertSame($expected, $tag);
+    }
+
+    public function testLinkTagTitle()
+    {
+        $tag = link_tag('default.css', 'stylesheet', 'text/css', 'Default Style');
+
+        $expected = '<link href="http://example.com/default.css" rel="stylesheet" type="text/css" title="Default Style" />';
+        $this->assertSame($expected, $tag);
     }
 
     public function testLinkTagFavicon()
@@ -344,6 +354,18 @@ final class HTMLHelperTest extends CIUnitTestCase
             '',
             'only screen and (max-width: 640px)'
         );
+
+        $expected = '<link href="http://sp.example.com/" rel="alternate" media="only screen and (max-width: 640px)" />';
+        $this->assertSame($expected, $tag);
+    }
+
+    public function testLinkTagArrayAlternate()
+    {
+        $tag = link_tag([
+            'href'  => 'http://sp.example.com/',
+            'rel'   => 'alternate',
+            'media' => 'only screen and (max-width: 640px)',
+        ]);
 
         $expected = '<link href="http://sp.example.com/" rel="alternate" media="only screen and (max-width: 640px)" />';
         $this->assertSame($expected, $tag);


### PR DESCRIPTION
**Description**
Follow-up #3247
From https://forum.codeigniter.com/showthread.php?tid=85954

```php
link_tag('feed', 'alternate', 'application/rss+xml', 'My RSS Feed');
```
```
Expected :'<link href="http://example.com/feed" rel="alternate" type="application/rss+xml" title="My RSS Feed" />'
Actual   :'<link href="http://example.com/feed" rel="alternate" title="My RSS Feed" />'
```

`alternate` may use `type` attribute.
See https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
