### PR TITLE
refactor: deprecate $request and $response in Exceptions::__construct()

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -28,6 +28,7 @@ use Rector\CodingStyle\Rector\ClassMethod\FuncGetArgsToVariadicParamRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector;
@@ -87,6 +88,11 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker
             __DIR__ . '/tests/system/Test/ReflectionHelperTest.php',
+        ],
+
+        RemoveUnusedConstructorParamRector::class => [
+            // there are deprecated parameters
+            __DIR__ . '/system/Debug/Exceptions.php',
         ],
 
         // call on purpose for nothing happen check

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -250,6 +250,8 @@ class Services extends BaseService
      *  - register_shutdown_function
      *
      * @return Exceptions
+     *
+     * @deprecated The parameter $request and $response are deprecated.
      */
     public static function exceptions(
         ?ExceptionsConfig $config = null,
@@ -262,7 +264,9 @@ class Services extends BaseService
         }
 
         $config ??= config('Exceptions');
-        $request ??= AppServices::request();
+        /** @var ExceptionsConfig $config */
+
+        // @TODO remove instantiation of Response in the future.
         $response ??= AppServices::response();
 
         return new Exceptions($config, $request, $response);

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -21,6 +21,7 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Paths;
+use Config\Services;
 use ErrorException;
 use Psr\Log\LogLevel;
 use Throwable;
@@ -71,15 +72,15 @@ class Exceptions
     private ?Throwable $exceptionCaughtByExceptionHandler = null;
 
     /**
-     * @param CLIRequest|IncomingRequest $request
+     * @param CLIRequest|IncomingRequest|null $request
+     *
+     * @deprecated The parameter $request and $response are deprecated. No longer used.
      */
-    public function __construct(ExceptionsConfig $config, $request, ResponseInterface $response)
+    public function __construct(ExceptionsConfig $config, $request, ResponseInterface $response) /** @phpstan-ignore-line */
     {
         $this->ob_level = ob_get_level();
         $this->viewPath = rtrim($config->errorViewPath, '\\/ ') . DIRECTORY_SEPARATOR;
         $this->config   = $config;
-        $this->request  = $request;
-        $this->response = $response;
 
         // workaround for upgraded users
         // This causes "Deprecated: Creation of dynamic property" in PHP 8.2.
@@ -118,6 +119,9 @@ class Exceptions
         $this->exceptionCaughtByExceptionHandler = $exception;
 
         [$statusCode, $exitCode] = $this->determineCodes($exception);
+
+        $this->request  = Services::request();
+        $this->response = Services::response();
 
         if ($this->config->log === true && ! in_array($statusCode, $this->config->ignoreCodes, true)) {
             log_message('critical', "{message}\nin {exFile} on line {exLine}.\n{trace}", [

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -39,7 +39,6 @@ final class FormHelperTest extends CIUnitTestCase
         Services::injectMock('uri', $uri);
 
         $config            = new App();
-        $config->baseURL   = '';
         $config->indexPage = 'index.php';
 
         $request = Services::request($config);


### PR DESCRIPTION
**Description**
This PR is required for #7239.

When registering Exception Handler, `Request` object was generated. 
But it was too early, and difficult to understand.

Before:
```
Services.php:535, CodeIgniter\Config\Services::incomingrequest()
Services.php:501, CodeIgniter\Config\Services::request()
BaseService.php:252, CodeIgniter\Config\BaseService::__callStatic()
BaseService.php:193, CodeIgniter\Config\BaseService::request()
BaseService.php:193, CodeIgniter\Config\BaseService::getSharedInstance()
Services.php:497, CodeIgniter\Config\Services::request()
BaseService.php:252, CodeIgniter\Config\BaseService::__callStatic()
Services.php:265, CodeIgniter\Config\BaseService::request()
Services.php:265, CodeIgniter\Config\Services::exceptions()
BaseService.php:252, CodeIgniter\Config\BaseService::__callStatic()
BaseService.php:193, CodeIgniter\Config\BaseService::exceptions()
BaseService.php:193, CodeIgniter\Config\BaseService::getSharedInstance()
Services.php:261, CodeIgniter\Config\Services::exceptions()
BaseService.php:252, CodeIgniter\Config\BaseService::__callStatic()
CodeIgniter.php:186, CodeIgniter\Config\BaseService::exceptions()
CodeIgniter.php:186, CodeIgniter\CodeIgniter->initialize()
index.php:55, require_once()
rewrite.php:47, {main}()
```

After:
```
Services.php:539, CodeIgniter\Config\Services::incomingrequest()
BaseService.php:252, CodeIgniter\Config\BaseService::__callStatic()
Services.php:520, CodeIgniter\Config\BaseService::incomingrequest()
Services.php:520, CodeIgniter\Config\Services::createRequest()
BaseService.php:252, CodeIgniter\Config\BaseService::__callStatic()
CodeIgniter.php:646, CodeIgniter\Config\BaseService::createRequest()
CodeIgniter.php:646, CodeIgniter\CodeIgniter->getRequestObject()
CodeIgniter.php:331, CodeIgniter\CodeIgniter->run()
index.php:67, require_once()
rewrite.php:47, {main}()
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
