### PR TITLE
Bug Fix: [QueryBuilder] where() generates incorrect SQL when using RawSql

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -728,9 +728,16 @@ class BaseBuilder
      */
     protected function whereHaving(string $qbKey, $key, $value = null, string $type = 'AND ', ?bool $escape = null)
     {
+        $rawSqlOnly = false;
+
         if ($key instanceof RawSql) {
-            $keyValue = [(string) $key => $key];
-            $escape   = false;
+            if ($value === null) {
+                $keyValue   = [(string) $key => $key];
+                $rawSqlOnly = true;
+            } else {
+                $keyValue = [(string) $key => $value];
+            }
+            $escape = false;
         } elseif (! is_array($key)) {
             $keyValue = [$key => $value];
         } else {
@@ -745,7 +752,7 @@ class BaseBuilder
         foreach ($keyValue as $k => $v) {
             $prefix = empty($this->{$qbKey}) ? $this->groupGetType('') : $this->groupGetType($type);
 
-            if ($v instanceof RawSql) {
+            if ($rawSqlOnly === true) {
                 $k  = '';
                 $op = '';
             } elseif ($v !== null) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -737,6 +737,7 @@ class BaseBuilder
             } else {
                 $keyValue = [(string) $key => $value];
             }
+            $escape = false;
         } elseif (! is_array($key)) {
             $keyValue = [$key => $value];
         } else {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -737,7 +737,6 @@ class BaseBuilder
             } else {
                 $keyValue = [(string) $key => $value];
             }
-            $escape = false;
         } elseif (! is_array($key)) {
             $keyValue = [$key => $value];
         } else {

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -174,6 +174,51 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
+    public function testWhereValueRawSql()
+    {
+        $sql = $this->db->table('auth_bearer')
+            ->select('*')
+            ->where('expires', new RawSql('DATE_ADD(NOW(), INTERVAL 2 HOUR)'))
+            ->getCompiledSelect(true);
+
+        $expected = <<<'SQL'
+            SELECT *
+            FROM "auth_bearer"
+            WHERE "expires" = DATE_ADD(NOW(), INTERVAL 2 HOUR)
+            SQL;
+        $this->assertSame($expected, $sql);
+    }
+
+    public function testWhereKeyAndValueRawSql()
+    {
+        $sql = $this->db->table('auth_bearer')
+            ->select('*')
+            ->where(new RawSql('CURRENT_TIMESTAMP()'), new RawSql('DATE_ADD(column, INTERVAL 2 HOUR)'))
+            ->getCompiledSelect(true);
+
+        $expected = <<<'SQL'
+            SELECT *
+            FROM "auth_bearer"
+            WHERE CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)
+            SQL;
+        $this->assertSame($expected, $sql);
+    }
+
+    public function testWhereKeyAndValueRawSqlWithOperator()
+    {
+        $sql = $this->db->table('auth_bearer')
+            ->select('*')
+            ->where(new RawSql('CURRENT_TIMESTAMP() >='), new RawSql('DATE_ADD(column, INTERVAL 2 HOUR)'))
+            ->getCompiledSelect(true);
+
+        $expected = <<<'SQL'
+            SELECT *
+            FROM "auth_bearer"
+            WHERE CURRENT_TIMESTAMP() >= DATE_ADD(column, INTERVAL 2 HOUR)
+            SQL;
+        $this->assertSame($expected, $sql);
+    }
+
     public function testWhereValueSubQuery()
     {
         $expectedSQL = 'SELECT * FROM "neworder" WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)';

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -189,6 +189,21 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expected, $sql);
     }
 
+    public function testWhereKeyOnlyRawSql()
+    {
+        $sql = $this->db->table('auth_bearer')
+            ->select('*')
+            ->where(new RawSql('DATE_ADD(NOW(), INTERVAL 2 HOUR)'), '2023-01-01')
+            ->getCompiledSelect(true);
+
+        $expected = <<<'SQL'
+            SELECT *
+            FROM "auth_bearer"
+            WHERE DATE_ADD(NOW(), INTERVAL 2 HOUR) = '2023-01-01'
+            SQL;
+        $this->assertSame($expected, $sql);
+    }
+
     public function testWhereKeyAndValueRawSql()
     {
         $sql = $this->db->table('auth_bearer')


### PR DESCRIPTION
This fixes some of the problems noted ~~here https://github.com/codeigniter4/CodeIgniter4/issues/7117~~ and here https://github.com/codeigniter4/CodeIgniter4/issues/7143

The following was failing before this fix:

```php
        $sql = $this->db->table('auth_bearer')
            ->select('*')
            ->where('expires', new RawSql('DATE_ADD(NOW(), INTERVAL 2 HOUR)'))
            ->getCompiledSelect(true);

        $expected = <<<'SQL'
            SELECT *
            FROM "auth_bearer"
            WHERE "expires" = DATE_ADD(NOW(), INTERVAL 2 HOUR)
            SQL;
        $this->assertSame($expected, $sql);
```
Generated:
```
'SELECT *
FROM "auth_bearer"
WHERE DATE_ADD(NOW(), INTERVAL 2 HOUR)'
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
