### PR TITLE
docs: add note for URI Segments

### DIFF
--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -206,9 +206,9 @@ URI Segments
 
 Each section of the path between the slashes is a single segment.
 
-.. note:: URI Segments mean only the URI path part relative to the baseURL. If
-    your baseURL contains sub folders, the values will be different from the
-    current URI path.
+.. note:: In the case of your site URI, URI Segments mean only the URI path part
+    relative to the baseURL. If your baseURL contains sub folders, the values
+    will be different from the current URI path.
 
 The URI class provides a simple way to determine
 what the values of the segments are. The segments start at 1 being the furthest left of the path.

--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -204,7 +204,13 @@ to an on-page anchor. Media URI's can make use of them in various other ways.
 URI Segments
 ============
 
-Each section of the path between the slashes is a single segment. The URI class provides a simple way to determine
+Each section of the path between the slashes is a single segment.
+
+.. note:: URI Segments mean only the URI path part relative to the baseURL. If
+    your baseURL contains sub folders, the values will be different from the
+    current URI path.
+
+The URI class provides a simple way to determine
 what the values of the segments are. The segments start at 1 being the furthest left of the path.
 
 .. literalinclude:: uri/023.php


### PR DESCRIPTION
**Description**
- add note for URI Segments

baseURL: http://localhost:8888/ci431/public/

```php
<?php

namespace App\Controllers;

class Home extends BaseController
{
    public function index()
    {
        var_dump($this->request->getUri()->getSegments());
        var_dump($this->request->getUri()->getSegment(1));
    }
}
```

Navigate to http://localhost:8888/ci431/public/one/two/three

```
/Applications/MAMP/htdocs/ci431/app/Controllers/Home.php:9:
array (size=3)
  0 => string 'one' (length=3)
  1 => string 'two' (length=3)
  2 => string 'three' (length=5)

/Applications/MAMP/htdocs/ci431/app/Controllers/Home.php:10:string 'one' (length=3)
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
