### PR TITLE
feat: add SiteURIFactory

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -236,7 +236,7 @@ class IncomingRequest extends Request
      * Detects the relative path based on
      * the URIProtocol Config setting.
      *
-     * @deprecated Moved to SiteURIFactory.
+     * @deprecated 4.4.0 Moved to SiteURIFactory.
      */
     public function detectPath(string $protocol = ''): string
     {
@@ -268,7 +268,7 @@ class IncomingRequest extends Request
      *
      * @return string The URI it found.
      *
-     * @deprecated Moved to SiteURIFactory.
+     * @deprecated 4.4.0 Moved to SiteURIFactory.
      */
     protected function parseRequestURI(): string
     {
@@ -328,7 +328,7 @@ class IncomingRequest extends Request
      *
      * Will parse QUERY_STRING and automatically detect the URI from it.
      *
-     * @deprecated Moved to SiteURIFactory.
+     * @deprecated 4.4.0 Moved to SiteURIFactory.
      */
     protected function parseQueryString(): string
     {
@@ -502,7 +502,7 @@ class IncomingRequest extends Request
     }
 
     /**
-     * @deprecated Moved to SiteURIFactory.
+     * @deprecated 4.4.0 Moved to SiteURIFactory.
      */
     private function determineHost(App $config, string $baseURL): string
     {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -235,6 +235,8 @@ class IncomingRequest extends Request
     /**
      * Detects the relative path based on
      * the URIProtocol Config setting.
+     *
+     * @deprecated Moved to SiteURIFactory.
      */
     public function detectPath(string $protocol = ''): string
     {
@@ -265,6 +267,8 @@ class IncomingRequest extends Request
      * fixing the query string if necessary.
      *
      * @return string The URI it found.
+     *
+     * @deprecated Moved to SiteURIFactory.
      */
     protected function parseRequestURI(): string
     {
@@ -323,6 +327,8 @@ class IncomingRequest extends Request
      * Parse QUERY_STRING
      *
      * Will parse QUERY_STRING and automatically detect the URI from it.
+     *
+     * @deprecated Moved to SiteURIFactory.
      */
     protected function parseQueryString(): string
     {
@@ -495,6 +501,9 @@ class IncomingRequest extends Request
         return $this;
     }
 
+    /**
+     * @deprecated Moved to SiteURIFactory.
+     */
     private function determineHost(App $config, string $baseURL): string
     {
         $host = parse_url($baseURL, PHP_URL_HOST);

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\HTTP\Exceptions\HTTPException;
+use Config\App;
+
+class SiteURIFactory
+{
+    /**
+     * @var array Superglobal SERVER array
+     */
+    private array $server;
+
+    private App $appConfig;
+
+    /**
+     * @param array $server Superglobal $_SERVER array
+     */
+    public function __construct(array $server, App $appConfig)
+    {
+        $this->server    = $server;
+        $this->appConfig = $appConfig;
+    }
+
+    /**
+     * Create the current URI object from superglobals.
+     *
+     * This method updates superglobal $_SERVER and $_GET.
+     */
+    public function createFromGlobals(): SiteURI
+    {
+        $routePath = $this->detectRoutePath();
+
+        return $this->createURIFromRoutePath($routePath);
+    }
+
+    /**
+     * Create the SiteURI object from URI string.
+     *
+     * @internal Used for testing purposes only.
+     */
+    public function createFromString(string $uri): SiteURI
+    {
+        // Validate URI
+        if (filter_var($uri, FILTER_VALIDATE_URL) === false) {
+            throw HTTPException::forUnableToParseURI($uri);
+        }
+
+        $parts = parse_url($uri);
+
+        if ($parts === false) {
+            throw HTTPException::forUnableToParseURI($uri);
+        }
+
+        $query = $fragment = '';
+        if (isset($parts['query'])) {
+            $query = '?' . $parts['query'];
+        }
+        if (isset($parts['fragment'])) {
+            $fragment = '#' . $parts['fragment'];
+        }
+
+        $relativePath = $parts['path'] . $query . $fragment;
+
+        return new SiteURI($this->appConfig, $relativePath, $parts['host'], $parts['scheme']);
+    }
+
+    /**
+     * Detects the current URI path relative to baseURL based on the URIProtocol
+     * Config setting.
+     *
+     * @param string $protocol URIProtocol
+     *
+     * @return string The route path
+     *
+     * @internal Used for testing purposes only.
+     */
+    public function detectRoutePath(string $protocol = ''): string
+    {
+        if ($protocol === '') {
+            $protocol = $this->appConfig->uriProtocol;
+        }
+
+        switch ($protocol) {
+            case 'REQUEST_URI':
+                $routePath = $this->parseRequestURI();
+                break;
+
+            case 'QUERY_STRING':
+                $routePath = $this->parseQueryString();
+                break;
+
+            case 'PATH_INFO':
+            default:
+                $routePath = $this->server[$protocol] ?? $this->parseRequestURI();
+                break;
+        }
+
+        return ($routePath === '/' || $routePath === '') ? '/' : ltrim($routePath, '/');
+    }
+
+    /**
+     * Will parse the REQUEST_URI and automatically detect the URI from it,
+     * fixing the query string if necessary.
+     *
+     * This method updates superglobal $_SERVER and $_GET.
+     *
+     * @return string The route path (before normalization).
+     */
+    private function parseRequestURI(): string
+    {
+        if (! isset($this->server['REQUEST_URI'], $this->server['SCRIPT_NAME'])) {
+            return '';
+        }
+
+        // parse_url() returns false if no host is present, but the path or query
+        // string contains a colon followed by a number. So we attach a dummy
+        // host since REQUEST_URI does not include the host. This allows us to
+        // parse out the query string and path.
+        $parts = parse_url('http://dummy' . $this->server['REQUEST_URI']);
+        $query = $parts['query'] ?? '';
+        $path  = $parts['path'] ?? '';
+
+        // Strip the SCRIPT_NAME path from the URI
+        if (
+            $path !== '' && isset($this->server['SCRIPT_NAME'][0])
+            && pathinfo($this->server['SCRIPT_NAME'], PATHINFO_EXTENSION) === 'php'
+        ) {
+            // Compare each segment, dropping them until there is no match
+            $segments = $keep = explode('/', $path);
+
+            foreach (explode('/', $this->server['SCRIPT_NAME']) as $i => $segment) {
+                // If these segments are not the same then we're done
+                if (! isset($segments[$i]) || $segment !== $segments[$i]) {
+                    break;
+                }
+
+                array_shift($keep);
+            }
+
+            $path = implode('/', $keep);
+        }
+
+        // This section ensures that even on servers that require the URI to
+        // contain the query string (Nginx) a correct URI is found, and also
+        // fixes the QUERY_STRING Server var and $_GET array.
+        if (trim($path, '/') === '' && strncmp($query, '/', 1) === 0) {
+            $parts    = explode('?', $query, 2);
+            $path     = $parts[0];
+            $newQuery = $query[1] ?? '';
+
+            $this->server['QUERY_STRING'] = $newQuery;
+            $this->updateServer('QUERY_STRING', $newQuery);
+        } else {
+            $this->server['QUERY_STRING'] = $query;
+            $this->updateServer('QUERY_STRING', $query);
+        }
+
+        // Update our global GET for values likely to have been changed
+        parse_str($this->server['QUERY_STRING'], $get);
+        $this->updateGetArray($get);
+
+        return URI::removeDotSegments($path);
+    }
+
+    private function updateServer(string $key, string $value): void
+    {
+        $_SERVER[$key] = $value;
+    }
+
+    private function updateGetArray(array $array): void
+    {
+        $_GET = $array;
+    }
+
+    /**
+     * Will parse QUERY_STRING and automatically detect the URI from it.
+     *
+     * This method updates superglobal $_SERVER and $_GET.
+     *
+     * @return string The route path (before normalization).
+     */
+    private function parseQueryString(): string
+    {
+        $query = $this->server['QUERY_STRING'] ?? @getenv('QUERY_STRING');
+
+        if (trim($query, '/') === '') {
+            return '/';
+        }
+
+        if (strncmp($query, '/', 1) === 0) {
+            $parts    = explode('?', $query, 2);
+            $path     = $parts[0];
+            $newQuery = $parts[1] ?? '';
+
+            $this->server['QUERY_STRING'] = $newQuery;
+            $this->updateServer('QUERY_STRING', $newQuery);
+        } else {
+            $path = $query;
+        }
+
+        // Update our global GET for values likely to have been changed
+        parse_str($this->server['QUERY_STRING'], $get);
+        $this->updateGetArray($get);
+
+        return URI::removeDotSegments($path);
+    }
+
+    /**
+     * Create current URI object.
+     *
+     * @param string $routePath URI path relative to baseURL
+     */
+    private function createURIFromRoutePath(string $routePath): SiteURI
+    {
+        $query = $this->server['QUERY_STRING'] ?? '';
+
+        $relativePath = $query !== '' ? $routePath . '?' . $query : $routePath;
+
+        return new SiteURI($this->appConfig, $relativePath, $this->getHost());
+    }
+
+    /**
+     * @return string|null The current hostname. Returns null if no host header.
+     */
+    private function getHost(): ?string
+    {
+        $host = null;
+
+        $httpHostPort = $this->server['HTTP_HOST'] ?? null;
+        if ($httpHostPort !== null) {
+            [$httpHost] = explode(':', $httpHostPort, 2);
+
+            if (in_array($httpHost, $this->appConfig->allowedHostnames, true)) {
+                $host = $httpHost;
+            }
+        }
+
+        return $host;
+    }
+}

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -15,7 +15,7 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Superglobals;
 use Config\App;
 
-class SiteURIFactory
+final class SiteURIFactory
 {
     private App $appConfig;
     private Superglobals $superglobals;

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -131,7 +131,7 @@ class SiteURIFactory
 
         // Strip the SCRIPT_NAME path from the URI
         if (
-            $path !== '' && isset($this->superglobals->server('SCRIPT_NAME')[0])
+            $path !== '' && $this->superglobals->server('SCRIPT_NAME') !== ''
             && pathinfo($this->superglobals->server('SCRIPT_NAME'), PATHINFO_EXTENSION) === 'php'
         ) {
             // Compare each segment, dropping them until there is no match

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -178,7 +178,7 @@ class SiteURIFactory
      */
     private function parseQueryString(): string
     {
-        $query = $this->superglobals->server('QUERY_STRING') ?? @getenv('QUERY_STRING');
+        $query = $this->superglobals->server('QUERY_STRING') ?? (string) getenv('QUERY_STRING');
 
         if (trim($query, '/') === '') {
             return '/';

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -17,13 +17,13 @@ use Config\App;
 
 class SiteURIFactory
 {
-    private Superglobals $superglobals;
     private App $appConfig;
+    private Superglobals $superglobals;
 
-    public function __construct(Superglobals $superglobals, App $appConfig)
+    public function __construct(App $appConfig, Superglobals $superglobals)
     {
-        $this->superglobals = $superglobals;
         $this->appConfig    = $appConfig;
+        $this->superglobals = $superglobals;
     }
 
     /**

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -71,8 +71,9 @@ class SiteURIFactory
         }
 
         $relativePath = $parts['path'] . $query . $fragment;
+        $host         = $this->getValidHost($parts['host']);
 
-        return new SiteURI($this->appConfig, $relativePath, $parts['host'], $parts['scheme']);
+        return new SiteURI($this->appConfig, $relativePath, $host, $parts['scheme']);
     }
 
     /**
@@ -231,21 +232,30 @@ class SiteURIFactory
     }
 
     /**
-     * @return string|null The current hostname. Returns null if no host header.
+     * @return string|null The current hostname. Returns null if no valid host.
      */
     private function getHost(): ?string
     {
-        $host = null;
-
         $httpHostPort = $this->server['HTTP_HOST'] ?? null;
+
         if ($httpHostPort !== null) {
             [$httpHost] = explode(':', $httpHostPort, 2);
 
-            if (in_array($httpHost, $this->appConfig->allowedHostnames, true)) {
-                $host = $httpHost;
-            }
+            return $this->getValidHost($httpHost);
         }
 
-        return $host;
+        return null;
+    }
+
+    /**
+     * @return string|null The valid hostname. Returns null if not valid.
+     */
+    private function getValidHost(string $host): ?string
+    {
+        if (in_array($host, $this->appConfig->allowedHostnames, true)) {
+            return $host;
+        }
+
+        return null;
     }
 }

--- a/system/Superglobals.php
+++ b/system/Superglobals.php
@@ -18,18 +18,37 @@ namespace CodeIgniter;
  */
 final class Superglobals
 {
+    private array $server;
+    private array $get;
+
+    public function __construct(?array $server = null, ?array $get = null)
+    {
+        $this->server = $server ?? $_SERVER;
+        $this->get    = $get ?? $_GET;
+    }
+
     public function server(string $key): ?string
     {
-        return $_SERVER[$key] ?? null;
+        return $this->server[$key] ?? null;
     }
 
     public function setServer(string $key, string $value): void
     {
-        $_SERVER[$key] = $value;
+        $this->server[$key] = $value;
+        $_SERVER[$key]      = $value;
+    }
+
+    /**
+     * @return array|string|null
+     */
+    public function get(string $key)
+    {
+        return $this->get[$key] ?? null;
     }
 
     public function setGetArray(array $array): void
     {
-        $_GET = $array;
+        $this->get = $array;
+        $_GET      = $array;
     }
 }

--- a/system/Superglobals.php
+++ b/system/Superglobals.php
@@ -46,6 +46,12 @@ final class Superglobals
         return $this->get[$key] ?? null;
     }
 
+    public function setGet(string $key, string $value): void
+    {
+        $this->get[$key] = $value;
+        $_GET[$key]      = $value;
+    }
+
     public function setGetArray(array $array): void
     {
         $this->get = $array;

--- a/system/Superglobals.php
+++ b/system/Superglobals.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter;
+
+/**
+ * Superglobals manipulation.
+ *
+ * @internal
+ */
+final class Superglobals
+{
+    public function server(string $key): ?string
+    {
+        return $_SERVER[$key] ?? null;
+    }
+
+    public function setServer(string $key, string $value): void
+    {
+        $_SERVER[$key] = $value;
+    }
+
+    public function setGetArray(array $array): void
+    {
+        $_GET = $array;
+    }
+}

--- a/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
+++ b/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 
@@ -34,7 +35,10 @@ final class SiteURIFactoryDetectRoutePathTest extends CIUnitTestCase
     {
         $appConfig ??= new App();
 
-        return new SiteURIFactory($server, $appConfig);
+        $_SERVER      = $server;
+        $superglobals = new Superglobals();
+
+        return new SiteURIFactory($superglobals, $appConfig);
     }
 
     public function testDefault()

--- a/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
+++ b/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
+
+/**
+ * @backupGlobals enabled
+ *
+ * @internal
+ *
+ * @group Others
+ */
+final class SiteURIFactoryDetectRoutePathTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_GET = $_SERVER = [];
+    }
+
+    private function createSiteURIFactory(array $server, ?App $appConfig = null): SiteURIFactory
+    {
+        $appConfig ??= new App();
+
+        return new SiteURIFactory($server, $appConfig);
+    }
+
+    public function testDefault()
+    {
+        // /index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath());
+    }
+
+    public function testDefaultEmpty()
+    {
+        // /
+        $_SERVER['REQUEST_URI'] = '/';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = '/';
+        $this->assertSame($expected, $factory->detectRoutePath());
+    }
+
+    public function testRequestURI()
+    {
+        // /index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINested()
+    {
+        // I'm not sure but this is a case of Apache config making such SERVER
+        // values?
+        // The current implementation doesn't use the value of the URI object.
+        // So I removed the code to set URI. Therefore, it's exactly the same as
+        // the method above as a test.
+        // But it may be changed in the future to use the value of the URI object.
+        // So I don't remove this test case.
+
+        // /ci/index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURISubfolder()
+    {
+        // /ci/index.php/popcorn/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/ci/index.php/popcorn/woot';
+        $_SERVER['SCRIPT_NAME'] = '/ci/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'popcorn/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINoIndex()
+    {
+        // /sub/example
+        $_SERVER['REQUEST_URI'] = '/sub/example';
+        $_SERVER['SCRIPT_NAME'] = '/sub/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'example';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINginx()
+    {
+        // /ci/index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot?code=good';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURINginxRedirecting()
+    {
+        // /?/ci/index.php/woot
+        $_SERVER['REQUEST_URI'] = '/?/ci/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'ci/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testRequestURISuppressed()
+    {
+        // /woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/woot';
+        $_SERVER['SCRIPT_NAME'] = '/';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    public function testQueryString()
+    {
+        // /index.php?/ci/woot
+        $_SERVER['REQUEST_URI']  = '/index.php?/ci/woot';
+        $_SERVER['QUERY_STRING'] = '/ci/woot';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+
+        $_GET['/ci/woot'] = '';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'ci/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('QUERY_STRING'));
+    }
+
+    public function testQueryStringWithQueryString()
+    {
+        // /index.php?/ci/woot?code=good#pos
+        $_SERVER['REQUEST_URI']  = '/index.php?/ci/woot?code=good';
+        $_SERVER['QUERY_STRING'] = '/ci/woot?code=good';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+
+        $_GET['/ci/woot?code'] = 'good';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'ci/woot';
+        $this->assertSame($expected, $factory->detectRoutePath('QUERY_STRING'));
+        $this->assertSame('code=good', $_SERVER['QUERY_STRING']);
+        $this->assertSame(['code' => 'good'], $_GET);
+    }
+
+    public function testQueryStringEmpty()
+    {
+        // /index.php?
+        $_SERVER['REQUEST_URI'] = '/index.php?';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = '/';
+        $this->assertSame($expected, $factory->detectRoutePath('QUERY_STRING'));
+    }
+
+    public function testPathInfoUnset()
+    {
+        // /index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI'] = '/index.php/woot';
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('PATH_INFO'));
+    }
+
+    public function testPathInfoSubfolder()
+    {
+        $appConfig          = new App();
+        $appConfig->baseURL = 'http://localhost:8888/ci431/public/';
+
+        // http://localhost:8888/ci431/public/index.php/woot?code=good#pos
+        $_SERVER['PATH_INFO']   = '/woot';
+        $_SERVER['REQUEST_URI'] = '/ci431/public/index.php/woot?code=good';
+        $_SERVER['SCRIPT_NAME'] = '/ci431/public/index.php';
+
+        $factory = $this->createSiteURIFactory($_SERVER, $appConfig);
+
+        $expected = 'woot';
+        $this->assertSame($expected, $factory->detectRoutePath('PATH_INFO'));
+    }
+}

--- a/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
+++ b/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
@@ -38,7 +38,7 @@ final class SiteURIFactoryDetectRoutePathTest extends CIUnitTestCase
         $_SERVER      = $server;
         $superglobals = new Superglobals();
 
-        return new SiteURIFactory($superglobals, $appConfig);
+        return new SiteURIFactory($appConfig, $superglobals);
     }
 
     public function testDefault()

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
+
+/**
+ * @backupGlobals enabled
+ *
+ * @internal
+ *
+ * @group Others
+ */
+final class SiteURIFactoryTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $_GET = $_SERVER = [];
+    }
+
+    public function testCreateFromGlobals()
+    {
+        // http://localhost:8080/index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI']  = '/index.php/woot?code=good';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+        $_SERVER['QUERY_STRING'] = 'code=good';
+        $_SERVER['HTTP_HOST']    = 'localhost:8080';
+        $_SERVER['PATH_INFO']    = '/woot';
+
+        $_GET['code'] = 'good';
+
+        $factory = new SiteURIFactory($_SERVER, new App());
+
+        $uri = $factory->createFromGlobals();
+
+        $this->assertInstanceOf(SiteURI::class, $uri);
+        $this->assertSame('http://localhost:8080/index.php/woot?code=good', (string) $uri);
+        $this->assertSame('/index.php/woot', $uri->getPath());
+        $this->assertSame('woot', $uri->getRoutePath());
+    }
+
+    public function testCreateFromGlobalsAllowedHost()
+    {
+        // http://users.example.jp/index.php/woot?code=good#pos
+        $_SERVER['REQUEST_URI']  = '/index.php/woot?code=good';
+        $_SERVER['SCRIPT_NAME']  = '/index.php';
+        $_SERVER['QUERY_STRING'] = 'code=good';
+        $_SERVER['HTTP_HOST']    = 'users.example.jp';
+        $_SERVER['PATH_INFO']    = '/woot';
+
+        $_GET['code'] = 'good';
+
+        $config                   = new App();
+        $config->baseURL          = 'http://example.jp/';
+        $config->allowedHostnames = ['users.example.jp'];
+
+        $factory = new SiteURIFactory($_SERVER, $config);
+
+        $uri = $factory->createFromGlobals();
+
+        $this->assertInstanceOf(SiteURI::class, $uri);
+        $this->assertSame('http://users.example.jp/index.php/woot?code=good', (string) $uri);
+        $this->assertSame('/index.php/woot', $uri->getPath());
+        $this->assertSame('woot', $uri->getRoutePath());
+    }
+
+    public function testCreateFromString()
+    {
+        $factory = new SiteURIFactory($_SERVER, new App());
+
+        $uriString = 'http://invalid.example.jp/foo/bar?page=3';
+        $uri       = $factory->createFromString($uriString);
+
+        $this->assertInstanceOf(SiteURI::class, $uri);
+        $this->assertSame('http://localhost:8080/index.php/foo/bar?page=3', (string) $uri);
+        $this->assertSame('/index.php/foo/bar', $uri->getPath());
+        $this->assertSame('foo/bar', $uri->getRoutePath());
+    }
+}

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 
@@ -41,7 +42,8 @@ final class SiteURIFactoryTest extends CIUnitTestCase
 
         $_GET['code'] = 'good';
 
-        $factory = new SiteURIFactory($_SERVER, new App());
+        $superglobals = new Superglobals();
+        $factory      = new SiteURIFactory($superglobals, new App());
 
         $uri = $factory->createFromGlobals();
 
@@ -66,7 +68,8 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         $config->baseURL          = 'http://example.jp/';
         $config->allowedHostnames = ['users.example.jp'];
 
-        $factory = new SiteURIFactory($_SERVER, $config);
+        $superglobals = new Superglobals();
+        $factory      = new SiteURIFactory($superglobals, $config);
 
         $uri = $factory->createFromGlobals();
 
@@ -78,7 +81,8 @@ final class SiteURIFactoryTest extends CIUnitTestCase
 
     public function testCreateFromString()
     {
-        $factory = new SiteURIFactory($_SERVER, new App());
+        $superglobals = new Superglobals();
+        $factory      = new SiteURIFactory($superglobals, new App());
 
         $uriString = 'http://invalid.example.jp/foo/bar?page=3';
         $uri       = $factory->createFromString($uriString);

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -36,7 +36,7 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         $config ??= new App();
         $superglobals ??= new Superglobals();
 
-        return new SiteURIFactory($superglobals, $config);
+        return new SiteURIFactory($config, $superglobals);
     }
 
     public function testCreateFromGlobals()

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -31,6 +31,14 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         $_GET = $_SERVER = [];
     }
 
+    private function createSiteURIFactory(?App $config = null, ?Superglobals $superglobals = null): SiteURIFactory
+    {
+        $config ??= new App();
+        $superglobals ??= new Superglobals();
+
+        return new SiteURIFactory($superglobals, $config);
+    }
+
     public function testCreateFromGlobals()
     {
         // http://localhost:8080/index.php/woot?code=good#pos
@@ -42,8 +50,7 @@ final class SiteURIFactoryTest extends CIUnitTestCase
 
         $_GET['code'] = 'good';
 
-        $superglobals = new Superglobals();
-        $factory      = new SiteURIFactory($superglobals, new App());
+        $factory = $this->createSiteURIFactory();
 
         $uri = $factory->createFromGlobals();
 
@@ -68,8 +75,7 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         $config->baseURL          = 'http://example.jp/';
         $config->allowedHostnames = ['users.example.jp'];
 
-        $superglobals = new Superglobals();
-        $factory      = new SiteURIFactory($superglobals, $config);
+        $factory = $this->createSiteURIFactory($config);
 
         $uri = $factory->createFromGlobals();
 
@@ -81,8 +87,7 @@ final class SiteURIFactoryTest extends CIUnitTestCase
 
     public function testCreateFromString()
     {
-        $superglobals = new Superglobals();
-        $factory      = new SiteURIFactory($superglobals, new App());
+        $factory = $this->createSiteURIFactory();
 
         $uriString = 'http://invalid.example.jp/foo/bar?page=3';
         $uri       = $factory->createFromString($uriString);

--- a/tests/system/SuperglobalsTest.php
+++ b/tests/system/SuperglobalsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter;
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ *
+ * @group Others
+ */
+final class SuperglobalsTest extends CIUnitTestCase
+{
+    public function testSetGet()
+    {
+        $globals = new Superglobals([], []);
+
+        $globals->setGet('test', 'value1');
+
+        $this->assertSame('value1', $globals->get('test'));
+    }
+}


### PR DESCRIPTION
~~Needs #7252~~

**Description**
Supersedes #7239

Add `SiteURIFactory` to create the current URI object.

To create the current URI object before the Request object creation. 
Also, to remove all URI adjustment processing currently performed in the constructor of the Request object.

This PR does not change any existing features yet. The next #7282 changes the behavior.

- add `SiteURIFactory::createFromGlobals()`
- add `Superglobals`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
