### PR TITLE
Fix handling of null bytes in `Exceptions::renderBacktrace()`

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -531,9 +531,6 @@ class Exceptions
                     case is_resource($value):
                         return sprintf('resource (%s)', get_resource_type($value));
 
-                    case is_string($value):
-                        return var_export(clean_path($value), true);
-
                     default:
                         return var_export($value, true);
                 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Fixes #7262.

The `clean_path()` function should not be there to begin with.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
