### PR TITLE
docs: update CSP description

### DIFF
--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -170,7 +170,7 @@ call basis, by providing an optional second parameter to the adding method call.
 Runtime Configuration
 ---------------------
 
-If your application needs to make changes at run-time, you can access the instance at ``$this->response->CSP`` in your controllers. The
+If your application needs to make changes at run-time, you can access the instance at ``$this->response->getCSP()`` in your controllers. The
 class holds a number of methods that map pretty clearly to the appropriate header value that you need to set.
 Examples are shown below, with different combinations of parameters, though all accept either a directive
 name or an array of them:

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -180,7 +180,7 @@ name or an array of them:
 The first parameter to each of the "add" methods is an appropriate string value,
 or an array of them.
 
-The ``reportOnly`` method allows you to specify the default reporting treatment
+The ``reportOnly()`` method allows you to specify the default reporting treatment
 for subsequent sources, unless over-ridden. For instance, you could specify
 that youtube.com was allowed, and then provide several allowed but reported sources:
 

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -214,7 +214,7 @@ life, and is most secure when generated on the fly. To make this simple, you can
 
 If you don't like this auto replacement functionality, you can turn it off with setting ``$autoNonce = false`` in **app/Config/ContentSecurityPolicy.php**.
 
-In this case, you can use the functions, ``csp_script_nonce()`` and ``csp_style_nonce()``::
+In this case, you can use the functions, :php:func:`csp_script_nonce()` and :php:func:`csp_style_nonce()`::
 
     // Original
     <script <?= csp_script_nonce() ?>>

--- a/user_guide_src/source/outgoing/response/012.php
+++ b/user_guide_src/source/outgoing/response/012.php
@@ -1,30 +1,33 @@
 <?php
 
+// get the CSP instance
+$csp = $this->response->getCSP();
+
 // specify the default directive treatment
-$this->response->CSP->reportOnly(false);
+$csp->reportOnly(false);
 
 // specify the origin to use if none provided for a directive
-$this->response->CSP->setDefaultSrc('cdn.example.com');
+$csp->setDefaultSrc('cdn.example.com');
 
 // specify the URL that "report-only" reports get sent to
-$this->response->CSP->setReportURI('http://example.com/csp/reports');
+$csp->setReportURI('http://example.com/csp/reports');
 
 // specify that HTTP requests be upgraded to HTTPS
-$this->response->CSP->upgradeInsecureRequests(true);
+$csp->upgradeInsecureRequests(true);
 
 // add types or origins to CSP directives
 // assuming that the default treatment is to block rather than just report
-$this->response->CSP->addBaseURI('example.com', true); // report only
-$this->response->CSP->addChildSrc('https://youtube.com'); // blocked
-$this->response->CSP->addConnectSrc('https://*.facebook.com', false); // blocked
-$this->response->CSP->addFontSrc('fonts.example.com');
-$this->response->CSP->addFormAction('self');
-$this->response->CSP->addFrameAncestor('none', true); // report this one
-$this->response->CSP->addImageSrc('cdn.example.com');
-$this->response->CSP->addMediaSrc('cdn.example.com');
-$this->response->CSP->addManifestSrc('cdn.example.com');
-$this->response->CSP->addObjectSrc('cdn.example.com', false); // reject from here
-$this->response->CSP->addPluginType('application/pdf', false); // reject this media type
-$this->response->CSP->addScriptSrc('scripts.example.com', true); // allow but report requests from here
-$this->response->CSP->addStyleSrc('css.example.com');
-$this->response->CSP->addSandbox(['allow-forms', 'allow-scripts']);
+$csp->addBaseURI('example.com', true); // report only
+$csp->addChildSrc('https://youtube.com'); // blocked
+$csp->addConnectSrc('https://*.facebook.com', false); // blocked
+$csp->addFontSrc('fonts.example.com');
+$csp->addFormAction('self');
+$csp->addFrameAncestor('none', true); // report this one
+$csp->addImageSrc('cdn.example.com');
+$csp->addMediaSrc('cdn.example.com');
+$csp->addManifestSrc('cdn.example.com');
+$csp->addObjectSrc('cdn.example.com', false); // reject from here
+$csp->addPluginType('application/pdf', false); // reject this media type
+$csp->addScriptSrc('scripts.example.com', true); // allow but report requests from here
+$csp->addStyleSrc('css.example.com');
+$csp->addSandbox(['allow-forms', 'allow-scripts']);

--- a/user_guide_src/source/outgoing/response/013.php
+++ b/user_guide_src/source/outgoing/response/013.php
@@ -1,6 +1,9 @@
 <?php
 
-$this->response->CSP->addChildSrc('https://youtube.com'); // allowed
-$this->response->CSP->reportOnly(true);
-$this->response->CSP->addChildSrc('https://metube.com'); // allowed but reported
-$this->response->CSP->addChildSrc('https://ourtube.com', false); // allowed
+// get the CSP instance
+$csp = $this->response->getCSP();
+
+$csp->addChildSrc('https://youtube.com'); // allowed
+$csp->reportOnly(true);
+$csp->addChildSrc('https://metube.com'); // allowed but reported
+$csp->addChildSrc('https://ourtube.com', false); // allowed


### PR DESCRIPTION
**Description**
- use `getCSP()` instead of the deprecated `CSP` property

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
