### PR TITLE
fix: change `getFile()` function of \CodeIgniter\Events\Events to static.

### DIFF
--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -246,7 +246,7 @@ class Events
      *
      * @return string[]
      */
-    public function getFiles()
+    public static function getFiles()
     {
         return static::$files;
     }

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -55,21 +55,21 @@ final class EventsTest extends CIUnitTestCase
 
         // it should start out empty
         MockEvents::setFiles([]);
-        $this->assertEmpty($this->manager->getFiles());
+        $this->assertEmpty(Events::getFiles());
 
         // make sure we have a default events file
         $default = [APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php'];
         $this->manager->unInitialize();
         MockEvents::initialize();
-        $this->assertSame($default, $this->manager->getFiles());
+        $this->assertSame($default, Events::getFiles());
 
         // but we should be able to change it through the backdoor
         MockEvents::setFiles(['/peanuts']);
-        $this->assertSame(['/peanuts'], $this->manager->getFiles());
+        $this->assertSame(['/peanuts'], Events::getFiles());
 
         // re-initializing should have no effect
         MockEvents::initialize();
-        $this->assertSame(['/peanuts'], $this->manager->getFiles());
+        $this->assertSame(['/peanuts'], Events::getFiles());
     }
 
     public function testPerformance()

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -55,21 +55,21 @@ final class EventsTest extends CIUnitTestCase
 
         // it should start out empty
         MockEvents::setFiles([]);
-        $this->assertEmpty($this->manager->getFiles());
+        $this->assertEmpty(MockEvents::getFiles());
 
         // make sure we have a default events file
         $default = [APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php'];
         $this->manager->unInitialize();
         MockEvents::initialize();
-        $this->assertSame($default, $this->manager->getFiles());
+        $this->assertSame($default, MockEvents::getFiles());
 
         // but we should be able to change it through the backdoor
         MockEvents::setFiles(['/peanuts']);
-        $this->assertSame(['/peanuts'], $this->manager->getFiles());
+        $this->assertSame(['/peanuts'], MockEvents::getFiles());
 
         // re-initializing should have no effect
         MockEvents::initialize();
-        $this->assertSame(['/peanuts'], $this->manager->getFiles());
+        $this->assertSame(['/peanuts'], MockEvents::getFiles());
     }
 
     public function testPerformance()

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -55,21 +55,21 @@ final class EventsTest extends CIUnitTestCase
 
         // it should start out empty
         MockEvents::setFiles([]);
-        $this->assertEmpty(MockEvents::getFiles());
+        $this->assertEmpty($this->manager->getFiles());
 
         // make sure we have a default events file
         $default = [APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php'];
         $this->manager->unInitialize();
         MockEvents::initialize();
-        $this->assertSame($default, MockEvents::getFiles());
+        $this->assertSame($default, $this->manager->getFiles());
 
         // but we should be able to change it through the backdoor
         MockEvents::setFiles(['/peanuts']);
-        $this->assertSame(['/peanuts'], MockEvents::getFiles());
+        $this->assertSame(['/peanuts'], $this->manager->getFiles());
 
         // re-initializing should have no effect
         MockEvents::initialize();
-        $this->assertSame(['/peanuts'], MockEvents::getFiles());
+        $this->assertSame(['/peanuts'], $this->manager->getFiles());
     }
 
     public function testPerformance()


### PR DESCRIPTION
**Description**
Fixes #7045
 
But I have a question is does the `$this->manager` still be needed in the test case of `test\system\Events\EventsTest.php` file?

Because all the functions in Event class are static, does it mean that this class no longer needs to be constructed?

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
