### PR TITLE
refactor: use config(Cache::class) in CodeIgniter

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -122,7 +122,7 @@ class CodeIgniter
     /**
      * Cache expiration time
      *
-     * @var int
+     * @var int seconds
      */
     protected static $cacheTTL = 0;
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -734,7 +734,7 @@ class CodeIgniter
      * Caches the full response from the current request. Used for
      * full-page caching for very high performance.
      *
-     * @return mixed
+     * @return bool
      */
     public function cachePage(Cache $config)
     {
@@ -920,7 +920,7 @@ class CodeIgniter
      *  2. PHP CLI: accessed by CLI via php public/index.php, arguments become URI segments,
      *      sent to Controllers via Routes, output varies
      *
-     * @param mixed $class
+     * @param Controller $class
      *
      * @return false|ResponseInterface|string|void
      */

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -965,7 +965,7 @@ class CodeIgniter
 
             unset($override);
 
-            $cacheConfig = new Cache();
+            $cacheConfig = config(Cache::class);
             $this->gatherOutput($cacheConfig, $returned);
             if ($this->returnResponse) {
                 return $this->response;

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -351,7 +351,7 @@ class CodeIgniter
 
         // Check for a cached page. Execution will stop
         // if the page has been cached.
-        $cacheConfig = new Cache();
+        $cacheConfig = config(Cache::class);
         $response    = $this->displayCache($cacheConfig);
         if ($response instanceof ResponseInterface) {
             if ($returnResponse) {

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -53,7 +53,7 @@ final class CodeIgniterTest extends CIUnitTestCase
     {
         parent::tearDown();
 
-        if (count(ob_list_handlers()) > 1) {
+        if (ob_get_level() > 1) {
             ob_end_clean();
         }
 
@@ -799,7 +799,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
             $this->assertSame($string, $output);
 
-            if (count(ob_list_handlers()) > 1) {
+            if (ob_get_level() > 1) {
                 ob_end_clean();
             }
         }


### PR DESCRIPTION
**Description**
- refactor CodeIgniter
- improve test

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
