### PR TITLE
docs: deprecate random_string() basic,md5,sha1

### DIFF
--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -538,6 +538,8 @@ if (! function_exists('random_string')) {
      *
      * @param string $type Type of random string.  basic, alpha, alnum, numeric, nozero, md5, sha1, and crypto
      * @param int    $len  Number of characters
+     *
+     * @deprecated The type 'basic', 'md5', and 'sha1' are deprecated. They are not cryptographically secure.
      */
     function random_string(string $type = 'alnum', int $len = 8): string
     {

--- a/user_guide_src/source/changelogs/v4.3.4.rst
+++ b/user_guide_src/source/changelogs/v4.3.4.rst
@@ -21,6 +21,9 @@ Changes
 Deprecations
 ************
 
+- **Text Helper:** :php:func:`random_string()`'s type ``basic``, ``md5``, and
+  ``sha1`` are deprecated. They are not cryptographically secure.
+
 Bugs Fixed
 **********
 

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -33,17 +33,18 @@ The following functions are available:
     .. warning:: For types: **basic**, **md5**, and **sha1**, generated strings
         are not cryptographically secure. Therefore, these types cannot be used
         for cryptographic purposes or purposes requiring unguessable return values.
+        Since v4.3.3, these types are deprecated.
 
     The first parameter specifies the type of string, the second parameter
     specifies the length. The following choices are available:
 
     - **alpha**: A string with lower and uppercase letters only.
     - **alnum**: Alphanumeric string with lower and uppercase characters.
-    - **basic**: A random number based on ``mt_rand()`` (length ignored).
+    - **basic**: [deprecated] A random number based on ``mt_rand()`` (length ignored).
     - **numeric**: Numeric string.
     - **nozero**: Numeric string with no zeros.
-    - **md5**: An encrypted random number based on ``md5()`` (fixed length of 32).
-    - **sha1**: An encrypted random number based on ``sha1()`` (fixed length of 40).
+    - **md5**: [deprecated] An encrypted random number based on ``md5()`` (fixed length of 32).
+    - **sha1**: [deprecated] An encrypted random number based on ``sha1()`` (fixed length of 40).
     - **crypto**: A random string based on ``random_bytes()``.
 
     .. note:: When you use **crypto**, you must set an even number to the second parameter.


### PR DESCRIPTION
**Description**
Supersedes #7327
See https://forum.codeigniter.com/showthread.php?tid=87026

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
