### PR TITLE
Fix: Throttler token time calculation

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -139,7 +139,7 @@ class Throttler implements ThrottlerInterface
         // How many seconds till a new token is available.
         // We must have a minimum wait of 1 second for a new token.
         // Primarily stored to allow devs to report back to users.
-        $newTokenAvailable = (int) ($refresh - $elapsed - $refresh * $tokens);
+        $newTokenAvailable = (int) round((1 - $tokens) * $refresh);
         $this->tokenTime   = max(1, $newTokenAvailable);
 
         return false;

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -193,7 +193,7 @@ final class ThrottleTest extends CIUnitTestCase
      */
     public function testTokenTimeCalculationUCs(int $capacity, int $seconds, array $checkInputs): void
     {
-        $key = 'testkey';
+        $key       = 'testkey';
         $throttler = new Throttler($this->cache);
 
         // clear $key before test start
@@ -203,8 +203,8 @@ final class ThrottleTest extends CIUnitTestCase
             $throttler->setTestTime($checkInput['testTime']);
             $checkResult = $throttler->check($key, $capacity, $seconds, $checkInput['cost']);
 
-            $this->assertEquals($checkInput['expectedCheckResult'], $checkResult, "Input#{$index}: Wrong check() result");
-            $this->assertEquals($checkInput['expectedTokenTime'], $throttler->getTokenTime(), "Input#{$index}: Wrong tokenTime");
+            $this->assertSame($checkInput['expectedCheckResult'], $checkResult, "Input#{$index}: Wrong check() result");
+            $this->assertSame($checkInput['expectedTokenTime'], $throttler->getTokenTime(), "Input#{$index}: Wrong tokenTime");
         }
     }
 

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -191,7 +191,8 @@ final class ThrottleTest extends CIUnitTestCase
     /**
      * @dataProvider tokenTimeUsecases
      */
-    public function testTokenTimeCalculationUCs(int $capacity, int $seconds, array $checkInputs): void {
+    public function testTokenTimeCalculationUCs(int $capacity, int $seconds, array $checkInputs): void
+    {
         $key = 'testkey';
         $throttler = new Throttler($this->cache);
 
@@ -202,121 +203,122 @@ final class ThrottleTest extends CIUnitTestCase
             $throttler->setTestTime($checkInput['testTime']);
             $checkResult = $throttler->check($key, $capacity, $seconds, $checkInput['cost']);
 
-            $this->assertEquals($checkInput['expectedCheckResult'], $checkResult, "Input#$index: Wrong check() result");
-            $this->assertEquals($checkInput['expectedTokenTime'], $throttler->getTokenTime(), "Input#$index: Wrong tokenTime");
+            $this->assertEquals($checkInput['expectedCheckResult'], $checkResult, "Input#{$index}: Wrong check() result");
+            $this->assertEquals($checkInput['expectedTokenTime'], $throttler->getTokenTime(), "Input#{$index}: Wrong tokenTime");
         }
     }
 
-    public function tokenTimeUsecases(): array {
+    public function tokenTimeUsecases(): array
+    {
         return [
             '2 capacity / 200 seconds (100s refresh, 0.01 tokens/s) -> 5 checks, 1 cost each' => [
-                'capacity' => 2,
-                'seconds' => 200,
+                'capacity'    => 2,
+                'seconds'     => 200,
                 'checkInputs' => [
                     [   // 2 -> 1
-                        'testTime' => 0,
-                        'cost' => 1,
+                        'testTime'            => 0,
+                        'cost'                => 1,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +3s / 1.03 -> 0.03
-                        'testTime' => 3,
-                        'cost' => 1,
+                        'testTime'            => 3,
+                        'cost'                => 1,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +0s / 0.03 -> 0.03 / (1 - 0.03) * 100 = 97
-                        'testTime' => 3,
-                        'cost' => 1,
+                        'testTime'            => 3,
+                        'cost'                => 1,
                         'expectedCheckResult' => false,
-                        'expectedTokenTime' => 97
+                        'expectedTokenTime'   => 97,
                     ],
                     [   // +1m 32s / 0.95 -> 0.95 / (1 - 0.95) * 100 = 5
-                        'testTime' => 95,
-                        'cost' => 1,
+                        'testTime'            => 95,
+                        'cost'                => 1,
                         'expectedCheckResult' => false,
-                        'expectedTokenTime' => 5
+                        'expectedTokenTime'   => 5,
                     ],
                     [   // +7s / 1.02 -> 0.02
-                        'testTime' => 102,
-                        'cost' => 1,
+                        'testTime'            => 102,
+                        'cost'                => 1,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +13s / 0.15 / (1 - 0.15) * 100 = 85
-                        'testTime' => 115,
-                        'cost' => 1,
+                        'testTime'            => 115,
+                        'cost'                => 1,
                         'expectedCheckResult' => false,
-                        'expectedTokenTime' => 85
-                    ]
-                ]
+                        'expectedTokenTime'   => 85,
+                    ],
+                ],
             ],
             '1 capacity / 3600 seconds (3600s refresh, 2.77e-4 tokens/s) -> 2 checks with 1 cost each' => [
-                'capacity' => 1,
-                'seconds' => 3600,
+                'capacity'    => 1,
+                'seconds'     => 3600,
                 'checkInputs' => [
                     [   // 1 -> 0
-                        'testTime' => 0,
-                        'cost' => 1,
+                        'testTime'            => 0,
+                        'cost'                => 1,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +6m / 0.1 -> 0.1 / (1 - 0.1) * 3600 = 3240
-                        'testTime' => 360,
-                        'cost' => 1,
+                        'testTime'            => 360,
+                        'cost'                => 1,
                         'expectedCheckResult' => false,
-                        'expectedTokenTime' => 3240
-                    ]
-                ]
+                        'expectedTokenTime'   => 3240,
+                    ],
+                ],
             ],
             '10 capacity / 200 seconds (20s refresh, 0.05 tokens/s) -> 7 checks with different costs (RNG)' => [
-                'capacity' => 10,
-                'seconds' => 200,
+                'capacity'    => 10,
+                'seconds'     => 200,
                 'checkInputs' => [
                     [   // -2t / 10 -> 8
-                        'testTime' => 0,
-                        'cost' => 2,
+                        'testTime'            => 0,
+                        'cost'                => 2,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +19s -2t / 8.95 -> 6.95
-                        'testTime' => 19,
-                        'cost' => 2,
+                        'testTime'            => 19,
+                        'cost'                => 2,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +16s -3t / 7.75 -> 4.75
-                        'testTime' => 35,
-                        'cost' => 3,
+                        'testTime'            => 35,
+                        'cost'                => 3,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +4s -2t / 4.95 -> 2.95
-                        'testTime' => 39,
-                        'cost' => 2,
+                        'testTime'            => 39,
+                        'cost'                => 2,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +13s -5t / 3.6 -> -1.4 (blow allowed)
-                        'testTime' => 52,
-                        'cost' => 5,
+                        'testTime'            => 52,
+                        'cost'                => 5,
                         'expectedCheckResult' => true,
-                        'expectedTokenTime' => 0
+                        'expectedTokenTime'   => 0,
                     ],
                     [   // +2s -2t / -1.3 -> -1.3 / (1 - (-1.3)) * 20 = 46
-                        'testTime' => 54,
-                        'cost' => 2,
+                        'testTime'            => 54,
+                        'cost'                => 2,
                         'expectedCheckResult' => false,
-                        'expectedTokenTime' => 46
+                        'expectedTokenTime'   => 46,
                     ],
                     [   // +7s -2t / -0.95 - -0.95 / (1 - (-0.95)) * 20 = 39
-                        'testTime' => 61,
-                        'cost' => 2,
+                        'testTime'            => 61,
+                        'cost'                => 2,
                         'expectedCheckResult' => false,
-                        'expectedTokenTime' => 39
-                    ]
-                ]
-            ]
+                        'expectedTokenTime'   => 39,
+                    ],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
In one of my applications where I use `Throttler` I detected the `getTokenTime()` is already at the minimum of 1 seconds even if the token refresh rate is far from reached:

Example: 1 capacity, 3600 seconds -> After 10 minutes I expected 50 minutes to be left, but I was already at "1 second". Waiting another minute and executing the check, I was still at "1 second left".

This made me clear that the calculation for `Throttler::getTokenTime()` is still off, but the token value is calculated correctly after all, return `false` if `$token < 1`. This PR should fix that.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
