### PR TITLE
fix: Autoloader may not add Composer package's namespaces

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -381,7 +381,12 @@ class Autoloader
             );
         }
         // This method requires Composer 2.0.14 or later.
-        $packageList = InstalledVersions::getAllRawData()[0]['versions'];
+        $allData     = InstalledVersions::getAllRawData();
+        $packageList = [];
+
+        foreach ($allData as $list) {
+            $packageList = array_merge($packageList, $list['versions']);
+        }
 
         // Check config for $composerPackages.
         $only    = $composerPackages['only'] ?? [];


### PR DESCRIPTION
**Description**
Fixes https://github.com/codeigniter4/shield/issues/610

PHPStan invokes phar (`require 'phar://phpstan.phar/bin/phpstan';`).
In that case, `InstalledVersions::getAllRawData()[0]['versions']` does not contain correct data.

When I see `getInstalledPackages()`:
https://github.com/composer/composer/blob/50cded331ced9acb4e926be3dda1f74b86af2a3b/src/Composer/InstalledVersions.php#L46-L64
it seems better to use all items in the returned array.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
