### PR TITLE
feat: link Shield to the HTML docs. [ci-skip]

### DIFF
--- a/user_guide_src/source/libraries/official_packages.rst
+++ b/user_guide_src/source/libraries/official_packages.rst
@@ -17,7 +17,7 @@ additional functionality that not every site will need or want.
 Shield
 ******
 
-`CodeIgniter Shield <https://github.com/codeigniter4/shield>`_ is an authentication
+`CodeIgniter Shield <https://codeigniter4.github.io/shield/>`_ is an authentication
 and authorization framework for CodeIgniter 4. It is designed to be secure, flexible,
 and easily extendable to meet the needs of many different types of websites.
 Among the many features, it includes:


### PR DESCRIPTION
This just changes the link in the user guide to Shield to link to the HTML docs instead of the GitHub repo.