### PR TITLE
refactor: make Filters::$arguments deprecated

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -14,6 +14,9 @@ class Filters extends BaseConfig
     /**
      * Configures aliases for Filter classes to
      * make reading things nicer and simpler.
+     *
+     * @var array<string, string>
+     * @phpstan-var array<string, class-string>
      */
     public array $aliases = [
         'csrf'          => CSRF::class,
@@ -26,6 +29,9 @@ class Filters extends BaseConfig
     /**
      * List of filter aliases that are always
      * applied before and after every request.
+     *
+     * @var array<string, array<string, array<string, string>>>|array<string, array<string>>
+     * @phpstan-var array<string, list<string>>|array<string, array<string, array<string, string>>>
      */
     public array $globals = [
         'before' => [

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -63,7 +63,7 @@ class Filters
      * The processed filters that will
      * be used to check against.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $filters = [
         'before' => [],
@@ -74,7 +74,7 @@ class Filters
      * The collection of filters' class names that will
      * be used to execute in each position.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $filtersClass = [
         'before' => [],
@@ -84,14 +84,16 @@ class Filters
     /**
      * Any arguments to be passed to filters.
      *
-     * @var array
+     * @var array<string, array<int, string>> [name => params]
+     * @phpstan-var array<string, list<string>>
      */
     protected $arguments = [];
 
     /**
      * Any arguments to be passed to filtersClass.
      *
-     * @var array
+     * @var array<string, array|null> [classname => arguments]
+     * @phpstan-var array<class-string, array<string, list<string>>|null>
      */
     protected $argumentsClass = [];
 
@@ -367,6 +369,8 @@ class Filters
      * Filters can have "arguments". This is done by placing a colon immediately
      * after the filter name, followed by a comma-separated list of arguments that
      * are passed to the filter when executed.
+     *
+     * @params array<string> $names Filter names
      *
      * @return Filters
      */

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -170,7 +170,10 @@ class Filters
             }
 
             if ($position === 'before') {
-                $result = $class->before($this->request, $this->argumentsClass[$className] ?? null);
+                $result = $class->before(
+                    $this->request,
+                    $this->argumentsClass[$className] ?? null
+                );
 
                 if ($result instanceof RequestInterface) {
                     $this->request = $result;
@@ -193,7 +196,11 @@ class Filters
             }
 
             if ($position === 'after') {
-                $result = $class->after($this->request, $this->response, $this->argumentsClass[$className] ?? null);
+                $result = $class->after(
+                    $this->request,
+                    $this->response,
+                    $this->argumentsClass[$className] ?? null
+                );
 
                 if ($result instanceof ResponseInterface) {
                     $this->response = $result;

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -86,6 +86,8 @@ class Filters
      *
      * @var array<string, array<int, string>> [name => params]
      * @phpstan-var array<string, list<string>>
+     *
+     * @deprecated When running filters, $argumentsClass is used now. This should be removed.
      */
     protected $arguments = [];
 
@@ -387,6 +389,8 @@ class Filters
      * Returns the arguments for a specified key, or all.
      *
      * @return mixed
+     *
+     * @deprecated $this->arguments is deprecated, and this method seems only for testing.
      */
     public function getArguments(?string $key = null)
     {

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -803,8 +803,6 @@ final class FiltersTest extends CIUnitTestCase
         $found = $filters->getFilters();
 
         $this->assertContains('role', $found['before']);
-        $this->assertSame(['admin', 'super'], $filters->getArguments('role'));
-        $this->assertSame(['role' => ['admin', 'super']], $filters->getArguments());
 
         $response = $filters->run('admin/foo/bar', 'before');
 

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.3.2
     v4.3.1
     v4.3.0
     v4.2.12

--- a/user_guide_src/source/changelogs/v4.3.2.rst
+++ b/user_guide_src/source/changelogs/v4.3.2.rst
@@ -1,0 +1,22 @@
+Version 4.3.2
+#############
+
+Release Date: Unreleased
+
+**4.3.2 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 3
+
+Deprecations
+************
+
+- ``Filters::$arguments`` and ``Filters::getArguments()`` are deprecated.
+
+Bugs Fixed
+**********
+
+See the repo's
+`CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
+for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
- `Filters::$arguments` is temporary variable now. `$argumentsClass` has all arguments.
- add PHPDoc types

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
