### PR TITLE
fix: URI::getSegment() returns non-existent segment

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -537,17 +537,21 @@ class URI
      * @param string $default Default value
      *
      * @return string The value of the segment. If no segment is found,
-     *                throws InvalidArgumentError
+     *                throws HTTPException
      */
     public function getSegment(int $number, string $default = ''): string
     {
-        // The segment should treat the array as 1-based for the user
-        // but we still have to deal with a zero-based array.
-        $number--;
+        if ($number < 1) {
+            throw HTTPException::forURISegmentOutOfRange($number);
+        }
 
         if ($number > count($this->segments) && ! $this->silent) {
             throw HTTPException::forURISegmentOutOfRange($number);
         }
+
+        // The segment should treat the array as 1-based for the user
+        // but we still have to deal with a zero-based array.
+        $number--;
 
         return $this->segments[$number] ?? $default;
     }

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -62,7 +62,6 @@ final class URITest extends CIUnitTestCase
         $this->assertSame('path', $uri->getSegment(1));
         $this->assertSame('to', $uri->getSegment(2));
         $this->assertSame('script', $uri->getSegment(3));
-        $this->assertSame('', $uri->getSegment(4));
 
         $this->assertSame(3, $uri->getTotalSegments());
     }
@@ -70,22 +69,43 @@ final class URITest extends CIUnitTestCase
     public function testSegmentOutOfRange()
     {
         $this->expectException(HTTPException::class);
+
         $uri = new URI('http://hostname/path/to/script');
-        $uri->getSegment(5);
+        $uri->getSegment(4);
+    }
+
+    public function testSegmentOutOfRangeZero()
+    {
+        $this->expectException(HTTPException::class);
+
+        $uri = new URI('http://hostname/path/to/script');
+        $uri->getSegment(0);
+    }
+
+    public function testSegmentOutOfRangeNegative()
+    {
+        $this->expectException(HTTPException::class);
+
+        $uri = new URI('http://hostname/path/to/script');
+        $uri->getSegment(-1);
     }
 
     public function testSegmentOutOfRangeWithSilent()
     {
         $url = 'http://abc.com/a123/b/c';
         $uri = new URI($url);
+
+        $this->assertSame('', $uri->setSilent()->getSegment(4));
         $this->assertSame('', $uri->setSilent()->getSegment(22));
     }
 
     public function testSegmentOutOfRangeWithDefaultValue()
     {
         $this->expectException(HTTPException::class);
+
         $url = 'http://abc.com/a123/b/c';
         $uri = new URI($url);
+
         $uri->getSegment(22, 'something');
     }
 
@@ -93,6 +113,7 @@ final class URITest extends CIUnitTestCase
     {
         $url = 'http://abc.com/a123/b/c';
         $uri = new URI($url);
+
         $this->assertSame('something', $uri->setSilent()->getSegment(22, 'something'));
     }
 

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -168,6 +168,8 @@ final class PagerTest extends CIUnitTestCase
 
     public function testStoreWithSegments()
     {
+        $this->createPager('/3?page=3&foo=bar');
+
         $_GET['page'] = 3;
         $_GET['foo']  = 'bar';
 

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -20,6 +20,13 @@ BREAKING
 Behavior Changes
 ================
 
+URI::getSegment() and Non-Existent Segment
+------------------------------------------
+
+An exception is now thrown whenever a non-existent segment number is passed.
+In previous versions, an exception was not thrown if the last segment ``+1`` was
+specified.
+
 Interface Changes
 =================
 

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -15,6 +15,18 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Breaking Changes
 ****************
 
+URI::getSegment() Change
+========================
+
+Dut to a bug, in previous versions an exception was not thrown if the last segment
+``+1`` was specified. This bug has been fixed. If the non-existent segment is
+specified, an exception is always thrown.
+
+If your code depends on this bug, add ``->setSilent()`` before the call.
+
+.. literalinclude:: upgrade_440/001.php
+   :lines: 2-
+
 Mandatory File Changes
 **********************
 

--- a/user_guide_src/source/installation/upgrade_440/001.php
+++ b/user_guide_src/source/installation/upgrade_440/001.php
@@ -1,0 +1,5 @@
+<?php
+
+$uri->getSegment(2);
+// ↓
+$uri->setSilent()->getSegment(2);

--- a/user_guide_src/source/libraries/uri/024.php
+++ b/user_guide_src/source/libraries/uri/024.php
@@ -2,13 +2,17 @@
 
 // URI = http://example.com/users/15/profile
 
+echo $uri->getSegment(1, 'foo');
+// will print 'users'
+
+echo $uri->getSegment(3, 'bar');
 // will print 'profile'
-echo $uri->getSegment(3, 'foo');
-// will print 'bar'
-echo $uri->getSegment(4, 'bar');
+
+echo $uri->getSegment(4, 'baz');
 // will throw an exception
-echo $uri->getSegment(5, 'baz');
+
+echo $uri->setSilent()->getSegment(4, 'baz');
 // will print 'baz'
-echo $uri->setSilent()->getSegment(5, 'baz');
+
+echo $uri->setSilent()->getSegment(4);
 // will print '' (empty string)
-echo $uri->setSilent()->getSegment(5);


### PR DESCRIPTION
**Description**
Fixes #7246 (and #2962)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
