### PR TITLE
fix: migrate:rollback -b negative number

### DIFF
--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -57,7 +57,7 @@ class MigrateRollback extends BaseCommand
      * @var array
      */
     protected $options = [
-        '-b' => 'Specify a batch to roll back to; e.g. "3" to return to batch #3 or "-2" to roll back twice',
+        '-b' => 'Specify a batch to roll back to; e.g. "3" to return to batch #3',
         '-g' => 'Set database group',
         '-f' => 'Force command - this option allows you to bypass the confirmation question when running this command in a production environment',
     ];

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -144,7 +144,7 @@ Rolls back all migrations, taking the database group to a blank slate, effective
 You can use (rollback) with the following options:
 
 - ``-g`` - to choose database group, otherwise default database group will be used.
-- ``-b`` - to choose a batch: natural numbers specify the batch, negatives indicate a relative batch
+- ``-b`` - to choose a batch: natural numbers specify the batch.
 - ``-f`` - to force a bypass confirmation question, it is only asked in a production environment
 
 refresh

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -124,7 +124,7 @@ You can use (migrate) with the following options:
 
 - ``-g`` - to chose database group, otherwise default database group will be used.
 - ``-n`` - to choose namespace, otherwise (App) namespace will be used.
-- ``--all`` - to migrate all namespaces to the latest migration
+- ``--all`` - to migrate all namespaces to the latest migration.
 
 This example will migrate ``Acme\Blog`` namespace with any new migrations on the test database group::
 
@@ -145,7 +145,7 @@ You can use (rollback) with the following options:
 
 - ``-g`` - to choose database group, otherwise default database group will be used.
 - ``-b`` - to choose a batch: natural numbers specify the batch.
-- ``-f`` - to force a bypass confirmation question, it is only asked in a production environment
+- ``-f`` - to force a bypass confirmation question, it is only asked in a production environment.
 
 refresh
 =======
@@ -158,8 +158,8 @@ You can use (refresh) with the following options:
 
 - ``-g`` - to choose database group, otherwise default database group will be used.
 - ``-n`` - to choose namespace, otherwise (App) namespace will be used.
-- ``--all`` - to refresh all namespaces
-- ``-f`` - to force a bypass confirmation question, it is only asked in a production environment
+- ``--all`` - to refresh all namespaces.
+- ``-f`` - to force a bypass confirmation question, it is only asked in a production environment.
 
 status
 ======


### PR DESCRIPTION
**Description**
See #7349

Fixes the incorrect documentation and help.
We cannot specify negative number as an option value on CLI.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
