### PR TITLE
docs: update deprecated `migrate:create` examples

### DIFF
--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -22,11 +22,11 @@ and must extend ``CodeIgniter\CLI\BaseCommand``, and implement the ``run()`` met
 The following properties should be used in order to get listed in CLI commands and to add help functionality to your command:
 
 * ``$group``: a string to describe the group the command is lumped under when listing commands. For example: ``Database``
-* ``$name``: a string to describe the command's name. For example: ``migrate:create``
-* ``$description``: a string to describe the command. For example: ``Creates a new migration file.``
-* ``$usage``: a string to describe the command usage. For example: ``migrate:create [name] [options]``
-* ``$arguments``: an array of strings to describe each command argument. For example: ``'name' => 'The migration file name'``
-* ``$options``: an array of strings to describe each command option. For example: ``'-n' => 'Set migration namespace'``
+* ``$name``: a string to describe the command's name. For example: ``make:controller``
+* ``$description``: a string to describe the command. For example: ``Generates a new controller file.``
+* ``$usage``: a string to describe the command usage. For example: ``make:controller <name> [options]``
+* ``$arguments``: an array of strings to describe each command argument. For example: ``'name' => 'The controller class name.'``
+* ``$options``: an array of strings to describe each command option. For example: ``'--force' => 'Force overwrite existing file.'``
 
 **Help description will be automatically generated according to the above parameters.**
 

--- a/user_guide_src/source/cli/cli_commands/001.php
+++ b/user_guide_src/source/cli/cli_commands/001.php
@@ -1,3 +1,3 @@
 <?php
 
-echo command('migrate:create TestMigration');
+echo command('make:migration TestMigration');

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -34,7 +34,7 @@ where ``<generator_command>`` will be replaced with the command to check.
     namespace defined in your ``$psr4`` array in ``Config\Autoload`` or defined in your composer autoload
     file. Otherwise, code generation will be interrupted.
 
-.. important:: Use of ``migrate:create`` to create migration files is now deprecated. It will be removed in
+.. important:: Since v4.0.5, use of ``migrate:create`` to create migration files has been deprecated. It will be removed in
     future releases. Please use ``make:migration`` as replacement. Also, please use ``make:migration --session``
     to use instead of the deprecated ``session:migration``.
 


### PR DESCRIPTION
**Description**
`migrate:create` is deprecated.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
