### PR TITLE
fix: CURLRequest - clear response headers between requests

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -112,7 +112,7 @@ class CURLRequest extends OutgoingRequest
 
         parent::__construct('GET', $uri);
 
-        $this->responseOrig   = $response;
+        $this->responseOrig   = $response ?? new Response(config('App'));
         $this->baseURI        = $uri->useRawQueryString();
         $this->defaultOptions = $options;
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -29,6 +29,13 @@ class CURLRequest extends OutgoingRequest
     protected $response;
 
     /**
+     * The original response object associated with this request
+     *
+     * @var ResponseInterface|null
+     */
+    protected $responseOrig;
+
+    /**
      * The URI associated with this request
      *
      * @var URI
@@ -105,7 +112,7 @@ class CURLRequest extends OutgoingRequest
 
         parent::__construct('GET', $uri);
 
-        $this->response       = $response;
+        $this->responseOrig   = $response;
         $this->baseURI        = $uri->useRawQueryString();
         $this->defaultOptions = $options;
 
@@ -125,6 +132,8 @@ class CURLRequest extends OutgoingRequest
      */
     public function request($method, string $url, array $options = []): ResponseInterface
     {
+        $this->response = clone $this->responseOrig;
+
         $this->parseOptions($options);
 
         $url = $this->prepareURL($url);
@@ -469,10 +478,6 @@ class CURLRequest extends OutgoingRequest
      */
     protected function setResponseHeaders(array $headers = [])
     {
-        foreach ($this->response->headers() as $header) {
-            $this->response->removeHeader($header->getName());
-        }
-
         foreach ($headers as $header) {
             if (($pos = strpos($header, ':')) !== false) {
                 $title = substr($header, 0, $pos);

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -469,10 +469,8 @@ class CURLRequest extends OutgoingRequest
      */
     protected function setResponseHeaders(array $headers = [])
     {
-        if ($this->shareOptions === false) {
-            foreach ($this->response->headers() as $header) {
-                $this->response->removeHeader($header->getName());
-            }
+        foreach ($this->response->headers() as $header) {
+            $this->response->removeHeader($header->getName());
         }
 
         foreach ($headers as $header) {

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -469,6 +469,12 @@ class CURLRequest extends OutgoingRequest
      */
     protected function setResponseHeaders(array $headers = [])
     {
+        if ($this->shareOptions === false) {
+            foreach ($this->response->headers() as $header) {
+                $this->response->removeHeader($header->getName());
+            }
+        }
+
         foreach ($headers as $header) {
             if (($pos = strpos($header, ':')) !== false) {
                 $title = substr($header, 0, $pos);

--- a/system/Test/Mock/MockCURLRequest.php
+++ b/system/Test/Mock/MockCURLRequest.php
@@ -34,6 +34,8 @@ class MockCURLRequest extends CURLRequest
 
     protected function sendRequest(array $curlOptions = []): string
     {
+        $this->response = clone $this->responseOrig;
+
         // Save so we can access later.
         $this->curl_options = $curlOptions;
 

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -766,15 +766,71 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame('<title>Update success! config</title>', $response->getBody());
 
         $responseHeaderKeys = [
-            'Cache-Control',
-            'Content-Type',
             'Server',
             'Connection',
             'Keep-Alive',
             'Set-Cookie',
             'Date',
             'Expires',
+            'Cache-Control',
             'Pragma',
+            'Content-Type',
+            'Transfer-Encoding',
+        ];
+        $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * See: https://github.com/codeigniter4/CodeIgniter4/issues/7394
+     */
+    public function testResponseHeadersWithMultipleRequests()
+    {
+        $request = $this->getRequest([
+            'base_uri' => 'http://www.foo.com/api/v1/',
+        ]);
+
+        $output = "HTTP/2.0 200 OK
+Server: ddos-guard
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
+        $request->setOutput($output);
+
+        $response = $request->get('answer1');
+
+        $this->assertSame('<title>Hello1</title>', $response->getBody());
+
+        $responseHeaderKeys = [
+            'Server',
+            'Expires',
+            'Cache-Control',
+            'Pragma',
+            'Content-Type',
+            'Transfer-Encoding',
+        ];
+        $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $output = "HTTP/2.0 200 OK
+Server: ddos-guard
+Expires: Thu, 19 Nov 1982 08:52:00 GMT
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
+        $request->setOutput($output);
+
+        $response = $request->get('answer2');
+
+        $this->assertSame('<title>Hello2</title>', $response->getBody());
+
+        $responseHeaderKeys = [
+            'Server',
+            'Expires',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -766,15 +766,15 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame('<title>Update success! config</title>', $response->getBody());
 
         $responseHeaderKeys = [
+            'Cache-Control',
+            'Content-Type',
             'Server',
             'Connection',
             'Keep-Alive',
             'Set-Cookie',
             'Date',
             'Expires',
-            'Cache-Control',
             'Pragma',
-            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -805,11 +805,11 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
         $this->assertSame('<title>Hello1</title>', $response->getBody());
 
         $responseHeaderKeys = [
+            'Cache-Control',
+            'Content-Type',
             'Server',
             'Expires',
-            'Cache-Control',
             'Pragma',
-            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -817,8 +817,8 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
         $this->assertSame(200, $response->getStatusCode());
 
         $output = "HTTP/2.0 200 OK
-Server: ddos-guard
 Expires: Thu, 19 Nov 1982 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
 Content-Type: application/xml; charset=utf-8
 Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
         $request->setOutput($output);
@@ -828,9 +828,9 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
         $this->assertSame('<title>Hello2</title>', $response->getBody());
 
         $responseHeaderKeys = [
-            'Server',
-            'Expires',
+            'Cache-Control',
             'Content-Type',
+            'Expires',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -749,15 +749,15 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame('<title>Update success! config</title>', $response->getBody());
 
         $responseHeaderKeys = [
-            'Cache-Control',
-            'Content-Type',
             'Server',
             'Connection',
             'Keep-Alive',
             'Set-Cookie',
             'Date',
             'Expires',
+            'Cache-Control',
             'Pragma',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -780,19 +780,19 @@ Expires: Thu, 19 Nov 1981 08:52:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Pragma: no-cache
 Content-Type: application/xml; charset=utf-8
-Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello</title>";
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
         $request->setOutput($output);
 
-        $response = $request->get('answer');
+        $response = $request->get('answer1');
 
-        $this->assertSame('<title>Hello</title>', $response->getBody());
+        $this->assertSame('<title>Hello1</title>', $response->getBody());
 
         $responseHeaderKeys = [
-            'Cache-Control',
-            'Content-Type',
             'Server',
             'Expires',
+            'Cache-Control',
             'Pragma',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -803,19 +803,17 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello</title>";
 Server: ddos-guard
 Expires: Thu, 19 Nov 1982 08:52:00 GMT
 Content-Type: application/xml; charset=utf-8
-Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello</title>";
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
         $request->setOutput($output);
 
-        $response = $request->get('answer');
+        $response = $request->get('answer2');
 
-        $this->assertSame('<title>Hello</title>', $response->getBody());
+        $this->assertSame('<title>Hello2</title>', $response->getBody());
 
         $responseHeaderKeys = [
-            'Cache-Control',
-            'Content-Type',
             'Server',
             'Expires',
-            'Pragma',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -765,6 +765,64 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame(200, $response->getStatusCode());
     }
 
+    /**
+     * See: https://github.com/codeigniter4/CodeIgniter4/issues/7394
+     */
+    public function testResponseHeadersWithMultipleRequests()
+    {
+        $request = $this->getRequest([
+            'base_uri' => 'http://www.foo.com/api/v1/',
+        ]);
+
+        $output = "HTTP/2.0 200 OK
+Server: ddos-guard
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello</title>";
+        $request->setOutput($output);
+
+        $response = $request->get('answer');
+
+        $this->assertSame('<title>Hello</title>', $response->getBody());
+
+        $responseHeaderKeys = [
+            'Cache-Control',
+            'Content-Type',
+            'Server',
+            'Expires',
+            'Pragma',
+            'Transfer-Encoding',
+        ];
+        $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $output = "HTTP/2.0 200 OK
+Server: ddos-guard
+Expires: Thu, 19 Nov 1982 08:52:00 GMT
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello</title>";
+        $request->setOutput($output);
+
+        $response = $request->get('answer');
+
+        $this->assertSame('<title>Hello</title>', $response->getBody());
+
+        $responseHeaderKeys = [
+            'Cache-Control',
+            'Content-Type',
+            'Server',
+            'Expires',
+            'Pragma',
+            'Transfer-Encoding',
+        ];
+        $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     public function testSplitResponse()
     {
         $request = $this->getRequest([

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -749,15 +749,15 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame('<title>Update success! config</title>', $response->getBody());
 
         $responseHeaderKeys = [
+            'Cache-Control',
+            'Content-Type',
             'Server',
             'Connection',
             'Keep-Alive',
             'Set-Cookie',
             'Date',
             'Expires',
-            'Cache-Control',
             'Pragma',
-            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -788,11 +788,11 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
         $this->assertSame('<title>Hello1</title>', $response->getBody());
 
         $responseHeaderKeys = [
+            'Cache-Control',
+            'Content-Type',
             'Server',
             'Expires',
-            'Cache-Control',
             'Pragma',
-            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -800,8 +800,8 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
         $this->assertSame(200, $response->getStatusCode());
 
         $output = "HTTP/2.0 200 OK
-Server: ddos-guard
 Expires: Thu, 19 Nov 1982 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
 Content-Type: application/xml; charset=utf-8
 Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
         $request->setOutput($output);
@@ -811,9 +811,9 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
         $this->assertSame('<title>Hello2</title>', $response->getBody());
 
         $responseHeaderKeys = [
-            'Server',
-            'Expires',
+            'Cache-Control',
             'Content-Type',
+            'Expires',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));

--- a/user_guide_src/source/changelogs/v4.3.4.rst
+++ b/user_guide_src/source/changelogs/v4.3.4.rst
@@ -27,6 +27,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **CURLRequest:** Clear response headers between requests when ``Config\CURLRequest::$shareOptions`` is disabled.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/changelogs/v4.3.4.rst
+++ b/user_guide_src/source/changelogs/v4.3.4.rst
@@ -27,7 +27,7 @@ Deprecations
 Bugs Fixed
 **********
 
-- **CURLRequest:** Clear response headers between requests when ``Config\CURLRequest::$shareOptions`` is disabled.
+- **CURLRequest:** Clear response headers between requests.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.3.4.rst
+++ b/user_guide_src/source/changelogs/v4.3.4.rst
@@ -27,7 +27,7 @@ Deprecations
 Bugs Fixed
 **********
 
-- **CURLRequest:** Clear response headers between requests.
+- **CURLRequest:** Fixed a bug where the response class was shared between requests.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
Fixes #7394

- create a new Response object for a request

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
