### PR TITLE
fix: missing cipher field for ci3 encryption compatibility

### DIFF
--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -63,7 +63,7 @@ class Encryption extends BaseConfig
      *
      * Set to aes-128-cbc for CI3 Encryption compatibility.
      */
-    public string $cipher = 'aes-256-ctr';
+    public string $cipher = 'AES-256-CTR';
 
     /**
      * Whether the cipher-text should be raw. If set to false, then it will be base64 encoded.

--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -57,6 +57,14 @@ class Encryption extends BaseConfig
      */
     public string $digest = 'SHA512';
 
+   	/**
+	 * The cipher to use.
+	 * This setting is only used by OpenSSLHandler.
+	 *
+	 * Set to aes-128-cbc for CI3 Encryption compatibility.
+	 */
+	public string $cipher = 'aes-256-ctr';
+    
     /**
      * Whether the cipher-text should be raw. If set to false, then it will be base64 encoded.
      * This setting is only used by OpenSSLHandler.

--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -64,7 +64,7 @@ class Encryption extends BaseConfig
      * Set to aes-128-cbc for CI3 Encryption compatibility.
      */
     public string $cipher = 'aes-256-ctr';
-    
+
     /**
      * Whether the cipher-text should be raw. If set to false, then it will be base64 encoded.
      * This setting is only used by OpenSSLHandler.

--- a/app/Config/Encryption.php
+++ b/app/Config/Encryption.php
@@ -57,13 +57,13 @@ class Encryption extends BaseConfig
      */
     public string $digest = 'SHA512';
 
-   	/**
-	 * The cipher to use.
-	 * This setting is only used by OpenSSLHandler.
-	 *
-	 * Set to aes-128-cbc for CI3 Encryption compatibility.
-	 */
-	public string $cipher = 'aes-256-ctr';
+    /**
+     * The cipher to use.
+     * This setting is only used by OpenSSLHandler.
+     *
+     * Set to aes-128-cbc for CI3 Encryption compatibility.
+     */
+    public string $cipher = 'aes-256-ctr';
     
     /**
      * Whether the cipher-text should be raw. If set to false, then it will be base64 encoded.

--- a/user_guide_src/source/libraries/encryption/013.php
+++ b/user_guide_src/source/libraries/encryption/013.php
@@ -5,7 +5,7 @@ use Config\Services;
 
 $config         = new Encryption();
 $config->driver = 'OpenSSL';
-$config->cipher = 'aes-128-cbc';
+$config->cipher = 'AES-128-CBC';
 // Your CI3's encryption_key
 $config->key            = hex2bin('64c70b0b8d45b80b9eba60b8b3c8a34d0193223d20fea46f8644b848bf7ce67f');
 $config->rawData        = false;

--- a/user_guide_src/source/libraries/encryption/013.php
+++ b/user_guide_src/source/libraries/encryption/013.php
@@ -5,6 +5,7 @@ use Config\Services;
 
 $config         = new Encryption();
 $config->driver = 'OpenSSL';
+$config->cipher = 'aes-128-cbc';
 // Your CI3's encryption_key
 $config->key            = hex2bin('64c70b0b8d45b80b9eba60b8b3c8a34d0193223d20fea46f8644b848bf7ce67f');
 $config->rawData        = false;


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
@kenjis did the work of getting backward compatibility with CI3 encryption. However since CI3 defaulted to the aes-128-cbc encryption cipher, we need a way to tell CI4 to use that algorithm when decoding CI3 encrypted data. This change adds the field to \App\Config\Encryption.php

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
