### PR TITLE
Feature: New method DownloadResponse::inline()

### DIFF
--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -269,7 +269,10 @@ class DownloadResponse extends Response
             $this->setContentTypeByMimeType();
         }
 
-        $this->setHeader('Content-Disposition', $this->getContentDisposition());
+        if (! $this->hasHeader('Content-Disposition')) {
+            $this->setHeader('Content-Disposition', $this->getContentDisposition());
+        }
+
         $this->setHeader('Expires-Disposition', '0');
         $this->setHeader('Content-Transfer-Encoding', 'binary');
         $this->setHeader('Content-Length', (string) $this->getContentLength());
@@ -322,6 +325,18 @@ class DownloadResponse extends Response
     private function sendBodyByBinary()
     {
         echo $this->binary;
+
+        return $this;
+    }
+
+    /**
+     * Sets the response header to display the file in the browser.
+     *
+     * @return DownloadResponse
+     */
+    public function inline()
+    {
+        $this->setHeader('Content-Disposition', 'inline');
 
         return $this;
     }

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -120,6 +120,14 @@ final class DownloadResponseTest extends CIUnitTestCase
         $this->assertSame('attachment; filename="myFile.txt"; filename*=UTF-8\'\'myFile.txt', $response->getHeaderLine('Content-Disposition'));
     }
 
+    public function testDispositionInline(): void
+    {
+        $response = new DownloadResponse('unit-test.txt', true);
+        $response->inline();
+        $response->buildHeaders();
+        $this->assertSame('inline', $response->getHeaderLine('Content-Disposition'));
+    }
+
     public function testNoCache()
     {
         $response = new DownloadResponse('unit-test.txt', true);

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -28,8 +28,9 @@ Method Signature Changes
 
 Enhancements
 ************
-- Added ``DownloadResponse::inline()`` method that sets the ``Content-Disposition: inline`` header to display the file
-in the browser.
+
+- Added ``DownloadResponse::inline()`` method that sets the ``Content-Disposition: inline`` header to display the
+file in the browser.
 
 Commands
 ========
@@ -71,6 +72,7 @@ Message Changes
 
 Changes
 *******
+
 - The ``DownloadResponse`` class, when generating response headers, does not replace the ``Content-Disposition`` header
 if it was previously specified.
 

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -28,6 +28,8 @@ Method Signature Changes
 
 Enhancements
 ************
+- Added ``DownloadResponse::inline()`` method that sets the ``Content-Disposition: inline`` header to display the file
+in the browser.
 
 Commands
 ========
@@ -69,6 +71,8 @@ Message Changes
 
 Changes
 *******
+- The ``DownloadResponse`` class, when generating response headers, does not replace the ``Content-Disposition`` header
+if it was previously specified.
 
 Deprecations
 ************

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -29,8 +29,6 @@ Method Signature Changes
 Enhancements
 ************
 
-- Added ``DownloadResponse::inline()`` method that sets the ``Content-Disposition: inline`` header to display the file in the browser.
-
 Commands
 ========
 
@@ -61,6 +59,9 @@ Helpers and Functions
 Others
 ======
 
+- **DownloadResponse:** Added ``DownloadResponse::inline()`` method that sets
+  the ``Content-Disposition: inline`` header to display the file in the browser.
+  See :ref:`open-file-in-browser` for details.
 - **View:** Added optional 2nd parameter ``$saveData`` on ``renderSection()`` to prevent from auto cleans the data after displaying. See :ref:`View Layouts <creating-a-layout>` for details.
 - **Auto Routing (Improved)**: Now you can use URI without a method name like
   ``product/15`` where ``15`` is an arbitrary number.
@@ -72,7 +73,7 @@ Message Changes
 Changes
 *******
 
-- The ``DownloadResponse`` class, when generating response headers, does not replace the ``Content-Disposition`` header if it was previously specified.
+- **DownloadResponse:** When generating response headers, does not replace the ``Content-Disposition`` header if it was previously specified.
 
 Deprecations
 ************

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -29,8 +29,7 @@ Method Signature Changes
 Enhancements
 ************
 
-- Added ``DownloadResponse::inline()`` method that sets the ``Content-Disposition: inline`` header to display the
-file in the browser.
+- Added ``DownloadResponse::inline()`` method that sets the ``Content-Disposition: inline`` header to display the file in the browser.
 
 Commands
 ========
@@ -73,8 +72,7 @@ Message Changes
 Changes
 *******
 
-- The ``DownloadResponse`` class, when generating response headers, does not replace the ``Content-Disposition`` header
-if it was previously specified.
+- The ``DownloadResponse`` class, when generating response headers, does not replace the ``Content-Disposition`` header if it was previously specified.
 
 Deprecations
 ************

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -93,7 +93,9 @@ Use the optional ``setFileName()`` method to change the filename as it is sent t
 .. note:: The response object MUST be returned for the download to be sent to the client. This allows the response
     to be passed through all **after** filters before being sent to the client.
 
-Open file in browser
+.. _open-file-in-browser:
+
+Open File in Browser
 --------------------
 
 Some browsers can display files such as PDF. To tell the browser to display the file instead of saving it, call the

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -99,7 +99,7 @@ Open file in browser
 Some browsers can display files such as PDF. To tell the browser to display the file instead of saving it, call the
 ``DownloadResponse::inline()`` method.
 
-.. literalinclude:: response/007.php
+.. literalinclude:: response/028.php
 
 HTTP Caching
 ============

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -93,6 +93,14 @@ Use the optional ``setFileName()`` method to change the filename as it is sent t
 .. note:: The response object MUST be returned for the download to be sent to the client. This allows the response
     to be passed through all **after** filters before being sent to the client.
 
+Open file in browser
+--------------------
+
+Some browsers can display files such as PDF. To tell the browser to display the file instead of saving it, call the
+``DownloadResponse::inline()`` method.
+
+.. literalinclude:: response/007.php
+
 HTTP Caching
 ============
 

--- a/user_guide_src/source/outgoing/response/028.php
+++ b/user_guide_src/source/outgoing/response/028.php
@@ -1,0 +1,6 @@
+<?php
+
+$data = 'Here is some text!';
+$name = 'mytext.txt';
+
+return $this->response->download($name, $data)->inline();


### PR DESCRIPTION
**Description**
There is currently no way to change the ``Content-Disposition`` header when downloading a file, as this header will be overwritten when generating headers in the ``DownloadResponse`` class.

This PR prevents the ``Content-Disposition`` header from being changed when generating headers if that header has already been set.
It also adds a ``DownloadRespone::inline()`` helper method that sets the ``Content-Disposition: inline`` header.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
