### PR TITLE
docs: add explanation for Cookie $expire is `0`

### DIFF
--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -25,7 +25,7 @@ The following functions are available:
 
     :param    mixed    $name: Cookie name *or* associative array of all of the parameters available to this function
     :param    string    $value: Cookie value
-    :param    int    $expire: Number of seconds until expiration
+    :param    int    $expire: Number of seconds until expiration. If set to ``0`` the cookie will only last as long as the browser is open
     :param    string    $domain: Cookie domain (usually: .yourdomain.com)
     :param    string    $path: Cookie path
     :param    string    $prefix: Cookie name prefix. If ``''``, the default from **app/Config/Cookie.php** is used

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -366,7 +366,7 @@ The methods provided by the parent class that are available are:
 
         :param array|Cookie|string $name: Cookie name or an array of parameters or an instance of ``CodeIgniter\Cookie\Cookie``
         :param string $value: Cookie value
-        :param int $expire: Cookie expiration time in seconds
+        :param int $expire: Cookie expiration time in seconds. If set to ``0`` the cookie will only last as long as the browser is open
         :param string $domain: Cookie domain
         :param string $path: Cookie path
         :param string $prefix: Cookie name prefix. If set to ``''``, the default value from **app/Config/Cookie.php** will be used


### PR DESCRIPTION
**Description**
- 0 has a special meaning

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
