### PR TITLE
test: fix out-of-dated test code in CodeIgniterTest

### DIFF
--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -709,9 +709,9 @@ final class CodeIgniterTest extends CIUnitTestCase
     public function testPageCacheWithCacheQueryString($cacheQueryStringValue, int $expectedPagesInCache, array $testingUrls)
     {
         // Suppress command() output
-        CITestStreamFilter::$buffer = '';
-        $outputStreamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        $errorStreamFilter          = stream_filter_append(STDERR, 'CITestStreamFilter');
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+        CITestStreamFilter::addErrorFilter();
 
         // Create cache config with cacheQueryString value from the dataProvider
         $cacheConfig                   = new Cache();
@@ -756,8 +756,8 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertSame($expectedPagesInCache, $newPagesCached);
 
         // Remove stream filters
-        stream_filter_remove($outputStreamFilter);
-        stream_filter_remove($errorStreamFilter);
+        CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeErrorFilter();
     }
 
     public function cacheQueryStringProvider(): array


### PR DESCRIPTION
**Description**
If I run the test method only, it causes Error.

- fix out-of-dated test code

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
