### PR TITLE
fix: respondNoContent() returns Kint script in development mode

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -92,8 +92,10 @@ trait ResponseTrait
         if ($data === null && $status === null) {
             $status = 404;
             $output = null;
+            $this->format($data);
         } elseif ($data === null && is_numeric($status)) {
             $output = null;
+            $this->format($data);
         } else {
             $status = empty($status) ? 200 : $status;
             $output = $this->format($data);

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -331,6 +331,7 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $this->invoke($controller, 'respondNoContent', ['']);
 
+        $this->assertStringStartsWith('application/json', $this->response->getHeaderLine('Content-Type'));
         $this->assertSame('No Content', $this->response->getReason());
         $this->assertSame(204, $this->response->getStatusCode());
     }


### PR DESCRIPTION
**Description**
Fixes #7346 about API\ResponseTrait::respondNoContent() returns Kint script in development mode.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
