### PR TITLE
docs: add support for PHP 8.2 in changelog

### DIFF
--- a/user_guide_src/source/changelogs/v4.2.11.rst
+++ b/user_guide_src/source/changelogs/v4.2.11.rst
@@ -23,6 +23,11 @@ BREAKING
   :ref:`sessions-memcachedhandler-driver` and :ref:`sessions-redishandler-driver`
   has changed. See :ref:`Upgrading Guide <upgrade-4211-session-key>`.
 
+Enhancements
+************
+
+- Full support for PHP 8.2.
+
 Bugs Fixed
 **********
 


### PR DESCRIPTION
**Description**
- add support for PHP 8.2

See https://github.com/codeigniter4/CodeIgniter4/issues/6170#issuecomment-1312929443
The issue was closed on Nov 23, 2022, and PHP 8.2 was released on [08 Dec 2022](https://www.php.net/ChangeLog-8.php#PHP_8_2).
So I add this in v4.2.11 (December 21, 2022).

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
