### PR TITLE
fix: [QueryBuilder] RawSql causes error when using like() and countAllResults()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3082,6 +3082,10 @@ class BaseBuilder
                     continue;
                 }
 
+                if ($qbkey instanceof RawSql) {
+                    continue;
+                }
+
                 if ($qbkey['condition'] instanceof RawSql) {
                     $qbkey = $qbkey['condition'];
 

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Database\Live;
 
+use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Tests\Support\Database\Seeds\CITestSeeder;
@@ -120,5 +121,33 @@ final class LikeTest extends CIUnitTestCase
 
         $this->assertCount(1, $spaces);
         $this->assertCount(1, $tabs);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/7268
+     */
+    public function testLikeRawSqlAndCountAllResultsAndGet()
+    {
+        $builder = $this->db->table('job');
+        $builder->like(new RawSql('name'), 'Developer');
+        $count   = $builder->countAllResults(false);
+        $results = $builder->get()->getResult();
+
+        $this->assertSame(1, $count);
+        $this->assertSame('Developer', $results[0]->name);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/7268
+     */
+    public function testLikeRawSqlAndGetAndCountAllResults()
+    {
+        $builder = $this->db->table('job');
+        $builder->like(new RawSql('name'), 'Developer');
+        $results = $builder->get(null, 0, false)->getResult();
+        $count   = $builder->countAllResults();
+
+        $this->assertSame(1, $count);
+        $this->assertSame('Developer', $results[0]->name);
     }
 }

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -129,7 +129,14 @@ final class LikeTest extends CIUnitTestCase
     public function testLikeRawSqlAndCountAllResultsAndGet()
     {
         $builder = $this->db->table('job');
-        $builder->like(new RawSql('name'), 'Developer');
+
+        if ($this->db->DBDriver === 'OCI8') {
+            $key = new RawSql('"name"');
+        } else {
+            $key = new RawSql('name');
+        }
+
+        $builder->like($key, 'Developer');
         $count   = $builder->countAllResults(false);
         $results = $builder->get()->getResult();
 
@@ -143,7 +150,14 @@ final class LikeTest extends CIUnitTestCase
     public function testLikeRawSqlAndGetAndCountAllResults()
     {
         $builder = $this->db->table('job');
-        $builder->like(new RawSql('name'), 'Developer');
+
+        if ($this->db->DBDriver === 'OCI8') {
+            $key = new RawSql('"name"');
+        } else {
+            $key = new RawSql('name');
+        }
+
+        $builder->like($key, 'Developer');
         $results = $builder->get(null, 0, false)->getResult();
         $count   = $builder->countAllResults();
 


### PR DESCRIPTION
**Description**
Fixes #7268

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
