### PR TITLE
Prep for 4.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.3.0...v4.3.1)
 
 ### Fixed Bugs
+
 * fix: Email config in the .env doesn't appear as expected by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7078
 * fix: TypeError in Validation is_unique/is_not_unique by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7085
 * fix: revert method name resetQuery() changed accidentally by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7083
@@ -12,6 +13,7 @@
 * fix: Call to undefined method Composer\InstalledVersions::getAllRawData() error by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7107
 
 ### Refactoring
+
 * [Rector] Enable AddDefaultValueForUndefinedVariableRector by @samsonasik in https://github.com/codeigniter4/CodeIgniter4/pull/7088
 
 ## [v4.3.0](https://github.com/codeigniter4/CodeIgniter4/tree/v4.3.0) (2023-01-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v4.3.1](https://github.com/codeigniter4/CodeIgniter4/tree/v4.3.1) (2023-01-14)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.3.0...v4.3.1)
+
+### Fixed Bugs
+* fix: Email config in the .env doesn't appear as expected by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7078
+* fix: TypeError in Validation is_unique/is_not_unique by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7085
+* fix: revert method name resetQuery() changed accidentally by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7083
+* fix: handling float in Validation Strcit Rules (greater_than, greater_than_equal_to, less_than, less_than_equal_to) by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7098
+* docs: add missing instruction for Config/Exceptions in PHP 8.2 by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7100
+* fix: Call to undefined method Composer\InstalledVersions::getAllRawData() error by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7107
+
+### Refactoring
+* [Rector] Enable AddDefaultValueForUndefinedVariableRector by @samsonasik in https://github.com/codeigniter4/CodeIgniter4/pull/7088
+
 ## [v4.3.0](https://github.com/codeigniter4/CodeIgniter4/tree/v4.3.0) (2023-01-10)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.2.12...v4.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 * fix: exceptionHandler may return invalid HTTP status code by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6228
 * feat: add Form helpers for Validation Errors by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6384
 * fix: ValidationInterface by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6253
-* [Reverted] Make Unique Index Name Unique by @sclubricants in https://github.com/codeigniter4/CodeIgniter4/pull/6516
 * fix: types in database classes by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6527
 * fix: ResponseInterface (1) by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/6556
 * Improve BaseConnection::getForeignKeyData() and Forge::addForeignKey() by @sclubricants in https://github.com/codeigniter4/CodeIgniter4/pull/6468

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -47,7 +47,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.3.0';
+    public const CI_VERSION = '4.3.1';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/v4.3.1.rst
+++ b/user_guide_src/source/changelogs/v4.3.1.rst
@@ -1,7 +1,7 @@
 Version 4.3.1
 #############
 
-Release Date: Unreleased
+Release Date: January 14, 2023
 
 **4.3.1 release of CodeIgniter4**
 
@@ -9,20 +9,14 @@ Release Date: Unreleased
     :local:
     :depth: 3
 
-BREAKING
-********
-
-Message Changes
-***************
-
-Changes
-*******
-
-Deprecations
-************
-
 Bugs Fixed
 **********
+
+* Fixed: some environment variable (**.env**) values were not reflected in Email Config
+* Fixed: TypeError in Validation ``is_unique`` and ``is_not_unique``
+* Fixed: revert method name ``BaseBuilder::resetQuery()`` changed accidentally
+* Fixed: handling float in Validation Strcit Rules (``greater_than``, ``greater_than_equal_to``, ``less_than``, ``less_than_equal_to``)
+* Fixed: missing instruction for ``Config\Exceptions`` in PHP 8.2 in the user guide
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2019-' + str(year_now) + ' CodeIgniter Foundation'
 version = '4.3'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.3.0'
+release = '4.3.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_431.rst
+++ b/user_guide_src/source/installation/upgrade_431.rst
@@ -1,0 +1,81 @@
+##############################
+Upgrading from 4.3.0 to 4.3.1
+##############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+Composer Version
+****************
+
+.. important:: If you use Composer, CodeIgniter v4.3 requires
+    Composer 2.0.14 or later.
+
+If you are using older version of Composer, upgrade your ``composer`` tool,
+and delete the **vendor/** directory, and run ``composer update`` again.
+
+The procedure, for example, is as follows::
+
+    > composer self-update
+    > rm -rf vendor/
+    > composer update
+
+Mandatory File Changes
+**********************
+
+Config Files
+============
+
+app/Config/Email.php
+--------------------
+
+- If you updated **app/Config/Email.php** when upgrading to v4.3.0, you must
+  set the default values to ``$fromEmail``, ``$fromName``,  ``$recipients``,
+  ``$SMTPHost``, ``$SMTPUser`` and ``$SMTPPass`` to apply environment variable
+  (**.env**) values.
+- If no default values are set, setting environment variables for them will not
+  be reflected in the Config object.
+
+app/Config/Exceptions.php
+-------------------------
+
+- If you are using PHP 8.2, you need to add new properties ``$logDeprecations`` and ``$deprecationLogLevel``.
+
+Project Files
+*************
+
+Some files in the **project space** (root, app, public, writable) received updates. Due to
+these files being outside of the **system** scope they will not be changed without your intervention.
+
+There are some third-party CodeIgniter modules available to assist with merging changes to
+the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+Content Changes
+===============
+
+The following files received significant changes (including deprecations or visual adjustments)
+and it is recommended that you merge the updated versions with your application:
+
+Config
+------
+
+- app/Config/Encryption.php
+    - Set the default value ``''`` to ``$fromEmail``, ``$fromName``,
+      ``$recipients``, ``$SMTPHost``, ``$SMTPUser`` and ``$SMTPPass``
+      to apply environment variable (**.env**) values.
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+-   app/Config/Email.php
+-   composer.json

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -16,6 +16,7 @@ See also :doc:`./backward_compatibility_notes`.
 
     backward_compatibility_notes
 
+    upgrade_431
     upgrade_430
     upgrade_4212
     upgrade_4211


### PR DESCRIPTION
**Description**
Updates changelog and version references for 4.3.1.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
