### PR TITLE
docs: use Request::is() instead of getMethod()

### DIFF
--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -44,9 +44,13 @@ Do one of the following:
 
 E.g.::
 
-    if (strtolower($this->request->getMethod()) !== 'post') {
+    if (! $this->request->is('post')) {
         return $this->response->setStatusCode(405)->setBody('Method Not Allowed');
     }
+
+.. note:: The :ref:`$this->request->is() <incomingrequest-is>` method can be used since v4.3.0.
+    In previous versions, you need to use
+    ``if (strtolower($this->request->getMethod()) !== 'post')``.
 
 When Auto-Routing is Enabled
 ----------------------------
@@ -55,7 +59,7 @@ When Auto-Routing is Enabled
 
 E.g.::
 
-    if (strtolower($this->request->getMethod()) !== 'post') {
+    if (! $this->request->is('post')) {
         return $this->response->setStatusCode(405)->setBody('Method Not Allowed');
     }
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -121,6 +121,10 @@ this code and save it to your **app/Controllers/** folder:
 
 .. literalinclude:: validation/001.php
 
+.. note:: The :ref:`$this->request->is() <incomingrequest-is>` method can be used since v4.3.0.
+    In previous versions, you need to use
+    ``if (strtolower($this->request->getMethod()) !== 'post')``.
+
 The Routes
 ==========
 

--- a/user_guide_src/source/libraries/validation/001.php
+++ b/user_guide_src/source/libraries/validation/001.php
@@ -10,7 +10,7 @@ class Form extends BaseController
 
     public function index()
     {
-        if (strtolower($this->request->getMethod()) !== 'post') {
+        if (! $this->request->is('post')) {
             return view('signup');
         }
 


### PR DESCRIPTION
**Description**
Follow-up #6995

- use Request::is() instead of getMethod()

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
