### PR TITLE
fix: incorrect segment number in URI::getSegment() exception message

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -532,12 +532,14 @@ class URI
 
     /**
      * Returns the value of a specific segment of the URI path.
+     * Allows to get only existing segments or the next one.
      *
-     * @param int    $number  Segment number
+     * @param int    $number  Segment number starting at 1
      * @param string $default Default value
      *
-     * @return string The value of the segment. If no segment is found,
-     *                throws InvalidArgumentError
+     * @return string The value of the segment. If you specify the last +1
+     *                segment, the $default value. If you specify the last +2
+     *                or more throws HTTPException.
      */
     public function getSegment(int $number, string $default = ''): string
     {
@@ -556,7 +558,8 @@ class URI
      * Set the value of a specific segment of the URI path.
      * Allows to set only existing segments or add new one.
      *
-     * @param mixed $value (string or int)
+     * @param int        $number Segment number starting at 1
+     * @param int|string $value
      *
      * @return $this
      */

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -543,13 +543,14 @@ class URI
      */
     public function getSegment(int $number, string $default = ''): string
     {
+
+        if ($number > count($this->segments) + 1 && ! $this->silent) {
+            throw HTTPException::forURISegmentOutOfRange($number);
+        }
+
         // The segment should treat the array as 1-based for the user
         // but we still have to deal with a zero-based array.
         $number--;
-
-        if ($number > count($this->segments) && ! $this->silent) {
-            throw HTTPException::forURISegmentOutOfRange($number);
-        }
 
         return $this->segments[$number] ?? $default;
     }

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -543,6 +543,9 @@ class URI
      */
     public function getSegment(int $number, string $default = ''): string
     {
+        if ($number < 1) {
+            throw HTTPException::forURISegmentOutOfRange($number);
+        }
 
         if ($number > count($this->segments) + 1 && ! $this->silent) {
             throw HTTPException::forURISegmentOutOfRange($number);


### PR DESCRIPTION
**Description**
Supersedes #7249

- fix incorrect segment number in `URI::getSegment()` exception message
- throw an exception for an impossible segment number

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
