### PR TITLE
feat: add timestamp to `base_url()`

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -147,8 +147,19 @@ if (! function_exists('base_url')) {
             : $request->getUri()->getBaseURL();
 
         $config->indexPage = '';
+        
+        
+        $addTimestamp = '';
 
-        return site_url($relativePath, $scheme, $config);
+        if(env('CI_ENVIRONMENT')!='production') {
+            $array = explode('.', $relativePath);
+            $extension = array_pop($array);
+            if(in_array($extension, ['png', 'jpg', 'css', 'js', 'ico'])) {
+                $addTimestamp = '?t='.time();
+            }
+        }
+
+        return site_url($relativePath, $scheme, $config).$addTimestamp;
     }
 }
 


### PR DESCRIPTION
**Description**
when you create a website, the local cache is a problem, if you add a timestamp to a url in develop, this get more confortable.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
