### PR TITLE
docs: add note for URI::getSegment()

### DIFF
--- a/user_guide_src/source/libraries/uri.rst
+++ b/user_guide_src/source/libraries/uri.rst
@@ -213,6 +213,10 @@ You can also set a different default value for a particular segment by using the
 
 .. literalinclude:: uri/024.php
 
+.. note:: You can get the last +1 segment. When you try to get the last +2 or
+    more segment, an exception will be thrown by default. You could prevent
+    throwing exceptions with the ``setSilent()`` method.
+
 You can get a count of the total segments:
 
 .. literalinclude:: uri/025.php


### PR DESCRIPTION
**Description**
Closes #7246

- add note for URI::getSegment()

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
