### PR TITLE
test: add `@TODO` to incorrect `(:any)` usages

### DIFF
--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -266,6 +266,8 @@ final class CommonFunctionsTest extends CIUnitTestCase
     {
         // prime the pump
         $routes = service('routes');
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
         $this->assertSame('/path/string/to/13', route_to('myController::goto', 'string', 13));
@@ -275,6 +277,8 @@ final class CommonFunctionsTest extends CIUnitTestCase
     {
         Services::createRequest(new App(), true);
         $routes = service('routes');
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
         $this->assertSame('/path/string/to/13', route_to('myController::goto', 'string', 13));
@@ -284,6 +288,8 @@ final class CommonFunctionsTest extends CIUnitTestCase
     {
         Services::createRequest(new App(), true);
         $routes = service('routes');
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
 
         $this->assertSame(
@@ -296,6 +302,8 @@ final class CommonFunctionsTest extends CIUnitTestCase
     {
         Services::createRequest(new App(), false);
         $routes = service('routes');
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'path-to']);
 
         $this->assertSame(

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -835,6 +835,8 @@ final class MiscUrlTest extends CIUnitTestCase
         $_SERVER['HTTP_HOST'] = 'example.com';
 
         $routes = service('routes');
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'gotoPage']);
         $routes->add('route/(:any)/to/(:num)', 'myOtherController::goto/$1/$2');
 

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -56,6 +56,8 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
         $match = $routes->reverseRoute('myController::goto', 'string', 13);
@@ -67,6 +69,8 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
         $match = $routes->reverseRoute('myController::goto', 'string', 13);
@@ -78,6 +82,8 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1');
 
         $this->assertFalse($routes->reverseRoute('myController::goto', 'string', 13));
@@ -87,6 +93,8 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
         $this->assertFalse($routes->reverseRoute('myBadController::goto', 'string', 13));
@@ -96,6 +104,8 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
         $this->expectException(RouterException::class);

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -889,6 +889,8 @@ final class RouteCollectionTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'namedRoute']);
 
         $match = $routes->reverseRoute('namedRoute', 'string', 13);
@@ -900,6 +902,8 @@ final class RouteCollectionTest extends CIUnitTestCase
     {
         $routes = $this->getCollector();
 
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('{locale}/path/(:any)/to/(:num)', 'myController::goto/$1/$2', ['as' => 'namedRoute']);
 
         $match = $routes->reverseRoute('namedRoute', 'string', 13);

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -96,6 +96,8 @@ final class ParserPluginTest extends CIUnitTestCase
     {
         // prime the pump
         $routes = service('routes');
+        // @TODO Do not put any placeholder after (:any).
+        //       Because the number of parameters passed to the controller method may change.
         $routes->add('path/(:any)/to/(:num)', 'myController::goto/$1/$2');
 
         $template = '{+ route myController::goto string 13 +}';


### PR DESCRIPTION
**Description**
These tests are a misuse of (:any). They are not appropriate test code.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
