### PR TITLE
docs: add missing instruction for Config/Exceptions in PHP 8.2

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -80,6 +80,8 @@ class Exceptions
         $this->response = $response;
 
         // workaround for upgraded users
+        // This causes "Deprecated: Creation of dynamic property" in PHP 8.2.
+        // @TODO remove this after dropping PHP 8.1 support.
         if (! isset($this->config->sensitiveDataInTrace)) {
             $this->config->sensitiveDataInTrace = [];
         }

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -42,6 +42,11 @@ app/Config/Kint.php
     - ``Kint\Renderer\Renderer`` with ``Kint\Renderer\AbstractRenderer``
     - ``Renderer::SORT_FULL`` with ``AbstractRenderer::SORT_FULL``
 
+app/Config/Exceptions.php
+-------------------------
+
+- If you are using PHP 8.2, you need to add new properties ``$logDeprecations`` and ``$deprecationLogLevel``.
+
 Mock Config Classes
 -------------------
 

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -33,7 +33,18 @@ The following files received significant changes and
 Config Files
 ============
 
-- **app/Config/Kint.php** has been updated for Kint 5.0. You need to replace ``Kint\Renderer\Renderer`` with ``Kint\Renderer\AbstractRenderer`` and replace ``Renderer::SORT_FULL`` with ``AbstractRenderer::SORT_FULL``.
+app/Config/Kint.php
+-------------------
+
+- **app/Config/Kint.php** has been updated for Kint 5.0.
+- You need to replace:
+
+    - ``Kint\Renderer\Renderer`` with ``Kint\Renderer\AbstractRenderer``
+    - ``Renderer::SORT_FULL`` with ``AbstractRenderer::SORT_FULL``
+
+Mock Config Classes
+-------------------
+
 - If you are using the following Mock Config classes in testing, you need to update the corresponding Config files in **app/Config**:
 
     - ``MockAppConfig`` (``Config\App``)


### PR DESCRIPTION
**Description**
Fixes #7097

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
