### PR TITLE
feat: [SQLSRV] getFieldData() supports nullable

### DIFF
--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -341,9 +341,11 @@ class Connection extends BaseConnection
      */
     protected function _fieldData(string $table): array
     {
-        $sql = 'SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, COLUMN_DEFAULT
-			FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME= ' . $this->escape(($table));
+        $sql = 'SELECT
+                COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION,
+                COLUMN_DEFAULT, IS_NULLABLE
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME= ' . $this->escape(($table));
 
         if (($query = $this->query($sql)) === false) {
             throw new DatabaseException(lang('Database.failGetFieldData'));
@@ -362,6 +364,8 @@ class Connection extends BaseConnection
             $retVal[$i]->max_length = $query[$i]->CHARACTER_MAXIMUM_LENGTH > 0
                 ? $query[$i]->CHARACTER_MAXIMUM_LENGTH
                 : $query[$i]->NUMERIC_PRECISION;
+
+            $retVal[$i]->nullable = $query[$i]->IS_NULLABLE !== 'NO';
         }
 
         return $retVal;

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -848,6 +848,7 @@ final class ForgeTest extends CIUnitTestCase
             'name' => [
                 'type'       => 'VARCHAR',
                 'constraint' => 255,
+                'null'       => true,
             ],
             'active' => [
                 'type'       => 'INTEGER',
@@ -889,7 +890,7 @@ final class ForgeTest extends CIUnitTestCase
                     'name'        => 'name',
                     'type'        => 'varchar',
                     'max_length'  => 255,
-                    'nullable'    => false,
+                    'nullable'    => true,
                     'default'     => null,
                     'primary_key' => 0,
                 ],
@@ -929,7 +930,7 @@ final class ForgeTest extends CIUnitTestCase
                 2 => [
                     'name'       => 'name',
                     'type'       => 'character varying',
-                    'nullable'   => false,
+                    'nullable'   => true,
                     'default'    => null,
                     'max_length' => '255',
                 ],
@@ -965,7 +966,7 @@ final class ForgeTest extends CIUnitTestCase
                     'max_length'  => null,
                     'default'     => null,
                     'primary_key' => false,
-                    'nullable'    => false,
+                    'nullable'    => true,
                 ],
                 3 => [
                     'name'        => 'active',
@@ -983,24 +984,28 @@ final class ForgeTest extends CIUnitTestCase
                     'type'       => 'int',
                     'default'    => null,
                     'max_length' => 10,
+                    'nullable'   => false,
                 ],
                 1 => [
                     'name'       => 'username',
                     'type'       => 'varchar',
                     'default'    => null,
                     'max_length' => 255,
+                    'nullable'   => false,
                 ],
                 2 => [
                     'name'       => 'name',
                     'type'       => 'varchar',
                     'default'    => null,
                     'max_length' => 255,
+                    'nullable'   => true,
                 ],
                 3 => [
                     'name'       => 'active',
                     'type'       => 'int',
                     'default'    => '((0))', // Why?
                     'max_length' => 10,
+                    'nullable'   => false,
                 ],
             ];
         } elseif ($this->db->DBDriver === 'OCI8') {
@@ -1023,8 +1028,8 @@ final class ForgeTest extends CIUnitTestCase
                     'name'       => 'name',
                     'type'       => 'VARCHAR2',
                     'max_length' => '255',
-                    'default'    => '',
-                    'nullable'   => false,
+                    'default'    => null,
+                    'nullable'   => true,
                 ],
                 3 => [
                     'name'       => 'active',

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -61,6 +61,7 @@ Others
 
 - **MySQLi:** Added the ``numberNative`` attribute to the Database Config to keep the variable type obtained after SQL Query consistent with the type set in the database.
   See :ref:`Database Configuration <database-configuration-explanation-of-values>`.
+- **SQLSRV:** Field Metadata now includes ``nullable``. See :ref:`db-metadata-getfielddata`.
 
 Model
 =====

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -78,6 +78,8 @@ performing an action. Returns a boolean true/false. Usage example:
 Retrieve Field Metadata
 =======================
 
+.. _db-metadata-getfielddata:
+
 $db->getFieldData()
 -------------------
 
@@ -104,8 +106,10 @@ database:
 -  type - the type of the column
 -  max_length - maximum length of the column
 -  primary_key - integer ``1`` if the column is a primary key (all integer ``1``, even if there are multiple primary keys), otherwise integer ``0`` (This field is currently only available for MySQL and SQLite3)
--  nullable - boolean ``true`` if the column is nullable, otherwise boolean ``false`` (This field is currently not available in SQL Server)
+-  nullable - boolean ``true`` if the column is nullable, otherwise boolean ``false``
 -  default - the default value
+
+.. note:: Since v4.4.0, SQLSRV supported ``nullable``.
 
 List the Indexes in a Table
 ===========================


### PR DESCRIPTION
**Description**
- `getFieldData()` supports nullable

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
