### PR TITLE
fix: can't change and override valid locales

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -549,6 +549,18 @@ class IncomingRequest extends Request
     }
 
     /**
+     * Set the valid locales.
+     *
+     * @return $this
+     */
+    public function setValidLocales(array $locales)
+    {
+        $this->validLocales = $locales;
+
+        return $this;
+    }
+
+    /**
      * Gets the current locale, with a fallback to the default
      * locale if none is set.
      */

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -205,6 +205,21 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame('es', $request->getLocale());
     }
 
+    public function testSetValidLocales()
+    {
+        $config                   = new App();
+        $config->supportedLocales = ['en', 'es'];
+        $config->defaultLocale    = 'es';
+        $config->baseURL          = 'http://example.com/';
+
+        $request = new IncomingRequest($config, new URI(), null, new UserAgent());
+
+        $request->setValidLocales(['ja']);
+        $request->setLocale('ja');
+
+        $this->assertSame('ja', $request->getLocale());
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/2774
      */

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -85,6 +85,7 @@ Others
   ``product/15`` where ``15`` is an arbitrary number.
   See :ref:`controller-default-method-fallback` for details.
 - **Filters:** Now you can use Filter Arguments with :ref:`$filters property <filters-filters-filter-arguments>`.
+- **Request:** Added ``IncomingRequest::setValidLocales()`` method to set valid locales.
 
 Message Changes
 ***************

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -54,6 +54,9 @@ will be used to set the locale.
 
 Should you ever need to set the locale directly you may use ``IncomingRequest::setLocale(string $locale)``.
 
+Since v4.4.0, ``IncomingRequest::setValidLocales()`` has been added to set
+(and reset) valid locales that are set from ``Config\App::$supportedLocales`` setting.
+
 Content Negotiation
 -------------------
 


### PR DESCRIPTION
**Description**
Fixes #4297

- add `IncomingRequest::setValidLocales()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
