### PR TITLE
fix: add try/catch to real_path() in clean_path()

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -90,7 +90,11 @@ if (! function_exists('clean_path')) {
     function clean_path(string $path): string
     {
         // Resolve relative paths
-        $path = realpath($path) ?: $path;
+        try {
+            $path = realpath($path) ?: $path;
+        } catch (ErrorException|ValueError $e) {
+            $path = 'error file path: ' . urlencode($path);
+        }
 
         switch (true) {
             case strpos($path, APPPATH) === 0:


### PR DESCRIPTION
**Description**
From Slack and https://forum.codeigniter.com/showthread.php?tid=86511

If `real_path()` throws Exception, we cannot see the true backtrace. 

Before:
![Screenshot 2023-01-28 at 21-23-03 ErrorException](https://user-images.githubusercontent.com/87955/215266222-49feeff6-61ff-4610-a4bf-d65b83fb6117.png)

After:
![Screenshot 2023-01-28 at 21-23-28 ValueError](https://user-images.githubusercontent.com/87955/215266231-14558cc5-70ec-4945-8a7d-67e052b731e6.png)

Before:
```
CRITICAL - 2023-01-28 12:32:16 --> Uncaught ValueError: realpath(): Argument #1 ($path) must not contain any null bytes in /Users/kenji/work/codeigniter/official/CodeIgniter4/system/Common.php:94
Stack trace:
#0 /Users/kenji/work/codeigniter/official/CodeIgniter4/system/Common.php(94): realpath('\x13\x00#\xB6\t\xC5\xE6\xC9/C\xB4\xB5')
#1 /Users/kenji/work/codeigniter/official/CodeIgniter4/system/Debug/Exceptions.php(524): clean_path('\x13\x00#\xB6\t\xC5\xE6\xC9/C\xB4\xB5')
#2 [internal function]: CodeIgniter\Debug\Exceptions::CodeIgniter\Debug\{closure}('\x13\x00#\xB6\t\xC5\xE6\xC9/C\xB4\xB5')
#3 /Users/kenji/work/codeigniter/official/CodeIgniter4/system/Debug/Exceptions.php(529): array_map(Object(Closure), Array)
#4 /Users/kenji/work/codeigniter/official/CodeIgniter4/system/Debug/Exceptions.php(123): CodeIgniter\Debug\Exceptions::renderBacktrace(Array)
#5 [internal function]: CodeIgniter\Debug\Exceptions->exceptionHandler(Object(ValueError))
#6 {main}
  thrown
in SYSTEMPATH/Common.php on line 94.
 1 [internal function]: CodeIgniter\Debug\Exceptions->shutdownHandler()
```
After:
```
CRITICAL - 2023-01-28 12:32:44 --> realpath(): Argument #1 ($path) must not contain any null bytes
in APPPATH/Controllers/Home.php on line 9.
 1 APPPATH/Controllers/Home.php(9): realpath('error file path: %13%00%23%B6%09%C5%E6%C9%2FC%B4%B5')
 2 SYSTEMPATH/CodeIgniter.php(934): App\Controllers\Home->index()
 3 SYSTEMPATH/CodeIgniter.php(499): CodeIgniter\CodeIgniter->runController(Object(App\Controllers\Home))
 4 SYSTEMPATH/CodeIgniter.php(368): CodeIgniter\CodeIgniter->handleRequest(null, Object(Config\Cache), false)
 5 FCPATH/index.php(67): CodeIgniter\CodeIgniter->run()
 6 SYSTEMPATH/Commands/Server/rewrite.php(47): require_once('FCPATH/index.php')
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
