### PR TITLE
docs: add missing backslashes

### DIFF
--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -15,10 +15,10 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Trouble Shooting
 ****************
 
-Call to undefined method Composer\InstalledVersions::getAllRawData()
-====================================================================
+Call to undefined method Composer\\InstalledVersions::getAllRawData()
+=====================================================================
 
-Some users reported "*Fatal error: Uncaught Error: Call to undefined method Composer\InstalledVersions::getAllRawData()*" after upgrading with Composer.
+Some users reported "*Fatal error: Uncaught Error: Call to undefined method Composer\\InstalledVersions::getAllRawData()*" after upgrading with Composer.
 
 If you get the error, upgrade your ``composer`` tool, and delete the **vendor/**
 directory, and run ``composer update`` again.


### PR DESCRIPTION
**Description**
Follow-up #7101

- we need to escape `\` withh `\`. See https://codeigniter4.github.io/CodeIgniter4/installation/upgrade_430.html#call-to-undefined-method-composerinstalledversions-getallrawdata

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
