### PR TITLE
Fixing bug with legacy autoRoute when testing

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -574,8 +574,6 @@ class Router implements RouterInterface
     {
         if (empty($dir)) {
             $this->directory = null;
-
-            return;
         }
 
         if ($this->autoRouter instanceof AutoRouter) {


### PR DESCRIPTION
When legacy autoRoute is used in case of using controller that sits in sub directory, that directory is determined and stored in `$this->directory` and new AutoRouter class. But if we subsequently try to load controller without that is not in a directory, then codeigniter can't find it because the `$this->directory` var in AutoRoute instance is still holding reference to previous directory. This only happens when we load several controllers from console. In my case after upgrading to 4.2.11 my tests fail because of it.

I suggest to remove this return; statement to reset directory in AutoRoute instance also.

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
