### PR TITLE
chore: update admin/*/composer.json

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -42,6 +42,11 @@
         "ext-fileinfo": "Improves mime type detection for files",
         "ext-readline": "Improves CLI::input() usability"
     },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
     "autoload": {
         "psr-4": {
             "CodeIgniter\\": "system/"

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -14,7 +14,29 @@
         "phpunit/phpunit": "^9.1"
     },
     "suggest": {
-        "ext-fileinfo": "Improves mime type detection for files"
+        "ext-curl": "If you use CURLRequest class",
+        "ext-imagick": "If you use Image class ImageMagickHandler",
+        "ext-gd": "If you use Image class GDHandler",
+        "ext-exif": "If you run Image class tests",
+        "ext-simplexml": "If you format XML",
+        "ext-mysqli": "If you use MySQL",
+        "ext-oci8": "If you use Oracle Database",
+        "ext-pgsql": "If you use PostgreSQL",
+        "ext-sqlsrv": "If you use SQL Server",
+        "ext-sqlite3": "If you use SQLite3",
+        "ext-memcache": "If you use Cache class MemcachedHandler with Memcache",
+        "ext-memcached": "If you use Cache class MemcachedHandler with Memcached",
+        "ext-redis": "If you use Cache class RedisHandler",
+        "ext-dom": "If you use TestResponse",
+        "ext-libxml": "If you use TestResponse",
+        "ext-xdebug": "If you use CIUnitTestCase::assertHeaderEmitted()",
+        "ext-fileinfo": "Improves mime type detection for files",
+        "ext-readline": "Improves CLI::input() usability"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
     },
     "autoload": {
         "exclude-from-classmap": [

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -13,26 +13,6 @@
         "mikey179/vfsstream": "^1.6",
         "phpunit/phpunit": "^9.1"
     },
-    "suggest": {
-        "ext-curl": "If you use CURLRequest class",
-        "ext-imagick": "If you use Image class ImageMagickHandler",
-        "ext-gd": "If you use Image class GDHandler",
-        "ext-exif": "If you run Image class tests",
-        "ext-simplexml": "If you format XML",
-        "ext-mysqli": "If you use MySQL",
-        "ext-oci8": "If you use Oracle Database",
-        "ext-pgsql": "If you use PostgreSQL",
-        "ext-sqlsrv": "If you use SQL Server",
-        "ext-sqlite3": "If you use SQLite3",
-        "ext-memcache": "If you use Cache class MemcachedHandler with Memcache",
-        "ext-memcached": "If you use Cache class MemcachedHandler with Memcached",
-        "ext-redis": "If you use Cache class RedisHandler",
-        "ext-dom": "If you use TestResponse",
-        "ext-libxml": "If you use TestResponse",
-        "ext-xdebug": "If you use CIUnitTestCase::assertHeaderEmitted()",
-        "ext-fileinfo": "Improves mime type detection for files",
-        "ext-readline": "Improves CLI::input() usability"
-    },
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",

--- a/tests/system/AutoReview/ComposerJsonTest.php
+++ b/tests/system/AutoReview/ComposerJsonTest.php
@@ -81,11 +81,7 @@ final class ComposerJsonTest extends TestCase
 
     public function testStarterSuggestIsTheSameWithDevSuggest(): void
     {
-        $this->assertSame(
-            $this->devComposer['suggest'],
-            $this->starterComposer['suggest'],
-            'The starter\'s "suggest" section is not updated with the main composer.json.'
-        );
+        $this->checkStarter('suggest');
     }
 
     public function testFrameworkConfigIsTheSameWithDevSuggest(): void
@@ -99,10 +95,15 @@ final class ComposerJsonTest extends TestCase
 
     public function testStarterConfigIsTheSameWithDevSuggest(): void
     {
+        $this->checkStarter('config');
+    }
+
+    private function checkStarter(string $section): void
+    {
         $this->assertSame(
-            $this->devComposer['config'],
-            $this->starterComposer['config'],
-            'The starter\'s "config" section is not updated with the main composer.json.'
+            $this->devComposer[$section],
+            $this->starterComposer[$section],
+            'The starter\'s "' . $section . '" section is not updated with the main composer.json.'
         );
     }
 

--- a/tests/system/AutoReview/ComposerJsonTest.php
+++ b/tests/system/AutoReview/ComposerJsonTest.php
@@ -71,11 +71,6 @@ final class ComposerJsonTest extends TestCase
         $this->checkFramework('suggest');
     }
 
-    public function testStarterSuggestIsTheSameWithDevSuggest(): void
-    {
-        $this->checkStarter('suggest');
-    }
-
     public function testFrameworkConfigIsTheSameWithDevSuggest(): void
     {
         $this->checkFramework('config');

--- a/tests/system/AutoReview/ComposerJsonTest.php
+++ b/tests/system/AutoReview/ComposerJsonTest.php
@@ -40,11 +40,7 @@ final class ComposerJsonTest extends TestCase
 
     public function testFrameworkRequireIsTheSameWithDevRequire(): void
     {
-        $this->assertSame(
-            $this->devComposer['require'],
-            $this->frameworkComposer['require'],
-            'The framework\'s "require" section is not updated with the main composer.json.'
-        );
+        $this->checkFramework('require');
     }
 
     public function testFrameworkRequireDevIsTheSameWithDevRequireDev(): void
@@ -72,11 +68,7 @@ final class ComposerJsonTest extends TestCase
 
     public function testFrameworkSuggestIsTheSameWithDevSuggest(): void
     {
-        $this->assertSame(
-            $this->devComposer['suggest'],
-            $this->frameworkComposer['suggest'],
-            'The framework\'s "suggest" section is not updated with the main composer.json.'
-        );
+        $this->checkFramework('suggest');
     }
 
     public function testStarterSuggestIsTheSameWithDevSuggest(): void
@@ -86,16 +78,21 @@ final class ComposerJsonTest extends TestCase
 
     public function testFrameworkConfigIsTheSameWithDevSuggest(): void
     {
-        $this->assertSame(
-            $this->devComposer['config'],
-            $this->frameworkComposer['config'],
-            'The framework\'s "config" section is not updated with the main composer.json.'
-        );
+        $this->checkFramework('config');
     }
 
     public function testStarterConfigIsTheSameWithDevSuggest(): void
     {
         $this->checkStarter('config');
+    }
+
+    private function checkFramework(string $section): void
+    {
+        $this->assertSame(
+            $this->devComposer[$section],
+            $this->frameworkComposer[$section],
+            'The framework\'s "' . $section . '" section is not updated with the main composer.json.'
+        );
     }
 
     private function checkStarter(string $section): void

--- a/tests/system/AutoReview/ComposerJsonTest.php
+++ b/tests/system/AutoReview/ComposerJsonTest.php
@@ -27,6 +27,7 @@ final class ComposerJsonTest extends TestCase
 {
     private array $devComposer;
     private array $frameworkComposer;
+    private array $starterComposer;
 
     protected function setUp(): void
     {
@@ -34,6 +35,7 @@ final class ComposerJsonTest extends TestCase
 
         $this->devComposer       = $this->getComposerJson(dirname(__DIR__, 3) . '/composer.json');
         $this->frameworkComposer = $this->getComposerJson(dirname(__DIR__, 3) . '/admin/framework/composer.json');
+        $this->starterComposer   = $this->getComposerJson(dirname(__DIR__, 3) . '/admin/starter/composer.json');
     }
 
     public function testFrameworkRequireIsTheSameWithDevRequire(): void
@@ -74,6 +76,33 @@ final class ComposerJsonTest extends TestCase
             $this->devComposer['suggest'],
             $this->frameworkComposer['suggest'],
             'The framework\'s "suggest" section is not updated with the main composer.json.'
+        );
+    }
+
+    public function testStarterSuggestIsTheSameWithDevSuggest(): void
+    {
+        $this->assertSame(
+            $this->devComposer['suggest'],
+            $this->starterComposer['suggest'],
+            'The starter\'s "suggest" section is not updated with the main composer.json.'
+        );
+    }
+
+    public function testFrameworkConfigIsTheSameWithDevSuggest(): void
+    {
+        $this->assertSame(
+            $this->devComposer['config'],
+            $this->frameworkComposer['config'],
+            'The framework\'s "config" section is not updated with the main composer.json.'
+        );
+    }
+
+    public function testStarterConfigIsTheSameWithDevSuggest(): void
+    {
+        $this->assertSame(
+            $this->devComposer['config'],
+            $this->starterComposer['config'],
+            'The starter\'s "config" section is not updated with the main composer.json.'
         );
     }
 


### PR DESCRIPTION
**Description**
Both appstarter and framework are for CodeIgniter projects, and the configuration itmes to be added in this PR should be the same.

- add `config`
- remove `suggest` in appstarter

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
