### PR TITLE
fix: [QueryBuilder] RawSql passed to set() disappears without error

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3209,6 +3209,10 @@ class BaseBuilder
             return $object;
         }
 
+        if ($object instanceof RawSql) {
+            throw new InvalidArgumentException('RawSql "' . $object . '" cannot be used here.');
+        }
+
         $array = [];
 
         foreach (get_object_vars($object) as $key => $val) {

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\Database\Query;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use InvalidArgumentException;
 
 /**
  * @internal
@@ -278,5 +279,23 @@ final class InsertTest extends CIUnitTestCase
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('insertBatch() has no data.');
         $builder->insertBatch([]);
+    }
+
+    public function testSetIncorrectRawSqlUsage()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'RawSql "expires = DATE_ADD(NOW(), INTERVAL 2 HOUR)" cannot be used here.'
+        );
+
+        $builder = $this->db->table('auth_bearer');
+
+        $builder->testMode()
+            ->set([
+                'jti'       => 'jti',
+                'proctorID' => '12',
+            ])
+            ->set(new RawSql('expires = DATE_ADD(NOW(), INTERVAL 2 HOUR)'))
+            ->insert();
     }
 }


### PR DESCRIPTION
**Description**
Fixes the issue https://github.com/codeigniter4/CodeIgniter4/issues/7143#issuecomment-1385258336

- Throws an exception

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
