### PR TITLE
fix: Honeypot field appears when CSP is enabled

### DIFF
--- a/app/Config/Honeypot.php
+++ b/app/Config/Honeypot.php
@@ -24,7 +24,7 @@ class Honeypot extends BaseConfig
     /**
      * Honeypot HTML Template
      */
-    public string $template = '<label>{label}</label><input type="text" name="{name}" value=""/>';
+    public string $template = '<label>{label}</label><input type="text" name="{name}" value="">';
 
     /**
      * Honeypot container

--- a/app/Config/Honeypot.php
+++ b/app/Config/Honeypot.php
@@ -29,7 +29,7 @@ class Honeypot extends BaseConfig
     /**
      * Honeypot container
      *
-     * If you enables CSP, you can remove `style="display:none"`.
+     * If you enabled CSP, you can remove `style="display:none"`.
      */
     public string $container = '<div style="display:none">{template}</div>';
 

--- a/app/Config/Honeypot.php
+++ b/app/Config/Honeypot.php
@@ -28,6 +28,15 @@ class Honeypot extends BaseConfig
 
     /**
      * Honeypot container
+     *
+     * If you enables CSP, you can remove `style="display:none"`.
      */
     public string $container = '<div style="display:none">{template}</div>';
+
+    /**
+     * The id attribute for Honeypot container tag
+     *
+     * Used when CSP is enabled.
+     */
+    public string $containerId = 'hpc';
 }

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -46,6 +46,8 @@ class Honeypot
             $this->config->container = '<div style="display:none">{template}</div>';
         }
 
+        $this->config->containerId ??= 'hpc';
+
         if ($this->config->template === '') {
             throw HoneypotException::forNoTemplate();
         }
@@ -70,10 +72,26 @@ class Honeypot
      */
     public function attachHoneypot(ResponseInterface $response)
     {
+        if ($response->getCSP()->enabled()) {
+            // Add id attribute to the container tag.
+            $this->config->container = str_ireplace(
+                '>{template}',
+                ' id="' . $this->config->containerId . '">{template}',
+                $this->config->container
+            );
+        }
+
         $prepField = $this->prepareTemplate($this->config->template);
 
         $body = $response->getBody();
         $body = str_ireplace('</form>', $prepField . '</form>', $body);
+
+        if ($response->getCSP()->enabled()) {
+            // Add style tag for the container tag in the head tag.
+            $style = '<style ' . csp_style_nonce() . '>#' . $this->config->containerId . ' { display:none }</style>';
+            $body  = str_ireplace('</head>', $style . '</head>', $body);
+        }
+
         $response->setBody($body);
     }
 

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -67,13 +67,13 @@ final class HoneypotTest extends CIUnitTestCase
     {
         $this->response->setBody('<form></form>');
         $this->honeypot->attachHoneypot($this->response);
-        $expected = '<form><div style="display:none"><label>Fill This Field</label><input type="text" name="honeypot" value=""/></div></form>';
+        $expected = '<form><div style="display:none"><label>Fill This Field</label><input type="text" name="honeypot" value=""></div></form>';
         $this->assertSame($expected, $this->response->getBody());
 
         $this->config->container = '<div class="hidden">{template}</div>';
         $this->response->setBody('<form></form>');
         $this->honeypot->attachHoneypot($this->response);
-        $expected = '<form><div class="hidden"><label>Fill This Field</label><input type="text" name="honeypot" value=""/></div></form>';
+        $expected = '<form><div class="hidden"><label>Fill This Field</label><input type="text" name="honeypot" value=""></div></form>';
         $this->assertSame($expected, $this->response->getBody());
     }
 

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -18,6 +18,7 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Honeypot as HoneypotConfig;
 
 /**
  * @backupGlobals enabled
@@ -28,7 +29,7 @@ use CodeIgniter\Test\CIUnitTestCase;
  */
 final class HoneypotTest extends CIUnitTestCase
 {
-    private \Config\Honeypot $config;
+    private HoneypotConfig $config;
     private Honeypot $honeypot;
 
     /**
@@ -41,7 +42,7 @@ final class HoneypotTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->config   = new \Config\Honeypot();
+        $this->config   = new HoneypotConfig();
         $this->honeypot = new Honeypot($this->config);
 
         unset($_POST[$this->config->name]);
@@ -147,7 +148,7 @@ final class HoneypotTest extends CIUnitTestCase
 
     public function testEmptyConfigContainer()
     {
-        $config            = new \Config\Honeypot();
+        $config            = new HoneypotConfig();
         $config->container = '';
         $honeypot          = new Honeypot($config);
 
@@ -159,7 +160,7 @@ final class HoneypotTest extends CIUnitTestCase
 
     public function testNoTemplateConfigContainer()
     {
-        $config            = new \Config\Honeypot();
+        $config            = new HoneypotConfig();
         $config->container = '<div></div>';
         $honeypot          = new Honeypot($config);
 

--- a/user_guide_src/source/changelogs/v4.3.0.rst
+++ b/user_guide_src/source/changelogs/v4.3.0.rst
@@ -291,6 +291,7 @@ The following items are affected:
 
 - Typography class: Creation of ``br`` tag
 - View Parser: The ``nl2br`` filter
+- Honeypot: ``input`` tag
 - Form helper
 - HTML helper
 - Common Functions
@@ -364,3 +365,4 @@ Bugs Fixed
 - Fixed a bug when all types of ``Prepared Queries`` were returning a ``Result`` object instead of a bool value for write-type queries.
 - Fixed a bug with variable filtering in JSON requests using with ``IncomingRequest::getVar()`` or ``IncomingRequest::getJsonVar()`` methods.
 - Fixed a bug when variable type may be changed when using a specified index with ``IncomingRequest::getVar()`` or ``IncomingRequest::getJsonVar()`` methods.
+- Fixed a bug that Honeypot field appears when CSP is enabled. See also :ref:`upgrade-430-honeypot-and-csp`.

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -216,6 +216,16 @@ Database
 - The ``Model::update()`` method now raises a ``DatabaseException`` if it generates an SQL
   statement without a WHERE clause. If you need to update all records in a table, use Query Builder instead. E.g., ``$model->builder()->update($data)``.
 
+.. _upgrade-430-honeypot-and-csp:
+
+Honeypot and CSP
+================
+
+When CSP is enabled, id attribute ``id="hpc"`` will be injected into the container tag
+for the Honeypot field to hide the field. If the id is already used in your views, you need to change it
+with ``Config\Honeypot::$containerId``.
+And you can remove ``style="display:none"`` in ``Config\Honeypot::$container``.
+
 Others
 ======
 
@@ -260,6 +270,10 @@ Config
 - app/Config/Exceptions.php
     - Two additional public properties were added: ``$logDeprecations`` and ``$deprecationLogLevel``.
       See See :ref:`logging_deprecation_warnings` for details.
+- app/Config/Honeypot.php
+    - The new property ``$containerId`` is added to set id attribute value for the container tag
+      when CSP is enabled.
+    - The ``input`` tag in the property ``$template`` value has been changed to HTML5 compatible.
 - app/Config/Logger.php
     - The property ``$threshold`` has been changed to ``9`` in other than ``production``
       environment.

--- a/user_guide_src/source/libraries/honeypot.rst
+++ b/user_guide_src/source/libraries/honeypot.rst
@@ -3,7 +3,7 @@ Honeypot Class
 ##############
 
 The Honeypot Class makes it possible to determine when a Bot makes a request to a CodeIgniter4 application,
-if it's enabled in ``Application\Config\Filters.php`` file. This is done by attaching form fields to any form,
+if it's enabled in **app\Config\Filters.php** file. This is done by attaching form fields to any form,
 and this form field is hidden from a human but accessible to a Bot. When data is entered into the field, it's
 assumed the request is coming from a Bot, and you can throw a ``HoneypotException``.
 
@@ -20,8 +20,8 @@ from the ``$globals`` array, like:
 
 .. literalinclude:: honeypot/001.php
 
-A sample Honeypot filter is bundled, as ``system/Filters/Honeypot.php``.
-If it is not suitable, make your own at ``app/Filters/Honeypot.php``,
+A sample Honeypot filter is bundled, as **system/Filters/Honeypot.php**.
+If it is not suitable, make your own at **app/Filters/Honeypot.php**,
 and modify the ``$aliases`` in the configuration appropriately.
 
 ********************
@@ -31,7 +31,7 @@ Customizing Honeypot
 Honeypot can be customized. The fields below can be set either in
 **app/Config/Honeypot.php** or in **.env**.
 
-* ``hidden`` - true|false to control visibility of the honeypot field; default is ``true``
-* ``label`` - HTML label for the honeypot field, default is 'Fill This Field'
-* ``name`` - name of the HTML form field used for the template; default is 'honeypot'
-* ``template`` - form field template used for the honeypot; default is '<label>{label}</label><input type="text" name="{name}" value=""/>'
+* ``$hidden`` - ``true`` or ``false`` to control visibility of the honeypot field; default is ``true``
+* ``$label`` - HTML label for the honeypot field, default is ``'Fill This Field'``
+* ``$name`` - name of the HTML form field used for the template; default is ``'honeypot'``
+* ``$template`` - form field template used for the honeypot; default is ``'<label>{label}</label><input type="text" name="{name}" value="">'``

--- a/user_guide_src/source/libraries/honeypot.rst
+++ b/user_guide_src/source/libraries/honeypot.rst
@@ -35,3 +35,6 @@ Honeypot can be customized. The fields below can be set either in
 * ``$label`` - HTML label for the honeypot field, default is ``'Fill This Field'``
 * ``$name`` - name of the HTML form field used for the template; default is ``'honeypot'``
 * ``$template`` - form field template used for the honeypot; default is ``'<label>{label}</label><input type="text" name="{name}" value="">'``
+* ``$container`` - container tag for the template; default is ``'<div style="display:none">{template}</div>'``.
+  If you enables CSP, you can remove ``style="display:none"``.
+* ``$containerId`` - [Since v4.3.0] this setting is used only when you enables CSP. You can change the id attribute for the container tag; default is ``'hpc'``

--- a/user_guide_src/source/libraries/honeypot.rst
+++ b/user_guide_src/source/libraries/honeypot.rst
@@ -1,6 +1,6 @@
-=====================
+##############
 Honeypot Class
-=====================
+##############
 
 The Honeypot Class makes it possible to determine when a Bot makes a request to a CodeIgniter4 application,
 if it's enabled in ``Application\Config\Filters.php`` file. This is done by attaching form fields to any form,
@@ -11,8 +11,9 @@ assumed the request is coming from a Bot, and you can throw a ``HoneypotExceptio
     :local:
     :depth: 2
 
+*****************
 Enabling Honeypot
-=====================
+*****************
 
 To enable a Honeypot, changes have to be made to the **app/Config/Filters.php**. Just uncomment honeypot
 from the ``$globals`` array, like:
@@ -23,8 +24,9 @@ A sample Honeypot filter is bundled, as ``system/Filters/Honeypot.php``.
 If it is not suitable, make your own at ``app/Filters/Honeypot.php``,
 and modify the ``$aliases`` in the configuration appropriately.
 
+********************
 Customizing Honeypot
-=====================
+********************
 
 Honeypot can be customized. The fields below can be set either in
 **app/Config/Honeypot.php** or in **.env**.

--- a/user_guide_src/source/libraries/honeypot/001.php
+++ b/user_guide_src/source/libraries/honeypot/001.php
@@ -6,14 +6,18 @@ use CodeIgniter\Config\BaseConfig;
 
 class Filters extends BaseConfig
 {
+    // ...
+
     public $globals = [
         'before' => [
             'honeypot',
             // 'csrf',
+            // 'invalidchars',
         ],
         'after' => [
             'toolbar',
             'honeypot',
+            // 'secureheaders',
         ],
     ];
 


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=85960

- fix bug
- add `Config\Honeypot::$containerId`

### How to Test

```diff
diff --git a/app/Config/App.php b/app/Config/App.php
index 0a23462b6..e8f314371 100644
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -446,5 +446,5 @@ class App extends BaseConfig
      * @see http://www.html5rocks.com/en/tutorials/security/content-security-policy/
      * @see http://www.w3.org/TR/CSP/
      */
-    public bool $CSPEnabled = false;
+    public bool $CSPEnabled = true;
 }
diff --git a/app/Config/Filters.php b/app/Config/Filters.php
index 7b70c4fb3..12bb9619c 100644
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -29,13 +29,13 @@ class Filters extends BaseConfig
      */
     public array $globals = [
         'before' => [
-            // 'honeypot',
+            'honeypot',
             // 'csrf',
             // 'invalidchars',
         ],
         'after' => [
             'toolbar',
-            // 'honeypot',
+            'honeypot',
             // 'secureheaders',
         ],
     ];
diff --git a/app/Controllers/Home.php b/app/Controllers/Home.php
index 7f867e95f..c451f5302 100644
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -6,6 +6,6 @@ class Home extends BaseController
 {
     public function index()
     {
-        return view('welcome_message');
+        return '<head></head><form></form>';
     }
 }
```
You will see `Fill This Field` before this PR.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
