### PR TITLE
Fix @param null $arguments on FilterInterface

### DIFF
--- a/system/Filters/FilterInterface.php
+++ b/system/Filters/FilterInterface.php
@@ -29,7 +29,7 @@ interface FilterInterface
      * sent back to the client, allowing for error pages,
      * redirects, etc.
      *
-     * @param null $arguments
+     * @param array|null $arguments
      *
      * @return mixed
      */
@@ -41,7 +41,7 @@ interface FilterInterface
      * to stop execution of other after filters, short of
      * throwing an Exception or Error.
      *
-     * @param null $arguments
+     * @param array|null $arguments
      *
      * @return mixed
      */


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

I think `@param null $arguments` should be used `@param array|null $arguments` on `FilterInterface`

**Checklist:**
- [x] Securely signed commits
