### PR TITLE
fix: random_string() numeric

### DIFF
--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -543,7 +543,6 @@ if (! function_exists('random_string')) {
     {
         switch ($type) {
             case 'alnum':
-            case 'numeric':
             case 'nozero':
             case 'alpha':
                 switch ($type) {
@@ -555,16 +554,18 @@ if (! function_exists('random_string')) {
                         $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
                         break;
 
-                    case 'numeric':
-                        $pool = '0123456789';
-                        break;
-
                     case 'nozero':
                         $pool = '123456789';
                         break;
                 }
 
                 return substr(str_shuffle(str_repeat($pool, (int) ceil($len / strlen($pool)))), 0, $len);
+
+            case 'numeric':
+                $max  = 10 ** $len - 1;
+                $rand = random_int(0, $max);
+
+                return sprintf('%0' . $len . 'd', $rand);
 
             case 'md5':
                 return md5(uniqid((string) mt_rand(), true));

--- a/user_guide_src/source/changelogs/v4.3.3.rst
+++ b/user_guide_src/source/changelogs/v4.3.3.rst
@@ -13,6 +13,7 @@ SECURITY
 ********
 
 - **Email:** Added missing TLS 1.3 support.
+- **Text Helper:** The :php:func:`random_string()` type **numeric** is now cryptographically secure.
 
 BREAKING
 ********

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -30,7 +30,7 @@ The following functions are available:
     Generates a random string based on the type and length you specify.
     Useful for creating passwords or generating random hashes.
 
-    .. warning:: Except for type **crypto**, no cryptographically secure
+    .. warning:: Except for type **numeric** and **crypto**, no cryptographically secure
         strings are generated. Therefore, it must not be used for cryptographic
         purposes or purposes that requires return values to be unguessable.
 
@@ -48,6 +48,9 @@ The following functions are available:
 
     .. note:: When you use **crypto**, you must set an even number to the second parameter.
         Since v4.2.2, if you set an odd number, ``InvalidArgumentException`` will be thrown.
+
+    .. note:: Since v4.3.3, **numeric** uses ``random_int()``. In the previous
+        versions, it used ``str_shuffle()`` that is not cryptographically secure.
 
     Usage example:
 


### PR DESCRIPTION
**Description**
See #7326
Related #7327

- use `random_int()` in `random_string('numeric')`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
