### PR TITLE
docs: fix $systemDirectory path in existing project.

### DIFF
--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -152,7 +152,7 @@ Setting Up
 
     1. Copy the **app**, **public**, **tests** and **writable** folders from **vendor/codeigniter4/framework** to your project root
     2. Copy the **env**, **phpunit.xml.dist** and **spark** files, from **vendor/codeigniter4/framework** to your project root
-    3. You will have to adjust the ``$systemDirectory`` property in **app/Config/Paths.php** to refer to the vendor one, e.g., ``ROOTPATH . '/vendor/codeigniter4/framework/system'``.
+    3. You will have to adjust the ``$systemDirectory`` property in **app/Config/Paths.php** to refer to the vendor one, e.g., ``__DIR__ . '/../../vendor/codeigniter4/framework/system'``.
 
 Initial Configuration
 ---------------------


### PR DESCRIPTION
**Description**

In [Adding CodeIgniter4 to an Existing Project](https://codeigniter.com/user_guide/installation/installing_composer.html#adding-codeigniter4-to-an-existing-project) docs is an incorrectly defined how to adjust the `$systemDirectory` property. 

`$systemDirectory` should be defined as in [appstarter project](https://github.com/codeigniter4/appstarter/blob/2f3d1531b449337217524e47baa7d680003829ea/app/Config/Paths.php#L26).

`ROOTPATH` constant causes an error with `php spark serve` like:

```sh
PHP Fatal error:  Uncaught Error: Undefined constant "Config\ROOTPATH" in /Users/jrebjak/CodeIgniter4/test-existing-project/spark:72

Stack trace:
#0 {main} thrown in /Users/jrebjak/CodeIgniter4/test-existing-project/spark on line 72
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
