### PR TITLE
feat: add `--host` option to `spark routes`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -125,8 +125,7 @@
     </UndefinedGlobalVariable>
   </file>
   <file src="tests/_support/Config/Routes.php">
-    <UndefinedGlobalVariable occurrences="2">
-      <code>$routes</code>
+    <UndefinedGlobalVariable occurrences="5">
       <code>$routes</code>
     </UndefinedGlobalVariable>
   </file>

--- a/tests/_support/Config/Routes.php
+++ b/tests/_support/Config/Routes.php
@@ -14,3 +14,6 @@ namespace Tests\Support\Config;
 // This is a simple file to include for testing the RouteCollection class.
 $routes->add('testing', 'TestController::index', ['as' => 'testing-index']);
 $routes->get('closure', static fn () => 'closure test');
+$routes->get('/', 'Blog::index', ['hostname' => 'blog.example.com']);
+$routes->get('/', 'Sub::index', ['subdomain' => 'sub']);
+$routes->get('/all', 'AllDomain::index', ['subdomain' => '*']);

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -53,7 +53,7 @@ final class RoutesTest extends CIUnitTestCase
 
     public function testRoutesCommand()
     {
-        $this->getCleanRoutes();
+        Services::injectMock('routes', null);
 
         command('routes');
 
@@ -79,7 +79,7 @@ final class RoutesTest extends CIUnitTestCase
 
     public function testRoutesCommandSortByHandler()
     {
-        $this->getCleanRoutes();
+        Services::injectMock('routes', null);
 
         command('routes -h');
 
@@ -89,6 +89,62 @@ final class RoutesTest extends CIUnitTestCase
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             | GET     | closure | »             | (Closure)                              |                | toolbar       |
             | GET     | /       | »             | \App\Controllers\Home::index           |                | toolbar       |
+            | GET     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | POST    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | CLI     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            EOL;
+        $this->assertStringContainsString($expected, $this->getBuffer());
+    }
+
+    public function testRoutesCommandHostHostname()
+    {
+        Services::injectMock('routes', null);
+
+        command('routes --host blog.example.com');
+
+        $expected = <<<'EOL'
+            Host: blog.example.com
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            | Method  | Route   | Name          | Handler                                | Before Filters | After Filters |
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            | GET     | /       | »             | \App\Controllers\Blog::index           |                | toolbar       |
+            | GET     | closure | »             | (Closure)                              |                | toolbar       |
+            | GET     | all     | »             | \App\Controllers\AllDomain::index      |                | toolbar       |
+            | GET     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | POST    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | CLI     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            EOL;
+        $this->assertStringContainsString($expected, $this->getBuffer());
+    }
+
+    public function testRoutesCommandHostSubdomain()
+    {
+        Services::injectMock('routes', null);
+
+        command('routes --host sub.example.com');
+
+        $expected = <<<'EOL'
+            Host: sub.example.com
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            | Method  | Route   | Name          | Handler                                | Before Filters | After Filters |
+            +---------+---------+---------------+----------------------------------------+----------------+---------------+
+            | GET     | /       | »             | \App\Controllers\Sub::index            |                | toolbar       |
+            | GET     | closure | »             | (Closure)                              |                | toolbar       |
+            | GET     | all     | »             | \App\Controllers\AllDomain::index      |                | toolbar       |
             | GET     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
             | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
             | POST    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
@@ -139,6 +195,7 @@ final class RoutesTest extends CIUnitTestCase
     public function testRoutesCommandRouteLegacy()
     {
         $routes = $this->getCleanRoutes();
+        $routes->loadRoutes();
 
         $routes->setAutoRoute(true);
         $namespace = 'Tests\Support\Controllers';

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -32,6 +32,9 @@ Enhancements
 Commands
 ========
 
+- Now ``spark routes`` command can specify the host in the request URL.
+  See :ref:`routing-spark-routes-specify-host`.
+
 Testing
 =======
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -858,3 +858,14 @@ Sort by Handler
 You can sort the routes by *Handler*::
 
     > php spark routes -h
+
+.. _routing-spark-routes-specify-host:
+
+Specify Host
+------------
+
+.. versionadded:: 4.4.0
+
+You can specify the host in the request URL with the ``--host`` option::
+
+    > php spark routes --host accounts.example.com


### PR DESCRIPTION
**Description**
- add option to specify host in the request URL

```diff
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -31,6 +31,9 @@ $routes->set404Override();
 // route since we don't have to scan directories.
 $routes->get('/', 'Home::index');
 
+$routes->get('/', 'Account::index', ['hostname' => 'account.example.com']);
+$routes->get('/', 'Media::index', ['subdomain' => 'media']);
+
 /*
  * --------------------------------------------------------------------
  * Additional Routing
```
```console
$ php spark routes

CodeIgniter v4.3.1 Command Line Tool - Server Time: 2023-02-02 05:25:26 UTC+00:00

+--------+-------+------+------------------------------+----------------+---------------+
| Method | Route | Name | Handler                      | Before Filters | After Filters |
+--------+-------+------+------------------------------+----------------+---------------+
| GET    | /     | »    | \App\Controllers\Home::index |                | toolbar       |
+--------+-------+------+------------------------------+----------------+---------------+
```
```console
$ php spark routes --host account.example.com

CodeIgniter v4.3.1 Command Line Tool - Server Time: 2023-02-02 05:25:31 UTC+00:00

Host: account.example.com
+--------+-------+------+---------------------------------+----------------+---------------+
| Method | Route | Name | Handler                         | Before Filters | After Filters |
+--------+-------+------+---------------------------------+----------------+---------------+
| GET    | /     | »    | \App\Controllers\Account::index |                | toolbar       |
+--------+-------+------+---------------------------------+----------------+---------------+
```
```console
$ php spark routes --host media.example.com

CodeIgniter v4.3.1 Command Line Tool - Server Time: 2023-02-02 05:25:34 UTC+00:00

Host: media.example.com
+--------+-------+------+-------------------------------+----------------+---------------+
| Method | Route | Name | Handler                       | Before Filters | After Filters |
+--------+-------+------+-------------------------------+----------------+---------------+
| GET    | /     | »    | \App\Controllers\Media::index |                | toolbar       |
+--------+-------+------+-------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
