### PR TITLE
perf: RouteCollection $routes optimization

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1388,10 +1388,11 @@ class RouteCollection implements RouteCollectionInterface
             }
         }
 
+        $routeKey = $from;
         // Replace our regex pattern placeholders with the actual thing
         // so that the Router doesn't need to know about any of this.
         foreach ($this->placeholders as $tag => $pattern) {
-            $from = str_ireplace(':' . $tag, $pattern, $from);
+            $routeKey = str_ireplace(':' . $tag, $pattern, $routeKey);
         }
 
         // If is redirect, No processing
@@ -1406,7 +1407,7 @@ class RouteCollection implements RouteCollectionInterface
             $to = '\\' . ltrim($to, '\\');
         }
 
-        $name = $options['as'] ?? $from;
+        $name = $options['as'] ?? $routeKey;
 
         helper('array');
 
@@ -1415,16 +1416,16 @@ class RouteCollection implements RouteCollectionInterface
         // routes should always be the "source of truth".
         // this works only because discovered routes are added just prior
         // to attempting to route the request.
-        $fromExists = dot_array_search('*.route.' . $from, $this->routes[$verb] ?? []) !== null;
+        $fromExists = dot_array_search('*.route.' . $routeKey, $this->routes[$verb] ?? []) !== null;
         if ((isset($this->routes[$verb][$name]) || $fromExists) && ! $overwrite) {
             return;
         }
 
         $this->routes[$verb][$name] = [
-            'route' => [$from => $to],
+            'route' => [$routeKey => $to],
         ];
 
-        $this->routesOptions[$verb][$from] = $options;
+        $this->routesOptions[$verb][$routeKey] = $options;
 
         // Is this a redirect?
         if (isset($options['redirect']) && is_numeric($options['redirect'])) {

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -640,12 +640,14 @@ class RouteCollection implements RouteCollectionInterface
     {
         // Use the named route's pattern if this is a named route.
         if (array_key_exists($to, $this->routes['*'])) {
-            $to = $this->routes['*'][$to]['route'];
+            $redirectTo = $this->routes['*'][$to]['route'];
         } elseif (array_key_exists($to, $this->routes['get'])) {
-            $to = $this->routes['get'][$to]['route'];
+            $redirectTo = $this->routes['get'][$to]['route'];
+        } else {
+            $redirectTo = $to;
         }
 
-        $this->create('*', $from, $to, ['redirect' => $status]);
+        $this->create('*', $from, $redirectTo, ['redirect' => $status]);
 
         return $this;
     }

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -119,6 +119,7 @@ class RouteCollection implements RouteCollectionInterface
      *         routeName => [
      *             'route' => [
      *                 routeKey(regex) => handler,
+     *                 or routeKey(regex)(from) => [routeKey(regex)(to) => handler], // redirect
      *             ],
      *             'redirect' => statusCode,
      *         ]

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1462,8 +1462,8 @@ class RouteCollection implements RouteCollectionInterface
         // routes should always be the "source of truth".
         // this works only because discovered routes are added just prior
         // to attempting to route the request.
-        $fromExists = isset($this->routes[$verb][$routeKey]);
-        if ((isset($this->routesNames[$verb][$name]) || $fromExists) && ! $overwrite) {
+        $routeKeyExists = isset($this->routes[$verb][$routeKey]);
+        if ((isset($this->routesNames[$verb][$name]) || $routeKeyExists) && ! $overwrite) {
             return;
         }
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1691,7 +1691,7 @@ class RouteCollection implements RouteCollectionInterface
 
         if ($verb === '*') {
             foreach ($this->defaultHTTPMethods as $tmpVerb) {
-                foreach ($this->routes[$tmpVerb] as $routeKey => $route) {
+                foreach ($this->routes[$tmpVerb] as $route) {
                     $controller = $this->getControllerName($route['handler']);
                     if ($controller !== null) {
                         $controllers[] = $controller;

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -117,16 +117,18 @@ class RouteCollection implements RouteCollectionInterface
      * [
      *     verb => [
      *         routeKey(regex) => [
-     *             'name'     => routeName
-     *             'handler'  => handler,
-     *              'from'    => from,
+     *             'name'    => routeName
+     *             'handler' => handler,
+     *             'from'    => from,
      *         ],
-     *         // redirect route
-     *         or routeKey(regex)(from) => [
+     *     ],
+     *     // redirect route
+     *     '*' => [
+     *          routeKey(regex)(from) => [
      *             'name'     => routeName
      *             'handler'  => [routeKey(regex)(to) => handler],
+     *             'from'     => from,
      *             'redirect' => statusCode,
-     *             'from'    => from,
      *         ],
      *     ],
      * ]

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1114,8 +1114,8 @@ class RouteCollection implements RouteCollectionInterface
         // all routes to find a match.
         foreach ($this->routes as $collection) {
             foreach ($collection as $route) {
-                $from = key($route['route']);
-                $to   = $route['route'][$from];
+                $routeKey = key($route['route']);
+                $to       = $route['route'][$routeKey];
 
                 // ignore closures
                 if (! is_string($to)) {
@@ -1139,7 +1139,7 @@ class RouteCollection implements RouteCollectionInterface
                     continue;
                 }
 
-                return $this->buildReverseRoute($from, $params);
+                return $this->buildReverseRoute($routeKey, $params);
             }
         }
 
@@ -1254,21 +1254,21 @@ class RouteCollection implements RouteCollectionInterface
      * @param array $params One or more parameters to be passed to the route.
      *                      The last parameter allows you to set the locale.
      */
-    protected function buildReverseRoute(string $from, array $params): string
+    protected function buildReverseRoute(string $routeKey, array $params): string
     {
         $locale = null;
 
         // Find all of our back-references in the original route
-        preg_match_all('/\(([^)]+)\)/', $from, $matches);
+        preg_match_all('/\(([^)]+)\)/', $routeKey, $matches);
 
         if (empty($matches[0])) {
-            if (strpos($from, '{locale}') !== false) {
+            if (strpos($routeKey, '{locale}') !== false) {
                 $locale = $params[0] ?? null;
             }
 
-            $from = $this->replaceLocale($from, $locale);
+            $routeKey = $this->replaceLocale($routeKey, $locale);
 
-            return '/' . ltrim($from, '/');
+            return '/' . ltrim($routeKey, '/');
         }
 
         // Locale is passed?
@@ -1286,13 +1286,13 @@ class RouteCollection implements RouteCollectionInterface
 
             // Ensure that the param we're inserting matches
             // the expected param type.
-            $pos  = strpos($from, $pattern);
-            $from = substr_replace($from, $params[$index], $pos, strlen($pattern));
+            $pos      = strpos($routeKey, $pattern);
+            $routeKey = substr_replace($routeKey, $params[$index], $pos, strlen($pattern));
         }
 
-        $from = $this->replaceLocale($from, $locale);
+        $routeKey = $this->replaceLocale($routeKey, $locale);
 
-        return '/' . ltrim($from, '/');
+        return '/' . ltrim($routeKey, '/');
     }
 
     /**

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -654,12 +654,14 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Determines if the route is a redirecting route.
+     *
+     * @param string $routeKey routeKey or route name
      */
-    public function isRedirect(string $from): bool
+    public function isRedirect(string $routeKey): bool
     {
         foreach ($this->routes['*'] as $name => $route) {
             // Named route?
-            if ($name === $from || key($route['route']) === $from) {
+            if ($name === $routeKey || key($route['route']) === $routeKey) {
                 return isset($route['redirect']) && is_numeric($route['redirect']);
             }
         }
@@ -669,12 +671,14 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Grabs the HTTP status code from a redirecting Route.
+     *
+     * @param string $routeKey routeKey or route name
      */
-    public function getRedirectCode(string $from): int
+    public function getRedirectCode(string $routeKey): int
     {
         foreach ($this->routes['*'] as $name => $route) {
             // Named route?
-            if ($name === $from || key($route['route']) === $from) {
+            if ($name === $routeKey || key($route['route']) === $routeKey) {
                 return $route['redirect'] ?? 0;
             }
         }

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -116,17 +116,44 @@ class RouteCollection implements RouteCollectionInterface
      *
      * [
      *     verb => [
-     *         routeName => [
-     *             'route' => [
-     *                 routeKey(regex) => handler,
-     *                 or routeKey(regex)(from) => [routeKey(regex)(to) => handler], // redirect
-     *             ],
+     *         routeKey(regex) => [
+     *             'name'     => routeName
+     *             'handler'  => handler,
+     *         ],
+     *         // redirect route
+     *         or routeKey(regex)(from) => [
+     *             'name'     => routeName
+     *             'handler'  => [routeKey(regex)(to) => handler],
      *             'redirect' => statusCode,
-     *         ]
+     *         ],
      *     ],
      * ]
      */
     protected $routes = [
+        '*'       => [],
+        'options' => [],
+        'get'     => [],
+        'head'    => [],
+        'post'    => [],
+        'put'     => [],
+        'delete'  => [],
+        'trace'   => [],
+        'connect' => [],
+        'cli'     => [],
+    ];
+
+    /**
+     * Array of routes names
+     *
+     * @var array
+     *
+     * [
+     *     verb => [
+     *         routeName => routeKey(regex)
+     *     ],
+     * ]
+     */
+    protected $routesNames = [
         '*'       => [],
         'options' => [],
         'get'     => [],
@@ -538,9 +565,8 @@ class RouteCollection implements RouteCollectionInterface
             // before any of the generic, "add" routes.
             $collection = $this->routes[$verb] + ($this->routes['*'] ?? []);
 
-            foreach ($collection as $r) {
-                $key          = key($r['route']);
-                $routes[$key] = $r['route'][$key];
+            foreach ($collection as $routeKey => $r) {
+                $routes[$routeKey] = $r['handler'];
             }
         }
 
@@ -639,11 +665,16 @@ class RouteCollection implements RouteCollectionInterface
     public function addRedirect(string $from, string $to, int $status = 302)
     {
         // Use the named route's pattern if this is a named route.
-        if (array_key_exists($to, $this->routes['*'])) {
-            $redirectTo = $this->routes['*'][$to]['route'];
-        } elseif (array_key_exists($to, $this->routes['get'])) {
-            $redirectTo = $this->routes['get'][$to]['route'];
+        if (array_key_exists($to, $this->routesNames['*'])) {
+            $routeName  = $to;
+            $routeKey   = $this->routesNames['*'][$routeName];
+            $redirectTo = [$routeKey => $this->routes['*'][$routeKey]['handler']];
+        } elseif (array_key_exists($to, $this->routesNames['get'])) {
+            $routeName  = $to;
+            $routeKey   = $this->routesNames['get'][$routeName];
+            $redirectTo = [$routeKey => $this->routes['get'][$routeKey]['handler']];
         } else {
+            // The named route is not found.
             $redirectTo = $to;
         }
 
@@ -659,11 +690,16 @@ class RouteCollection implements RouteCollectionInterface
      */
     public function isRedirect(string $routeKey): bool
     {
-        foreach ($this->routes['*'] as $name => $route) {
-            // Named route?
-            if ($name === $routeKey || key($route['route']) === $routeKey) {
-                return isset($route['redirect']) && is_numeric($route['redirect']);
-            }
+        if (isset($this->routes['*'][$routeKey]['redirect'])) {
+            return true;
+        }
+
+        // This logic is not used. Should be deprecated?
+        $routeName = $this->routes['*'][$routeKey]['name'] ?? null;
+        if ($routeName === $routeKey) {
+            $routeKey = $this->routesNames['*'][$routeName];
+
+            return isset($this->routes['*'][$routeKey]['redirect']);
         }
 
         return false;
@@ -676,11 +712,16 @@ class RouteCollection implements RouteCollectionInterface
      */
     public function getRedirectCode(string $routeKey): int
     {
-        foreach ($this->routes['*'] as $name => $route) {
-            // Named route?
-            if ($name === $routeKey || key($route['route']) === $routeKey) {
-                return $route['redirect'] ?? 0;
-            }
+        if (isset($this->routes['*'][$routeKey]['redirect'])) {
+            return $this->routes['*'][$routeKey]['redirect'];
+        }
+
+        // This logic is not used. Should be deprecated?
+        $routeName = $this->routes['*'][$routeKey]['name'] ?? null;
+        if ($routeName === $routeKey) {
+            $routeKey = $this->routesNames['*'][$routeName];
+
+            return $this->routes['*'][$routeKey]['redirect'];
         }
 
         return 0;
@@ -1095,9 +1136,11 @@ class RouteCollection implements RouteCollectionInterface
     public function reverseRoute(string $search, ...$params)
     {
         // Named routes get higher priority.
-        foreach ($this->routes as $collection) {
+        foreach ($this->routesNames as $collection) {
             if (array_key_exists($search, $collection)) {
-                return $this->buildReverseRoute(key($collection[$search]['route']), $params);
+                $routeKey = $collection[$search];
+
+                return $this->buildReverseRoute($routeKey, $params);
             }
         }
 
@@ -1113,9 +1156,8 @@ class RouteCollection implements RouteCollectionInterface
         // If it's not a named route, then loop over
         // all routes to find a match.
         foreach ($this->routes as $collection) {
-            foreach ($collection as $route) {
-                $routeKey = key($route['route']);
-                $to       = $route['route'][$routeKey];
+            foreach ($collection as $routeKey => $route) {
+                $to = $route['handler'];
 
                 // ignore closures
                 if (! is_string($to)) {
@@ -1340,7 +1382,7 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         // When redirecting to named route, $to is an array like `['zombies' => '\Zombies::index']`.
-        if (is_array($to) && count($to) === 2) {
+        if (is_array($to) && isset($to[0])) {
             $to = $this->processArrayCallableSyntax($from, $to);
         }
 
@@ -1420,20 +1462,21 @@ class RouteCollection implements RouteCollectionInterface
         // routes should always be the "source of truth".
         // this works only because discovered routes are added just prior
         // to attempting to route the request.
-        $fromExists = dot_array_search('*.route.' . $routeKey, $this->routes[$verb] ?? []) !== null;
-        if ((isset($this->routes[$verb][$name]) || $fromExists) && ! $overwrite) {
+        $fromExists = isset($this->routes[$verb][$routeKey]);
+        if ((isset($this->routesNames[$verb][$name]) || $fromExists) && ! $overwrite) {
             return;
         }
 
-        $this->routes[$verb][$name] = [
-            'route' => [$routeKey => $to],
+        $this->routes[$verb][$routeKey] = [
+            'name'    => $name,
+            'handler' => $to,
         ];
-
         $this->routesOptions[$verb][$routeKey] = $options;
+        $this->routesNames[$verb][$name]       = $routeKey;
 
         // Is this a redirect?
         if (isset($options['redirect']) && is_numeric($options['redirect'])) {
-            $this->routes['*'][$name]['redirect'] = $options['redirect'];
+            $this->routes['*'][$routeKey]['redirect'] = $options['redirect'];
         }
     }
 
@@ -1574,11 +1617,14 @@ class RouteCollection implements RouteCollectionInterface
      */
     public function resetRoutes()
     {
-        $this->routes = ['*' => []];
+        $this->routes = $this->routesNames = ['*' => []];
 
         foreach ($this->defaultHTTPMethods as $verb) {
-            $this->routes[$verb] = [];
+            $this->routes[$verb]      = [];
+            $this->routesNames[$verb] = [];
         }
+
+        $this->routesOptions = [];
 
         $this->prioritizeDetected = false;
         $this->didDiscover        = false;
@@ -1645,9 +1691,8 @@ class RouteCollection implements RouteCollectionInterface
 
         if ($verb === '*') {
             foreach ($this->defaultHTTPMethods as $tmpVerb) {
-                foreach ($this->routes[$tmpVerb] as $route) {
-                    $routeKey   = key($route['route']);
-                    $controller = $this->getControllerName($route['route'][$routeKey]);
+                foreach ($this->routes[$tmpVerb] as $routeKey => $route) {
+                    $controller = $this->getControllerName($route['handler']);
                     if ($controller !== null) {
                         $controllers[] = $controller;
                     }

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -119,12 +119,14 @@ class RouteCollection implements RouteCollectionInterface
      *         routeKey(regex) => [
      *             'name'     => routeName
      *             'handler'  => handler,
+     *              'from'    => from,
      *         ],
      *         // redirect route
      *         or routeKey(regex)(from) => [
      *             'name'     => routeName
      *             'handler'  => [routeKey(regex)(to) => handler],
      *             'redirect' => statusCode,
+     *             'from'    => from,
      *         ],
      *     ],
      * ]
@@ -1470,6 +1472,7 @@ class RouteCollection implements RouteCollectionInterface
         $this->routes[$verb][$routeKey] = [
             'name'    => $name,
             'handler' => $to,
+            'from'    => $from,
         ];
         $this->routesOptions[$verb][$routeKey] = $options;
         $this->routesNames[$verb][$name]       = $routeKey;

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -179,12 +179,12 @@ interface RouteCollectionInterface
     /**
      * Determines if the route is a redirecting route.
      */
-    public function isRedirect(string $from): bool;
+    public function isRedirect(string $routeKey): bool;
 
     /**
      * Grabs the HTTP status code from a redirecting Route.
      */
-    public function getRedirectCode(string $from): int;
+    public function getRedirectCode(string $routeKey): int;
 
     /**
      * Get the flag that limit or not the routes with {locale} placeholder to App::$supportedLocales

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -144,6 +144,8 @@ Changes
   So if you installed CodeIgniter under the folder that contains the special
   characters like ``(``, ``)``, etc., CodeIgniter didn't work. Since v4.4.0,
   this restriction has been removed.
+- **RouteCollection:** The array structure of the protected property ``$routes``
+  has been modified for performance.
 
 Deprecations
 ************

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -66,6 +66,15 @@ Interface Changes
 Some interface changes have been made. Classes that implement them should update
 their APIs to reflect the changes. See :ref:`v440-interface-changes` for details.
 
+RouteCollection::$routes
+========================
+
+The array structure of the protected property ``$routes`` has been modified for
+performance.
+
+If you extend ``RouteCollection`` and use the ``$routes``, update your code to
+match the new array structure.
+
 Mandatory File Changes
 **********************
 


### PR DESCRIPTION
~~Needs #7174~~
~~This PR should go to `4.4` branch.~~

**Description**
Ref https://github.com/codeigniter4/CodeIgniter4/issues/6889#issuecomment-1402605541

- change `RouteCollection::$routes` structure

Before:
```
     * [
     *     verb => [
     *         routeName => [
     *             'route' => [
     *                 routeKey(regex) => handler,
     *             ],
     *         ],
     *     ],
     *     // redirect route
     *     '*' => [
     *         routeName => [
     *             'route' => [
     *                 routeKey(regex)(from) => [routeKey(regex)(to) => handler],
     *             ],
     *             'redirect' => statusCode,
     *         ]
     *     ],
     * ]
```
After:
```
     * [
     *     verb => [
     *         routeKey(regex) => [
     *             'name'    => routeName
     *             'handler' => handler,
     *             'from'    => from,
     *         ],
     *     ],
     *     // redirect route
     *     '*' => [
     *          routeKey(regex)(from) => [
     *             'name'     => routeName
     *             'handler'  => [routeKey(regex)(to) => handler],
     *             'from'     => from,
     *             'redirect' => statusCode,
     *         ],
     *     ],
     * ]
```

- add `RouteCollection::$routesName`

**Benchmark**
`app/Config/Routes.php`:
```php
helper('text');

for ($i = 0; $i < 5000; $i++) {
    $from[] = random_string('alpha');
}

timer('register 5001 routes');

for ($i = 0; $i < 5000; $i++) {
    $routes->get($from[$i], 'Home::index' . $i);
}
$routes->get('last', 'Last::last');
timer('register 5001 routes');
d(timer()->getElapsedTime('register 5001 routes'));

$_SERVER['REQUEST_METHOD'] = 'GET';
$requet                    = \Config\Services::incomingrequest(null, false);
$router                    = new \CodeIgniter\Router\Router($routes, $requet);

timer('find last route');
$router->handle('last');
timer('find last route');
dd(timer()->getElapsedTime('find last route'));
```

register 5001 routes:
```
 v4.2.7:  0.0243 seconds
 v4.3.1:  10.2108
This PR:  0.0259
```

find last route:
```
 v4.2.7:  0.0417 seconds
 v4.3.1:  0.0456
This PR:  0.0458
```

macOS 12.6.6
PHP 8.1.20 (cli) (built: Jun  8 2023 20:06:33) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.20, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.20, Copyright (c), by Zend Technologies

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
