### PR TITLE
chore: remove post-update-cmd in framework composer.json

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -56,9 +56,6 @@
         ]
     },
     "scripts": {
-        "post-update-cmd": [
-            "CodeIgniter\\ComposerScripts::postUpdate"
-        ],
         "test": "phpunit"
     },
     "support": {

--- a/user_guide_src/source/installation/upgrade_432.rst
+++ b/user_guide_src/source/installation/upgrade_432.rst
@@ -27,6 +27,28 @@ slash (``/``). Now it returns baseURL with a trailing slash. For example:
 
 If you have code to call ``base_url()`` without argument, you may need to adjust the URLs.
 
+Mandatory File Changes
+**********************
+
+composer.json
+=============
+
+If you have installed CodeIgnter manually and are using or planning to use Composer,
+remove the following line:
+
+.. code-block:: text
+
+    {
+        ...
+        "scripts": {
+            "post-update-cmd": [
+                "CodeIgniter\\ComposerScripts::postUpdate"  <-- Remove this line
+            ],
+            "test": "phpunit"
+        },
+        ...
+    }
+
 Project Files
 *************
 


### PR DESCRIPTION
**Description**
If a dev has installed the Composer packages, they will be used. There is no need to update the source code in the `system/ThirdParty/` folder.

See https://github.com/codeigniter4/CodeIgniter4/pull/7170#issuecomment-1407811493

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
