### PR TITLE
fix: view cell cannot locate the auto-generated view file

### DIFF
--- a/system/Commands/Generators/CellGenerator.php
+++ b/system/Commands/Generators/CellGenerator.php
@@ -88,11 +88,8 @@ class CellGenerator extends BaseCommand
         // Form the view name
         $segments = explode('\\', $this->qualifyClassName());
 
-        $view = array_pop($segments);
-        $view = str_replace('Cell', '', decamelize($view));
-        if (strpos($view, '_cell') === false) {
-            $view .= '_cell';
-        }
+        $view       = array_pop($segments);
+        $view       = decamelize($view);
         $segments[] = $view;
         $view       = implode('\\', $segments);
 

--- a/system/View/Cells/Cell.php
+++ b/system/View/Cells/Cell.php
@@ -75,7 +75,7 @@ class Cell
         if (empty($view)) {
             // According to the docs, the name of the view file should be the
             // snake_cased version of the cell's class name, but for backward
-            // compactibility, the name also accepts '_cell' being omitted.
+            // compatibility, the name also accepts '_cell' being omitted.
             $ref      = new ReflectionClass($this);
             $view     = decamelize($ref->getShortName());
             $viewPath = dirname($ref->getFileName()) . DIRECTORY_SEPARATOR . $view . '.php';

--- a/system/View/Cells/Cell.php
+++ b/system/View/Cells/Cell.php
@@ -73,8 +73,13 @@ class Cell
 
         // If no view is specified, we'll try to guess it based on the class name.
         if (empty($view)) {
-            $view = decamelize((new ReflectionClass($this))->getShortName());
-            $view = str_replace('_cell', '', $view);
+            // According to the docs, the name of the view file should be the
+            // snake_cased version of the cell's class name, but for backward
+            // compactibility, the name also accepts '_cell' being omitted.
+            $ref      = new ReflectionClass($this);
+            $view     = decamelize($ref->getShortName());
+            $viewPath = dirname($ref->getFileName()) . DIRECTORY_SEPARATOR . $view . '.php';
+            $view     = file_exists($viewPath) ? $viewPath : str_replace('_cell', '', $view);
         }
 
         // Locate our view, preferring the directory of the class.

--- a/system/View/Cells/Cell.php
+++ b/system/View/Cells/Cell.php
@@ -79,7 +79,7 @@ class Cell
             $ref      = new ReflectionClass($this);
             $view     = decamelize($ref->getShortName());
             $viewPath = dirname($ref->getFileName()) . DIRECTORY_SEPARATOR . $view . '.php';
-            $view     = file_exists($viewPath) ? $viewPath : str_replace('_cell', '', $view);
+            $view     = is_file($viewPath) ? $viewPath : str_replace('_cell', '', $view);
         }
 
         // Locate our view, preferring the directory of the class.

--- a/tests/_support/View/Cells/AwesomeCell.php
+++ b/tests/_support/View/Cells/AwesomeCell.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\View\Cells;
+
+use CodeIgniter\View\Cells\Cell;
+
+class AwesomeCell extends Cell
+{
+    public string $message = 'Found!';
+}

--- a/tests/_support/View/Cells/awesome_cell.php
+++ b/tests/_support/View/Cells/awesome_cell.php
@@ -1,0 +1,1 @@
+<div><?= $message ?></div>

--- a/tests/system/Commands/CellGeneratorTest.php
+++ b/tests/system/Commands/CellGeneratorTest.php
@@ -73,7 +73,7 @@ final class CellGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('class Another extends Cell', $contents);
 
         // Check the view was generated
-        $file = APPPATH . 'Cells/another_cell.php';
+        $file = APPPATH . 'Cells/another.php';
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
     }

--- a/tests/system/View/ControlledCellTest.php
+++ b/tests/system/View/ControlledCellTest.php
@@ -21,6 +21,7 @@ use Tests\Support\View\Cells\MultiplierCell;
 use Tests\Support\View\Cells\RenderedExtraDataNotice;
 use Tests\Support\View\Cells\RenderedNotice;
 use Tests\Support\View\Cells\SimpleNotice;
+use Tests\Support\View\Cells\AwesomeCell;
 
 /**
  * @internal
@@ -34,6 +35,13 @@ final class ControlledCellTest extends CIUnitTestCase
         $result = view_cell(GreetingCell::class);
 
         $this->assertStringContainsString('Hello World', $result);
+    }
+
+    public function testCellRendersViewWithActualClassName()
+    {
+        $result = view_cell(AwesomeCell::class);
+
+        $this->assertStringContainsString('Found!', $result);
     }
 
     public function testCellWithNamedView()

--- a/tests/system/View/ControlledCellTest.php
+++ b/tests/system/View/ControlledCellTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\View;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
 use Tests\Support\View\Cells\AdditionCell;
+use Tests\Support\View\Cells\AwesomeCell;
 use Tests\Support\View\Cells\ColorsCell;
 use Tests\Support\View\Cells\GreetingCell;
 use Tests\Support\View\Cells\ListerCell;
@@ -21,7 +22,6 @@ use Tests\Support\View\Cells\MultiplierCell;
 use Tests\Support\View\Cells\RenderedExtraDataNotice;
 use Tests\Support\View\Cells\RenderedNotice;
 use Tests\Support\View\Cells\SimpleNotice;
-use Tests\Support\View\Cells\AwesomeCell;
 
 /**
  * @internal


### PR DESCRIPTION
Fixes #7391 

- fix a bug that View Cells cannot load a view file with `_cell` when the classname ends with `Cell`.
- fix a bug that `spark make:cell` creates a view file with `_cell` when the classname does not end with `Cell`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide