### PR TITLE
fix: use first exception in exceptionHandler()

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -119,6 +119,11 @@ class Exceptions
 
         [$statusCode, $exitCode] = $this->determineCodes($exception);
 
+        // Get the first exception.
+        while ($prevException = $exception->getPrevious()) {
+            $exception = $prevException;
+        }
+
         if ($this->config->log === true && ! in_array($statusCode, $this->config->ignoreCodes, true)) {
             log_message('critical', "{message}\nin {exFile} on line {exLine}.\n{trace}", [
                 'message' => $exception->getMessage(),


### PR DESCRIPTION
**Description**
Fixes #7339

Now the last Exception is shown, but showing the first Exception helps for debugging.
This PR shows the first Exception.

```php
<?php

namespace App\Controllers;

use CodeIgniter\HTTP\RequestInterface;
use CodeIgniter\HTTP\ResponseInterface;
use Psr\Log\LoggerInterface;

class Tests extends BaseController
{
    public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
    {
        // Do Not Edit This Line
        parent::initController($request, $response, $logger);

        $this->xx(); // Call to undefined method App\Controllers\Tests::xx()
    }

    public function __destruct()
    {
        dd($this->info); // Undefined property: App\Controllers\Tests::$info
    }

    public function index()
    {
    }
}
```
Before:
```
$ php public/index.php tests


[ErrorException]

Undefined property: App\Controllers\Tests::$info

at APPPATH/Controllers/Tests.php:21

Backtrace:
  1    APPPATH/Controllers/Tests.php:21
       CodeIgniter\Debug\Exceptions()->errorHandler(2, 'Undefined property: App\\Controllers\\Tests::$info', '/Users/kenji/work/codeigniter/official/CodeIgniter4/app/Controllers/Tests.php', 21)

  2    SYSTEMPATH/CodeIgniter.php:490
       App\Controllers\Tests()->__destruct()

  3    SYSTEMPATH/CodeIgniter.php:368
       CodeIgniter\CodeIgniter()->handleRequest(null, Object(Config\Cache), false)

  4    FCPATH/index.php:67
       CodeIgniter\CodeIgniter()->run()
```
After:
```
$ php public/index.php tests


[Error]

Call to undefined method App\Controllers\Tests::xx()

at APPPATH/Controllers/Tests.php:16

Backtrace:
  1    SYSTEMPATH/CodeIgniter.php:907
       App\Controllers\Tests()->initController(Object(CodeIgniter\HTTP\CLIRequest), Object(CodeIgniter\HTTP\Response), Object(CodeIgniter\Log\Logger))

  2    SYSTEMPATH/CodeIgniter.php:490
       CodeIgniter\CodeIgniter()->createController()

  3    SYSTEMPATH/CodeIgniter.php:368
       CodeIgniter\CodeIgniter()->handleRequest(null, Object(Config\Cache), false)

  4    FCPATH/index.php:67
       CodeIgniter\CodeIgniter()->run()
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
