### PR TITLE
Add RawSql[] on @param on Basebuilder::updateFields()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2021,9 +2021,9 @@ class BaseBuilder
     /**
      * Sets update fields for upsert, update
      *
-     * @param string|string[] $set
-     * @param bool            $addToDefault adds update fields to the default ones
-     * @param array|null      $ignore       ignores items in set
+     * @param RawSql[]|string|string[] $set
+     * @param bool                     $addToDefault adds update fields to the default ones
+     * @param array|null               $ignore       ignores items in set
      *
      * @return $this
      */


### PR DESCRIPTION
**Description**

This detected on run `RemoveAlwaysTrueIfConditionRector` on dependabot PR:

- https://github.com/codeigniter4/CodeIgniter4/pull/7294

https://github.com/codeigniter4/CodeIgniter4/actions/runs/4244147097/jobs/7377846287#step:9:21

Because it not part of `@param` doc

**Checklist:**
- [x] Securely signed commits
