### PR TITLE
fix: save object when useAutoIncrement is disabled

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -685,8 +685,12 @@ class Model extends BaseModel
             }
         }
 
-        if ($this->useAutoIncrement === false && isset($data[$this->primaryKey])) {
-            $this->tempPrimaryKeyValue = $data[$this->primaryKey];
+        if ($this->useAutoIncrement === false) {
+            if (is_array($data) && isset($data[$this->primaryKey])) {
+                $this->tempPrimaryKeyValue = $data[$this->primaryKey];
+            } elseif (is_object($data) && isset($data->{$this->primaryKey})) {
+                $this->tempPrimaryKeyValue = $data->{$this->primaryKey};
+            }
         }
 
         $this->escape   = $this->tempData['escape'] ?? [];

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -322,4 +322,27 @@ final class SaveModelTest extends LiveModelTestCase
         $this->assertSame($insert['key'], $this->model->getInsertID());
         $this->seeInDatabase('without_auto_increment', $update);
     }
+
+    public function testUseAutoIncrementSetToFalseSaveObject(): void
+    {
+        $this->createModel(WithoutAutoIncrementModel::class);
+
+        $insert = [
+            'key'   => 'some_random_key',
+            'value' => 'some value',
+        ];
+        $this->model->save((object) $insert);
+
+        $this->assertSame($insert['key'], $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $insert);
+
+        $update = [
+            'key'   => 'some_random_key',
+            'value' => 'some different value',
+        ];
+        $this->model->save((object) $update);
+
+        $this->assertSame($insert['key'], $this->model->getInsertID());
+        $this->seeInDatabase('without_auto_increment', $update);
+    }
 }


### PR DESCRIPTION
**Description**
Fixes: #7040

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
