### PR TITLE
Fix @param null on RequestInterface::getServer() $filter argument

### DIFF
--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -40,8 +40,8 @@ interface RequestInterface extends OutgoingRequestInterface
      * Fetch an item from the $_SERVER array.
      * Supplied by RequestTrait.
      *
-     * @param string   $index  Index for item to be fetched from $_SERVER
-     * @param int|null $filter A filter name to be applied
+     * @param string          $index  Index for item to be fetched from $_SERVER
+     * @param int|string|null $filter A filter name to be applied
      *
      * @return mixed
      */

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -40,8 +40,8 @@ interface RequestInterface extends OutgoingRequestInterface
      * Fetch an item from the $_SERVER array.
      * Supplied by RequestTrait.
      *
-     * @param string $index  Index for item to be fetched from $_SERVER
-     * @param null   $filter A filter name to be applied
+     * @param string   $index  Index for item to be fetched from $_SERVER
+     * @param int|null $filter A filter name to be applied
      *
      * @return mixed
      */

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -40,8 +40,8 @@ interface RequestInterface extends OutgoingRequestInterface
      * Fetch an item from the $_SERVER array.
      * Supplied by RequestTrait.
      *
-     * @param string          $index  Index for item to be fetched from $_SERVER
-     * @param int|string|null $filter A filter name to be applied
+     * @param array|string|null $index  Index for item to be fetched from $_SERVER
+     * @param int|null          $filter A filter name to be applied
      *
      * @return mixed
      */


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

Looking at the usage, the `$filter` can be null or integer, eg: 

```php
$referer = $_SESSION['_ci_previous_url'] ?? Services::request()->getServer('HTTP_REFERER', FILTER_SANITIZE_URL);
```

or

```php
$request->getServer(['SERVER_PROTOCOL', 'REQUEST_URI']);
```

so it seems can use `@param string|int|null` for it.

**Checklist:**
- [x] Securely signed commits
