### PR TITLE
fix: random_string() alpha alnum nozero

### DIFF
--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -559,7 +559,7 @@ if (! function_exists('random_string')) {
                         break;
                 }
 
-                return substr(str_shuffle(str_repeat($pool, (int) ceil($len / strlen($pool)))), 0, $len);
+                return _from_random($len, $pool);
 
             case 'numeric':
                 $max  = 10 ** $len - 1;
@@ -584,6 +584,69 @@ if (! function_exists('random_string')) {
         }
         // 'basic' type treated as default
         return (string) mt_rand();
+    }
+}
+
+if (! function_exists('_from_random')) {
+    /**
+     * The following function was derived from code of Symfony (v6.2.7 - 2023-02-28)
+     * https://github.com/symfony/symfony/blob/80cac46a31d4561804c17d101591a4f59e6db3a2/src/Symfony/Component/String/ByteString.php#L45
+     * Code subject to the MIT license (https://github.com/symfony/symfony/blob/v6.2.7/LICENSE).
+     * Copyright (c) 2004-present Fabien Potencier
+     *
+     * The following method was derived from code of the Hack Standard Library (v4.40 - 2020-05-03)
+     * https://github.com/hhvm/hsl/blob/80a42c02f036f72a42f0415e80d6b847f4bf62d5/src/random/private.php#L16
+     * Code subject to the MIT license (https://github.com/hhvm/hsl/blob/master/LICENSE).
+     * Copyright (c) 2004-2020, Facebook, Inc. (https://www.facebook.com/)
+     *
+     * @internal Outside the framework this should not be used directly.
+     */
+    function _from_random(int $length, string $pool): string
+    {
+        if ($length <= 0) {
+            throw new InvalidArgumentException(
+                sprintf('A strictly positive length is expected, "%d" given.', $length)
+            );
+        }
+
+        $poolSize = \strlen($pool);
+        $bits     = (int) ceil(log($poolSize, 2.0));
+        if ($bits <= 0 || $bits > 56) {
+            throw new InvalidArgumentException(
+                'The length of the alphabet must in the [2^1, 2^56] range.'
+            );
+        }
+
+        $string = '';
+
+        while ($length > 0) {
+            $urandomLength = (int) ceil(2 * $length * $bits / 8.0);
+            $data          = random_bytes($urandomLength);
+            $unpackedData  = 0;
+            $unpackedBits  = 0;
+
+            for ($i = 0; $i < $urandomLength && $length > 0; $i++) {
+                // Unpack 8 bits
+                $unpackedData = ($unpackedData << 8) | \ord($data[$i]);
+                $unpackedBits += 8;
+
+                // While we have enough bits to select a character from the alphabet, keep
+                // consuming the random data
+                for (; $unpackedBits >= $bits && $length > 0; $unpackedBits -= $bits) {
+                    $index = ($unpackedData & ((1 << $bits) - 1));
+                    $unpackedData >>= $bits;
+                    // Unfortunately, the alphabet size is not necessarily a power of two.
+                    // Worst case, it is 2^k + 1, which means we need (k+1) bits and we
+                    // have around a 50% chance of missing as k gets larger
+                    if ($index < $poolSize) {
+                        $string .= $pool[$index];
+                        $length--;
+                    }
+                }
+            }
+        }
+
+        return $string;
     }
 }
 

--- a/user_guide_src/source/changelogs/v4.3.3.rst
+++ b/user_guide_src/source/changelogs/v4.3.3.rst
@@ -13,7 +13,8 @@ SECURITY
 ********
 
 - **Email:** Added missing TLS 1.3 support.
-- **Text Helper:** The :php:func:`random_string()` type **numeric** is now cryptographically secure.
+- **Text Helper:** The :php:func:`random_string()` type **alpha**, **alnum**,
+  **numeric** and **nozero** are now cryptographically secure.
 
 BREAKING
 ********

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -30,10 +30,9 @@ The following functions are available:
     Generates a random string based on the type and length you specify.
     Useful for creating passwords or generating random hashes.
 
-    .. warning:: Except for type **alpha**, **alnum**, **numeric**, **nozero**,
-        and **crypto**, no cryptographically secure
-        strings are generated. Therefore, it must not be used for cryptographic
-        purposes or purposes that requires return values to be unguessable.
+    .. warning:: For types: **basic**, **md5**, and **sha1**, generated strings
+        are not cryptographically secure. Therefore, these types cannot be used
+        for cryptographic purposes or purposes requiring unguessable return values.
 
     The first parameter specifies the type of string, the second parameter
     specifies the length. The following choices are available:

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -30,7 +30,8 @@ The following functions are available:
     Generates a random string based on the type and length you specify.
     Useful for creating passwords or generating random hashes.
 
-    .. warning:: Except for type **numeric** and **crypto**, no cryptographically secure
+    .. warning:: Except for type **alpha**, **alnum**, **numeric**, **nozero**,
+        and **crypto**, no cryptographically secure
         strings are generated. Therefore, it must not be used for cryptographic
         purposes or purposes that requires return values to be unguessable.
 
@@ -49,8 +50,10 @@ The following functions are available:
     .. note:: When you use **crypto**, you must set an even number to the second parameter.
         Since v4.2.2, if you set an odd number, ``InvalidArgumentException`` will be thrown.
 
-    .. note:: Since v4.3.3, **numeric** uses ``random_int()``. In the previous
-        versions, it used ``str_shuffle()`` that is not cryptographically secure.
+    .. note:: Since v4.3.3, **alpha**, **alnum** and **nozero** use ``random_byte()``,
+        and **numeric** uses ``random_int()``.
+        In the previous versions, it used ``str_shuffle()`` that is not
+        cryptographically secure.
 
     Usage example:
 


### PR DESCRIPTION
**Description**
See #7326
Related #7336, #7327

- use `random_bytes()` in `random_string()` alpha alnum nozero

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
