### PR TITLE
fix: `spark routes` shows incorrect hostname routes

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1316,13 +1316,12 @@ class RouteCollection implements RouteCollectionInterface
         // Hostname limiting?
         if (! empty($options['hostname'])) {
             // @todo determine if there's a way to whitelist hosts?
-            if (isset($this->httpHost) && strtolower($this->httpHost) !== strtolower($options['hostname'])) {
+            if (! $this->checkHostname($options['hostname'])) {
                 return;
             }
 
             $overwrite = true;
         }
-
         // Limiting to subdomains?
         elseif (! empty($options['subdomain'])) {
             // If we don't match the current subdomain, then
@@ -1393,6 +1392,22 @@ class RouteCollection implements RouteCollectionInterface
         if (isset($options['redirect']) && is_numeric($options['redirect'])) {
             $this->routes['*'][$name]['redirect'] = $options['redirect'];
         }
+    }
+
+    /**
+     * Compares the hostname passed in against the current hostname
+     * on this page request.
+     *
+     * @param string $hostname Hostname in route options
+     */
+    private function checkHostname($hostname): bool
+    {
+        // CLI calls can't be on hostname.
+        if (! isset($this->httpHost)) {
+            return false;
+        }
+
+        return strtolower($this->httpHost) === strtolower($hostname);
     }
 
     private function processArrayCallableSyntax(string $from, array $to): string


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=86264

HTTP_HOST do not exist in CLI, so routes for hostnames cannot currently be displayed by `spark routes`.

It is strange that `another.domain` is shown as preferred.

```php
$routes->get('/', 'Controller::default');
$routes->get('/', 'Controller::another', ['hostname' => 'another.domain']);
$routes->get('/', 'Controller::subdomain', ['subdomain' => 'subdomain']);
```
Before:
```
+--------+-------+------+--------------------------------------+----------------+---------------+
| Method | Route | Name | Handler                              | Before Filters | After Filters |
+--------+-------+------+--------------------------------------+----------------+---------------+
| GET    | /     | »    | \App\Controllers\Controller::another |                | toolbar       |
+--------+-------+------+--------------------------------------+----------------+---------------+
```
After:
```
+--------+-------+------+--------------------------------------+----------------+---------------+
| Method | Route | Name | Handler                              | Before Filters | After Filters |
+--------+-------+------+--------------------------------------+----------------+---------------+
| GET    | /     | »    | \App\Controllers\Controller::default |                | toolbar       |
+--------+-------+------+--------------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
