### PR TITLE
A spelling correction in model.html

### DIFF
--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -727,7 +727,7 @@ Additionally, each model may allow (default) or deny callbacks class-wide by set
 
 .. literalinclude:: model/052.php
 
-You may also change this setting temporarily for a single model call sing the ``allowCallbacks()`` method:
+You may also change this setting temporarily for a single model call using the ``allowCallbacks()`` method:
 
 .. literalinclude:: model/053.php
 


### PR DESCRIPTION
**Description**

I have changed the word 'sing' for 'using' in the documentation: 
Using CodeIgniter's Model -> In-Model Validation -> Specifying Callbacks To Run

**Checklist:**
- [x ] User guide updated

