### PR TITLE
test: replace deprecated assertObjectHasAttribute()

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -172,6 +172,11 @@
       <code>UnexsistenceClass</code>
     </UndefinedClass>
   </file>
+  <file src="tests/system/Config/BaseConfigTest.php">
+    <UndefinedClass occurrences="1">
+        <code>SimpleConfig</code>
+    </UndefinedClass>
+  </file>
   <file src="tests/system/Config/FactoriesTest.php">
     <UndefinedClass occurrences="1">
       <code>'SomeWidget'</code>

--- a/rector.php
+++ b/rector.php
@@ -40,6 +40,7 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
+use Rector\PHPUnit\Rector\MethodCall\AssertPropertyExistsRector;
 use Rector\PHPUnit\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
@@ -80,6 +81,8 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/tests/_support',
         JsonThrowOnErrorRector::class,
         StringifyStrNeedlesRector::class,
+        // assertObjectHasAttribute() is deprecated
+        AssertPropertyExistsRector::class,
 
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -35,14 +35,14 @@ final class BaseCommandTest extends CIUnitTestCase
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertObjectHasAttribute('group', $command);
+        $this->assertTrue(isset($command->group));
     }
 
     public function testMagicIssetFalse()
     {
         $command = new AppInfo($this->logger, service('commands'));
 
-        $this->assertObjectNotHasAttribute('foobar', $command);
+        $this->assertFalse(isset($command->foobar));
     }
 
     public function testMagicGet()

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -110,7 +110,7 @@ final class BaseConfigTest extends CIUnitTestCase
         // override config with shortPrefix ENV var
         $this->assertSame('hubbahubba', $config->delta);
         // incorrect env name should not inject property
-        $this->assertObjectNotHasAttribute('notthere', $config);
+        $this->assertFalse(property_exists($config, 'notthere'));
         // empty ENV var should not affect config setting
         $this->assertSame('pineapple', $config->fruit);
         // non-empty ENV var should overrideconfig setting

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -96,7 +96,7 @@ final class EntityTest extends CIUnitTestCase
 
         $this->assertSame(123, $entity->foo);
         $this->assertSame('bar:234:bar', $entity->bar);
-        $this->assertObjectNotHasAttribute('baz', $entity);
+        $this->assertSame(4556, $entity->baz);
     }
 
     /**

--- a/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
@@ -66,10 +66,11 @@ final class ChromeLoggerHandlerTest extends CIUnitTestCase
         $config->handlers['CodeIgniter\Log\Handlers\TestHandler']['handles'] = ['critical'];
 
         $logger = new ChromeLoggerHandler($config->handlers['CodeIgniter\Log\Handlers\TestHandler']);
+
         $result = $logger->setDateFormat('F j, Y');
 
-        $this->assertObjectHasAttribute('dateFormat', $result);
-        $this->assertObjectHasAttribute('dateFormat', $logger);
+        $this->assertSame('F j, Y', $this->getPrivateProperty($result, 'dateFormat'));
+        $this->assertSame('F j, Y', $this->getPrivateProperty($logger, 'dateFormat'));
     }
 
     public function testChromeLoggerHeaderSent()

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -406,7 +406,7 @@ final class FabricatorTest extends CIUnitTestCase
         $this->assertIsInt($result->created_at);
         $this->assertIsInt($result->updated_at);
 
-        $this->assertObjectHasAttribute('deleted_at', $result);
+        $this->assertTrue(property_exists($result, 'deleted_at'));
         $this->assertNull($result->deleted_at);
     }
 


### PR DESCRIPTION
**Description**
See https://github.com/sebastianbergmann/phpunit/issues/4601

- replace deprecated `assertObjectHasAttribute()`
- skip `AssertPropertyExistsRector`
- update `psalm-baseline.xml`

```
1) CodeIgniter\Commands\BaseCommandTest::testMagicIssetTrue
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10.

phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97

2) CodeIgniter\Commands\BaseCommandTest::testMagicIssetFalse
assertObjectNotHasAttribute() is deprecated and will be removed in PHPUnit 10.

phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97

3) CodeIgniter\Entity\EntityTest::testFill
assertObjectNotHasAttribute() is deprecated and will be removed in PHPUnit 10.

phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97

4) CodeIgniter\Log\Handlers\ChromeLoggerHandlerTest::testSetDateFormat
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10.

phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97

5) CodeIgniter\Test\FabricatorTest::testCreateMockSetsDatabaseFields
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10.

phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:97
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/4088819987/jobs/7050873682

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
