### PR TITLE
docs: add uri_string() BC in v4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Breaking Changes
 
 * fix: base_url() removes trailing slash in baseURL by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7200
+* fix: remove parameter $relative in `uri_string()` by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7135
 
 ### Fixed Bugs
 
@@ -14,7 +15,6 @@
 * fix: remove `All` from `Options All -Indexes` in .htaccess by @sba in https://github.com/codeigniter4/CodeIgniter4/pull/7093
 * fix: bug on stuck content-type header in Feature Testing by @baycik in https://github.com/codeigniter4/CodeIgniter4/pull/7112
 * fix: ordering `Validation` show error by call `setRule()` by @ddevsr in https://github.com/codeigniter4/CodeIgniter4/pull/7149
-* fix: remove parameter $relative in `uri_string()` by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7135
 * fix: [QueryBuilder] where() generates incorrect SQL when using RawSql by @sclubricants in https://github.com/codeigniter4/CodeIgniter4/pull/7147
 * fix: [QueryBuilder] RawSql passed to set() disappears without error by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7148
 * fix: [Parser] local_currency causes "Passing null to parameter" by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7157

--- a/user_guide_src/source/changelogs/v4.3.2.rst
+++ b/user_guide_src/source/changelogs/v4.3.2.rst
@@ -18,10 +18,10 @@ Behavior Changes
 base_url()
 ----------
 
-Due to a bug, in previous versions :php:func:`base_url()` without argument returned baseURL
-without a trailing slash (``/``) like ``http://localhost:8080``. Now it returns
-baseURL with a trailing slash. This is the same behavior as ``base_url()`` in
-CodeIgniter 3.
+- Due to a bug, in previous versions :php:func:`base_url()` without argument
+  returned baseURL without a trailing slash (``/``) like ``http://localhost:8080``.
+- Now it returns baseURL with a trailing slash. This is the same behavior as
+  ``base_url()`` in CodeIgniter 3.
 
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.3.2.rst
+++ b/user_guide_src/source/changelogs/v4.3.2.rst
@@ -23,11 +23,16 @@ base_url()
 - Now it returns baseURL with a trailing slash. This is the same behavior as
   ``base_url()`` in CodeIgniter 3.
 
-Changes
-*******
+.. _v432-uri-string:
+
+uri_string()
+------------
 
 - The parameter ``$relative`` in :php:func:`uri_string()` was removed. Due to a bug,
-  the function always returned a path relative to baseURL. No behavior changes.
+  the function always returned a path relative to baseURL.
+- When baseURL is accessed, it will now return an empty string (``''``). This is
+  the same behavior as ``uri_string()`` in CodeIgniter 3. In previous versions
+  it returned ``/``.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.3.3.rst
+++ b/user_guide_src/source/changelogs/v4.3.3.rst
@@ -32,6 +32,9 @@ Bugs Fixed
 
 - **Config:** Added missing ``Config\Encryption::$cipher``.
 - **UserGuide:** Fixed the sample code for :ref:`encryption-compatible-with-ci3`.
+- **UserGuide:** Added a missing breaking change in ``uri_string()`` in
+  :ref:`ChangeLog <v432-uri-string>` and
+  :ref:`Upgrading Guide <upgrade-432-uri-string>` v4.3.2.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/helpers/url_helper.rst
+++ b/user_guide_src/source/helpers/url_helper.rst
@@ -155,6 +155,10 @@ The following functions are available:
         However, due to a bug, this function always returned a path relative to baseURL.
         Since v4.3.2, the parameter has been removed.
 
+    .. note:: In previous versions, when you navigate to the baseURL, this function
+        returned ``/``. Since v4.3.2, the bug has been fixed and it returns an
+        empty string(``''``).
+
 .. php:function:: index_page([$altConfig = null])
 
     :param \\Config\\App $altConfig: Alternate configuration to use

--- a/user_guide_src/source/installation/upgrade_432.rst
+++ b/user_guide_src/source/installation/upgrade_432.rst
@@ -18,7 +18,7 @@ Breaking Changes
 base_url()
 ==========
 
-The :php:func:`base_url()` behavior has been fix. In previous versions, when you
+The :php:func:`base_url()` behavior has been fixed. In previous versions, when you
 call ``base_url()`` **without argument**, it returned baseURL without a trailing
 slash (``/``). Now it returns baseURL with a trailing slash. For example:
 

--- a/user_guide_src/source/installation/upgrade_432.rst
+++ b/user_guide_src/source/installation/upgrade_432.rst
@@ -27,6 +27,21 @@ slash (``/``). Now it returns baseURL with a trailing slash. For example:
 
 If you have code to call ``base_url()`` without argument, you may need to adjust the URLs.
 
+.. _upgrade-432-uri-string:
+
+uri_string()
+============
+
+The :php:func:`uri_string()` behavior has been fixed. In previous versions, when you
+navigate to the baseURL, it returned ``/``. Now it returns an empty string (``''``).
+
+If you have code to call ``uri_string()``, you may need to adjust it.
+
+.. note:: The :php:func:`uri_string()` returns a URI path relative to baseURL.
+    It is not a full URI path if the baseURL contains subfolders.
+    If you use it for HTML links, it is better to use it with :php:func:`site_url()`
+    like ``site_url(uri_string())``.
+
 Mandatory File Changes
 **********************
 


### PR DESCRIPTION
**Description**
Follow-up #7135

- add uri_string() BC in v4.3.2

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
