### PR TITLE
fix: [SQLite3][Postgres][SQLSRV][OCI8] Forge::modifyColumn() changes NULL constraint incorrectly

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -153,7 +153,7 @@ class Forge
      *
      * @internal Used for marking nullable fields. Not covered by BC promise.
      */
-    protected $null = '';
+    protected $null = 'NULL';
 
     /**
      * DEFAULT value representation in CREATE/ALTER TABLE statements

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -897,13 +897,19 @@ class Forge
             $this->_attributeDefault($attributes, $field);
 
             if (isset($attributes['NULL'])) {
+                $nullString = ' ' . $this->null;
+
                 if ($attributes['NULL'] === true) {
-                    $field['null'] = empty($this->null) ? '' : ' ' . $this->null;
+                    $field['null'] = empty($this->null) ? '' : $nullString;
+                } elseif ($attributes['NULL'] === $nullString) {
+                    $field['null'] = $nullString;
+                } elseif ($attributes['NULL'] === '') {
+                    $field['null'] = '';
                 } else {
-                    $field['null'] = ' NOT NULL';
+                    $field['null'] = ' NOT ' . $this->null;
                 }
             } elseif ($createTable === true) {
-                $field['null'] = ' NOT NULL';
+                $field['null'] = ' NOT ' . $this->null;
             }
 
             $this->_attributeAutoIncrement($attributes, $field);

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -562,7 +562,7 @@ class Forge
     }
 
     /**
-     * @return string
+     * @return string SQL string
      *
      * @deprecated $ifNotExists is no longer used, and will be removed.
      */

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -120,10 +120,17 @@ class Forge extends BaseForge
                 // If a null constraint is added to a column with a null constraint,
                 // ORA-01451 will occur,
                 // so add null constraint is used only when it is different from the current null constraint.
-                $isWantToAddNull    = strpos($field[$i]['null'], ' NOT') === false;
-                $currentNullAddable = $nullableMap[$field[$i]['name']];
+                // If a not null constraint is added to a column with a not null constraint,
+                // ORA-01442 will occur.
+                $wantToAddNull   = strpos($field[$i]['null'], ' NOT') === false;
+                $currentNullable = $nullableMap[$field[$i]['name']];
 
-                if ($isWantToAddNull === $currentNullAddable) {
+                if ($wantToAddNull === true && $currentNullable === true) {
+                    $field[$i]['null'] = '';
+                } elseif ($field[$i]['null'] === '' && $currentNullable === false) {
+                    // Nullable by default
+                    $field[$i]['null'] = ' NULL';
+                } elseif ($wantToAddNull === false && $currentNullable === false) {
                     $field[$i]['null'] = '';
                 }
             }

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -110,10 +110,8 @@ class Forge extends BaseForge
             }
 
             $nullable = true; // Nullable by default.
-            if (isset($data['null'])) {
-                if ($data['null'] === false || $data['null'] === ' NOT ' . $this->null) {
-                    $nullable = false;
-                }
+            if (isset($data['null']) && ($data['null'] === false || $data['null'] === ' NOT ' . $this->null)) {
+                $nullable = false;
             }
             $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
                 . ($nullable === true ? ' DROP' : ' SET') . ' NOT NULL';

--- a/system/Database/Postgre/Forge.php
+++ b/system/Database/Postgre/Forge.php
@@ -109,10 +109,14 @@ class Forge extends BaseForge
                     . " SET DEFAULT {$data['default']}";
             }
 
+            $nullable = true; // Nullable by default.
             if (isset($data['null'])) {
-                $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                    . ($data['null'] === true ? ' DROP' : ' SET') . ' NOT NULL';
+                if ($data['null'] === false || $data['null'] === ' NOT ' . $this->null) {
+                    $nullable = false;
+                }
             }
+            $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
+                . ($nullable === true ? ' DROP' : ' SET') . ' NOT NULL';
 
             if (! empty($data['new_name'])) {
                 $sqls[] = $sql . ' RENAME COLUMN ' . $this->db->escapeIdentifiers($data['name'])

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -203,10 +203,14 @@ class Forge extends BaseForge
                     . " DEFAULT {$data['default']} FOR " . $this->db->escapeIdentifiers($data['name']);
             }
 
+            $nullable = true; // Nullable by default.
             if (isset($data['null'])) {
-                $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
-                    . ($data['null'] === true ? ' DROP' : '') . " {$data['type']}{$data['length']} NOT NULL";
+                if ($data['null'] === false || $data['null'] === ' NOT ' . $this->null) {
+                    $nullable = false;
+                }
             }
+            $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
+                . " {$data['type']}{$data['length']} " . ($nullable === true ? '' : 'NOT') . ' NULL';
 
             if (! empty($data['comment'])) {
                 $sqls[] = 'EXEC sys.sp_addextendedproperty '

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -204,10 +204,8 @@ class Forge extends BaseForge
             }
 
             $nullable = true; // Nullable by default.
-            if (isset($data['null'])) {
-                if ($data['null'] === false || $data['null'] === ' NOT ' . $this->null) {
-                    $nullable = false;
-                }
+            if (isset($data['null']) && ($data['null'] === false || $data['null'] === ' NOT ' . $this->null)) {
+                $nullable = false;
             }
             $sqls[] = $sql . ' ALTER COLUMN ' . $this->db->escapeIdentifiers($data['name'])
                 . " {$data['type']}{$data['length']} " . ($nullable === true ? '' : 'NOT') . ' NULL';

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -183,14 +183,14 @@ class Table
      *
      * @return Table
      */
-    public function modifyColumn(array $field)
+    public function modifyColumn(array $fields)
     {
-        $field = $field[0];
+        foreach ($fields as $field) {
+            $oldName = $field['name'];
+            unset($field['name']);
 
-        $oldName = $field['name'];
-        unset($field['name']);
-
-        $this->fields[$oldName] = $field;
+            $this->fields[$oldName] = $field;
+        }
 
         return $this;
     }

--- a/tests/_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102301_Some_migration.php
+++ b/tests/_support/MigrationTestMigrations/Database/Migrations/2018-01-24-102301_Some_migration.php
@@ -21,7 +21,7 @@ class Migration_some_migration extends \CodeIgniter\Database\Migration
                 'constraint' => 255,
             ],
         ]);
-        $this->forge->createTable('foo', true);
+        $this->forge->createTable('foo');
 
         $this->db->table('foo')->insert([
             'key' => 'foobar',

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Commands\Database;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use Config\Database;
 
 /**
  * @group DatabaseLive
@@ -29,6 +30,9 @@ final class MigrateStatusTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $forge = Database::forge();
+        $forge->dropTable('foo', true);
+
         parent::setUp();
 
         if (! is_file($this->migrationFileFrom)) {

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -56,6 +56,9 @@ final class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $forge = Database::forge();
+        $forge->dropTable('foo', true);
+
         $this->setUpMethods[] = 'setUpAddNamespace';
 
         parent::setUp();

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database\DatabaseTestCase;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
 use Config\Services;
 
 /**
@@ -55,6 +56,9 @@ final class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $forge = Database::forge();
+        $forge->dropTable('foo', true);
+
         $this->setUpMethods[] = 'setUpAddNamespace';
 
         parent::setUp();

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
 use Config\Services;
 use Tests\Support\Database\Seeds\AnotherSeeder;
 use Tests\Support\Database\Seeds\CITestSeeder;
@@ -60,6 +61,9 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        $forge = Database::forge();
+        $forge->dropTable('foo', true);
+
         $this->setUpMethods[] = 'setUpAddNamespace';
 
         parent::setUp();

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\Database\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use LogicException;
 use RuntimeException;
 use stdClass;
 use Tests\Support\Database\Seeds\CITestSeeder;
@@ -1347,11 +1348,17 @@ final class ForgeTest extends CIUnitTestCase
     {
         $fields = $this->db->getFieldData($table);
 
-        return $fields[array_search(
+        $name = array_search(
             $column,
             array_column($fields, 'name'),
             true
-        )];
+        );
+
+        if ($name === false) {
+            throw new LogicException('Column not found: ' . $column);
+        }
+
+        return $fields[$name];
     }
 
     public function testConnectWithArrayGroup()

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1277,7 +1277,7 @@ final class ForgeTest extends CIUnitTestCase
         $this->forge->dropTable('forge_test_three', true);
     }
 
-    public function testModifyColumnNull()
+    public function testModifyColumnNullTrue()
     {
         if ($this->db->DBDriver === 'SQLSRV') {
             $this->markTestSkipped('SQLSRV does not support getFieldData() nullable.');
@@ -1302,6 +1302,39 @@ final class ForgeTest extends CIUnitTestCase
 
         $col1 = $this->getMetaData('col1', 'forge_test_modify');
         $this->assertTrue($col1->nullable);
+        $col2 = $this->getMetaData('col2', 'forge_test_modify');
+        $this->assertTrue($col2->nullable);
+        $col3 = $this->getMetaData('col3', 'forge_test_modify');
+        $this->assertFalse($col3->nullable);
+
+        $this->forge->dropTable('forge_test_modify', true);
+    }
+
+    public function testModifyColumnNullFalse()
+    {
+        if ($this->db->DBDriver === 'SQLSRV') {
+            $this->markTestSkipped('SQLSRV does not support getFieldData() nullable.');
+        }
+
+        $this->forge->dropTable('forge_test_modify', true);
+
+        $this->forge->addField([
+            'col1' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => false],
+            'col2' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => false],
+            'col3' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => false],
+        ]);
+        $this->forge->createTable('forge_test_modify');
+
+        $this->forge->modifyColumn('forge_test_modify', [
+            'col1' => ['type' => 'VARCHAR', 'constraint' => 1],
+            'col2' => ['type' => 'VARCHAR', 'constraint' => 1, 'null' => true],
+            'col3' => ['type' => 'VARCHAR', 'constraint' => 1, 'null' => false],
+        ]);
+
+        $this->db->resetDataCache();
+
+        $col1 = $this->getMetaData('col1', 'forge_test_modify');
+        $this->assertTrue($col1->nullable); // Nullable by default.
         $col2 = $this->getMetaData('col2', 'forge_test_modify');
         $this->assertTrue($col2->nullable);
         $col3 = $this->getMetaData('col3', 'forge_test_modify');

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1280,6 +1280,7 @@ final class ForgeTest extends CIUnitTestCase
 
     public function testModifyColumnNullTrue()
     {
+        // @TODO remove this in `4.4` branch
         if ($this->db->DBDriver === 'SQLSRV') {
             $this->markTestSkipped('SQLSRV does not support getFieldData() nullable.');
         }
@@ -1313,6 +1314,7 @@ final class ForgeTest extends CIUnitTestCase
 
     public function testModifyColumnNullFalse()
     {
+        // @TODO remove this in `4.4` branch
         if ($this->db->DBDriver === 'SQLSRV') {
             $this->markTestSkipped('SQLSRV does not support getFieldData() nullable.');
         }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use RuntimeException;
+use stdClass;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**
@@ -1274,6 +1275,50 @@ final class ForgeTest extends CIUnitTestCase
         $this->assertTrue($this->db->fieldExists('altered', 'forge_test_three'));
 
         $this->forge->dropTable('forge_test_three', true);
+    }
+
+    public function testModifyColumnNull()
+    {
+        if ($this->db->DBDriver === 'SQLSRV') {
+            $this->markTestSkipped('SQLSRV does not support getFieldData() nullable.');
+        }
+
+        $this->forge->dropTable('forge_test_modify', true);
+
+        $this->forge->addField([
+            'col1' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => true],
+            'col2' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => true],
+            'col3' => ['type' => 'VARCHAR', 'constraint' => 255, 'null' => true],
+        ]);
+        $this->forge->createTable('forge_test_modify');
+
+        $this->forge->modifyColumn('forge_test_modify', [
+            'col1' => ['type' => 'VARCHAR', 'constraint' => 1],
+            'col2' => ['type' => 'VARCHAR', 'constraint' => 1, 'null' => true],
+            'col3' => ['type' => 'VARCHAR', 'constraint' => 1, 'null' => false],
+        ]);
+
+        $this->db->resetDataCache();
+
+        $col1 = $this->getMetaData('col1', 'forge_test_modify');
+        $this->assertTrue($col1->nullable);
+        $col2 = $this->getMetaData('col2', 'forge_test_modify');
+        $this->assertTrue($col2->nullable);
+        $col3 = $this->getMetaData('col3', 'forge_test_modify');
+        $this->assertFalse($col3->nullable);
+
+        $this->forge->dropTable('forge_test_modify', true);
+    }
+
+    private function getMetaData(string $column, string $table): stdClass
+    {
+        $fields = $this->db->getFieldData($table);
+
+        return $fields[array_search(
+            $column,
+            array_column($fields, 'name'),
+            true
+        )];
     }
 
     public function testConnectWithArrayGroup()

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -349,6 +349,9 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
     public function testRegressSuccess()
     {
+        $forge = Database::forge();
+        $forge->dropTable('foo', true);
+
         $runner = new MigrationRunner($this->config);
         $runner->setSilent(false)
             ->setNamespace('Tests\Support\MigrationTestMigrations')
@@ -368,6 +371,9 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
     public function testLatestTriggersEvent()
     {
+        $forge = Database::forge();
+        $forge->dropTable('foo', true);
+
         $runner = new MigrationRunner($this->config);
         $runner->setSilent(false)
             ->setNamespace('Tests\Support\MigrationTestMigrations');
@@ -387,6 +393,9 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
     public function testRegressTriggersEvent()
     {
+        $forge = Database::forge();
+        $forge->dropTable('foo', true);
+
         $runner = new MigrationRunner($this->config);
         $runner->setSilent(false)
             ->setNamespace('Tests\Support\MigrationTestMigrations');

--- a/user_guide_src/source/changelogs/v4.3.4.rst
+++ b/user_guide_src/source/changelogs/v4.3.4.rst
@@ -35,6 +35,19 @@ Redirect Status Code
   always be used when you don't specify a status code. In previous versions,
   302 might be changed.
 
+Forge::modifyColumn()
+---------------------
+
+- The :ref:`$forge->modifyColumn() <db-forge-modifyColumn>` has been fixed. Due
+  to a bug, in previous versions, SQLite3/Postgres/SQLSRV might change
+  ``NULL``/``NOT NULL`` unpredictably.
+- In previous versions, the OCI8 driver did not change ``NULL``/``NOT NULL``
+  when you don't specify ``null`` value.
+- Now in all database drivers ``$forge->modifyColumn()`` always sets ``NULL``
+  when you don't specify ``null`` value.
+- The ``NULL``/``NOT NULL`` change may still be unexpectedly, it is recommended
+  to always specifiy ``null`` value.
+
 Message Changes
 ***************
 

--- a/user_guide_src/source/changelogs/v4.3.4.rst
+++ b/user_guide_src/source/changelogs/v4.3.4.rst
@@ -44,11 +44,11 @@ Forge::modifyColumn()
   to a bug, in previous versions, SQLite3/Postgres/SQLSRV might change
   ``NULL``/``NOT NULL`` unpredictably.
 - In previous versions, the OCI8 driver did not change ``NULL``/``NOT NULL``
-  when you don't specify ``null`` value.
+  when you don't specify the ``null`` key.
 - Now in all database drivers ``$forge->modifyColumn()`` always sets ``NULL``
-  when you don't specify ``null`` value.
+  when you don't specify the ``null`` key.
 - The ``NULL``/``NOT NULL`` change may still be unexpectedly, it is recommended
-  to always specifiy ``null`` value.
+  to always specify the ``null`` key.
 
 Message Changes
 ***************

--- a/user_guide_src/source/changelogs/v4.3.4.rst
+++ b/user_guide_src/source/changelogs/v4.3.4.rst
@@ -35,6 +35,8 @@ Redirect Status Code
   always be used when you don't specify a status code. In previous versions,
   302 might be changed.
 
+.. _v434-forge-modifycolumn:
+
 Forge::modifyColumn()
 ---------------------
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -297,7 +297,7 @@ change the name, you can add a "name" key into the field defining array.
 .. literalinclude:: forge/026.php
 
 .. note:: The ``modifyColumn()`` may unexpectedly change ``NULL``/``NOT NULL``.
-    So it is recommended to always specify ``null`` value. Unlike when creating
+    So it is recommended to always specify the value for ``null`` key. Unlike when creating
     a table, if ``null`` is not specified, the column will be ``NULL``, not
     ``NOT NULL``.
 

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -294,6 +294,15 @@ change the name, you can add a "name" key into the field defining array.
 
 .. literalinclude:: forge/026.php
 
+.. note:: The ``modifyColumn()`` may unexpectedly change ``NULL``/``NOT NULL``.
+    So it is recommended to always specify ``null`` value.
+
+.. note:: Due to a bug, prior v4.3.3, SQLite3 may not set ``NOT NULL`` even if you
+    specify ``'null' => false``.
+
+.. note:: Due to a bug, prior v4.3.3, Postgres and SQLSRV set ``NOT NULL`` even
+    if you specify ``'null' => false``.
+
 .. _db-forge-adding-keys-to-a-table:
 
 Adding Keys to a Table

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -285,6 +285,8 @@ Used to remove multiple columns from a table.
 Modifying a Field in a Table
 ============================
 
+.. _db-forge-modifyColumn:
+
 $forge->modifyColumn()
 ----------------------
 
@@ -295,7 +297,9 @@ change the name, you can add a "name" key into the field defining array.
 .. literalinclude:: forge/026.php
 
 .. note:: The ``modifyColumn()`` may unexpectedly change ``NULL``/``NOT NULL``.
-    So it is recommended to always specify ``null`` value.
+    So it is recommended to always specify ``null`` value. Unlike when creating
+    a table, if ``null`` is not specified, the column will be ``NULL``, not
+    ``NOT NULL``.
 
 .. note:: Due to a bug, prior v4.3.3, SQLite3 may not set ``NOT NULL`` even if you
     specify ``'null' => false``.

--- a/user_guide_src/source/dbmgmt/forge/026.php
+++ b/user_guide_src/source/dbmgmt/forge/026.php
@@ -4,7 +4,8 @@ $fields = [
     'old_name' => [
         'name' => 'new_name',
         'type' => 'TEXT',
+        'null' => false,
     ],
 ];
 $forge->modifyColumn('table_name', $fields);
-// gives ALTER TABLE `table_name` CHANGE `old_name` `new_name` TEXT
+// gives ALTER TABLE `table_name` CHANGE `old_name` `new_name` TEXT NOT NULL

--- a/user_guide_src/source/installation/upgrade_434.rst
+++ b/user_guide_src/source/installation/upgrade_434.rst
@@ -25,6 +25,18 @@ Redirect Status Code
   :ref:`ChangeLog v4.3.4 <v434-redirect-status-code>` and if the code is not
   what you want, :ref:`specify status codes <response-redirect-status-code>`.
 
+Forge::modifyColumn() and NULL
+==============================
+
+A bug fix may have changed the NULL constraint in the result of
+:ref:`$forge->modifyColumn() <db-forge-modifyColumn>`. See
+:ref:`Change Log <v434-forge-modifycolumn>`.
+To set the desired NULL constraint, change ``Forge::modifyColumn()`` to always
+specify the ``null`` value.
+
+Note that the bug may have changed unexpected NULL constraints in previous
+versions.
+
 Breaking Enhancements
 *********************
 

--- a/user_guide_src/source/installation/upgrade_434.rst
+++ b/user_guide_src/source/installation/upgrade_434.rst
@@ -32,7 +32,7 @@ A bug fix may have changed the NULL constraint in the result of
 :ref:`$forge->modifyColumn() <db-forge-modifyColumn>`. See
 :ref:`Change Log <v434-forge-modifycolumn>`.
 To set the desired NULL constraint, change ``Forge::modifyColumn()`` to always
-specify the ``null`` value.
+specify the ``null`` key.
 
 Note that the bug may have changed unexpected NULL constraints in previous
 versions.


### PR DESCRIPTION
**Description**
See #7302

- The `$forge->modifyColumn()` has been fixed. Due to a bug, in previous versions, SQLite3/Postgres/SQLSRV might change `NULL`/`NOT NULL` unpredictably.
- In previous versions, the OCI8 driver did not change `NULL`/`NOT NULL` when you don’t specify `null` value.
- Now in all database drivers `$forge->modifyColumn()` always sets `NULL` when you don’t specify `null` value.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
