### PR TITLE
docs: fix PHPDoc types in Database Results

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Database;
 
 use CodeIgniter\Entity\Entity;
+use stdClass;
 
 /**
  * @template TConnection of object|resource
@@ -116,7 +117,9 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the results as an array of custom objects.
      *
-     * @return mixed
+     * @phpstan-param class-string $className
+     *
+     * @return array
      */
     public function getCustomResultObject(string $className)
     {
@@ -205,6 +208,9 @@ abstract class BaseResult implements ResultInterface
      * Returns the results as an array of objects.
      *
      * If no results, an empty array is returned.
+     *
+     * @return array<int, stdClass>
+     * @phpstan-return list<stdClass>
      */
     public function getResultObject(): array
     {
@@ -248,10 +254,11 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param mixed  $n    The index of the results to return
+     * @param int    $n    The index of the results to return
      * @param string $type The type of result object. 'array', 'object' or class name.
      *
-     * @return mixed
+     * @return array|object|stdClass|null
+     * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : object|null))
      */
     public function getRow($n = 0, string $type = 'object')
     {
@@ -285,7 +292,7 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exists, returns null.
      *
-     * @return mixed
+     * @return array|null
      */
     public function getCustomRowObject(int $n, string $className)
     {
@@ -309,7 +316,7 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @return mixed
+     * @return array|null
      */
     public function getRowArray(int $n = 0)
     {
@@ -330,7 +337,7 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @return mixed
+     * @return object|stdClass|null
      */
     public function getRowObject(int $n = 0)
     {
@@ -377,7 +384,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the "first" row of the current results.
      *
-     * @return mixed
+     * @return array|object|null
      */
     public function getFirstRow(string $type = 'object')
     {
@@ -389,7 +396,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the "last" row of the current results.
      *
-     * @return mixed
+     * @return array|object|null
      */
     public function getLastRow(string $type = 'object')
     {
@@ -401,7 +408,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the "next" row of the current results.
      *
-     * @return mixed
+     * @return array|object|null
      */
     public function getNextRow(string $type = 'object')
     {
@@ -416,7 +423,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns the "previous" row of the current results.
      *
-     * @return mixed
+     * @return array|object|null
      */
     public function getPreviousRow(string $type = 'object')
     {
@@ -435,7 +442,7 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns an unbuffered row and move the pointer to the next row.
      *
-     * @return mixed
+     * @return array|object|null
      */
     public function getUnbufferedRow(string $type = 'object')
     {

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -141,7 +141,7 @@ class Result extends BaseResult
      *
      * Overridden by child classes.
      *
-     * @return bool|Entity|object
+     * @return Entity|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -92,7 +92,7 @@ class Result extends BaseResult
      *
      * Overridden by child classes.
      *
-     * @return bool|Entity|object
+     * @return Entity|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -107,7 +107,7 @@ class Result extends BaseResult
      *
      * Overridden by child classes.
      *
-     * @return bool|Entity|object
+     * @return Entity|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -147,7 +147,7 @@ class Result extends BaseResult
     /**
      * Returns the result set as an object.
      *
-     * @return bool|Entity|object
+     * @return Entity|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -124,7 +124,7 @@ class Result extends BaseResult
      *
      * Overridden by child classes.
      *
-     * @return bool|object
+     * @return Entity|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Test/Mock/MockResult.php
+++ b/system/Test/Mock/MockResult.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Test\Mock;
 
 use CodeIgniter\Database\BaseResult;
+use stdClass;
 
 /**
  * @extends BaseResult<object|resource, object|resource>
@@ -82,7 +83,7 @@ class MockResult extends BaseResult
      *
      * @param string $className
      *
-     * @return object
+     * @return object|stdClass
      */
     protected function fetchObject($className = 'stdClass')
     {


### PR DESCRIPTION
**Description**
See #6310
- fix PHPDoc types

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
