### PR TITLE
fix: routing behavior when $uriProtocol is QUERY_STRING

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -217,7 +217,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getDefaultNamespace\\(\\)\\.$#"
-			count: 3
+			count: 2
 			path: system/Router/Router.php
 
 		-

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -329,7 +329,7 @@ class IncomingRequest extends Request
         $uri = $_SERVER['QUERY_STRING'] ?? @getenv('QUERY_STRING');
 
         if (trim($uri, '/') === '') {
-            return '';
+            return '/';
         }
 
         if (strncmp($uri, '/', 1) === 0) {

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -155,6 +155,10 @@ class Router implements RouterInterface
     }
 
     /**
+     * Finds the controller method corresponding to the URI.
+     *
+     * @param string|null $uri URI path relative to baseURL
+     *
      * @return Closure|string Controller classname or Closure
      *
      * @throws PageNotFoundException

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -166,12 +166,9 @@ class Router implements RouterInterface
      */
     public function handle(?string $uri = null)
     {
-        // If we cannot find a URI to match against, then
-        // everything runs off of its default settings.
+        // If we cannot find a URI to match against, then set it to root (`/`).
         if ($uri === null || $uri === '') {
-            return strpos($this->controller, '\\') === false
-                ? $this->collection->getDefaultNamespace() . $this->controller
-                : $this->controller;
+            $uri = '/';
         }
 
         // Decode URL-encoded string

--- a/system/Router/RouterInterface.php
+++ b/system/Router/RouterInterface.php
@@ -27,7 +27,7 @@ interface RouterInterface
     /**
      * Finds the controller method corresponding to the URI.
      *
-     * @param string $uri
+     * @param string|null $uri URI path relative to baseURL
      *
      * @return Closure|string Controller classname or Closure
      */

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -46,7 +46,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->detectPath());
     }
 
-    public function testPathEmpty()
+    public function testPathDefaultEmpty()
     {
         // /
         $_SERVER['REQUEST_URI'] = '/';

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -137,6 +137,17 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->detectPath('QUERY_STRING'));
     }
 
+    public function testPathQueryStringWithQueryString()
+    {
+        // /index.php?/ci/woot?code=good#pos
+        $_SERVER['REQUEST_URI']  = '/index.php?/ci/woot?code=good';
+        $_SERVER['QUERY_STRING'] = '/ci/woot?code=good';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+
+        $expected = 'ci/woot';
+        $this->assertSame($expected, $this->request->detectPath('QUERY_STRING'));
+    }
+
     public function testPathQueryStringEmpty()
     {
         // /index.php?

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -155,7 +155,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_SERVER['QUERY_STRING'] = '';
         $_SERVER['SCRIPT_NAME']  = '/index.php';
 
-        $expected = '';
+        $expected = '/';
         $this->assertSame($expected, $this->request->detectPath('QUERY_STRING'));
     }
 

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -128,8 +128,8 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
 
     public function testPathQueryString()
     {
-        // /?/ci/index.php/woot
-        $_SERVER['REQUEST_URI']  = '/?/ci/woot';
+        // /index.php?/ci/woot
+        $_SERVER['REQUEST_URI']  = '/index.php?/ci/woot';
         $_SERVER['QUERY_STRING'] = '/ci/woot';
         $_SERVER['SCRIPT_NAME']  = '/index.php';
 
@@ -139,8 +139,8 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
 
     public function testPathQueryStringEmpty()
     {
-        // /?/ci/index.php/woot
-        $_SERVER['REQUEST_URI']  = '/?/ci/woot';
+        // /index.php?
+        $_SERVER['REQUEST_URI']  = '/index.php?';
         $_SERVER['QUERY_STRING'] = '';
         $_SERVER['SCRIPT_NAME']  = '/index.php';
 

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -31,127 +31,139 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
 
         $_POST = $_GET = $_SERVER = $_REQUEST = $_ENV = $_COOKIE = $_SESSION = [];
 
-        $origin = 'http://www.example.com/index.php/woot?code=good#pos';
-
+        // The URI object is not used in detectPath().
+        $origin        = 'http://www.example.com/index.php/woot?code=good#pos';
         $this->request = new IncomingRequest(new App(), new URI($origin), null, new UserAgent());
     }
 
     public function testPathDefault()
     {
-        $this->request->uri     = '/index.php/woot?code=good#pos';
+        // /index.php/woot?code=good#pos
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $expected               = 'woot';
+
+        $expected = 'woot';
         $this->assertSame($expected, $this->request->detectPath());
     }
 
     public function testPathEmpty()
     {
-        $this->request->uri     = '/';
+        // /
         $_SERVER['REQUEST_URI'] = '/';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $expected               = '/';
+
+        $expected = '/';
         $this->assertSame($expected, $this->request->detectPath());
     }
 
     public function testPathRequestURI()
     {
-        $this->request->uri     = '/index.php/woot?code=good#pos';
+        // /index.php/woot?code=good#pos
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $expected               = 'woot';
+
+        $expected = 'woot';
         $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINested()
     {
-        $this->request->uri     = '/ci/index.php/woot?code=good#pos';
+        // /ci/index.php/woot?code=good#pos
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $expected               = 'woot';
+
+        $expected = 'woot';
         $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURISubfolder()
     {
-        $this->request->uri     = '/ci/index.php/popcorn/woot?code=good#pos';
+        // /ci/index.php/popcorn/woot?code=good#pos
         $_SERVER['REQUEST_URI'] = '/ci/index.php/popcorn/woot';
         $_SERVER['SCRIPT_NAME'] = '/ci/index.php';
-        $expected               = 'popcorn/woot';
+
+        $expected = 'popcorn/woot';
         $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINoIndex()
     {
-        $this->request->uri     = '/sub/example';
+        // /sub/example
         $_SERVER['REQUEST_URI'] = '/sub/example';
         $_SERVER['SCRIPT_NAME'] = '/sub/index.php';
-        $expected               = 'example';
+
+        $expected = 'example';
         $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINginx()
     {
-        $this->request->uri     = '/ci/index.php/woot?code=good#pos';
+        // /ci/index.php/woot?code=good#pos
         $_SERVER['REQUEST_URI'] = '/index.php/woot?code=good';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $expected               = 'woot';
+
+        $expected = 'woot';
         $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURINginxRedirecting()
     {
-        $this->request->uri     = '/?/ci/index.php/woot';
+        // /?/ci/index.php/woot
         $_SERVER['REQUEST_URI'] = '/?/ci/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $expected               = 'ci/woot';
+
+        $expected = 'ci/woot';
         $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathRequestURISuppressed()
     {
-        $this->request->uri     = '/woot?code=good#pos';
+        // /woot?code=good#pos
         $_SERVER['REQUEST_URI'] = '/woot';
         $_SERVER['SCRIPT_NAME'] = '/';
-        $expected               = 'woot';
+
+        $expected = 'woot';
         $this->assertSame($expected, $this->request->detectPath('REQUEST_URI'));
     }
 
     public function testPathQueryString()
     {
-        $this->request->uri      = '/?/ci/index.php/woot';
+        // /?/ci/index.php/woot
         $_SERVER['REQUEST_URI']  = '/?/ci/woot';
         $_SERVER['QUERY_STRING'] = '/ci/woot';
         $_SERVER['SCRIPT_NAME']  = '/index.php';
-        $expected                = 'ci/woot';
+
+        $expected = 'ci/woot';
         $this->assertSame($expected, $this->request->detectPath('QUERY_STRING'));
     }
 
     public function testPathQueryStringEmpty()
     {
-        $this->request->uri      = '/?/ci/index.php/woot';
+        // /?/ci/index.php/woot
         $_SERVER['REQUEST_URI']  = '/?/ci/woot';
         $_SERVER['QUERY_STRING'] = '';
         $_SERVER['SCRIPT_NAME']  = '/index.php';
-        $expected                = '';
+
+        $expected = '';
         $this->assertSame($expected, $this->request->detectPath('QUERY_STRING'));
     }
 
     public function testPathPathInfo()
     {
-        $this->request->uri = '/index.php/woot?code=good#pos';
+        // /index.php/woot?code=good#pos
         $this->request->setGlobal('server', [
             'PATH_INFO' => null,
         ]);
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $expected               = 'woot';
+
+        $expected = 'woot';
         $this->assertSame($expected, $this->request->detectPath('PATH_INFO'));
     }
 
     public function testPathPathInfoGlobal()
     {
-        $this->request->uri = '/index.php/woot?code=good#pos';
+        // /index.php/woot?code=good#pos
         $this->request->setGlobal('server', [
             'PATH_INFO' => 'silliness',
         ]);

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -68,6 +68,14 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
 
     public function testPathRequestURINested()
     {
+        // I'm not sure but this is a case of Apache config making such SERVER
+        // values?
+        // The current implementation doesn't use the value of the URI object.
+        // So I removed the code to set URI. Therefore, it's exactly the same as
+        // the method above as a test.
+        // But it may be changed in the future to use the value of the URI object.
+        // So I don't remove this test case.
+
         // /ci/index.php/woot?code=good#pos
         $_SERVER['REQUEST_URI'] = '/index.php/woot';
         $_SERVER['SCRIPT_NAME'] = '/index.php';

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -39,6 +39,7 @@ final class RouterTest extends CIUnitTestCase
         $this->collection      = new RouteCollection(Services::locator(), $moduleConfig);
 
         $routes = [
+            '/'                                               => 'Home::index',
             'users'                                           => 'Users::index',
             'user-setting/show-list'                          => 'User_setting::show_list',
             'user-setting/(:segment)'                         => 'User_setting::detail/$1',
@@ -56,20 +57,20 @@ final class RouterTest extends CIUnitTestCase
             'objects/(:segment)/sort/(:segment)/([A-Z]{3,7})' => 'AdminList::objectsSortCreate/$1/$2/$3',
             '(:segment)/(:segment)/(:segment)'                => '$2::$3/$1',
         ];
-
         $this->collection->map($routes);
+
         $this->request = Services::request();
         $this->request->setMethod('get');
     }
 
-    public function testEmptyURIMatchesDefaults()
+    public function testEmptyURIMatchesRoot()
     {
         $router = new Router($this->collection, $this->request);
 
         $router->handle('');
 
-        $this->assertSame($this->collection->getDefaultController(), $router->controllerName());
-        $this->assertSame($this->collection->getDefaultMethod(), $router->methodName());
+        $this->assertSame('\Home', $router->controllerName());
+        $this->assertSame('index', $router->methodName());
     }
 
     public function testZeroAsURIPath()


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=86284&pid=406192#pid406192

When `Config\App::$uriProtocol` is `QUERY_STRING` and accessing baseURL:

- (1) Fix: the defined route `/` is ignored, and routed to the default controller
- (2) Fix: `Debug/Toolbar/Collectors/Routes.php` throws "ReflectionException: Class "Home" does not exist" 

**How to Reproduce**
```diff
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -59,7 +59,7 @@ class App extends BaseConfig
      *
      * WARNING: If you set this to 'PATH_INFO', URIs will always be URL-decoded!
      */
-    public string $uriProtocol = 'REQUEST_URI';
+    public string $uriProtocol = 'QUERY_STRING';
 
     /**
      * --------------------------------------------------------------------------
diff --git a/app/Config/Routes.php b/app/Config/Routes.php
index c251ec22c4..520078ff91 100644
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -29,7 +29,7 @@ $routes->set404Override();
 
 // We get a performance increase by specifying the default
 // route since we don't have to scan directories.
-$routes->get('/', 'Home::index');
+$routes->get('/', 'Index::index');
 
 /*
  * --------------------------------------------------------------------
```

(1) set `CI_ENVIRONMENT = production` in `.env`, and run `spark serve`.
Navigate to `http://localhost:8080/`.
You will see the Welcome page. But it should be 404 Not Found.
Because `Index::index` does not exist.

(2) set `CI_ENVIRONMENT = development` in `.env`, and run `spark serve`.
Navigate to `http://localhost:8080/`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
