### PR TITLE
feat: add URIFactory

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -28,6 +28,7 @@ use Rector\CodingStyle\Rector\ClassMethod\FuncGetArgsToVariadicParamRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveEmptyMethodCallRector;
@@ -87,6 +88,11 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker
             __DIR__ . '/tests/system/Test/ReflectionHelperTest.php',
+        ],
+
+        RemoveUnusedConstructorParamRector::class => [
+            // there are deprecated parameters
+            __DIR__ . '/system/Debug/Exceptions.php',
         ],
 
         // call on purpose for nothing happen check

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -250,6 +250,8 @@ class Services extends BaseService
      *  - register_shutdown_function
      *
      * @return Exceptions
+     *
+     * @deprecated The parameter $request and $response are deprecated.
      */
     public static function exceptions(
         ?ExceptionsConfig $config = null,
@@ -262,7 +264,9 @@ class Services extends BaseService
         }
 
         $config ??= config('Exceptions');
-        $request ??= AppServices::request();
+        /** @var ExceptionsConfig $config */
+
+        // @TODO remove instantiation of Response in the future.
         $response ??= AppServices::response();
 
         return new Exceptions($config, $request, $response);

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -21,6 +21,7 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Paths;
+use Config\Services;
 use ErrorException;
 use Psr\Log\LogLevel;
 use Throwable;
@@ -71,15 +72,15 @@ class Exceptions
     private ?Throwable $exceptionCaughtByExceptionHandler = null;
 
     /**
-     * @param CLIRequest|IncomingRequest $request
+     * @param CLIRequest|IncomingRequest|null $request
+     *
+     * @deprecated The parameter $request and $response are deprecated. No longer used.
      */
-    public function __construct(ExceptionsConfig $config, $request, ResponseInterface $response)
+    public function __construct(ExceptionsConfig $config, $request, ResponseInterface $response) /** @phpstan-ignore-line */
     {
         $this->ob_level = ob_get_level();
         $this->viewPath = rtrim($config->errorViewPath, '\\/ ') . DIRECTORY_SEPARATOR;
         $this->config   = $config;
-        $this->request  = $request;
-        $this->response = $response;
 
         // workaround for upgraded users
         // This causes "Deprecated: Creation of dynamic property" in PHP 8.2.
@@ -118,6 +119,9 @@ class Exceptions
         $this->exceptionCaughtByExceptionHandler = $exception;
 
         [$statusCode, $exitCode] = $this->determineCodes($exception);
+
+        $this->request  = Services::request();
+        $this->response = Services::response();
 
         if ($this->config->log === true && ! in_array($statusCode, $this->config->ignoreCodes, true)) {
             log_message('critical', "{message}\nin {exFile} on line {exLine}.\n{trace}", [

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -235,6 +235,8 @@ class IncomingRequest extends Request
     /**
      * Detects the relative path based on
      * the URIProtocol Config setting.
+     *
+     * @deprecated Moved to URIFactory.
      */
     public function detectPath(string $protocol = ''): string
     {
@@ -265,6 +267,8 @@ class IncomingRequest extends Request
      * fixing the query string if necessary.
      *
      * @return string The URI it found.
+     *
+     * @deprecated Moved to URIFactory.
      */
     protected function parseRequestURI(): string
     {
@@ -323,6 +327,8 @@ class IncomingRequest extends Request
      * Parse QUERY_STRING
      *
      * Will parse QUERY_STRING and automatically detect the URI from it.
+     *
+     * @deprecated Moved to URIFactory.
      */
     protected function parseQueryString(): string
     {
@@ -495,6 +501,9 @@ class IncomingRequest extends Request
         return $this;
     }
 
+    /**
+     * @deprecated Moved to URIFactory.
+     */
     private function determineHost(App $config, string $baseURL): string
     {
         $host = parse_url($baseURL, PHP_URL_HOST);

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -43,6 +43,7 @@ class URI
 
     /**
      * List of URI segments.
+     * URI Segments mean only the URI path part relative to the baseURL.
      *
      * Starts at 1 instead of 0
      *

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -492,6 +492,20 @@ class URI
     }
 
     /**
+     * Returns the URI path relative to baseURL.
+     *
+     * @return string The Route path.
+     */
+    public function getRoutePath(): string
+    {
+        if ($this->routePath === null) {
+            throw new BadMethodCallException('The $routePath is not set.');
+        }
+
+        return $this->routePath;
+    }
+
+    /**
      * Retrieve the query string
      */
     public function getQuery(array $options = []): string

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -98,6 +98,16 @@ class URI
     protected $path;
 
     /**
+     * URI path relative to baseURL.
+     *
+     * If the baseURL contains sub folders, this value will be different from
+     * the current URI path.
+     *
+     * @var string
+     */
+    protected $routePath;
+
+    /**
      * The name of any fragment.
      *
      * @var string
@@ -751,6 +761,22 @@ class URI
         $this->path = $this->filterPath($path);
 
         $tempPath = trim($this->path, '/');
+
+        $this->segments = ($tempPath === '') ? [] : explode('/', $tempPath);
+
+        return $this;
+    }
+
+    /**
+     * Sets the route path.
+     *
+     * @return $this
+     */
+    public function setRoutePath(string $path)
+    {
+        $this->routePath = $this->filterPath($path);
+
+        $tempPath = trim($this->routePath, '/');
 
         $this->segments = ($tempPath === '') ? [] : explode('/', $tempPath);
 

--- a/system/HTTP/URIFactory.php
+++ b/system/HTTP/URIFactory.php
@@ -51,61 +51,68 @@ class URIFactory
     }
 
     /**
-     * Detects the relative path based on
-     * the URIProtocol Config setting.
+     * Detects the current URI path relative to baseURL based on the URIProtocol
+     * Config setting.
+     *
+     * @param string $protocol URIProtocol
+     *
+     * @return string The route path
      */
-    public function detectPath(string $protocol = ''): string
+    public function detectRoutePath(string $protocol = ''): string
     {
-        if (empty($protocol)) {
-            $protocol = 'REQUEST_URI';
+        if ($protocol === '') {
+            $protocol = $this->appConfig->uriProtocol;
         }
 
         switch ($protocol) {
             case 'REQUEST_URI':
-                $this->path = $this->parseRequestURI();
+                $routePath = $this->parseRequestURI();
                 break;
 
             case 'QUERY_STRING':
-                $this->path = $this->parseQueryString();
+                $routePath = $this->parseQueryString();
                 break;
 
             case 'PATH_INFO':
             default:
-                $this->path = $this->fetchGlobal('server', $protocol) ?? $this->parseRequestURI();
+                $routePath = $this->server[$protocol] ?? $this->parseRequestURI();
                 break;
         }
 
-        return $this->path;
+        return $routePath;
     }
 
     /**
      * Will parse the REQUEST_URI and automatically detect the URI from it,
      * fixing the query string if necessary.
      *
-     * @return string The URI it found.
+     * This method updates superglobal $_SERVER and $_GET.
+     *
+     * @return string The route path.
      */
-    protected function parseRequestURI(): string
+    private function parseRequestURI(): string
     {
-        if (! isset($_SERVER['REQUEST_URI'], $_SERVER['SCRIPT_NAME'])) {
+        if (! isset($this->server['REQUEST_URI'], $this->server['SCRIPT_NAME'])) {
             return '';
         }
 
-        // parse_url() returns false if no host is present, but the path or query string
-        // contains a colon followed by a number. So we attach a dummy host since
-        // REQUEST_URI does not include the host. This allows us to parse out the query string and path.
-        $parts = parse_url('http://dummy' . $_SERVER['REQUEST_URI']);
+        // parse_url() returns false if no host is present, but the path or query
+        // string contains a colon followed by a number. So we attach a dummy
+        // host since REQUEST_URI does not include the host. This allows us to
+        // parse out the query string and path.
+        $parts = parse_url('http://dummy' . $this->server['REQUEST_URI']);
         $query = $parts['query'] ?? '';
         $uri   = $parts['path'] ?? '';
 
         // Strip the SCRIPT_NAME path from the URI
         if (
-            $uri !== '' && isset($_SERVER['SCRIPT_NAME'][0])
-            && pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php'
+            $uri !== '' && isset($this->server['SCRIPT_NAME'][0])
+            && pathinfo($this->server['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php'
         ) {
             // Compare each segment, dropping them until there is no match
             $segments = $keep = explode('/', $uri);
 
-            foreach (explode('/', $_SERVER['SCRIPT_NAME']) as $i => $segment) {
+            foreach (explode('/', $this->server['SCRIPT_NAME']) as $i => $segment) {
                 // If these segments are not the same then we're done
                 if (! isset($segments[$i]) || $segment !== $segments[$i]) {
                     break;
@@ -117,20 +124,19 @@ class URIFactory
             $uri = implode('/', $keep);
         }
 
-        // This section ensures that even on servers that require the URI to contain the query string (Nginx) a correct
-        // URI is found, and also fixes the QUERY_STRING Server var and $_GET array.
+        // This section ensures that even on servers that require the URI to
+        // contain the query string (Nginx) a correct URI is found, and also
+        // fixes the QUERY_STRING Server var and $_GET array.
         if (trim($uri, '/') === '' && strncmp($query, '/', 1) === 0) {
-            $query                   = explode('?', $query, 2);
-            $uri                     = $query[0];
-            $_SERVER['QUERY_STRING'] = $query[1] ?? '';
+            $query                        = explode('?', $query, 2);
+            $uri                          = $query[0];
+            $this->server['QUERY_STRING'] = $query[1] ?? '';
         } else {
-            $_SERVER['QUERY_STRING'] = $query;
+            $this->server['QUERY_STRING'] = $query;
         }
 
-        // Update our globals for values likely to been have changed
-        parse_str($_SERVER['QUERY_STRING'], $_GET);
-        $this->populateGlobals('server');
-        $this->populateGlobals('get');
+        // Update our globals for values likely to have been changed
+        parse_str($this->server['QUERY_STRING'], $this->get);
 
         $uri = URI::removeDotSegments($uri);
 
@@ -138,28 +144,28 @@ class URIFactory
     }
 
     /**
-     * Parse QUERY_STRING
-     *
      * Will parse QUERY_STRING and automatically detect the URI from it.
+     *
+     * This method updates superglobal $_SERVER and $_GET.
+     *
+     * @return string The route path.
      */
-    protected function parseQueryString(): string
+    private function parseQueryString(): string
     {
-        $uri = $_SERVER['QUERY_STRING'] ?? @getenv('QUERY_STRING');
+        $uri = $this->server['QUERY_STRING'] ?? @getenv('QUERY_STRING');
 
         if (trim($uri, '/') === '') {
             return '/';
         }
 
         if (strncmp($uri, '/', 1) === 0) {
-            $uri                     = explode('?', $uri, 2);
-            $_SERVER['QUERY_STRING'] = $uri[1] ?? '';
-            $uri                     = $uri[0];
+            $uri                          = explode('?', $uri, 2);
+            $this->server['QUERY_STRING'] = $uri[1] ?? '';
+            $uri                          = $uri[0];
         }
 
-        // Update our globals for values likely to been have changed
-        parse_str($_SERVER['QUERY_STRING'], $_GET);
-        $this->populateGlobals('server');
-        $this->populateGlobals('get');
+        // Update our globals for values likely to have been changed
+        parse_str($this->server['QUERY_STRING'], $this->get);
 
         $uri = URI::removeDotSegments($uri);
 
@@ -167,53 +173,49 @@ class URIFactory
     }
 
     /**
-     * Sets the relative path and updates the URI object.
+     * Create current URI object.
      *
-     * Note: Since current_url() accesses the shared request
-     * instance, this can be used to change the "current URL"
-     * for testing.
-     *
-     * @param string   $path   URI path relative to baseURL
-     * @param App|null $config Optional alternate config to use
-     *
-     * @return $this
+     * @param string $routePath URI path relative to baseURL
      */
-    public function setPath(string $path, ?App $config = null)
+    private function createURIFromRoutePath(string $routePath): URI
     {
-        $this->path = $path;
-
-        // @TODO remove this. The path of the URI object should be a full URI path,
-        //      not a URI path relative to baseURL.
-        $this->uri->setPath($path);
-
-        $config ??= $this->config;
+        $config = $this->appConfig;
 
         // It's possible the user forgot a trailing slash on their
         // baseURL, so let's help them out.
-        $baseURL = ($config->baseURL === '') ? $config->baseURL : rtrim($config->baseURL, '/ ') . '/';
+        $baseURL = ($config->baseURL === '')
+            ? $config->baseURL
+            : rtrim($config->baseURL, '/ ') . '/';
 
         // Based on our baseURL and allowedHostnames provided by the developer
         // and HTTP_HOST, set our current domain name, scheme.
         if ($baseURL !== '') {
-            $host = $this->determineHost($config, $baseURL);
+            $host = $this->determineHost($baseURL);
 
             // Set URI::$baseURL
             $uri            = new URI($baseURL);
             $currentBaseURL = (string) $uri->setHost($host);
-            $this->uri->setBaseURL($currentBaseURL);
+            $uri->setBaseURL($currentBaseURL);
 
-            $this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
-            $this->uri->setHost($host);
-            $this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
+            $uri->setPath($routePath);
+
+            $uri->setRoutePath($routePath);
+
+            $uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
+            $uri->setHost($host);
+            $uri->setPort(parse_url($baseURL, PHP_URL_PORT));
 
             // Ensure we have any query vars
-            $this->uri->setQuery($_SERVER['QUERY_STRING'] ?? '');
+            $uri->setQuery($this->server['QUERY_STRING'] ?? '');
 
             // Check if the scheme needs to be coerced into its secure version
-            if ($config->forceGlobalSecureRequests && $this->uri->getScheme() === 'http') {
-                $this->uri->setScheme('https');
+            if ($config->forceGlobalSecureRequests && $uri->getScheme() === 'http') {
+                $uri->setScheme('https');
             }
-        } elseif (! is_cli()) {
+
+            return $uri;
+        }
+        if (! is_cli()) {
             // Do not change exit() to exception; Request is initialized before
             // setting the exception handler, so if an exception is raised, an
             // error will be displayed even if in the production environment.
@@ -222,23 +224,26 @@ class URIFactory
             // @codeCoverageIgnoreEnd
         }
 
-        return $this;
+        return new URI();
     }
 
-    private function determineHost(App $config, string $baseURL): string
+    /**
+     * @return string The current hostname.
+     */
+    private function determineHost(string $baseURL): string
     {
         $host = parse_url($baseURL, PHP_URL_HOST);
 
-        if (empty($config->allowedHostnames)) {
+        if (empty($this->appConfig->allowedHostnames)) {
             return $host;
         }
 
         // Update host if it is valid.
-        $httpHostPort = $this->getServer('HTTP_HOST');
+        $httpHostPort = $this->server['HTTP_HOST'] ?? null;
         if ($httpHostPort !== null) {
             [$httpHost] = explode(':', $httpHostPort, 2);
 
-            if (in_array($httpHost, $config->allowedHostnames, true)) {
+            if (in_array($httpHost, $this->appConfig->allowedHostnames, true)) {
                 $host = $httpHost;
             }
         }

--- a/system/HTTP/URIFactory.php
+++ b/system/HTTP/URIFactory.php
@@ -58,6 +58,8 @@ class URIFactory
      * @param string $protocol URIProtocol
      *
      * @return string The route path
+     *
+     * @internal Used for testing purposes only.
      */
     public function detectRoutePath(string $protocol = ''): string
     {

--- a/system/HTTP/URIFactory.php
+++ b/system/HTTP/URIFactory.php
@@ -40,11 +40,11 @@ class URIFactory
     }
 
     /**
-     * Create the current URI object.
+     * Create the current URI object from superglobals.
      *
      * This method updates superglobal $_SERVER and $_GET.
      */
-    public function createCurrentURI(): URI
+    public function createFromGlobals(): URI
     {
         $routePath = $this->detectRoutePath();
 

--- a/system/HTTP/URIFactory.php
+++ b/system/HTTP/URIFactory.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use Config\App;
+
+class URIFactory
+{
+    /**
+     * @var array Superglobal SERVER array
+     */
+    private array $server;
+
+    /**
+     * @var array Superglobal GET array
+     */
+    private array $get;
+
+    private App $appConfig;
+
+    /**
+     * @param array $server Superglobal $_SERVER array
+     * @param array $get    Superglobal $_GET array
+     */
+    public function __construct(array &$server, array &$get, App $appConfig)
+    {
+        $this->server    = &$server;
+        $this->get       = &$get;
+        $this->appConfig = $appConfig;
+    }
+
+    /**
+     * Create the current URI object.
+     *
+     * This method updates superglobal $_SERVER and $_GET.
+     */
+    public function createCurrentURI(): URI
+    {
+        $routePath = $this->detectRoutePath();
+
+        return $this->createURIFromRoutePath($routePath);
+    }
+
+    /**
+     * Detects the relative path based on
+     * the URIProtocol Config setting.
+     */
+    public function detectPath(string $protocol = ''): string
+    {
+        if (empty($protocol)) {
+            $protocol = 'REQUEST_URI';
+        }
+
+        switch ($protocol) {
+            case 'REQUEST_URI':
+                $this->path = $this->parseRequestURI();
+                break;
+
+            case 'QUERY_STRING':
+                $this->path = $this->parseQueryString();
+                break;
+
+            case 'PATH_INFO':
+            default:
+                $this->path = $this->fetchGlobal('server', $protocol) ?? $this->parseRequestURI();
+                break;
+        }
+
+        return $this->path;
+    }
+
+    /**
+     * Will parse the REQUEST_URI and automatically detect the URI from it,
+     * fixing the query string if necessary.
+     *
+     * @return string The URI it found.
+     */
+    protected function parseRequestURI(): string
+    {
+        if (! isset($_SERVER['REQUEST_URI'], $_SERVER['SCRIPT_NAME'])) {
+            return '';
+        }
+
+        // parse_url() returns false if no host is present, but the path or query string
+        // contains a colon followed by a number. So we attach a dummy host since
+        // REQUEST_URI does not include the host. This allows us to parse out the query string and path.
+        $parts = parse_url('http://dummy' . $_SERVER['REQUEST_URI']);
+        $query = $parts['query'] ?? '';
+        $uri   = $parts['path'] ?? '';
+
+        // Strip the SCRIPT_NAME path from the URI
+        if (
+            $uri !== '' && isset($_SERVER['SCRIPT_NAME'][0])
+            && pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php'
+        ) {
+            // Compare each segment, dropping them until there is no match
+            $segments = $keep = explode('/', $uri);
+
+            foreach (explode('/', $_SERVER['SCRIPT_NAME']) as $i => $segment) {
+                // If these segments are not the same then we're done
+                if (! isset($segments[$i]) || $segment !== $segments[$i]) {
+                    break;
+                }
+
+                array_shift($keep);
+            }
+
+            $uri = implode('/', $keep);
+        }
+
+        // This section ensures that even on servers that require the URI to contain the query string (Nginx) a correct
+        // URI is found, and also fixes the QUERY_STRING Server var and $_GET array.
+        if (trim($uri, '/') === '' && strncmp($query, '/', 1) === 0) {
+            $query                   = explode('?', $query, 2);
+            $uri                     = $query[0];
+            $_SERVER['QUERY_STRING'] = $query[1] ?? '';
+        } else {
+            $_SERVER['QUERY_STRING'] = $query;
+        }
+
+        // Update our globals for values likely to been have changed
+        parse_str($_SERVER['QUERY_STRING'], $_GET);
+        $this->populateGlobals('server');
+        $this->populateGlobals('get');
+
+        $uri = URI::removeDotSegments($uri);
+
+        return ($uri === '/' || $uri === '') ? '/' : ltrim($uri, '/');
+    }
+
+    /**
+     * Parse QUERY_STRING
+     *
+     * Will parse QUERY_STRING and automatically detect the URI from it.
+     */
+    protected function parseQueryString(): string
+    {
+        $uri = $_SERVER['QUERY_STRING'] ?? @getenv('QUERY_STRING');
+
+        if (trim($uri, '/') === '') {
+            return '/';
+        }
+
+        if (strncmp($uri, '/', 1) === 0) {
+            $uri                     = explode('?', $uri, 2);
+            $_SERVER['QUERY_STRING'] = $uri[1] ?? '';
+            $uri                     = $uri[0];
+        }
+
+        // Update our globals for values likely to been have changed
+        parse_str($_SERVER['QUERY_STRING'], $_GET);
+        $this->populateGlobals('server');
+        $this->populateGlobals('get');
+
+        $uri = URI::removeDotSegments($uri);
+
+        return ($uri === '/' || $uri === '') ? '/' : ltrim($uri, '/');
+    }
+
+    /**
+     * Sets the relative path and updates the URI object.
+     *
+     * Note: Since current_url() accesses the shared request
+     * instance, this can be used to change the "current URL"
+     * for testing.
+     *
+     * @param string   $path   URI path relative to baseURL
+     * @param App|null $config Optional alternate config to use
+     *
+     * @return $this
+     */
+    public function setPath(string $path, ?App $config = null)
+    {
+        $this->path = $path;
+
+        // @TODO remove this. The path of the URI object should be a full URI path,
+        //      not a URI path relative to baseURL.
+        $this->uri->setPath($path);
+
+        $config ??= $this->config;
+
+        // It's possible the user forgot a trailing slash on their
+        // baseURL, so let's help them out.
+        $baseURL = ($config->baseURL === '') ? $config->baseURL : rtrim($config->baseURL, '/ ') . '/';
+
+        // Based on our baseURL and allowedHostnames provided by the developer
+        // and HTTP_HOST, set our current domain name, scheme.
+        if ($baseURL !== '') {
+            $host = $this->determineHost($config, $baseURL);
+
+            // Set URI::$baseURL
+            $uri            = new URI($baseURL);
+            $currentBaseURL = (string) $uri->setHost($host);
+            $this->uri->setBaseURL($currentBaseURL);
+
+            $this->uri->setScheme(parse_url($baseURL, PHP_URL_SCHEME));
+            $this->uri->setHost($host);
+            $this->uri->setPort(parse_url($baseURL, PHP_URL_PORT));
+
+            // Ensure we have any query vars
+            $this->uri->setQuery($_SERVER['QUERY_STRING'] ?? '');
+
+            // Check if the scheme needs to be coerced into its secure version
+            if ($config->forceGlobalSecureRequests && $this->uri->getScheme() === 'http') {
+                $this->uri->setScheme('https');
+            }
+        } elseif (! is_cli()) {
+            // Do not change exit() to exception; Request is initialized before
+            // setting the exception handler, so if an exception is raised, an
+            // error will be displayed even if in the production environment.
+            // @codeCoverageIgnoreStart
+            exit('You have an empty or invalid baseURL. The baseURL value must be set in app/Config/App.php, or through the .env file.');
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $this;
+    }
+
+    private function determineHost(App $config, string $baseURL): string
+    {
+        $host = parse_url($baseURL, PHP_URL_HOST);
+
+        if (empty($config->allowedHostnames)) {
+            return $host;
+        }
+
+        // Update host if it is valid.
+        $httpHostPort = $this->getServer('HTTP_HOST');
+        if ($httpHostPort !== null) {
+            [$httpHost] = explode(':', $httpHostPort, 2);
+
+            if (in_array($httpHost, $config->allowedHostnames, true)) {
+                $host = $httpHost;
+            }
+        }
+
+        return $host;
+    }
+}

--- a/system/HTTP/URIFactory.php
+++ b/system/HTTP/URIFactory.php
@@ -129,8 +129,9 @@ class URIFactory
         // contain the query string (Nginx) a correct URI is found, and also
         // fixes the QUERY_STRING Server var and $_GET array.
         if (trim($uri, '/') === '' && strncmp($query, '/', 1) === 0) {
-            $query                        = explode('?', $query, 2);
-            $uri                          = $query[0];
+            $query = explode('?', $query, 2);
+            $uri   = $query[0];
+
             $this->server['QUERY_STRING'] = $query[1] ?? '';
         } else {
             $this->server['QUERY_STRING'] = $query;
@@ -158,9 +159,10 @@ class URIFactory
         }
 
         if (strncmp($uri, '/', 1) === 0) {
-            $uri                          = explode('?', $uri, 2);
+            $uri = explode('?', $uri, 2);
+            $uri = $uri[0];
+
             $this->server['QUERY_STRING'] = $uri[1] ?? '';
-            $uri                          = $uri[0];
         }
 
         // Update our globals for values likely to have been changed

--- a/system/HTTP/URIFactory.php
+++ b/system/HTTP/URIFactory.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Exceptions\ConfigException;
 use Config\App;
 
 class URIFactory
@@ -212,12 +213,9 @@ class URIFactory
             return $uri;
         }
         if (! is_cli()) {
-            // Do not change exit() to exception; Request is initialized before
-            // setting the exception handler, so if an exception is raised, an
-            // error will be displayed even if in the production environment.
-            // @codeCoverageIgnoreStart
-            exit('You have an empty or invalid baseURL. The baseURL value must be set in app/Config/App.php, or through the .env file.');
-            // @codeCoverageIgnoreEnd
+            throw new ConfigException(
+                'You have an empty or invalid baseURL. The baseURL value must be set in app/Config/App.php, or through the .env file.'
+            );
         }
 
         return new URI();

--- a/system/HTTP/URIFactory.php
+++ b/system/HTTP/URIFactory.php
@@ -79,7 +79,7 @@ class URIFactory
                 break;
         }
 
-        return $routePath;
+        return ($routePath === '/' || $routePath === '') ? '/' : ltrim($routePath, '/');
     }
 
     /**
@@ -88,7 +88,7 @@ class URIFactory
      *
      * This method updates superglobal $_SERVER and $_GET.
      *
-     * @return string The route path.
+     * @return string The route path (before normalization).
      */
     private function parseRequestURI(): string
     {
@@ -138,9 +138,7 @@ class URIFactory
         // Update our globals for values likely to have been changed
         parse_str($this->server['QUERY_STRING'], $this->get);
 
-        $uri = URI::removeDotSegments($uri);
-
-        return ($uri === '/' || $uri === '') ? '/' : ltrim($uri, '/');
+        return URI::removeDotSegments($uri);
     }
 
     /**
@@ -148,7 +146,7 @@ class URIFactory
      *
      * This method updates superglobal $_SERVER and $_GET.
      *
-     * @return string The route path.
+     * @return string The route path (before normalization).
      */
     private function parseQueryString(): string
     {
@@ -167,9 +165,7 @@ class URIFactory
         // Update our globals for values likely to have been changed
         parse_str($this->server['QUERY_STRING'], $this->get);
 
-        $uri = URI::removeDotSegments($uri);
-
-        return ($uri === '/' || $uri === '') ? '/' : ltrim($uri, '/');
+        return URI::removeDotSegments($uri);
     }
 
     /**

--- a/tests/system/HTTP/URIFactoryDetectRoutePathTest.php
+++ b/tests/system/HTTP/URIFactoryDetectRoutePathTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
+
+/**
+ * @backupGlobals enabled
+ *
+ * @internal
+ *
+ * @group Others
+ */
+final class URIFactoryDetectRoutePathTest extends CIUnitTestCase
+{
+    private function createURIFactory(array &$server, array &$get, ?App $appConfig = null): URIFactory
+    {
+        $appConfig ??= new App();
+
+        return new URIFactory($server, $get, $appConfig);
+    }
+
+    public function testDefault()
+    {
+        $_GET = $_SERVER = [];
+
+        // /index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath());
+    }
+
+    public function testDefaultEmpty()
+    {
+        $_GET = $_SERVER = [];
+
+        // /
+        $_SERVER['REQUEST_URI'] = '/';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = '/';
+        $this->assertSame($expected, $factory->detectRoutePath());
+    }
+
+    public function testRequestURI()
+    {
+        $_GET = $_SERVER = [];
+
+        // /index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINested()
+    {
+        $_GET = $_SERVER = [];
+
+        // I'm not sure but this is a case of Apache config making such SERVER
+        // values?
+        // The current implementation doesn't use the value of the URI object.
+        // So I removed the code to set URI. Therefore, it's exactly the same as
+        // the method above as a test.
+        // But it may be changed in the future to use the value of the URI object.
+        // So I don't remove this test case.
+
+        // /ci/index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURISubfolder()
+    {
+        $_GET = $_SERVER = [];
+
+        // /ci/index.php/popcorn/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/ci/index.php/popcorn/woot';
+        $_SERVER['SCRIPT_NAME'] = '/ci/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'popcorn/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINoIndex()
+    {
+        $_GET = $_SERVER = [];
+
+        // /sub/example
+        $_SERVER['REQUEST_URI'] = '/sub/example';
+        $_SERVER['SCRIPT_NAME'] = '/sub/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'example';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINginx()
+    {
+        $_GET = $_SERVER = [];
+
+        // /ci/index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot?code=good';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINginxRedirecting()
+    {
+        $_GET = $_SERVER = [];
+
+        // /?/ci/index.php/woot
+        $_SERVER['REQUEST_URI'] = '/?/ci/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'ci/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURISuppressed()
+    {
+        $_GET = $_SERVER = [];
+
+        // /woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/woot';
+        $_SERVER['SCRIPT_NAME'] = '/';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testQueryString()
+    {
+        $_GET = $_SERVER = [];
+
+        // /index.php?/ci/woot
+        $_SERVER['REQUEST_URI']  = '/index.php?/ci/woot';
+        $_SERVER['QUERY_STRING'] = '/ci/woot';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+
+        $_GET['/ci/woot'] = '';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'ci/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('QUERY_STRING'));
+    }
+
+    public function testQueryStringWithQueryString()
+    {
+        $_GET = $_SERVER = [];
+
+        // /index.php?/ci/woot?code=good#pos
+        $_SERVER['REQUEST_URI']  = '/index.php?/ci/woot?code=good';
+        $_SERVER['QUERY_STRING'] = '/ci/woot?code=good';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+
+        $_GET['/ci/woot?code'] = 'good';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'ci/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('QUERY_STRING'));
+        $this->assertSame('code=good', $_SERVER['QUERY_STRING']);
+        $this->assertSame(['code' => 'good'], $_GET);
+    }
+
+    public function testQueryStringEmpty()
+    {
+        $_GET = $_SERVER = [];
+
+        // /index.php?
+        $_SERVER['REQUEST_URI'] = '/index.php?';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = '/';
+        $this->assertSame($expected, $factory->detectRoutePath('QUERY_STRING'));
+    }
+
+    public function testPathInfoUnset()
+    {
+        $_GET = $_SERVER = [];
+
+        // /index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('PATH_INFO'));
+    }
+
+    public function testPathInfoSubfolder()
+    {
+        $_GET = $_SERVER = [];
+
+        $appConfig          = new App();
+        $appConfig->baseURL = 'http://localhost:8888/ci431/public/';
+
+        // http://localhost:8888/ci431/public/index.php/woot?code=good#pos
+        $_SERVER['PATH_INFO']   = '/woot';
+        $_SERVER['REQUEST_URI'] = '/ci431/public/index.php/woot?code=good';
+        $_SERVER['SCRIPT_NAME'] = '/ci431/public/index.php';
+
+        $factory = $this->createURIFactory($_SERVER, $_GET, $appConfig);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('PATH_INFO'));
+    }
+}

--- a/tests/system/HTTP/URIFactoryTest.php
+++ b/tests/system/HTTP/URIFactoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Config\Factories;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
+
+/**
+ * @backupGlobals enabled
+ *
+ * @internal
+ *
+ * @group Others
+ */
+final class URIFactoryTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_GET = $_SERVER = [];
+    }
+
+    protected function tearDown(): void
+    {
+        Factories::reset('config');
+    }
+
+    public function testCreateCurrentURI()
+    {
+        // http://localhost:8080/index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI']  = '/index.php/woot?code=good';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+        $_SERVER['QUERY_STRING'] = 'code=good';
+        $_SERVER['HTTP_HOST']    = 'localhost:8080';
+        $_SERVER['PATH_INFO']    = '/woot';
+
+        $_GET['code'] = 'good';
+
+        $factory = new URIFactory($_SERVER, $_GET, new App());
+
+        $uri = $factory->createCurrentURI();
+
+        $this->assertInstanceOf(URI::class, $uri);
+        $this->assertSame('http://localhost:8080/woot?code=good', (string) $uri);
+        $this->assertSame('woot', $uri->getPath());
+        $this->assertSame('woot', $uri->getRoutePath());
+    }
+}

--- a/tests/system/HTTP/URIFactoryTest.php
+++ b/tests/system/HTTP/URIFactoryTest.php
@@ -49,7 +49,7 @@ final class URIFactoryTest extends CIUnitTestCase
 
         $factory = new URIFactory($_SERVER, $_GET, new App());
 
-        $uri = $factory->createCurrentURI();
+        $uri = $factory->createFromGlobals();
 
         $this->assertInstanceOf(URI::class, $uri);
         $this->assertSame('http://localhost:8080/woot?code=good', (string) $uri);

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -39,7 +39,6 @@ final class FormHelperTest extends CIUnitTestCase
         Services::injectMock('uri', $uri);
 
         $config            = new App();
-        $config->baseURL   = '';
         $config->indexPage = 'index.php';
 
         $request = Services::request($config);


### PR DESCRIPTION
Needs #7232

**Description**
Add `URIFactory` to create the current URI object.

To create the current URI object before the Request object. Also, to remove all URI adjustment processing currently performed in the constructor of the Request object.

This PR does not change any existing features yet.

- add `URIFactory::createFromGlobals()`
- add `URI::setRoutePath()` and `URI::getRoutePath()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
