### PR TITLE
fix: revert method name changed accidentally

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3274,7 +3274,7 @@ class BaseBuilder
      *
      * @return $this
      */
-    public function resetQueryAsData()
+    public function resetQuery()
     {
         $this->resetSelect();
         $this->resetWrite();
@@ -3456,7 +3456,7 @@ class BaseBuilder
      */
     protected function cleanClone()
     {
-        return (clone $this)->from([], true)->resetQueryAsData();
+        return (clone $this)->from([], true)->resetQuery();
     }
 
     /**

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -309,4 +309,18 @@ final class SelectTest extends CIUnitTestCase
 
         $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
+
+    public function testSelectResetQuery()
+    {
+        $builder = new BaseBuilder('users', $this->db);
+        $builder->select('name, role');
+
+        $builder->resetQuery();
+
+        $sql = $builder->getCompiledSelect();
+        $this->assertSame(
+            'SELECT * FROM "users"',
+            str_replace("\n", ' ', $sql)
+        );
+    }
 }


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=86096&pid=405141#pid405141

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
