### PR TITLE
fix: site_url() does not support protocol-relative links

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -117,13 +117,20 @@ if (! function_exists('site_url')) {
     {
         $uri = _get_uri($relativePath, $config);
 
-        return URI::createURIString(
+        $uriString = URI::createURIString(
             $scheme ?? $uri->getScheme(),
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
             $uri->getFragment()
         );
+
+        // For protocol-relative links
+        if ($scheme === '') {
+            $uriString = '//' . $uriString;
+        }
+
+        return $uriString;
     }
 }
 

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -304,7 +304,21 @@ final class SiteUrlTest extends CIUnitTestCase
         ];
     }
 
-    // base_url
+    public function testSiteURLWithEmptyStringScheme()
+    {
+        $this->config->baseURL                   = 'http://example.com/';
+        $this->config->indexPage                 = 'index.php';
+        $this->config->forceGlobalSecureRequests = false;
+
+        $this->assertSame(
+            '//example.com/index.php/test',
+            site_url('test', '', $this->config)
+        );
+        $this->assertSame(
+            '//example.com/img/test.jpg',
+            base_url('img/test.jpg', '')
+        );
+    }
 
     /**
      * These tests are only really relevant to show that base_url()


### PR DESCRIPTION
**Description**
CI3 supports protocol-relative links.
```php
$this->load->helpers('url');
echo site_url('test', ''); // outputs "//localhost:8888/index.php/test"
```
- https://github.com/bcit-ci/CodeIgniter/blob/a6faab2ebf082eefff9c2422fce016e49da548bf/system/core/Config.php#L243-L253
- https://github.com/bcit-ci/CodeIgniter/blob/a6faab2ebf082eefff9c2422fce016e49da548bf/system/core/Config.php#L306-L316

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
