### PR TITLE
fix: RouteCollection::getRegisteredControllers() may not return all controllers

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1583,36 +1583,46 @@ class RouteCollection implements RouteCollectionInterface
      */
     public function getRegisteredControllers(?string $verb = '*'): array
     {
-        $handlers = [];
+        $controllers = [];
 
         if ($verb === '*') {
             foreach ($this->defaultHTTPMethods as $tmpVerb) {
                 foreach ($this->routes[$tmpVerb] as $route) {
-                    $key        = key($route['route']);
-                    $handlers[] = $route['route'][$key];
+                    $routeKey   = key($route['route']);
+                    $controller = $this->getControllerName($route['route'][$routeKey]);
+                    if ($controller !== null) {
+                        $controllers[] = $controller;
+                    }
                 }
             }
         } else {
             $routes = $this->getRoutes($verb);
 
             foreach ($routes as $handler) {
-                $handlers[] = $handler;
+                $controller = $this->getControllerName($handler);
+                if ($controller !== null) {
+                    $controllers[] = $controller;
+                }
             }
-        }
-
-        $controllers = [];
-
-        foreach ($handlers as $handler) {
-            if (! is_string($handler)) {
-                continue;
-            }
-
-            [$controller] = explode('::', $handler, 2);
-
-            $controllers[] = $controller;
         }
 
         return array_unique($controllers);
+    }
+
+    /**
+     * @param Closure|string $handler Handler
+     *
+     * @return string|null Controller classname
+     */
+    private function getControllerName($handler)
+    {
+        if (! is_string($handler)) {
+            return null;
+        }
+
+        [$controller] = explode('::', $handler, 2);
+
+        return $controller;
     }
 
     /**

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1577,31 +1577,32 @@ class RouteCollection implements RouteCollectionInterface
      * Get all controllers in Route Handlers
      *
      * @param string|null $verb HTTP verb. `'*'` returns all controllers in any verb.
+     *
+     * @return array<int, string> controller name list
+     * @phpstan-return list<string>
      */
     public function getRegisteredControllers(?string $verb = '*'): array
     {
-        $routes = [];
+        $handlers = [];
 
         if ($verb === '*') {
-            $rawRoutes = [];
-
             foreach ($this->defaultHTTPMethods as $tmpVerb) {
-                $rawRoutes = array_merge($rawRoutes, $this->routes[$tmpVerb]);
-            }
-
-            foreach ($rawRoutes as $route) {
-                $key     = key($route['route']);
-                $handler = $route['route'][$key];
-
-                $routes[$key] = $handler;
+                foreach ($this->routes[$tmpVerb] as $route) {
+                    $key        = key($route['route']);
+                    $handlers[] = $route['route'][$key];
+                }
             }
         } else {
             $routes = $this->getRoutes($verb);
+
+            foreach ($routes as $handler) {
+                $handlers[] = $handler;
+            }
         }
 
         $controllers = [];
 
-        foreach ($routes as $handler) {
+        foreach ($handlers as $handler) {
             if (! is_string($handler)) {
                 continue;
             }

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -1782,15 +1782,16 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testGetRegisteredControllersReturnsAllControllers()
     {
         $collection = $this->getCollector();
-        $collection->get('test', '\App\Controllers\Hello::get');
-        $collection->post('test', '\App\Controllers\Hello::post');
-        $collection->post('hello', '\App\Controllers\Test::hello');
+        $collection->get('test', '\App\Controllers\HelloGet::get');
+        $collection->post('test', '\App\Controllers\HelloPost::post');
+        $collection->post('hello', '\App\Controllers\TestPost::hello');
 
         $routes = $collection->getRegisteredControllers('*');
 
         $expects = [
-            '\App\Controllers\Hello',
-            '\App\Controllers\Test',
+            '\App\Controllers\HelloGet',
+            '\App\Controllers\HelloPost',
+            '\App\Controllers\TestPost',
         ];
         $this->assertSame($expects, $routes);
     }


### PR DESCRIPTION
**Description**
- fix logic

Before this PR, the following test fails. Because `array_merge()` overwrites handlers.
```php
    public function testGetRegisteredControllersReturnsAllControllers()
    {
        $collection = $this->getCollector();
        $collection->get('test', '\App\Controllers\HelloGet::get');
        $collection->post('test', '\App\Controllers\HelloPost::post');
        $collection->post('hello', '\App\Controllers\TestPost::hello');

        $routes = $collection->getRegisteredControllers('*');

        $expects = [
            '\App\Controllers\HelloGet',
            '\App\Controllers\HelloPost',
            '\App\Controllers\TestPost',
        ];
        $this->assertSame($expects, $routes);
    }
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
