### PR TITLE
test: replace deprecated expectErrorMessage()

### DIFF
--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -429,7 +429,7 @@ final class EntityTest extends CIUnitTestCase
     public function testCastTimestampException()
     {
         $this->expectException(CastException::class);
-        $this->expectErrorMessage('Type casting "timestamp" expects a correct timestamp.');
+        $this->expectExceptionMessage('Type casting "timestamp" expects a correct timestamp.');
 
         $entity        = $this->getCastEntity();
         $entity->ninth = 'some string';
@@ -725,7 +725,7 @@ final class EntityTest extends CIUnitTestCase
     public function testCustomCastException()
     {
         $this->expectException(CastException::class);
-        $this->expectErrorMessage('The "Tests\Support\Entity\Cast\NotExtendsBaseCast" class must inherit the "CodeIgniter\Entity\Cast\BaseCast" class');
+        $this->expectExceptionMessage('The "Tests\Support\Entity\Cast\NotExtendsBaseCast" class must inherit the "CodeIgniter\Entity\Cast\BaseCast" class');
 
         $entity = $this->getCustomCastEntity();
 


### PR DESCRIPTION
**Description**
```
1) CodeIgniter\Entity\EntityTest::testCastTimestampException
Expecting E_ERROR and E_USER_ERROR is deprecated and will no longer be possible in PHPUnit 10.

phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97

2) CodeIgniter\Entity\EntityTest::testCustomCastException
Expecting E_ERROR and E_USER_ERROR is deprecated and will no longer be possible in PHPUnit 10.

phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/4082500823/jobs/7036936331

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
