### PR TITLE
fix: [QueryBuilder] getOperatorFromWhereKey() misses EXISTS, BETWEEN

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3381,16 +3381,16 @@ class BaseBuilder
                 : '';
             $this->pregOperators = [
                 '\s*(?:<|>|!)?=\s*', // =, <=, >=, !=
-                '\s*<>?\s*', // <, <>
-                '\s*>\s*', // >
-                '\s+IS NULL', // IS NULL
-                '\s+IS NOT NULL', // IS NOT NULL
-                '\s+EXISTS\s*\(.*\)', // EXISTS(sql)
+                '\s*<>?\s*',         // <, <>
+                '\s*>\s*',           // >å
+                '\s+IS NULL',             // IS NULL
+                '\s+IS NOT NULL',         // IS NOT NULL
+                '\s+EXISTS\s*\(.*\)',     // EXISTS (sql)
                 '\s+NOT EXISTS\s*\(.*\)', // NOT EXISTS(sql)
-                '\s+BETWEEN\s+', // BETWEEN value AND value
-                '\s+IN\s*\(.*\)', // IN(list)
-                '\s+NOT IN\s*\(.*\)', // NOT IN (list)
-                '\s+LIKE\s+\S.*(' . $_les . ')?', // LIKE 'expr'[ ESCAPE '%s']
+                '\s+BETWEEN\s+',          // BETWEEN value AND value
+                '\s+IN\s*\(.*\)',         // IN (list)
+                '\s+NOT IN\s*\(.*\)',     // NOT IN (list)
+                '\s+LIKE\s+\S.*(' . $_les . ')?',     // LIKE 'expr'[ ESCAPE '%s']
                 '\s+NOT LIKE\s+\S.*(' . $_les . ')?', // NOT LIKE 'expr'[ ESCAPE '%s']
             ];
         }

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3382,7 +3382,7 @@ class BaseBuilder
             $this->pregOperators = [
                 '\s*(?:<|>|!)?=\s*', // =, <=, >=, !=
                 '\s*<>?\s*',         // <, <>
-                '\s*>\s*',           // >å
+                '\s*>\s*',           // >
                 '\s+IS NULL',             // IS NULL
                 '\s+IS NOT NULL',         // IS NOT NULL
                 '\s+EXISTS\s*\(.*\)',     // EXISTS (sql)
@@ -3422,6 +3422,7 @@ class BaseBuilder
             '\s+NOT EXISTS\s*\(.*\)', // NOT EXISTS (sql)
             '\s+BETWEEN\s+',          // BETWEEN value AND value
             '\s+IN\s*\(.*\)',         // IN (list)
+            '\s+NOT IN\s*\(.*\)',     // NOT IN (list)
             '\s+LIKE',                // LIKE
             '\s+NOT LIKE',            // NOT LIKE
         ];

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -783,7 +783,15 @@ class BaseBuilder
             } elseif (! $this->hasOperator($k) && $qbKey !== 'QBHaving') {
                 // value appears not to have been set, assign the test to IS NULL
                 $op = ' IS NULL';
-            } elseif (preg_match('/\s*(!?=|<>|IS(?:\s+NOT)?)\s*$/i', $k, $match, PREG_OFFSET_CAPTURE)) {
+            } elseif (
+                // The key ends with !=, =, <>, IS, IS NOT
+                preg_match(
+                    '/\s*(!?=|<>|IS(?:\s+NOT)?)\s*$/i',
+                    $k,
+                    $match,
+                    PREG_OFFSET_CAPTURE
+                )
+            ) {
                 $k  = substr($k, 0, $match[0][1]);
                 $op = $match[1][0] === '=' ? ' IS NULL' : ' IS NOT NULL';
             } else {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3413,13 +3413,17 @@ class BaseBuilder
         $whereKey = trim($whereKey);
 
         $pregOperators = [
-            '\s*(?:<|>|!)?=', // =, <=, >=, !=
-            '\s*<>?',         // <, <>
-            '\s*>',           // >
-            '\s+IS NULL',     // IS NULL
-            '\s+IS NOT NULL', // IS NOT NULL
-            '\s+LIKE',        // LIKE
-            '\s+NOT LIKE',    // NOT LIKE
+            '\s*(?:<|>|!)?=',         // =, <=, >=, !=
+            '\s*<>?',                 // <, <>
+            '\s*>',                   // >
+            '\s+IS NULL',             // IS NULL
+            '\s+IS NOT NULL',         // IS NOT NULL
+            '\s+EXISTS\s*\(.*\)',     // EXISTS (sql)
+            '\s+NOT EXISTS\s*\(.*\)', // NOT EXISTS (sql)
+            '\s+BETWEEN\s+',          // BETWEEN value AND value
+            '\s+IN\s*\(.*\)',         // IN (list)
+            '\s+LIKE',                // LIKE
+            '\s+NOT LIKE',            // NOT LIKE
         ];
 
         return preg_match_all(

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -761,9 +761,9 @@ class BaseBuilder
                     $k = trim($k);
 
                     end($op);
-
                     $op = trim(current($op));
 
+                    // Does the key end with operator?
                     if (substr($k, -strlen($op)) === $op) {
                         $k  = rtrim(substr($k, 0, -strlen($op)));
                         $op = " {$op}";

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -160,6 +160,53 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedBinds, $builder->getBinds());
     }
 
+    public function testWhereCustomStringWithOperatorEscapeFalse()
+    {
+        $builder = $this->db->table('jobs');
+
+        $where = 'CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)';
+        $builder->where($where, null, false);
+
+        $expectedSQL = 'SELECT * FROM "jobs" WHERE CURRENT_TIMESTAMP() = DATE_ADD(column, INTERVAL 2 HOUR)';
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+        $expectedBinds = [];
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereCustomStringWithoutOperatorEscapeFalse()
+    {
+        $builder = $this->db->table('jobs');
+
+        $where = "REPLACE(column, 'somestring', '')";
+        $builder->where($where, "''", false);
+
+        $expectedSQL = "SELECT * FROM \"jobs\" WHERE REPLACE(column, 'somestring', '') = ''";
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+        $expectedBinds = [
+            "REPLACE(column, 'somestring', '')" => [
+                0 => "''",
+                1 => false,
+            ],
+        ];
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
+    public function testWhereCustomStringWithBetweenEscapeFalse()
+    {
+        $builder = $this->db->table('jobs');
+
+        $where = "created_on BETWEEN '2022-07-01 00:00:00' AND '2022-12-31 23:59:59'";
+        $builder->where($where, null, false);
+
+        $expectedSQL = "SELECT * FROM \"jobs\" WHERE created_on BETWEEN '2022-07-01 00:00:00' AND '2022-12-31 23:59:59'";
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+
+        $expectedBinds = [];
+        $this->assertSame($expectedBinds, $builder->getBinds());
+    }
+
     public function testWhereRawSql()
     {
         $builder = $this->db->table('jobs');


### PR DESCRIPTION
**Description**
Follow-up #6986
Ref #7151, #7117

- fix `BaseBuilder::getOperatorFromWhereKey()` misses `EXISTS` or `BETWEEN`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
