### PR TITLE
fix: `spark migrate:status` shows incorrect filename when format is `Y_m_d_His_`

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -448,6 +448,8 @@ class MigrationRunner
     /**
      * Create a migration object from a file path.
      *
+     * @param string $path Full path to a valid migration file.
+     *
      * @return false|object Returns the migration object, or false on failure
      */
     protected function migrationFromFile(string $path, string $namespace)
@@ -525,6 +527,8 @@ class MigrationRunner
 
     /**
      * Extracts the migration number from a filename
+     *
+     * @param string $migration A migration filename w/o path.
      */
     protected function getMigrationNumber(string $migration): string
     {

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -532,9 +532,9 @@ class MigrationRunner
      */
     protected function getMigrationNumber(string $migration): string
     {
-        preg_match('/^\d{4}[_-]?\d{2}[_-]?\d{2}[_-]?\d{6}/', $migration, $matches);
+        preg_match($this->regex, $migration, $matches);
 
-        return count($matches) ? $matches[0] : '0';
+        return count($matches) ? $matches[1] : '0';
     }
 
     /**

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -458,9 +458,9 @@ class MigrationRunner
             return false;
         }
 
-        $name = basename($path, '.php');
+        $filename = basename($path, '.php');
 
-        if (! preg_match($this->regex, $name)) {
+        if (! preg_match($this->regex, $filename)) {
             return false;
         }
 
@@ -468,8 +468,8 @@ class MigrationRunner
 
         $migration = new stdClass();
 
-        $migration->version   = $this->getMigrationNumber($name);
-        $migration->name      = $this->getMigrationName($name);
+        $migration->version   = $this->getMigrationNumber($filename);
+        $migration->name      = $this->getMigrationName($filename);
         $migration->path      = $path;
         $migration->class     = $locator->getClassname($path);
         $migration->namespace = $namespace;

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -538,14 +538,18 @@ class MigrationRunner
     }
 
     /**
-     * Extracts the migration class name from a filename
+     * Extracts the migration name from a filename
+     *
+     * Note: The migration name should be the classname, but maybe they are
+     *       different.
+     *
+     * @param string $migration A migration filename w/o path.
      */
     protected function getMigrationName(string $migration): string
     {
         $parts = explode('_', $migration);
-        array_shift($parts);
 
-        return implode('_', $parts);
+        return array_pop($parts);
     }
 
     /**

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -67,7 +67,7 @@ class MigrationRunner
      *
      * @var string
      */
-    protected $regex = '/^\d{4}[_-]?\d{2}[_-]?\d{2}[_-]?\d{6}_(\w+)$/';
+    protected $regex = '/\A(\d{4}[_-]?\d{2}[_-]?\d{2}[_-]?\d{6})_(\w+)\z/';
 
     /**
      * The main database connection. Used to store
@@ -547,9 +547,9 @@ class MigrationRunner
      */
     protected function getMigrationName(string $migration): string
     {
-        $parts = explode('_', $migration);
+        preg_match($this->regex, $migration, $matches);
 
-        return array_pop($parts);
+        return count($matches) ? $matches[2] : '';
     }
 
     /**

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -186,6 +186,24 @@ final class MigrationRunnerTest extends CIUnitTestCase
         $this->assertSame('0', $method('Foo'));
     }
 
+    public function testGetMigrationNameDashes()
+    {
+        $runner = new MigrationRunner($this->config);
+
+        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationName');
+
+        $this->assertSame('Foo', $method('2019-08-06-235100_Foo'));
+    }
+
+    public function testGetMigrationNameUnderscores()
+    {
+        $runner = new MigrationRunner($this->config);
+
+        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationName');
+
+        $this->assertSame('Foo', $method('2019_08_06_235100_Foo'));
+    }
+
     public function testSetSilentStoresValue()
     {
         $runner = new MigrationRunner($this->config);

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -192,7 +192,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
         $method = $this->getPrivateMethodInvoker($runner, 'getMigrationName');
 
-        $this->assertSame('Foo', $method('2019-08-06-235100_Foo'));
+        $this->assertSame('Foo_bar', $method('2019-08-06-235100_Foo_bar'));
     }
 
     public function testGetMigrationNameUnderscores()
@@ -201,7 +201,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
         $method = $this->getPrivateMethodInvoker($runner, 'getMigrationName');
 
-        $this->assertSame('Foo', $method('2019_08_06_235100_Foo'));
+        $this->assertSame('Foo_bar', $method('2019_08_06_235100_Foo_bar'));
     }
 
     public function testSetSilentStoresValue()


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/7033#discussion_r1058721974

```console
+-----------+-------------------+-------------------------+-------+-------------+-------+
| Namespace | Version           | Filename                | Group | Migrated On | Batch |
+-----------+-------------------+-------------------------+-------+-------------+-------+
| App       | 2022_12_29_050744 | 12_29_050744_KenjisTest | ---   | ---         | ---   |
| App       | 2022_12_29_050800 | 12_29_050800_PooyaTest  | ---   | ---         | ---   |
+-----------+-------------------+-------------------------+-------+-------------+-------+
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
