### PR TITLE
Remove Autoloader::sanitizeFilename() checking

### DIFF
--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -306,8 +306,6 @@ class Autoloader
      */
     protected function includeFile(string $file)
     {
-        $file = $this->sanitizeFilename($file);
-
         if (is_file($file)) {
             include_once $file;
 
@@ -327,6 +325,8 @@ class Autoloader
      * and end of filename.
      *
      * @return string The sanitized filename
+     *
+     * @deprecated No longer used. See https://github.com/codeigniter4/CodeIgniter4/issues/7055
      */
     public function sanitizeFilename(string $filename): string
     {

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -94,11 +94,18 @@ Changes
 
 - **Config:** The deprecated Cookie items in **app/Config/App.php** has been removed.
 - **DownloadResponse:** When generating response headers, does not replace the ``Content-Disposition`` header if it was previously specified.
+- **Autoloader:** Before v4.4.0, CodeIgniter autoloader did not allow special
+  characters that are illegal in filenames on certain operating systems.
+  The symbols that can be used are ``/``, ``_``, ``.``, ``:``, ``\`` and space.
+  So if you installed CodeIgniter under the folder that contains the special
+  characters like ``(``, ``)``, etc., CodeIgniter didn't work. Since v4.4.0,
+  this restriction has been removed.
 
 Deprecations
 ************
 
 - **Entity:** ``Entity::setAttributes()`` is deprecated. Use ``Entity::injectRawData()`` instead.
+- **Autoloader:** ``Autoloader::sanitizeFilename()`` is deprecated.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -44,9 +44,12 @@ The command above will create a **project-root** folder.
 If you omit the "project-root" argument, the command will create an
 "appstarter" folder, which can be renamed as appropriate.
 
-.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems.
+.. note:: Before v4.4.0, CodeIgniter autoloader did not allow special
+    characters that are illegal in filenames on certain operating systems.
     The symbols that can be used are ``/``, ``_``, ``.``, ``:``, ``\`` and space.
-    So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
+    So if you installed CodeIgniter under the folder that contains the special
+    characters like ``(``, ``)``, etc., CodeIgniter didn't work. Since v4.4.0,
+    this restriction has been removed.
 
 .. important:: When you deploy to your production server, don't forget to run the
     following command::

--- a/user_guide_src/source/installation/installing_manual.rst
+++ b/user_guide_src/source/installation/installing_manual.rst
@@ -22,9 +22,12 @@ Installation
 Download the `latest version <https://github.com/CodeIgniter4/framework/releases/latest>`_,
 and extract it to become your project root.
 
-.. note:: CodeIgniter autoloader does not allow special characters that are illegal in filenames on certain operating systems.
+.. note:: Before v4.4.0, CodeIgniter autoloader did not allow special
+    characters that are illegal in filenames on certain operating systems.
     The symbols that can be used are ``/``, ``_``, ``.``, ``:``, ``\`` and space.
-    So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
+    So if you installed CodeIgniter under the folder that contains the special
+    characters like ``(``, ``)``, etc., CodeIgniter didn't work. Since v4.4.0,
+    this restriction has been removed.
 
 Initial Configuration
 =====================


### PR DESCRIPTION
**Description**
Closes #7055

- remove Autoloader::sanitizeFilename() checking
- deprecate Autoloader::sanitizeFilename()

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
