### PR TITLE
fix: [Parser] `!` does not work if delimiters are changed

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -508,7 +508,10 @@ class Parser extends View
         // Replace the content in the template
         return preg_replace_callback($pattern, function ($matches) use ($content, $escape) {
             // Check for {! !} syntax to not escape this one.
-            if (strpos($matches[0], '{!') === 0 && substr($matches[0], -2) === '!}') {
+            if (
+                strpos($matches[0], $this->leftDelimiter . '!') === 0
+                && substr($matches[0], -1 - strlen($this->rightDelimiter)) === '!' . $this->rightDelimiter
+            ) {
                 $escape = false;
             }
 

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -257,7 +257,9 @@ class Parser extends View
      */
     protected function parseSingle(string $key, string $val): array
     {
-        $pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key, '#') . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?' . $this->rightDelimiter . '#ums';
+        $pattern = '#' . $this->leftDelimiter . '!?\s*' . preg_quote($key, '#')
+            . '(?(?=\s*\|\s*)(\s*\|*\s*([|\w<>=\(\),:.\-\s\+\\\\/]+)*\s*))(\s*)!?'
+            . $this->rightDelimiter . '#ums';
 
         return [$pattern => $val];
     }

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -605,6 +605,19 @@ final class ParserTest extends CIUnitTestCase
         $this->assertSame('<script>Heroes</script>', $this->parser->renderString($template));
     }
 
+    public function testParserNoEscapeAndDelimiterChange()
+    {
+        $this->parser->setDelimiters('{{', '}}');
+
+        $data = [
+            'title' => '<script>Heroes</script>',
+        ];
+        $this->parser->setData($data);
+
+        $template = '{{! title !}}';
+        $this->assertSame('<script>Heroes</script>', $this->parser->renderString($template));
+    }
+
     public function testIgnoresComments()
     {
         $data = [

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -600,7 +600,7 @@ final class ParserTest extends CIUnitTestCase
             'title' => '<script>Heroes</script>',
         ];
 
-        $template = '{! title!}';
+        $template = '{! title !}';
         $this->parser->setData($data);
         $this->assertSame('<script>Heroes</script>', $this->parser->renderString($template));
     }


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=86155

- fix `!` does not work if delimiters are changed

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
