### PR TITLE
composer.lock removed from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,6 @@ phpunit
 # Composer
 #-------------------------
 vendor/
-composer.lock
 
 #-------------------------
 # IDE / Development Files


### PR DESCRIPTION
> once composer creates lock file for the first time it locks the dependencies ! 
once you push it to git composer.lock is important becuase without composer.lock file composer updates all dependencies!

I have faced with that issue my project is created with CIv4.1 and  someone else cloned my project 
and he has faced with issue of no composer.lock file in git repo and composer updates all dependecies
