### PR TITLE
docs: add about QueryBuilder::where() change in v4.3.0

### DIFF
--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -332,10 +332,6 @@ methods:
 
         .. literalinclude:: query_builder/027.php
 
-    When you set the third parameter ``$escape`` to ``false``, set ``null`` as the second parameter:
-
-    .. literalinclude:: query_builder/120.php
-
 .. _query-builder-where-rawsql:
 
 5. RawSql

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -275,6 +275,8 @@ Since v4.2.0, ``$builder->join()`` accepts a ``CodeIgniter\Database\RawSql`` ins
 Looking for Specific Data
 *************************
 
+.. _query-builder-where:
+
 Where
 =====
 
@@ -329,6 +331,10 @@ methods:
     .. warning:: If you are using user-supplied data within the string, you MUST escape the values and protect the identifiers manually. Failure to do so could result in SQL injections.
 
         .. literalinclude:: query_builder/027.php
+
+    When you set the third parameter ``$escape`` to ``false``, set ``null`` as the second parameter:
+
+    .. literalinclude:: query_builder/120.php
 
 .. _query-builder-where-rawsql:
 

--- a/user_guide_src/source/database/query_builder/120.php
+++ b/user_guide_src/source/database/query_builder/120.php
@@ -1,4 +1,0 @@
-<?php
-
-$where = 'CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)';
-$builder->where($where, null, false);

--- a/user_guide_src/source/database/query_builder/120.php
+++ b/user_guide_src/source/database/query_builder/120.php
@@ -1,0 +1,4 @@
+<?php
+
+$where = 'CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)';
+$builder->where($where, null, false);

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -231,6 +231,22 @@ The data returned has the following structure::
      * ]
      */
 
+Query Builder where() Change
+============================
+
+When you pass a **custom string** and the third parameter ``$escape = false``
+to :ref:`where() <query-builder-where>`, the following code worked in previous
+versions::
+
+    $where = 'CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)';
+    $builder->where($where, '', false); // The second parameter is empty string.
+
+But it is a misuse and it does not work in v4.3.0. You need to pass ``null`` as
+the second parameter::
+
+    $where = 'CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)';
+    $builder->where($where, null, false); // The second parameter is null.
+
 Breaking Enhancements
 *********************
 


### PR DESCRIPTION
**Description**
Add a breaking change reported in #7117

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
