### PR TITLE
fix: support for display of error message using wildcard (*)

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -741,9 +741,12 @@ if (! function_exists('validation_show_error')) {
         $config = config('Validation');
         $view   = Services::renderer();
 
-        $errors = validation_errors();
+        $errors = array_filter(validation_errors(), static fn ($key) => preg_match(
+            '/^' . str_replace(['\.\*', '\*\.'], ['\..+', '.+\.'], preg_quote($field, '/')) . '$/',
+            $key
+        ), ARRAY_FILTER_USE_KEY);
 
-        if (! array_key_exists($field, $errors)) {
+        if ($errors === []) {
             return '';
         }
 
@@ -751,7 +754,7 @@ if (! function_exists('validation_show_error')) {
             throw ValidationException::forInvalidTemplate($template);
         }
 
-        return $view->setVar('error', $errors[$field])
+        return $view->setVar('error', implode("\n", $errors))
             ->render($config->templates[$template]);
     }
 }

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -999,7 +999,16 @@ final class FormHelperTest extends CIUnitTestCase
     public function testValidationShowErrorForWildcards()
     {
         $validation = Services::validation();
-        $validation->setRule('user.0.name', 'Name', 'required')->run([]);
+        $validation->setRule('user.*.name', 'Name', 'required')
+            ->run([
+                'user' => [
+                    'friends' => [
+                        ['name' => 'Name1'],
+                        ['name' => ''],
+                        ['name' => 'Name2'],
+                    ]
+                ]
+            ]);
 
         $html = validation_show_error('user.*.name');
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -996,6 +996,16 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame('<span class="help-block">The ID field is required.</span>' . "\n", $html);
     }
 
+    public function testValidationShowErrorForWildcards()
+    {
+        $validation = Services::validation();
+        $validation->setRule('user.0.name', 'Name', 'required')->run([]);
+
+        $html = validation_show_error('user.*.name');
+
+        $this->assertSame('<span class="help-block">The Name field is required.</span>' . "\n", $html);
+    }
+
     public function testFormParseFormAttributesTrue()
     {
         $expected = 'readonly ';

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -1006,8 +1006,8 @@ final class FormHelperTest extends CIUnitTestCase
                         ['name' => 'Name1'],
                         ['name' => ''],
                         ['name' => 'Name2'],
-                    ]
-                ]
+                    ],
+                ],
             ]);
 
         $html = validation_show_error('user.*.name');


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
The `validation_show_error()` form helper does not support the use of wildcards (*) like the `getError()` validation method. 

For example, if I have a rule like this:
```php
$rules = [
    'users.*.name' => "required"
];
```
I expect that I should be able to display the error in the view using `validation_show_error('users.*.name')` just the same way I would if I use `$validation->getError('users.*.name')`.
This PR fixes that.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
