### PR TITLE
fix: [Email] add fallback to use gethostname()

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -2101,6 +2101,11 @@ class Email
             return '[' . $_SERVER['SERVER_ADDR'] . ']';
         }
 
+        $hostname = gethostname();
+        if ($hostname !== false) {
+            return $hostname;
+        }
+
         return '[127.0.0.1]';
     }
 


### PR DESCRIPTION
**Description**
`[127.0.0.1]` is not valid domain parameter.
127.0.0.1 is a loopback address.

See https://forum.codeigniter.com/showthread.php?tid=84852

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
