### PR TITLE
fix: remove parameter $relative in `uri_string()`

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -183,15 +183,14 @@ if (! function_exists('uri_string')) {
     /**
      * URL String
      *
-     * Returns the path part of the current URL
-     *
-     * @param bool $relative Whether the resulting path should be relative to baseURL
+     * Returns the path part (relative to baseURL) of the current URL
      */
-    function uri_string(bool $relative = false): string
+    function uri_string(): string
     {
-        return $relative
-            ? ltrim(Services::request()->getPath(), '/')
-            : Services::request()->getUri()->getPath();
+        // The value of Services::request()->getUri()->getPath() is overridden
+        // by IncomingRequest constructor. If we use it here, the current tests
+        // in CurrentUrlTest will fail.
+        return ltrim(Services::request()->getPath(), '/');
     }
 }
 
@@ -583,7 +582,7 @@ if (! function_exists('url_is')) {
     {
         // Setup our regex to allow wildcards
         $path        = '/' . trim(str_replace('*', '(\S)*', $path), '/ ');
-        $currentPath = '/' . trim(uri_string(true), '/ ');
+        $currentPath = '/' . trim(uri_string(), '/ ');
 
         return (bool) preg_match("|^{$path}$|", $currentPath, $matches);
     }

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -163,7 +163,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $this->assertSame(8080, $uri->getPort());
     }
 
-    public function testUriStringAbsolute()
+    public function testUriString()
     {
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
@@ -183,18 +183,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         Services::injectMock('request', $request);
     }
 
-    public function testUriStringRelative()
-    {
-        $_SERVER['HTTP_HOST']   = 'example.com';
-        $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
-
-        $uri = 'http://example.com/assets/image.jpg';
-        $this->setService($uri);
-
-        $this->assertSame('assets/image.jpg', uri_string(true));
-    }
-
-    public function testUriStringNoTrailingSlashAbsolute()
+    public function testUriStringNoTrailingSlash()
     {
         $_SERVER['HTTP_HOST']   = 'example.com';
         $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
@@ -207,33 +196,12 @@ final class CurrentUrlTest extends CIUnitTestCase
         $this->assertSame('assets/image.jpg', uri_string());
     }
 
-    public function testUriStringNoTrailingSlashRelative()
-    {
-        $_SERVER['HTTP_HOST']   = 'example.com';
-        $_SERVER['REQUEST_URI'] = '/assets/image.jpg';
-
-        $this->config->baseURL = 'http://example.com';
-
-        $uri = 'http://example.com/assets/image.jpg';
-        $this->setService($uri);
-
-        $this->assertSame('assets/image.jpg', uri_string(true));
-    }
-
-    public function testUriStringEmptyAbsolute()
+    public function testUriStringEmpty()
     {
         $uri = 'http://example.com/';
         $this->setService($uri);
 
-        $this->assertSame('/', uri_string());
-    }
-
-    public function testUriStringEmptyRelative()
-    {
-        $uri = 'http://example.com/';
-        $this->setService($uri);
-
-        $this->assertSame('', uri_string(true));
+        $this->assertSame('', uri_string());
     }
 
     public function testUriStringSubfolderAbsolute()
@@ -260,7 +228,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $uri = 'http://example.com/subfolder/assets/image.jpg';
         $this->setService($uri);
 
-        $this->assertSame('assets/image.jpg', uri_string(true));
+        $this->assertSame('assets/image.jpg', uri_string());
     }
 
     public function urlIsProvider()

--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.3.2
     v4.3.1
     v4.3.0
     v4.2.12

--- a/user_guide_src/source/changelogs/v4.3.2.rst
+++ b/user_guide_src/source/changelogs/v4.3.2.rst
@@ -1,0 +1,32 @@
+Version 4.3.2
+#############
+
+Release Date: Unreleased
+
+**4.3.2 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 3
+
+BREAKING
+********
+
+Message Changes
+***************
+
+Changes
+*******
+
+- The parameter ``$relative`` in :php:func:`uri_string()` was removed. Due to a bug,
+  the function always returned a path relative to baseURL. No behavior changes.
+
+Deprecations
+************
+
+Bugs Fixed
+**********
+
+See the repo's
+`CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
+for a complete list of bugs fixed.

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -121,27 +121,32 @@ The following functions are available:
         use a known and trusted source. If the session hasn't been loaded, or is otherwise unavailable,
         then a sanitized version of HTTP_REFERER will be used.
 
-.. php:function:: uri_string([$relative = false])
+.. php:function:: uri_string()
 
-    :param    boolean    $relative: True if you would like the string relative to baseURL
     :returns: A URI string
-    :rtype:    string
+    :rtype:   string
 
-    Returns the path part of the current URL.
-    For example, if your URL was this::
+    Returns the path part of the current URL relative to baseURL.
+
+    For example, when your baseURL is **http://some-site.com/** and the current URL is::
 
         http://some-site.com/blog/comments/123
 
     The function would return::
 
-        /blog/comments/123
+        blog/comments/123
 
-    Or with the optional relative parameter::
+    When your baseURL is **http://some-site.com/subfolder/** and the current URL is::
 
-        app.baseURL = http://some-site.com/subfolder/
+        http://some-site.com/subfolder/blog/comments/123
 
-        uri_string(); // "/subfolder/blog/comments/123"
-        uri_string(true); // "blog/comments/123"
+    The function would return::
+
+        blog/comments/123
+
+    .. note:: In previous versions, the parameter ``$relative = false`` was defined.
+        However, due to a bug, this function always returned a path relative to baseURL.
+        Since v4.3.2, the parameter has been removed.
 
 .. php:function:: index_page([$altConfig = null])
 


### PR DESCRIPTION
**Description**
Fixes #7124

- remove the parameter `$relative` which does not work

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
