### PR TITLE
fix: cannot create shared View instance when using debugbar

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -101,11 +101,6 @@ parameters:
 			path: system/Database/SQLSRV/Forge.php
 
 		-
-			message: "#^Call to an undefined method CodeIgniter\\\\View\\\\RendererInterface\\:\\:getPerformanceData\\(\\)\\.$#"
-			count: 1
-			path: system/Debug/Toolbar/Collectors/Events.php
-
-		-
 			message: "#^Property CodeIgniter\\\\Log\\\\Logger\\:\\:\\$logCache \\(array\\) on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: system/Debug/Toolbar/Collectors/Logs.php

--- a/system/Debug/Toolbar/Collectors/Events.php
+++ b/system/Debug/Toolbar/Collectors/Events.php
@@ -11,11 +11,8 @@
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use CodeIgniter\View\RendererInterface;
-use Config\Services;
-
 /**
- * Views collector
+ * Events collector
  */
 class Events extends BaseCollector
 {
@@ -25,7 +22,7 @@ class Events extends BaseCollector
      *
      * @var bool
      */
-    protected $hasTimeline = false;
+    protected $hasTimeline = true;
 
     /**
      * Whether this collector needs to display
@@ -52,21 +49,6 @@ class Events extends BaseCollector
     protected $title = 'Events';
 
     /**
-     * Instance of the Renderer service
-     *
-     * @var RendererInterface
-     */
-    protected $viewer;
-
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        $this->viewer = Services::renderer();
-    }
-
-    /**
      * Child classes should implement this to return the timeline data
      * formatted for correct usage.
      */
@@ -74,12 +56,12 @@ class Events extends BaseCollector
     {
         $data = [];
 
-        $rows = $this->viewer->getPerformanceData();
+        $rows = \CodeIgniter\Events\Events::getPerformanceLogs();
 
         foreach ($rows as $info) {
             $data[] = [
-                'name'      => 'View: ' . $info['view'],
-                'component' => 'Views',
+                'name'      => 'Event: ' . $info['event'],
+                'component' => 'Events',
                 'start'     => $info['start'],
                 'duration'  => $info['end'] - $info['start'],
             ];

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -60,9 +60,9 @@ class Views extends BaseCollector
     protected $title = 'Views';
 
     /**
-     * Instance of the Renderer service
+     * Instance of the shared Renderer service
      *
-     * @var RendererInterface
+     * @var RendererInterface|null
      */
     protected $viewer;
 
@@ -73,12 +73,9 @@ class Views extends BaseCollector
      */
     protected $views = [];
 
-    /**
-     * Constructor.
-     */
-    public function __construct()
+    private function getViewer(): void
     {
-        $this->viewer = Services::renderer();
+        $this->viewer ??= Services::renderer();
     }
 
     /**
@@ -87,6 +84,8 @@ class Views extends BaseCollector
      */
     protected function formatTimelineData(): array
     {
+        $this->getViewer();
+
         $data = [];
 
         $rows = $this->viewer->getPerformanceData();
@@ -121,8 +120,9 @@ class Views extends BaseCollector
      */
     public function getVarData(): array
     {
-        return [
+        $this->getViewer();
 
+        return [
             'View Data' => $this->viewer->getData(),
         ];
     }
@@ -132,6 +132,8 @@ class Views extends BaseCollector
      */
     public function getBadgeValue(): int
     {
+        $this->getViewer();
+
         return count($this->viewer->getPerformanceData());
     }
 

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -73,7 +73,7 @@ class Views extends BaseCollector
      */
     protected $views = [];
 
-    private function getViewer(): void
+    private function initViewer(): void
     {
         $this->viewer ??= Services::renderer();
     }
@@ -84,7 +84,7 @@ class Views extends BaseCollector
      */
     protected function formatTimelineData(): array
     {
-        $this->getViewer();
+        $this->initViewer();
 
         $data = [];
 
@@ -120,7 +120,7 @@ class Views extends BaseCollector
      */
     public function getVarData(): array
     {
-        $this->getViewer();
+        $this->initViewer();
 
         return [
             'View Data' => $this->viewer->getData(),
@@ -132,7 +132,7 @@ class Views extends BaseCollector
      */
     public function getBadgeValue(): int
     {
-        $this->getViewer();
+        $this->initViewer();
 
         return count($this->viewer->getPerformanceData());
     }


### PR DESCRIPTION
**Description**
- (1) fix: DebugBar initializes shared renderer instance
- (2) fix: Event collector does not collect Timeline data

(1) 
DebugBar initializes shared `renderer` instance.
The following code in a controller does not create a new instance with the view path.
```php
\Config\Services::renderer(__DIR__ . '/../Views');
```
(2)
After:
![Screenshot 2023-01-24 16 18 54](https://user-images.githubusercontent.com/87955/214233330-77c1bf47-5580-49d2-9e05-d233629a674d.png)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
