### PR TITLE
chore: update phpstan-baseline for PHPStan 1.9.9

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -26,11 +26,6 @@ parameters:
 			path: system/Cache/Handlers/MemcachedHandler.php
 
 		-
-			message: "#^Variable \\$data might not be defined\\.$#"
-			count: 1
-			path: system/Cache/Handlers/MemcachedHandler.php
-
-		-
 			message: "#^Property CodeIgniter\\\\Cache\\\\Handlers\\\\RedisHandler\\:\\:\\$redis \\(Redis\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: system/Cache/Handlers/RedisHandler.php


### PR DESCRIPTION
**Description**
- update phpstan-baseline

```
Error: Ignored error pattern #^Variable \$data might not be defined\.$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/Cache/Handlers/MemcachedHandler.php was not matched in reported errors.
 ------ ----------------------------------------------------------------------- 
  Line   system/Cache/Handlers/MemcachedHandler.php                             
 ------ ----------------------------------------------------------------------- 
         Ignored error pattern #^Variable \$data might not be defined\.$# in    
         path                                                                   
         /home/runner/work/CodeIgniter4/CodeIgniter4/system/Cache/Handlers/Mem  
         cachedHandler.php was not matched in reported errors.                  
 ------ ----------------------------------------------------------------------- 
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/3898215393/jobs/6656717730

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
