### PR TITLE
BaseResult - make isValidResultId() protected

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -470,7 +470,7 @@ abstract class BaseResult implements ResultInterface
         return $this->numRows = count($this->getResultArray());
     }
 
-    private function isValidResultId(): bool
+    protected function isValidResultId(): bool
     {
         return is_resource($this->resultID) || is_object($this->resultID);
     }


### PR DESCRIPTION
**Description**
When isValidResultId() was introduced it was defined as private. I have custom DB driver which has custom Result object which will return array as result. The private modifier makes it impossible to override the validation check.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
