### PR TITLE
fix: define of STDOUT in CLI init() method

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -161,8 +161,10 @@ class CLI
             static::parseCommandLine();
 
             static::$initialized = true;
-        // See: https://github.com/codeigniter4/CodeIgniter4/issues/7047
         } elseif (! defined('STDOUT')) {
+            // If the command is being called from a controller
+            // we need to define STDOUT ourselves
+            // For "! defined('STDOUT')" see: https://github.com/codeigniter4/CodeIgniter4/issues/7047
             // @codeCoverageIgnoreStart
             define('STDOUT', 'php://output');
             // @codeCoverageIgnoreEnd

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -164,7 +164,9 @@ class CLI
         } else {
             // If the command is being called from a controller
             // we need to define STDOUT ourselves
-            define('STDOUT', 'php://output'); // @codeCoverageIgnore
+            if (! defined('STDOUT')) {
+                define('STDOUT', 'php://output'); // @codeCoverageIgnore
+            }
         }
     }
 

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -150,23 +150,16 @@ class CLI
             // much more bash-like.
             // http://www.php.net/manual/en/readline.installation.php
             static::$readline_support = extension_loaded('readline');
-
             // clear segments & options to keep testing clean
             static::$segments = [];
             static::$options  = [];
-
             // Check our stream resource for color support
             static::$isColored = static::hasColorSupport(STDOUT);
-
             static::parseCommandLine();
-
             static::$initialized = true;
-        } else {
-            // If the command is being called from a controller
-            // we need to define STDOUT ourselves
-            if (! defined('STDOUT')) {
-                define('STDOUT', 'php://output'); // @codeCoverageIgnore
-            }
+        } elseif (! defined('STDOUT')) {
+            define('STDOUT', 'php://output');
+            // @codeCoverageIgnore
         }
     }
 

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -150,16 +150,22 @@ class CLI
             // much more bash-like.
             // http://www.php.net/manual/en/readline.installation.php
             static::$readline_support = extension_loaded('readline');
+
             // clear segments & options to keep testing clean
             static::$segments = [];
             static::$options  = [];
+
             // Check our stream resource for color support
             static::$isColored = static::hasColorSupport(STDOUT);
+
             static::parseCommandLine();
+
             static::$initialized = true;
+        // See: https://github.com/codeigniter4/CodeIgniter4/issues/7047
         } elseif (! defined('STDOUT')) {
+            // @codeCoverageIgnoreStart
             define('STDOUT', 'php://output');
-            // @codeCoverageIgnore
+            // @codeCoverageIgnoreEnd
         }
     }
 

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -165,9 +165,7 @@ class CLI
             // If the command is being called from a controller
             // we need to define STDOUT ourselves
             // For "! defined('STDOUT')" see: https://github.com/codeigniter4/CodeIgniter4/issues/7047
-            // @codeCoverageIgnoreStart
-            define('STDOUT', 'php://output');
-            // @codeCoverageIgnoreEnd
+            define('STDOUT', 'php://output'); // @codeCoverageIgnore
         }
     }
 


### PR DESCRIPTION
**Description**

In development and also in production environment where composer dependencies are installed without `--no-dev` composer flag we can have an issue with running commands from Controller with `command()` helper. 

Issue is there because of **Psalm** required package `amphp/byte-stream` in 

[functions.php](https://github.com/amphp/byte-stream/blob/b5a09a3abd7a638ca4cadcf0876ce0ccd8d911d3/src/functions.php#L15-L17)

Psalm is often installed with [devkit](https://github.com/codeigniter4/devkit), so we need to check if `STDOUT` is already defined.

Fixes #7047

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
