### PR TITLE
docs: remove out-of-dated comment on Config\App::$baseURL

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -12,15 +12,10 @@ class App extends BaseConfig
      * Base Site URL
      * --------------------------------------------------------------------------
      *
-     * URL to your CodeIgniter root. Typically this will be your base URL,
+     * URL to your CodeIgniter root. Typically, this will be your base URL,
      * WITH a trailing slash:
      *
      *    http://example.com/
-     *
-     * If this is not set then CodeIgniter will try guess the protocol, domain
-     * and path to your installation. However, you should always configure this
-     * explicitly and never rely on auto-guessing, especially in production
-     * environments.
      */
     public string $baseURL = 'http://localhost:8080/';
 


### PR DESCRIPTION
**Description**
CI4 doesn't guess the baseURL.
https://github.com/codeigniter4/CodeIgniter4/blob/ecef7f748df25a20f65bd2e2df26070fc3ebffdd/system/HTTP/IncomingRequest.php#L485

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
