### PR TITLE
Correcting documentation mistakes in upgrading from one version to another

### DIFF
--- a/user_guide_src/source/installation/upgrade_405.rst
+++ b/user_guide_src/source/installation/upgrade_405.rst
@@ -39,7 +39,7 @@ Additional related deprecations from the HTTP layer:
 
 * ``Message::isJSON()``: Check the "Content-Type" header directly
 * ``Request[Interface]::isValidIP()``: Use the Validation class with ``valid_ip``
-* ``Request[Interface]::getMethod()``: The ``$upper`` parameter will be removed, use str_to_upper()
+* ``Request[Interface]::getMethod()``: The ``$upper`` parameter will be removed, use strtoupper()
 * ``Request[Trait]::$ipAddress``: This property will become private
 * ``Request::$proxyIPs``: This property will be removed; access ``config('App')->proxyIPs`` directly
 * ``Request::__construct()``: The constructor will no longer take ``Config\App`` and has been made nullable to aid transition

--- a/user_guide_src/source/installation/upgrade_412.rst
+++ b/user_guide_src/source/installation/upgrade_412.rst
@@ -46,7 +46,7 @@ BaseConnection::query() Return Values
 ``BaseConnection::query()`` method in prior versions was incorrectly returning BaseResult objects
 even if the query failed. This method will now return ``false`` for failed queries (or throw an
 Exception if ``DBDebug`` is ``true``) and will return booleans for write-type queries. Review any use
-of ``query()`` method and be assess whether the value might be boolean instead of Result object.
+of ``query()`` method and assess whether the value might be boolean instead of Result object.
 For a better idea of what queries are write-type queries, check ``BaseConnection::isWriteType()``
 and any DBMS-specific override ``isWriteType()`` in the relevant Connection class.
 

--- a/user_guide_src/source/installation/upgrade_431.rst
+++ b/user_guide_src/source/installation/upgrade_431.rst
@@ -66,7 +66,7 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
-- app/Config/Encryption.php
+- app/Config/Email.php
     - Set the default value ``''`` to ``$fromEmail``, ``$fromName``,
       ``$recipients``, ``$SMTPHost``, ``$SMTPUser`` and ``$SMTPPass``
       to apply environment variable (**.env**) values.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Documentation problems
https://codeigniter.com/user_guide/installation/upgrade_405.html#message-getheader-s
In the line `Request[Interface]::getMethod(): The $upper parameter will be removed, use str_to_upper()`
The correct PHP function is `strtoupper()`

https://codeigniter.com/user_guide/installation/upgrade_412.html#baseconnection-query-return-values
In the line `Review any use of query() method and be assess whether the value might be boolean instead of Result object.`
The word "be" does not belong in the sentence.

https://codeigniter.com/user_guide/installation/upgrade_431.html#config
Based on the description below it `app/Config/Encryption.php` should be `app/Config/Email.php`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
