### PR TITLE
fix: convert object to array for insert and update when tempdata is empty

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -713,6 +713,8 @@ class Model extends BaseModel
                 $data = $this->transformDataToArray($data, 'insert');
                 $data = array_merge($this->tempData['data'], $data);
             }
+        } else {
+            $data = $this->transformDataToArray($data, 'insert');
         }
 
         if ($this->useAutoIncrement === false) {
@@ -747,8 +749,9 @@ class Model extends BaseModel
                 $data = $this->transformDataToArray($data, 'update');
                 $data = array_merge($this->tempData['data'], $data);
             }
+        } else {
+            $data = $this->transformDataToArray($data, 'update');
         }
-
         $this->escape   = $this->tempData['escape'] ?? [];
         $this->tempData = [];
 


### PR DESCRIPTION
**Description**
Fixes #7238

entity object was not converting to an array when tempdata was empty.  Added the option to convert object to array if the tempdata['data'] was empty in both the insert and update functions in system/Model.php class file

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
