### PR TITLE
docs: fix upgrade_432.rst

### DIFF
--- a/user_guide_src/source/installation/upgrade_432.rst
+++ b/user_guide_src/source/installation/upgrade_432.rst
@@ -64,9 +64,6 @@ Content Changes
 The following files received significant changes (including deprecations or visual adjustments)
 and it is recommended that you merge the updated versions with your application:
 
-Config
-------
-
 - app/Config/Email.php
 - app/Config/Mimes.php
 - app/Views/errors/html/error_exception.php

--- a/user_guide_src/source/installation/upgrade_432.rst
+++ b/user_guide_src/source/installation/upgrade_432.rst
@@ -64,7 +64,6 @@ Content Changes
 The following files received significant changes (including deprecations or visual adjustments)
 and it is recommended that you merge the updated versions with your application:
 
-- app/Config/Email.php
 - app/Config/Mimes.php
 - app/Views/errors/html/error_exception.php
 - composer.json
@@ -77,7 +76,6 @@ This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
 - app/Config/App.php
-- app/Config/Email.php
 - app/Config/Mimes.php
 - app/Views/errors/html/error_exception.php
 - composer.json


### PR DESCRIPTION
**Description**
- remove incorrect "Project Files". See https://github.com/codeigniter4/appstarter/commit/2f3d1531b449337217524e47baa7d680003829ea

Cloning a repository is time consuming, so I used the previous release repository. However, I seem to have forgotten to update `master`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
