### PR TITLE
docs: replace types `mixed` in `CacheInterface` and `BaseHandler` file.

### DIFF
--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -83,7 +83,7 @@ interface CacheInterface
      * The information returned and the structure of the data
      * varies depending on the handler.
      *
-     * @return array|bool|object|null
+     * @return array|false|object|null
      */
     public function getCacheInfo();
 

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -83,7 +83,7 @@ interface CacheInterface
      * The information returned and the structure of the data
      * varies depending on the handler.
      *
-     * @return array|bool|float|int|object|string|null
+     * @return array|bool|object|null
      */
     public function getCacheInfo();
 

--- a/system/Cache/CacheInterface.php
+++ b/system/Cache/CacheInterface.php
@@ -26,16 +26,16 @@ interface CacheInterface
      *
      * @param string $key Cache item name
      *
-     * @return mixed
+     * @return array|bool|float|int|object|string|null
      */
     public function get(string $key);
 
     /**
      * Saves an item to the cache store.
      *
-     * @param string $key   Cache item name
-     * @param mixed  $value The data to save
-     * @param int    $ttl   Time To Live, in seconds (default 60)
+     * @param string                                  $key   Cache item name
+     * @param array|bool|float|int|object|string|null $value The data to save
+     * @param int                                     $ttl   Time To Live, in seconds (default 60)
      *
      * @return bool Success or failure
      */
@@ -56,7 +56,7 @@ interface CacheInterface
      * @param string $key    Cache ID
      * @param int    $offset Step/value to increase by
      *
-     * @return mixed
+     * @return bool|int
      */
     public function increment(string $key, int $offset = 1);
 
@@ -66,7 +66,7 @@ interface CacheInterface
      * @param string $key    Cache ID
      * @param int    $offset Step/value to increase by
      *
-     * @return mixed
+     * @return bool|int
      */
     public function decrement(string $key, int $offset = 1);
 
@@ -83,7 +83,7 @@ interface CacheInterface
      * The information returned and the structure of the data
      * varies depending on the handler.
      *
-     * @return mixed
+     * @return array|bool|float|int|object|string|null
      */
     public function getCacheInfo();
 

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -77,7 +77,7 @@ abstract class BaseHandler implements CacheInterface
      * @param int     $ttl      Time to live
      * @param Closure $callback Callback return value
      *
-     * @return mixed
+     * @return array|bool|float|int|object|string|null
      */
     public function remember(string $key, int $ttl, Closure $callback)
     {


### PR DESCRIPTION
**Description**
See #6310 
It seems the return types of `increment` and `decrement` functions is int or bool, so I only leave the `bool|int` at that two functions.
And wish you all a merry Christmas!

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
