### PR TITLE
docs: fix upgrade_database.rst

### DIFF
--- a/user_guide_src/source/installation/upgrade_database.rst
+++ b/user_guide_src/source/installation/upgrade_database.rst
@@ -42,7 +42,7 @@ Upgrade Guide
     - ``$this->db->join('comments', 'comments.id = blogs.id');`` to ``$builder->join('comments', 'comments.id = blogs.id');``
     - ``$this->db->having('user_id',  45);`` to ``$builder->having('user_id',  45);``
 6. CI4 does not provide `Database Caching <https://www.codeigniter.com/userguide3/database/caching.html>`_
-   in CI3, so if you need to cache the result, use :doc:`../libraries/caching` instead.
+   layer known from CI3, so if you need to cache the result, use :doc:`../libraries/caching` instead.
 
 Code Example
 ============

--- a/user_guide_src/source/installation/upgrade_database.rst
+++ b/user_guide_src/source/installation/upgrade_database.rst
@@ -14,6 +14,7 @@ Documentations
 What has been changed
 =====================
 - The functionality in CI3 is basically the same as in CI4.
+- `Database Caching <https://www.codeigniter.com/userguide3/database/caching.html>`_ in CI3 is removed.
 - The method names have changed to camelCase and the :doc:`Query Builder <../database/query_builder>`
   now needs to be initialized before you can run queries on it.
 
@@ -40,6 +41,8 @@ Upgrade Guide
     - ``$this->db->select_max('age');`` to ``$builder->selectMax('age');``
     - ``$this->db->join('comments', 'comments.id = blogs.id');`` to ``$builder->join('comments', 'comments.id = blogs.id');``
     - ``$this->db->having('user_id',  45);`` to ``$builder->having('user_id',  45);``
+6. CI4 does not provide `Database Caching <https://www.codeigniter.com/userguide3/database/caching.html>`_
+   in CI3, so if you need to cache the result, use :doc:`../libraries/caching` instead.
 
 Code Example
 ============

--- a/user_guide_src/source/installation/upgrade_database.rst
+++ b/user_guide_src/source/installation/upgrade_database.rst
@@ -14,7 +14,7 @@ Documentations
 What has been changed
 =====================
 - The functionality in CI3 is basically the same as in CI4.
-- `Database Caching <https://www.codeigniter.com/userguide3/database/caching.html>`_ in CI3 is removed.
+- `Database Caching <https://www.codeigniter.com/userguide3/database/caching.html>`_ functionality known from CI3 was removed.
 - The method names have changed to camelCase and the :doc:`Query Builder <../database/query_builder>`
   now needs to be initialized before you can run queries on it.
 


### PR DESCRIPTION
**Description**
- add about DB caching. 
 
CI4 does not have DB caching. See #3608

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
