### PR TITLE
feat: [Auto Routing Improved] fallback to default method

### DIFF
--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -76,18 +76,37 @@ final class ControllerMethodReader
                         );
 
                         if ($routeWithoutController !== []) {
+                            // Route for the default controller.
                             $output = [...$output, ...$routeWithoutController];
 
                             continue;
+                        }
+
+                        $params      = [];
+                        $routeParams = '';
+                        $refParams   = $method->getParameters();
+
+                        foreach ($refParams as $param) {
+                            $required = true;
+                            if ($param->isOptional()) {
+                                $required = false;
+
+                                $routeParams .= '[/..]';
+                            } else {
+                                $routeParams .= '/..';
+                            }
+
+                            // [variable_name => required?]
+                            $params[$param->getName()] = $required;
                         }
 
                         // Route for the default method.
                         $output[] = [
                             'method'       => $httpVerb,
                             'route'        => $classInUri,
-                            'route_params' => '',
+                            'route_params' => $routeParams,
                             'handler'      => '\\' . $classname . '::' . $methodName,
-                            'params'       => [],
+                            'params'       => $params,
                         ];
 
                         continue;

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Router;
 
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Router\Exceptions\MethodNotFoundException;
 use ReflectionClass;
 use ReflectionException;
 
@@ -177,8 +178,21 @@ final class AutoRouterImproved implements AutoRouterInterface
         // Check parameter count
         try {
             $this->checkParameters($uri);
-        } catch (ReflectionException $e) {
-            throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
+        } catch (MethodNotFoundException $e) {
+            // Fallback to the default method
+            if (! isset($methodSegment)) {
+                throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
+            }
+
+            array_unshift($this->params, $methodSegment);
+            $method       = $this->method;
+            $this->method = $this->defaultMethod;
+
+            try {
+                $this->checkParameters($uri);
+            } catch (MethodNotFoundException $e) {
+                throw PageNotFoundException::forControllerNotFound($this->controller, $method);
+            }
         }
 
         return [$this->directory, $this->controller, $this->method, $this->params];
@@ -201,12 +215,21 @@ final class AutoRouterImproved implements AutoRouterInterface
 
     private function checkParameters(string $uri): void
     {
-        $refClass  = new ReflectionClass($this->controller);
-        $refMethod = $refClass->getMethod($this->method);
-        $refParams = $refMethod->getParameters();
+        try {
+            $refClass = new ReflectionClass($this->controller);
+        } catch (ReflectionException $e) {
+            throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
+        }
+
+        try {
+            $refMethod = $refClass->getMethod($this->method);
+            $refParams = $refMethod->getParameters();
+        } catch (ReflectionException $e) {
+            throw new MethodNotFoundException();
+        }
 
         if (! $refMethod->isPublic()) {
-            throw PageNotFoundException::forMethodNotFound($this->method);
+            throw new MethodNotFoundException();
         }
 
         if (count($refParams) < count($this->params)) {

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -168,13 +168,13 @@ final class AutoRouterImproved implements AutoRouterInterface
             '\\'
         );
 
-        // Ensure routes registered via $routes->cli() are not accessible via web.
+        // Ensure the controller is not defined in routes.
         $this->protectDefinedRoutes();
 
-        // Check _remap()
+        // Ensure the controller does not have _remap() method.
         $this->checkRemap();
 
-        // Check parameters
+        // Check parameter count
         try {
             $this->checkParameters($uri);
         } catch (ReflectionException $e) {

--- a/system/Router/Exceptions/MethodNotFoundException.php
+++ b/system/Router/Exceptions/MethodNotFoundException.php
@@ -9,17 +9,13 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Router\Controllers;
+namespace CodeIgniter\Router\Exceptions;
 
-use CodeIgniter\Controller;
+use RuntimeException;
 
-class Index extends Controller
+/**
+ * @internal
+ */
+final class MethodNotFoundException extends RuntimeException
 {
-    public function getIndex($p1 = '')
-    {
-    }
-
-    public function postIndex()
-    {
-    }
 }

--- a/tests/_support/Controllers/Newautorouting.php
+++ b/tests/_support/Controllers/Newautorouting.php
@@ -15,7 +15,7 @@ use CodeIgniter\Controller;
 
 class Newautorouting extends Controller
 {
-    public function getIndex()
+    public function getIndex(string $m = '')
     {
         return 'Hello';
     }

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -129,7 +129,7 @@ final class RoutesTest extends CIUnitTestCase
             | TRACE      | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
             | CONNECT    | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
             | CLI        | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
-            | GET(auto)  | newautorouting                 |               | \Tests\Support\Controllers\Newautorouting::getIndex |                | toolbar       |
+            | GET(auto)  | newautorouting[/..]            |               | \Tests\Support\Controllers\Newautorouting::getIndex |                | toolbar       |
             | POST(auto) | newautorouting/save/../..[/..] |               | \Tests\Support\Controllers\Newautorouting::postSave |                | toolbar       |
             +------------+--------------------------------+---------------+-----------------------------------------------------+----------------+---------------+
             EOL;

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
@@ -62,7 +62,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
         $expected = [
             0 => [
                 'GET(auto)',
-                'newautorouting',
+                'newautorouting[/..]',
                 '',
                 '\\Tests\\Support\\Controllers\\Newautorouting::getIndex',
                 '',
@@ -90,7 +90,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
         $expected = [
             0 => [
                 'GET(auto)',
-                'newautorouting',
+                'newautorouting[/..]',
                 '',
                 '\\Tests\\Support\\Controllers\\Newautorouting::getIndex',
                 '',

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -43,9 +43,11 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
             0 => [
                 'method'       => 'get',
                 'route'        => 'newautorouting',
-                'route_params' => '',
+                'route_params' => '[/..]',
                 'handler'      => '\Tests\Support\Controllers\Newautorouting::getIndex',
-                'params'       => [],
+                'params'       => [
+                    'm' => false,
+                ],
             ],
             [
                 'method'       => 'post',

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -199,6 +199,19 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame([], $params);
     }
 
+    public function testAutoRouteFallbackToDefaultMethod()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('index/15');
+
+        $this->assertNull($directory);
+        $this->assertSame('\\' . Index::class, $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame(['15'], $params);
+    }
+
     public function testAutoRouteRejectsSingleDot()
     {
         $this->expectException(PageNotFoundException::class);

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -58,8 +58,11 @@ Helpers and Functions
 
 Others
 ======
-- **View:** Added optional 2nd parameter ``$saveData`` on ``renderSection()`` to prevent from auto cleans the data after displaying. See :ref:`View Layouts <creating-a-layout>` for details.
 
+- **View:** Added optional 2nd parameter ``$saveData`` on ``renderSection()`` to prevent from auto cleans the data after displaying. See :ref:`View Layouts <creating-a-layout>` for details.
+- **Auto Routing (Improved)**: Now you can use URI without a method name like
+  ``product/15`` where ``15`` is an arbitrary number.
+  See :ref:`controller-default-method-fallback` for details.
 
 Message Changes
 ***************

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -263,6 +263,29 @@ Your method will be passed URI segments 3 and 4 (``'sandals'`` and ``'123'``):
 
 .. literalinclude:: controllers/022.php
 
+.. _controller-default-method-fallback:
+
+Default Method Fallback
+=======================
+
+.. versionadded:: 4.4.0
+
+If the controller method corresponding to the URI segment of the method name
+does not exist, and if the default method is defined, the URI segments are
+passed to the default method for execution.
+
+.. literalinclude:: controllers/024.php
+
+Load the following URL::
+
+    example.com/index.php/product/15/edit
+
+The method will be passed URI segments 2 and 3 (``'15'`` and ``'edit'``):
+
+.. note:: If there are more parameters in the URI than the method parameters,
+    Auto Routing (Improved) does not execute the method, and it results in 404
+    Not Found.
+
 Defining a Default Controller
 =============================
 

--- a/user_guide_src/source/incoming/controllers/024.php
+++ b/user_guide_src/source/incoming/controllers/024.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Controllers;
+
+class Product extends BaseController
+{
+    public function getIndex($id = null, $action = '')
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
**Description**
If there is no method in the controller for the request URI, fallback to the default method.

E.g.:
`GET /product/15`
→ `Product::get15()` Method not found
→ `Product::getIndex($id = '')` Method found and run `getIndex('15')`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
