### PR TITLE
Fixed: [Kint] Bool value exception while file validation

### DIFF
--- a/system/ThirdParty/Kint/Zval/Representation/SplFileInfoRepresentation.php
+++ b/system/ThirdParty/Kint/Zval/Representation/SplFileInfoRepresentation.php
@@ -181,7 +181,7 @@ class SplFileInfoRepresentation extends Representation
 
     public function getMTime(): ?string
     {
-        if (null !== $this->mtime) {
+        if ($this->mtime) {
             $year = \date('Y', $this->mtime);
 
             if ($year !== \date('Y')) {


### PR DESCRIPTION
**Description**
When a file validation run fails, $this->mtime is a bool and not null. So the condition got true and the date() function throws the exception. This is the case when you use the validation like below.

```php
 'userfile' => [
    'label' => 'Image File',
    'rules' => [
          'uploaded[userfile]',
          'is_image[userfile]',
          'mime_in[userfile,image/jpg,image/jpeg,image/gif,image/png,image/webp]',
          'max_size[userfile,100]',
          'max_dims[userfile,1024,768]',
    ],
]
```

![Screenshot (52)](https://user-images.githubusercontent.com/46279781/223113949-c8287049-6066-4a57-942d-c105983ff9e6.png)


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
