### PR TITLE
fix: bug on stuck content-type header in Feature Testing

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -364,7 +364,7 @@ trait FeatureTestTrait
 
             return $request;
         }
-        
+
         $request->removeHeader('Content-Type');
         if (isset($this->bodyFormat) && $this->bodyFormat !== '') {
             if (empty($params)) {
@@ -382,7 +382,7 @@ trait FeatureTestTrait
                 $request->setHeader('Content-Type', $formatMime);
             }
         }
-        
+
         return $request;
     }
 }

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -364,7 +364,8 @@ trait FeatureTestTrait
 
             return $request;
         }
-
+        
+        $request->removeHeader('Content-Type');
         if (isset($this->bodyFormat) && $this->bodyFormat !== '') {
             if (empty($params)) {
                 $params = $request->fetchGlobal('request');
@@ -381,7 +382,7 @@ trait FeatureTestTrait
                 $request->setHeader('Content-Type', $formatMime);
             }
         }
-
+        
         return $request;
     }
 }

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -286,7 +286,7 @@ trait FeatureTestTrait
     {
         $path    = URI::removeDotSegments($path);
         $config  = config(App::class);
-        $request = Services::request($config, true);
+        $request = Services::request($config, false);
 
         // $path may have a query in it
         $parts                   = explode('?', $path);
@@ -365,7 +365,6 @@ trait FeatureTestTrait
             return $request;
         }
 
-        $request->removeHeader('Content-Type');
         if (isset($this->bodyFormat) && $this->bodyFormat !== '') {
             if (empty($params)) {
                 $params = $request->fetchGlobal('request');


### PR DESCRIPTION
Supersedes #7079

When I use FeatureTestTrait if I use `withBodyFormat('json')` function on one request all subsequent requests are sent with `content-type: application/json` even if their body format is not 'json'.

This bug started when I upgraded CI from 4.0.x to 4.2.11. After long investigation I think I found the source of the problem. On line 289 initialization of request has been changed to `Services::request($config, true)` so for each subsequent test request same instance is used. That's why if content-type on one request is set then all other requests are sent with this header. We need some reset mechanism.



<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
