### PR TITLE
docs: update errors_list template

### DIFF
--- a/user_guide_src/source/libraries/validation/030.php
+++ b/user_guide_src/source/libraries/validation/030.php
@@ -1,7 +1,7 @@
 <?php if (! empty($errors)): ?>
     <div class="alert alert-danger">
     <?php foreach ($errors as $field => $error): ?>
-        <p><?= $error ?></p>
+        <p><?= esc($error) ?></p>
     <?php endforeach ?>
     </div>
 <?php endif ?>

--- a/user_guide_src/source/libraries/validation/030.php
+++ b/user_guide_src/source/libraries/validation/030.php
@@ -1,7 +1,7 @@
-<div class="alert alert-danger" role="alert">
-    <ul>
-    <?php foreach ($errors as $error): ?>
-        <li><?= esc($error) ?></li>
+<?php if (! empty($errors)): ?>
+    <div class="alert alert-danger">
+    <?php foreach ($errors as $field => $error): ?>
+        <p><?= $error ?></p>
     <?php endforeach ?>
-    </ul>
-</div>
+    </div>
+<?php endif ?>

--- a/user_guide_src/source/libraries/validation/030.php
+++ b/user_guide_src/source/libraries/validation/030.php
@@ -1,7 +1,9 @@
 <?php if (! empty($errors)): ?>
-    <div class="alert alert-danger">
-    <?php foreach ($errors as $field => $error): ?>
-        <p><?= esc($error) ?></p>
-    <?php endforeach ?>
+    <div class="alert alert-danger" role="alert">
+        <ul>
+        <?php foreach ($errors as $error): ?>
+            <li><?= esc($error) ?></li>
+        <?php endforeach ?>
+        </ul>
     </div>
 <?php endif ?>


### PR DESCRIPTION
check for empty $errors

now with the same content as 
https://github.com/codeigniter4/CodeIgniter4/blob/develop/user_guide_src/source/models/model/033.php

or is it better if we include the code-snippet here?
`.. literalinclude:: model/033.php`