### PR TITLE
test: Forge::modifyColumn() and null

### DIFF
--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1285,11 +1285,6 @@ final class ForgeTest extends CIUnitTestCase
 
     public function testModifyColumnNullTrue()
     {
-        // @TODO remove this in `4.4` branch
-        if ($this->db->DBDriver === 'SQLSRV') {
-            $this->markTestSkipped('SQLSRV does not support getFieldData() nullable.');
-        }
-
         $this->forge->dropTable('forge_test_modify', true);
 
         $this->forge->addField([
@@ -1319,11 +1314,6 @@ final class ForgeTest extends CIUnitTestCase
 
     public function testModifyColumnNullFalse()
     {
-        // @TODO remove this in `4.4` branch
-        if ($this->db->DBDriver === 'SQLSRV') {
-            $this->markTestSkipped('SQLSRV does not support getFieldData() nullable.');
-        }
-
         $this->forge->dropTable('forge_test_modify', true);
 
         $this->forge->addField([


### PR DESCRIPTION
~~Needs #7301~~

**Description**
From https://zenn.dev/naente/articles/50935eb55c14ea (CodeIgniter4 PostgreSQL always adds NOT NULL constraints when running `modifyColumn()`)

See the current behavior: https://github.com/codeigniter4/CodeIgniter4/pull/7302#issuecomment-1444980360

- add test for `Forge::modifyColumn()` and null

**This bug was fixed in v4.3.4**:
-  #7371

Related #7235

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
