### PR TITLE
chore: remove php-cs-fixer in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "kint-php/kint": "^5.0.4",
         "codeigniter/coding-standard": "^1.5",
         "fakerphp/faker": "^1.9",
-        "friendsofphp/php-cs-fixer": "3.13.0",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
         "nexusphp/tachycardia": "^1.0",


### PR DESCRIPTION
**Description**
Use coding-standard's dependency.
See https://github.com/CodeIgniter/coding-standard/releases/tag/v1.7.2

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
