### PR TITLE
fix: support single array objects in parsePair method

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -283,6 +283,12 @@ class Parser extends View
             PREG_SET_ORDER
         );
 
+        // If data is not a list of elements, convert single item to a list
+        $is_list = $data === [] || (array_keys($data) === range(0, count($data) - 1));
+        if (!$is_list){
+            $data = [$data];
+        }
+
         /*
          * Each match looks like:
          *


### PR DESCRIPTION
**Description**
Fixes #7096

Allow using a single-element object to support current syntax in documentation examples for Nested Substitutions (https://codeigniter4.github.io/userguide/outgoing/view_parser.html#nested-substitutions) and Cascading Data (https://codeigniter4.github.io/userguide/outgoing/view_parser.html#cascading-data) 

This fix will convert the object into an array list with 1 element.




**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
