### PR TITLE
docs: remove `:noindex:`

### DIFF
--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -417,7 +417,6 @@ The methods provided by the parent classes that are available are:
         Although GET data will be preferred in case of name conflict.
 
     .. php:method:: getCookie([$index = null[, $filter = null[, $flags = null]]])
-        :noindex:
 
         :param    mixed    $index: COOKIE name
         :param  int     $filter: The type of filter to apply. A list of filters can be
@@ -440,7 +439,6 @@ The methods provided by the parent classes that are available are:
             your configured ``Config\Cookie::$prefix`` value.
 
     .. php:method:: getServer([$index = null[, $filter = null[, $flags = null]]])
-        :noindex:
 
         :param    mixed    $index: Value name
         :param  int     $filter: The type of filter to apply. A list of filters can be

--- a/user_guide_src/source/libraries/email.rst
+++ b/user_guide_src/source/libraries/email.rst
@@ -269,7 +269,6 @@ Class Reference
         and strip the tags.
 
     .. php:method:: setHeader($header, $value)
-        :noindex:
 
         :param    string    $header: Header name
         :param    string    $value: Header value


### PR DESCRIPTION
**Description**

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
