### PR TITLE
feat: add new setter/getter for Entity

### DIFF
--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -82,6 +82,19 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame('bar:thanks:bar', $entity->bar);
     }
 
+    public function testNewGetterSetters()
+    {
+        $entity = $this->getNewSetterGetterEntity();
+
+        $entity->bar = 'thanks';
+
+        $this->assertSame('bar:thanks:bar', $entity->bar);
+
+        $entity->setBar('BAR');
+
+        $this->assertSame('BAR', $entity->getBar());
+    }
+
     public function testUnsetUnsetsAttribute()
     {
         $entity = $this->getEntity();
@@ -1090,6 +1103,52 @@ final class EntityTest extends CIUnitTestCase
             }
 
             public function getFakeBar()
+            {
+                return "{$this->attributes['bar']}:bar";
+            }
+        };
+    }
+
+    protected function getNewSetterGetterEntity()
+    {
+        return new class () extends Entity {
+            protected $attributes = [
+                'foo'        => null,
+                'bar'        => null,
+                'default'    => 'sumfin',
+                'created_at' => null,
+            ];
+            protected $original = [
+                'foo'        => null,
+                'bar'        => null,
+                'default'    => 'sumfin',
+                'created_at' => null,
+            ];
+            protected $datamap = [
+                'createdAt' => 'created_at',
+            ];
+            private string $bar;
+
+            public function setBar($value)
+            {
+                $this->bar = $value;
+
+                return $this;
+            }
+
+            public function getBar()
+            {
+                return $this->bar;
+            }
+
+            public function _setBar($value)
+            {
+                $this->attributes['bar'] = "bar:{$value}";
+
+                return $this;
+            }
+
+            public function _getBar()
             {
                 return "{$this->attributes['bar']}:bar";
             }

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -62,6 +62,9 @@ Others
 Model
 =====
 
+- Added special getter/setter to Entity to avoid method name conflicts.
+  See :ref:`entities-special-getter-setter`.
+
 Libraries
 =========
 

--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -131,6 +131,25 @@ business logic and create objects that are pleasant to use.
 
 .. literalinclude:: entities/007.php
 
+.. _entities-special-getter-setter:
+
+Special Getter/Setter
+---------------------
+
+.. versionadded:: 4.4.0
+
+For example, if your Entity's parent class already has a ``getParent()`` method
+defined, and your Entity also has a column named ``parent``, when you try to add
+business logic to the ``getParent()`` method in your Entity class, the method is
+already defined.
+
+In such a case, you can use the special getter/setter. Instead of ``getX()``/``setX()``,
+set ``_getX()``/``_setX()``.
+
+In the above example, if your Entity has the ``_getParent()`` method, the method
+will be used when you get ``$entity->parent``, and the ``_setParent()`` method
+will be used when you set ``$entity->parent``.
+
 Data Mapping
 ============
 


### PR DESCRIPTION
~~Needs  #7208~~

**Description**
Add special getter/setter to Entity to avoid method name conflicts.
- add new special setter method "`_set` + key" for a attribute
- add new special getter method "`_get` + key" for a attribute

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
