### PR TITLE
docs: fix out of dated description in autoloader.rst

### DIFF
--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -59,7 +59,7 @@ The value is the location to the directory the classes can be found in.
 
     > php spark namespaces
 
-By default, the application folder is namespace to the ``App`` namespace. You must namespace the controllers,
+By default, the application directory is namespace to the ``App`` namespace. You must namespace the controllers,
 libraries, or models in the application directory, and they will be found under the ``App`` namespace.
 
 You may change this namespace by editing the **app/Config/Constants.php** file and setting the

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -47,7 +47,7 @@ Namespaces
 
 The recommended method for organizing your classes is to create one or more namespaces for your
 application's files. This is most important for any business-logic related classes, entity classes,
-etc. The ``psr4`` array in the configuration file allows you to map the namespace to the directory
+etc. The ``$psr4`` array in the configuration file allows you to map the namespace to the directory
 those classes can be found in:
 
 .. literalinclude:: autoloader/001.php

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -53,8 +53,7 @@ those classes can be found in:
 .. literalinclude:: autoloader/001.php
 
 The key of each row is the namespace itself. This does not need a trailing back slash.
-The value is the location to the directory the classes can be found in. They should
-have a trailing slash.
+The value is the location to the directory the classes can be found in.
 
 .. note:: You can check the namespace configuration by ``spark namespaces`` command::
 

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -60,8 +60,9 @@ have a trailing slash.
 
     > php spark namespaces
 
-By default, the application folder is namespace to the ``App`` namespace. While you are not forced to namespace the controllers,
-libraries, or models in the application directory, if you do, they will be found under the ``App`` namespace.
+By default, the application folder is namespace to the ``App`` namespace. You must namespace the controllers,
+libraries, or models in the application directory, and they will be found under the ``App`` namespace.
+
 You may change this namespace by editing the **app/Config/Constants.php** file and setting the
 new namespace value under the ``APP_NAMESPACE`` setting:
 

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -67,6 +67,7 @@ You may change this namespace by editing the **app/Config/Constants.php** file a
 new namespace value under the ``APP_NAMESPACE`` setting:
 
 .. literalinclude:: autoloader/002.php
+   :lines: 2-
 
 You will need to modify any existing files that are referencing the current namespace.
 

--- a/user_guide_src/source/concepts/autoloader/001.php
+++ b/user_guide_src/source/concepts/autoloader/001.php
@@ -1,6 +1,16 @@
 <?php
 
-$psr4 = [
-    'App'         => APPPATH,
-    'CodeIgniter' => SYSTEMPATH,
-];
+namespace Config;
+
+use CodeIgniter\Config\AutoloadConfig;
+
+class Autoload extends AutoloadConfig
+{
+    // ...
+    public $psr4 = [
+        APP_NAMESPACE => APPPATH, // For custom app namespace
+        'Config'      => APPPATH . 'Config',
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/concepts/autoloader/002.php
+++ b/user_guide_src/source/concepts/autoloader/002.php
@@ -1,3 +1,3 @@
 <?php
 
-define('APP_NAMESPACE', 'App');
+defined('APP_NAMESPACE') || define('APP_NAMESPACE', 'App');

--- a/user_guide_src/source/concepts/autoloader/003.php
+++ b/user_guide_src/source/concepts/autoloader/003.php
@@ -1,5 +1,15 @@
 <?php
 
-$classmap = [
-    'Markdown' => APPPATH . 'third_party/markdown.php',
-];
+namespace Config;
+
+use CodeIgniter\Config\AutoloadConfig;
+
+class Autoload extends AutoloadConfig
+{
+    // ...
+    public $classmap = [
+        'Markdown' => APPPATH . 'third_party/markdown.php',
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/concepts/autoloader/003.php
+++ b/user_guide_src/source/concepts/autoloader/003.php
@@ -8,7 +8,7 @@ class Autoload extends AutoloadConfig
 {
     // ...
     public $classmap = [
-        'Markdown' => APPPATH . 'third_party/markdown.php',
+        'Markdown' => APPPATH . 'ThirdParty/markdown.php',
     ];
 
     // ...


### PR DESCRIPTION
**Description**
- fix out-of-dated description on App namespace
- update sample code

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
