### PR TITLE
fix: fixes in retrieving error messages after redirect

### DIFF
--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -114,7 +114,7 @@ class RedirectResponse extends Response
 
         if ($validation->getErrors()) {
             $session = Services::session();
-            $session->setFlashdata('_ci_validation_errors', $validation->getErrors());
+            $session->setFlashdata('_ci_validation_errors', serialize($validation->getErrors()));
         }
 
         return $this;

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -729,7 +729,11 @@ class Validation implements ValidationInterface
      */
     public function getErrors(): array
     {
-        return $this->errors;
+        if (empty($this->errors) && ! is_cli() && isset($_SESSION, $_SESSION['_ci_validation_errors'])) {
+            $this->errors = unserialize($_SESSION['_ci_validation_errors']);
+        }
+
+        return $this->errors ?? [];
     }
 
     /**


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
this pull request for fix issue 
[7330](https://github.com/codeigniter4/CodeIgniter4/issues/7330)
I fixed the `getErrors()` method in `CodeIgniter/Validation/Validation.php` so that it can retrieve error messages in the session



**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
