### PR TITLE
docs: fix out of date sample command in modules.rst

### DIFF
--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -208,7 +208,7 @@ Seeds
 Seed files can be used from both the CLI and called from within other seed files as long as the full namespace
 is provided. If calling on the CLI, you will need to provide double backslashes::
 
-    > php public/index.php migrations seed Acme\\Blog\\Database\\Seeds\\TestPostSeeder
+    > php spark db:seed Acme\\Blog\\Database\\Seeds\\TestPostSeeder
 
 Helpers
 =======


### PR DESCRIPTION
**Description**
- fix out of dated sample command

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
