### PR TITLE
feat: add `Entity::injectRawData()` to avoid name collision

### DIFF
--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -146,7 +146,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 
         return $this->resultID->fetch_object($className);

--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -102,7 +102,7 @@ class Result extends BaseResult
             return $row;
         }
         if (is_subclass_of($className, Entity::class)) {
-            return (new $className())->setAttributes((array) $row);
+            return (new $className())->injectRawData((array) $row);
         }
 
         $instance = new $className();

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -112,7 +112,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 
         return pg_fetch_object($this->resultID, null, $className);

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -152,7 +152,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->setAttributes($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 
         return sqlsrv_fetch_object($this->resultID, $className);

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -140,7 +140,7 @@ class Result extends BaseResult
         $classObj = new $className();
 
         if (is_subclass_of($className, Entity::class)) {
-            return $classObj->setAttributes($row);
+            return $classObj->injectRawData($row);
         }
 
         $classSet = Closure::bind(function ($key, $value) {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -279,13 +279,25 @@ class Entity implements JsonSerializable
      *
      * @return $this
      */
-    public function setAttributes(array $data)
+    public function injectRawData(array $data)
     {
         $this->attributes = $data;
 
         $this->syncOriginal();
 
         return $this;
+    }
+
+    /**
+     * Set raw data array without any mutations
+     *
+     * @return $this
+     *
+     * @deprecated Use injectRawData() instead.
+     */
+    public function setAttributes(array $data)
+    {
+        return $this->injectRawData($data);
     }
 
     /**
@@ -449,7 +461,7 @@ class Entity implements JsonSerializable
         // so maybe wants to do sth with null value automatically
         $method = 'set' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $key)));
 
-        if (method_exists($this, $method)) {
+        if (method_exists($this, $method) && $method !== 'setAttributes') {
             $this->{$method}($value);
 
             return $this;

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -34,6 +34,36 @@ final class EntityTest extends CIUnitTestCase
 {
     use ReflectionHelper;
 
+    public function testSetStringToPropertyNamedAttributes()
+    {
+        $entity = $this->getEntity();
+
+        $entity->attributes = 'attributes';
+
+        $this->assertSame('attributes', $entity->attributes);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues
+     */
+    public function testSetArrayToPropertyNamedAttributes()
+    {
+        $entity = new Entity();
+
+        $entity->a          = 1;
+        $entity->attributes = [1, 2, 3];
+
+        $expected = [
+            'a'          => 1,
+            'attributes' => [
+                0 => 1,
+                1 => 2,
+                2 => 3,
+            ],
+        ];
+        $this->assertSame($expected, $entity->toRawArray());
+    }
+
     public function testSimpleSetAndGet()
     {
         $entity = $this->getEntity();

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -83,6 +83,8 @@ Changes
 Deprecations
 ************
 
+- **Entity:** ``Entity::setAttributes()`` is deprecated. Use ``Entity::injectRawData()`` instead.
+
 Bugs Fixed
 **********
 


### PR DESCRIPTION
**Description**
Supersedes #5763, #5781
Fixes #5762

- add `Entity::injectRawData()`
- deprecate `Entity::setAttributes()`
- ~~require setter/getter methods must be public. See https://github.com/codeigniter4/CodeIgniter4/issues/5762#issuecomment-1179519591~~

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
