### PR TITLE
fix: Call to undefined method Composer\InstalledVersions::getAllRawData() error

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -373,16 +373,15 @@ class Autoloader
             unset($namespacePaths['CodeIgniter\\']);
         }
 
-        if (method_exists(InstalledVersions::class, 'getAllRawData')) {
-            // This method requires Composer 2.0.14 or later.
-            $packageList = InstalledVersions::getAllRawData()[0]['versions'];
-        } else {
+        if (! method_exists(InstalledVersions::class, 'getAllRawData')) {
             throw new RuntimeException(
                 'Your Composer version is too old.'
                 . ' Please update Composer (run `composer self-update`) to v2.0.14 or later'
                 . ' and remove your vendor/ directory, and run `composer update`.'
             );
         }
+        // This method requires Composer 2.0.14 or later.
+        $packageList = InstalledVersions::getAllRawData()[0]['versions'];
 
         // Check config for $composerPackages.
         $only    = $composerPackages['only'] ?? [];

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -373,7 +373,16 @@ class Autoloader
             unset($namespacePaths['CodeIgniter\\']);
         }
 
-        $packageList = InstalledVersions::getAllRawData()[0]['versions'];
+        if (method_exists(InstalledVersions::class, 'getAllRawData')) {
+            // This method requires Composer 2.0.14 or later.
+            $packageList = InstalledVersions::getAllRawData()[0]['versions'];
+        } else {
+            throw new RuntimeException(
+                'Your Composer version is too old.'
+                . ' Please update Composer (run `composer self-update`) and remove your vendor/ directory,'
+                . ' and run `composer update`.'
+            );
+        }
 
         // Check config for $composerPackages.
         $only    = $composerPackages['only'] ?? [];

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -379,8 +379,8 @@ class Autoloader
         } else {
             throw new RuntimeException(
                 'Your Composer version is too old.'
-                . ' Please update Composer (run `composer self-update`) and remove your vendor/ directory,'
-                . ' and run `composer update`.'
+                . ' Please update Composer (run `composer self-update`) to v2.0.14 or later'
+                . ' and remove your vendor/ directory, and run `composer update`.'
             );
         }
 

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -7,6 +7,8 @@ Composer Installation
 
 Composer can be used in several ways to install CodeIgniter4 on your system.
 
+.. important:: CodeIgniter4 requires Composer 2.0.14 or later.
+
 The first technique describes creating a skeleton project
 using CodeIgniter4, that you would then use as the base for a new webapp.
 The second technique described below lets you add CodeIgniter4 to an existing

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -15,7 +15,7 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Composer Version
 ****************
 
-.. important:: If you use Composer Installation, CodeIgniter v4.3.0 requires
+.. important:: If you use Composer, CodeIgniter v4.3.0 requires
     Composer 2.0.14 or later.
 
 If you are using older version of Composer, upgrade your ``composer`` tool,

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -12,16 +12,14 @@ Please refer to the upgrade instructions corresponding to your installation meth
     :local:
     :depth: 2
 
-Trouble Shooting
+Composer Version
 ****************
 
-Call to undefined method Composer\\InstalledVersions::getAllRawData()
-=====================================================================
+.. important:: If you use Composer Installation, CodeIgniter v4.3.0 requires
+    Composer 2.0.14 or later.
 
-Some users reported "*Fatal error: Uncaught Error: Call to undefined method Composer\\InstalledVersions::getAllRawData()*" after upgrading with Composer.
-
-If you get the error, upgrade your ``composer`` tool, and delete the **vendor/**
-directory, and run ``composer update`` again.
+If you are using older version of Composer, upgrade your ``composer`` tool,
+and delete the **vendor/** directory, and run ``composer update`` again.
 
 The procedure, for example, is as follows::
 


### PR DESCRIPTION
**Description**
Fixes #7106

The depreacted `getRawData()` is not reliable. See https://github.com/composer/composer/commit/f5e6cc89cd8d45c99cff77ee80d0f324ada45686#diff-817f0ad18cf006ca7b25f23ddd362c0c8b5cdcbea91c4b92be8d86ba59af223aR210
So using it does not make sense.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
