### PR TITLE
fix: remove `All` from `Options All -Indexes` in .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,5 +1,5 @@
 # Disable directory browsing
-Options All -Indexes
+Options -Indexes
 
 # ----------------------------------------------------------------------
 # Rewrite engine


### PR DESCRIPTION
Options All -Indexes causes a 500 Internal Server Error. (Apache on hostpoint.ch / interxion).

Without the -All it works fine.

I'm not sure about all the effects, but I think the -All is already handled in the Apache directive and has not to be in .htaccess