### PR TITLE
feat: [Auto Routing Improved] fallback to default controller's default method

### DIFF
--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -85,23 +85,7 @@ final class ControllerMethodReader
                             continue;
                         }
 
-                        $params      = [];
-                        $routeParams = '';
-                        $refParams   = $method->getParameters();
-
-                        foreach ($refParams as $param) {
-                            $required = true;
-                            if ($param->isOptional()) {
-                                $required = false;
-
-                                $routeParams .= '[/..]';
-                            } else {
-                                $routeParams .= '/..';
-                            }
-
-                            // [variable_name => required?]
-                            $params[$param->getName()] = $required;
-                        }
+                        [$params, $routeParams] = $this->getParameters($method);
 
                         // Route for the default method.
                         $output[] = [
@@ -117,23 +101,7 @@ final class ControllerMethodReader
 
                     $route = $classInUri . '/' . $methodInUri;
 
-                    $params      = [];
-                    $routeParams = '';
-                    $refParams   = $method->getParameters();
-
-                    foreach ($refParams as $param) {
-                        $required = true;
-                        if ($param->isOptional()) {
-                            $required = false;
-
-                            $routeParams .= '[/..]';
-                        } else {
-                            $routeParams .= '/..';
-                        }
-
-                        // [variable_name => required?]
-                        $params[$param->getName()] = $required;
-                    }
+                    [$params, $routeParams] = $this->getParameters($method);
 
                     // If it is the default controller, the method will not be
                     // routed.
@@ -153,6 +121,29 @@ final class ControllerMethodReader
         }
 
         return $output;
+    }
+
+    private function getParameters(ReflectionMethod $method): array
+    {
+        $params      = [];
+        $routeParams = '';
+        $refParams   = $method->getParameters();
+
+        foreach ($refParams as $param) {
+            $required = true;
+            if ($param->isOptional()) {
+                $required = false;
+
+                $routeParams .= '[/..]';
+            } else {
+                $routeParams .= '/..';
+            }
+
+            // [variable_name => required?]
+            $params[$param->getName()] = $required;
+        }
+
+        return [$params, $routeParams];
     }
 
     /**

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -73,7 +73,8 @@ final class ControllerMethodReader
                             $classInUri,
                             $classname,
                             $methodName,
-                            $httpVerb
+                            $httpVerb,
+                            $method
                         );
 
                         if ($routeForDefaultController !== []) {
@@ -180,7 +181,8 @@ final class ControllerMethodReader
         string $uriByClass,
         string $classname,
         string $methodName,
-        string $httpVerb
+        string $httpVerb,
+        ReflectionMethod $method
     ): array {
         $output = [];
 
@@ -189,12 +191,18 @@ final class ControllerMethodReader
             $routeWithoutController = rtrim(preg_replace($pattern, '', $uriByClass), '/');
             $routeWithoutController = $routeWithoutController ?: '/';
 
+            [$params, $routeParams] = $this->getParameters($method);
+
+            if ($routeWithoutController === '/' && $routeParams !== '') {
+                $routeWithoutController = '';
+            }
+
             $output[] = [
                 'method'       => $httpVerb,
                 'route'        => $routeWithoutController,
-                'route_params' => '',
+                'route_params' => $routeParams,
                 'handler'      => '\\' . $classname . '::' . $methodName,
-                'params'       => [],
+                'params'       => $params,
             ];
         }
 

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -242,6 +242,13 @@ final class AutoRouterImproved implements AutoRouterInterface
             $this->method = $method;
             $this->params = $params;
 
+            // Prevent access to default controller's method
+            if (strtolower($baseControllerName) === strtolower($this->defaultController)) {
+                throw new PageNotFoundException(
+                    'Cannot access the default controller "' . $this->controller . '::' . $this->method . '"'
+                );
+            }
+
             // Prevent access to default method path
             if (strtolower($this->method) === strtolower($this->defaultMethod)) {
                 throw new PageNotFoundException(

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -104,6 +104,14 @@ final class AutoRouterImproved implements AutoRouterInterface
         $this->method     = $this->defaultMethod;
     }
 
+    private function createSegments(string $uri)
+    {
+        $segments = explode('/', $uri);
+        $segments = array_filter($segments, static fn ($segment) => $segment !== '');
+        // numerically reindex the array, removing gaps
+        return array_values($segments);
+    }
+
     /**
      * Finds controller, method and params from the URI.
      *
@@ -111,7 +119,7 @@ final class AutoRouterImproved implements AutoRouterInterface
      */
     public function getRoute(string $uri): array
     {
-        $segments = explode('/', $uri);
+        $segments = $this->createSegments($uri);
 
         // Check for Module Routes.
         if (
@@ -275,10 +283,6 @@ final class AutoRouterImproved implements AutoRouterInterface
      */
     private function scanControllers(array $segments): array
     {
-        $segments = array_filter($segments, static fn ($segment) => $segment !== '');
-        // numerically reindex the array, removing gaps
-        $segments = array_values($segments);
-
         // Loop through our segments and return as soon as a controller
         // is found or when such a directory doesn't exist
         $c = count($segments);

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -217,7 +217,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                 strtolower($baseControllerName) === strtolower($this->defaultController)
             ) {
                 throw new PageNotFoundException(
-                    'Cannot access the default controller "' . $baseControllerName . '" with the controller name URI path.'
+                    'Cannot access the default controller "' . $this->controller . '" with the controller name URI path.'
                 );
             }
         } elseif ($this->searchLastDefaultController($segments)) {

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -201,11 +201,12 @@ final class AutoRouterImproved implements AutoRouterInterface
 
         // Check for Module Routes.
         if (
-            ($routingConfig = config(Routing::class))
+            $segments !== []
+            && ($routingConfig = config(Routing::class))
             && array_key_exists($segments[0], $routingConfig->moduleRoutes)
         ) {
             $uriSegment      = array_shift($segments);
-            $this->namespace = rtrim($routingConfig->moduleRoutes[$uriSegment], '\\') . '\\';
+            $this->namespace = rtrim($routingConfig->moduleRoutes[$uriSegment], '\\');
         }
 
         if ($this->searchFirstController($segments)) {

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -35,11 +35,6 @@ final class AutoRouterImproved implements AutoRouterInterface
     private ?string $directory = null;
 
     /**
-     * Sub-namespace that contains the requested controller class.
-     */
-    private ?string $subNamespace = null;
-
-    /**
      * The name of the controller class.
      */
     private string $controller;
@@ -113,6 +108,89 @@ final class AutoRouterImproved implements AutoRouterInterface
     }
 
     /**
+     * Search for the first controller corresponding to the URI segment.
+     *
+     * If there is a controller corresponding to the first segment, the search
+     * ends there. The remaining segments are parameters to the controller.
+     *
+     * @param array $segments URI segments
+     *
+     * @return bool true if a controller class is found.
+     */
+    private function searchFirstController(array $segments): bool
+    {
+        $controller = '\\' . trim($this->namespace, '\\');
+
+        while ($segments !== []) {
+            $segment = array_shift($segments);
+            $class   = $this->translateURIDashes(ucfirst($segment));
+
+            // as soon as we encounter any segment that is not PSR-4 compliant, stop searching
+            if (! $this->isValidSegment($class)) {
+                return false;
+            }
+
+            $controller .= '\\' . $class;
+
+            if (class_exists($controller)) {
+                $this->controller = $controller;
+                // The first item may be a method name.
+                $this->params = $segments;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Search for the last default controller corresponding to the URI segments.
+     *
+     * @param array $segments URI segments
+     *
+     * @return bool true if a controller class is found.
+     */
+    private function searchLastDefaultController(array $segments): bool
+    {
+        $params = [];
+
+        while ($segments !== []) {
+            $namespaces = array_map(
+                fn ($segment) => $this->translateURIDashes(ucfirst($segment)),
+                $segments
+            );
+
+            $controller = '\\' . trim($this->namespace, '\\')
+                . '\\' . implode('\\', $namespaces)
+                . '\\' . $this->defaultController;
+
+            if (class_exists($controller)) {
+                $this->controller = $controller;
+                $this->params     = $params;
+
+                return true;
+            }
+
+            // Prepend the last element in $segments to the beginning of $params.
+            array_unshift($params, array_pop($segments));
+        }
+
+        // Check for the default controller in Controllers directory.
+        $controller = '\\' . trim($this->namespace, '\\')
+            . '\\' . $this->defaultController;
+
+        if (class_exists($controller)) {
+            $this->controller = $controller;
+            $this->params     = $params;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Finds controller, method and params from the URI.
      *
      * @return array [directory_name, controller_name, controller_method, params]
@@ -130,40 +208,39 @@ final class AutoRouterImproved implements AutoRouterInterface
             $this->namespace = rtrim($routingConfig->moduleRoutes[$uriSegment], '\\') . '\\';
         }
 
-        // WARNING: Directories get shifted out of the segments array.
-        $nonDirSegments = $this->scanControllers($segments);
+        if ($this->searchFirstController($segments)) {
+            // Controller is found.
+            $baseControllerName = class_basename($this->controller);
 
-        $controllerSegment  = '';
-        $baseControllerName = $this->defaultController;
-
-        // If we don't have any segments left - use the default controller;
-        // If not empty, then the first segment should be the controller
-        if (! empty($nonDirSegments)) {
-            $controllerSegment = array_shift($nonDirSegments);
-
-            $baseControllerName = $this->translateURIDashes(ucfirst($controllerSegment));
+            // Prevent access to default controller path
+            if (
+                strtolower($baseControllerName) === strtolower($this->defaultController)
+            ) {
+                throw new PageNotFoundException(
+                    'Cannot access the default controller "' . $baseControllerName . '" with the controller name URI path.'
+                );
+            }
+        } elseif ($this->searchLastDefaultController($segments)) {
+            // The default Controller is found.
+            $baseControllerName = class_basename($this->controller);
+        } else {
+            // No Controller is found.
+            throw new PageNotFoundException('No controller is found for: ' . $uri);
         }
 
-        if (! $this->isValidSegment($baseControllerName)) {
-            throw new PageNotFoundException($baseControllerName . ' is not a valid controller name');
+        $params = $this->params;
+
+        $methodParam = array_shift($params);
+
+        $method = '';
+        if ($methodParam !== null) {
+            $method = $this->httpVerb . ucfirst($this->translateURIDashes($methodParam));
         }
 
-        // Prevent access to default controller path
-        if (
-            strtolower($baseControllerName) === strtolower($this->defaultController)
-            && strtolower($controllerSegment) === strtolower($this->defaultController)
-        ) {
-            throw new PageNotFoundException(
-                'Cannot access the default controller "' . $baseControllerName . '" with the controller name URI path.'
-            );
-        }
-
-        // Use the method name if it exists.
-        if (! empty($nonDirSegments)) {
-            $methodSegment = $this->translateURIDashes(array_shift($nonDirSegments));
-
-            // Prefix HTTP verb
-            $this->method = $this->httpVerb . ucfirst($methodSegment);
+        if ($methodParam !== null && method_exists($this->controller, $method)) {
+            // Method is found.
+            $this->method = $method;
+            $this->params = $params;
 
             // Prevent access to default method path
             if (strtolower($this->method) === strtolower($this->defaultMethod)) {
@@ -171,21 +248,15 @@ final class AutoRouterImproved implements AutoRouterInterface
                     'Cannot access the default method "' . $this->method . '" with the method name URI path.'
                 );
             }
+        } else {
+            if (method_exists($this->controller, $this->defaultMethod)) {
+                // The default method is found.
+                $this->method = $this->defaultMethod;
+            } else {
+                // No method is found.
+                throw PageNotFoundException::forControllerNotFound($this->controller, $method);
+            }
         }
-
-        if (! empty($nonDirSegments)) {
-            $this->params = $nonDirSegments;
-        }
-
-        // Ensure the controller stores the fully-qualified class name
-        $this->controller = '\\' . ltrim(
-            str_replace(
-                '/',
-                '\\',
-                $this->namespace . $this->subNamespace . $baseControllerName
-            ),
-            '\\'
-        );
 
         // Ensure the controller is not defined in routes.
         $this->protectDefinedRoutes();
@@ -197,23 +268,33 @@ final class AutoRouterImproved implements AutoRouterInterface
         try {
             $this->checkParameters($uri);
         } catch (MethodNotFoundException $e) {
-            // Fallback to the default method
-            if (! isset($methodSegment)) {
-                throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
-            }
-
-            array_unshift($this->params, $methodSegment);
-            $method       = $this->method;
-            $this->method = $this->defaultMethod;
-
-            try {
-                $this->checkParameters($uri);
-            } catch (MethodNotFoundException $e) {
-                throw PageNotFoundException::forControllerNotFound($this->controller, $method);
-            }
+            throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
         }
 
+        $this->setDirectory();
+
         return [$this->directory, $this->controller, $this->method, $this->params];
+    }
+
+    /**
+     * Get the directory path from the controller and set it to the property.
+     *
+     * @return void
+     */
+    private function setDirectory()
+    {
+        $segments = explode('\\', trim($this->controller, '\\'));
+
+        // Remove short classname.
+        array_pop($segments);
+
+        $namespaces = implode('\\', $segments);
+
+        $dir = substr($namespaces, strlen($this->namespace));
+
+        if ($dir !== '') {
+            $this->directory = substr($namespaces, strlen($this->namespace)) . '/';
+        }
     }
 
     private function protectDefinedRoutes(): void
@@ -275,46 +356,6 @@ final class AutoRouterImproved implements AutoRouterInterface
     }
 
     /**
-     * Scans the controller directory, attempting to locate a controller matching the supplied uri $segments
-     *
-     * @param array $segments URI segments
-     *
-     * @return array returns an array of remaining uri segments that don't map onto a directory
-     */
-    private function scanControllers(array $segments): array
-    {
-        // Loop through our segments and return as soon as a controller
-        // is found or when such a directory doesn't exist
-        $c = count($segments);
-
-        while ($c-- > 0) {
-            $segmentConvert = $this->translateURIDashes(ucfirst($segments[0]));
-
-            // as soon as we encounter any segment that is not PSR-4 compliant, stop searching
-            if (! $this->isValidSegment($segmentConvert)) {
-                return $segments;
-            }
-
-            $test = $this->namespace . $this->subNamespace . $segmentConvert;
-
-            // as long as each segment is *not* a controller file, add it to $this->subNamespace
-            if (! class_exists($test)) {
-                $this->setSubNamespace($segmentConvert, true, false);
-                array_shift($segments);
-
-                $this->directory .= $this->directory . $segmentConvert . '/';
-
-                continue;
-            }
-
-            return $segments;
-        }
-
-        // This means that all segments were actually directories
-        return $segments;
-    }
-
-    /**
      * Returns true if the supplied $segment string represents a valid PSR-4 compliant namespace/directory segment
      *
      * regex comes from https://www.php.net/manual/en/language.variables.basics.php
@@ -322,30 +363,6 @@ final class AutoRouterImproved implements AutoRouterInterface
     private function isValidSegment(string $segment): bool
     {
         return (bool) preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $segment);
-    }
-
-    /**
-     * Sets the sub-namespace that the controller is in.
-     *
-     * @param bool $validate if true, checks to make sure $dir consists of only PSR4 compliant segments
-     */
-    private function setSubNamespace(?string $namespace = null, bool $append = false, bool $validate = true): void
-    {
-        if ($validate) {
-            $segments = explode('/', trim($namespace, '/'));
-
-            foreach ($segments as $segment) {
-                if (! $this->isValidSegment($segment)) {
-                    return;
-                }
-            }
-        }
-
-        if ($append !== true || empty($this->subNamespace)) {
-            $this->subNamespace = trim($namespace, '/') . '\\';
-        } else {
-            $this->subNamespace .= trim($namespace, '/') . '\\';
-        }
     }
 
     private function translateURIDashes(string $classname): string

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -88,7 +88,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         string $httpVerb
     ) {
         $this->protectedControllers = $protectedControllers;
-        $this->namespace            = rtrim($namespace, '\\') . '\\';
+        $this->namespace            = rtrim($namespace, '\\');
         $this->translateURIDashes   = $translateURIDashes;
         $this->httpVerb             = $httpVerb;
         $this->defaultController    = $defaultController;
@@ -119,7 +119,7 @@ final class AutoRouterImproved implements AutoRouterInterface
      */
     private function searchFirstController(array $segments): bool
     {
-        $controller = '\\' . trim($this->namespace, '\\');
+        $controller = '\\' . $this->namespace;
 
         while ($segments !== []) {
             $segment = array_shift($segments);
@@ -161,7 +161,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                 $segments
             );
 
-            $controller = '\\' . trim($this->namespace, '\\')
+            $controller = '\\' . $this->namespace
                 . '\\' . implode('\\', $namespaces)
                 . '\\' . $this->defaultController;
 
@@ -177,7 +177,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         }
 
         // Check for the default controller in Controllers directory.
-        $controller = '\\' . trim($this->namespace, '\\')
+        $controller = '\\' . $this->namespace
             . '\\' . $this->defaultController;
 
         if (class_exists($controller)) {
@@ -288,10 +288,14 @@ final class AutoRouterImproved implements AutoRouterInterface
 
         $namespaces = implode('\\', $segments);
 
-        $dir = substr($namespaces, strlen($this->namespace));
+        $dir = str_replace(
+            '\\',
+            '/',
+            ltrim(substr($namespaces, strlen($this->namespace)), '\\')
+        );
 
         if ($dir !== '') {
-            $this->directory = substr($namespaces, strlen($this->namespace)) . '/';
+            $this->directory = $dir . '/';
         }
     }
 

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -248,14 +248,12 @@ final class AutoRouterImproved implements AutoRouterInterface
                     'Cannot access the default method "' . $this->method . '" with the method name URI path.'
                 );
             }
+        } elseif (method_exists($this->controller, $this->defaultMethod)) {
+            // The default method is found.
+            $this->method = $this->defaultMethod;
         } else {
-            if (method_exists($this->controller, $this->defaultMethod)) {
-                // The default method is found.
-                $this->method = $this->defaultMethod;
-            } else {
-                // No method is found.
-                throw PageNotFoundException::forControllerNotFound($this->controller, $method);
-            }
+            // No method is found.
+            throw PageNotFoundException::forControllerNotFound($this->controller, $method);
         }
 
         // Ensure the controller is not defined in routes.

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -235,6 +235,45 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame(['15'], $params);
     }
 
+    public function testAutoRouteFallbackToDefaultControllerOneParam()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('subfolder/15');
+
+        $this->assertSame('Subfolder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Home', $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame(['15'], $params);
+    }
+
+    public function testAutoRouteFallbackToDefaultControllerTwoParams()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('subfolder/15/20');
+
+        $this->assertSame('Subfolder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Home', $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame(['15', '20'], $params);
+    }
+
+    public function testAutoRouteFallbackToDefaultControllerNoParams()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('subfolder');
+
+        $this->assertSame('Subfolder/', $directory);
+        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Home', $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame([], $params);
+    }
+
     public function testAutoRouteRejectsSingleDot()
     {
         $this->expectException(PageNotFoundException::class);

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -167,6 +167,19 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame([], $params);
     }
 
+    public function testAutoRouteFindsControllerWithSubSubfolder()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('subfolder/sub/mycontroller/somemethod');
+
+        $this->assertSame('Subfolder/Sub/', $directory);
+        $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Sub\Mycontroller::class, $controller);
+        $this->assertSame('getSomemethod', $method);
+        $this->assertSame([], $params);
+    }
+
     public function testAutoRouteFindsDashedSubfolder()
     {
         $router = $this->createNewAutoRouter();

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -243,7 +243,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('subfolder/15');
 
         $this->assertSame('Subfolder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Home', $controller);
+        $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame(['15'], $params);
     }
@@ -256,7 +256,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('subfolder/15/20');
 
         $this->assertSame('Subfolder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Home', $controller);
+        $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame(['15', '20'], $params);
     }
@@ -269,7 +269,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             = $router->getRoute('subfolder');
 
         $this->assertSame('Subfolder/', $directory);
-        $this->assertSame('\CodeIgniter\Router\Controllers\Subfolder\Home', $controller);
+        $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
     }

--- a/tests/system/Router/Controllers/Subfolder/Home.php
+++ b/tests/system/Router/Controllers/Subfolder/Home.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers\Subfolder;
+
+use CodeIgniter\Controller;
+
+class Home extends Controller
+{
+    public function getIndex($p1 = null, $p2 = null)
+    {
+    }
+}

--- a/tests/system/Router/Controllers/Subfolder/Sub/Mycontroller.php
+++ b/tests/system/Router/Controllers/Subfolder/Sub/Mycontroller.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers\Subfolder\Sub;
+
+use CodeIgniter\Controller;
+
+class Mycontroller extends Controller
+{
+    public function getSomemethod()
+    {
+    }
+}

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -96,7 +96,10 @@ Others
 - **View:** Added optional 2nd parameter ``$saveData`` on ``renderSection()`` to prevent from auto cleans the data after displaying. See :ref:`View Layouts <creating-a-layout>` for details.
 - **Auto Routing (Improved)**: Now you can route to Modules.
   See :ref:`auto-routing-improved-module-routing` for details.
-- **Auto Routing (Improved)**: Now you can use URI without a method name like
+- **Auto Routing (Improved):** Now you can pass arguments to the the default
+  controller that is omitted in the URI.
+  See :ref:`controller-default-controller-fallback` for details.
+- **Auto Routing (Improved):** Now you can use URI without a method name like
   ``product/15`` where ``15`` is an arbitrary number.
   See :ref:`controller-default-method-fallback` for details.
 - **Filters:** Now you can use Filter Arguments with :ref:`$filters property <filters-filters-filter-arguments>`.

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -96,11 +96,10 @@ Others
 - **View:** Added optional 2nd parameter ``$saveData`` on ``renderSection()`` to prevent from auto cleans the data after displaying. See :ref:`View Layouts <creating-a-layout>` for details.
 - **Auto Routing (Improved)**: Now you can route to Modules.
   See :ref:`auto-routing-improved-module-routing` for details.
-- **Auto Routing (Improved):** Now you can pass arguments to the the default
-  controller that is omitted in the URI.
-  See :ref:`controller-default-controller-fallback` for details.
-- **Auto Routing (Improved):** Now you can use URI without a method name like
-  ``product/15`` where ``15`` is an arbitrary number.
+- **Auto Routing (Improved):** If a controller is found that corresponds to a URI
+  segment and that controller does not have a method defined for the URI segment,
+  the default method will now be executed. This addition allows for more flexible
+  handling of URIs in auto routing.
   See :ref:`controller-default-method-fallback` for details.
 - **Filters:** Now you can use Filter Arguments with :ref:`$filters property <filters-filters-filter-arguments>`.
 - **Request:** Added ``IncomingRequest::setValidLocales()`` method to set valid locales.

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -336,6 +336,9 @@ The method will be passed URI segments 2 and 3 (``'15'`` and ``'edit'``):
     Auto Routing (Improved) does not execute the method, and it results in 404
     Not Found.
 
+Fallback to Default Controller
+------------------------------
+
 If the controller corresponding to the URI segment of the controller name
 does not exist, and if the default controller (``Home`` by default) exists in
 the directory, the remaining URI segments are passed to the default controller's

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -279,44 +279,6 @@ Your method will be passed URI segments 3 and 4 (``'sandals'`` and ``'123'``):
 
 .. literalinclude:: controllers/022.php
 
-.. _controller-default-controller-fallback:
-
-Default Controller Fallback
-===========================
-
-.. versionadded:: 4.4.0
-
-If the controller corresponding to the URI segment of the controller name
-does not exist, and if the default controller (``Home`` by default) exists in
-the directory, the remaining URI segments are passed to the default controller
-for execution.
-
-For example, when you have the following default controller ``Home`` in the
-**app/Controllers/News** directory:
-
-.. literalinclude:: controllers/025.php
-
-Load the following URL::
-
-    example.com/index.php/news/list
-
-The ``News\Home`` controller will be found, and the ``getList()`` method will be
-executed.
-
-.. note:: If there is ``App\Controllers\News`` controller, it takes precedence.
-    The URI segments are searched sequentially and the first controller found
-    is used.
-
-Load the following URL::
-
-    example.com/index.php/news/101
-
-The default ``getIndex()`` method will be passed URI segments 2 (``'101'``):
-
-.. note:: If there are more parameters in the URI than the method parameters,
-    Auto Routing (Improved) does not execute the method, and it results in 404
-    Not Found.
-
 .. _controller-default-method-fallback:
 
 Default Method Fallback
@@ -337,6 +299,31 @@ Load the following URL::
 The method will be passed URI segments 2 and 3 (``'15'`` and ``'edit'``):
 
 .. important:: If there are more parameters in the URI than the method parameters,
+    Auto Routing (Improved) does not execute the method, and it results in 404
+    Not Found.
+
+If the controller corresponding to the URI segment of the controller name
+does not exist, and if the default controller (``Home`` by default) exists in
+the directory, the remaining URI segments are passed to the default controller's
+default method.
+
+For example, when you have the following default controller ``Home`` in the
+**app/Controllers/News** directory:
+
+.. literalinclude:: controllers/025.php
+
+Load the following URL::
+
+    example.com/index.php/news/101
+
+The ``News\Home`` controller and the default ``getIndex()`` method will be found.
+So the default method will be passed URI segments 2 (``'101'``):
+
+.. note:: If there is ``App\Controllers\News`` controller, it takes precedence.
+    The URI segments are searched sequentially and the first controller found
+    is used.
+
+.. note:: If there are more parameters in the URI than the method parameters,
     Auto Routing (Improved) does not execute the method, and it results in 404
     Not Found.
 

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -279,6 +279,44 @@ Your method will be passed URI segments 3 and 4 (``'sandals'`` and ``'123'``):
 
 .. literalinclude:: controllers/022.php
 
+.. _controller-default-controller-fallback:
+
+Default Controller Fallback
+===========================
+
+.. versionadded:: 4.4.0
+
+If the controller corresponding to the URI segment of the controller name
+does not exist, and if the default controller (``Home`` by default) exists in
+the directory, the remaining URI segments are passed to the default controller
+for execution.
+
+For example, when you have the following default controller ``Home`` in the
+**app/Controllers/News** directory:
+
+.. literalinclude:: controllers/025.php
+
+Load the following URL::
+
+    example.com/index.php/news/list
+
+The ``News\Home`` controller will be found, and the ``getList()`` method will be
+executed.
+
+.. note:: If there is ``App\Controllers\News`` controller, it takes precedence.
+    The URI segments are searched sequentially and the first controller found
+    is used.
+
+Load the following URL::
+
+    example.com/index.php/news/101
+
+The default ``getIndex()`` method will be passed URI segments 2 (``'101'``):
+
+.. note:: If there are more parameters in the URI than the method parameters,
+    Auto Routing (Improved) does not execute the method, and it results in 404
+    Not Found.
+
 .. _controller-default-method-fallback:
 
 Default Method Fallback
@@ -287,8 +325,8 @@ Default Method Fallback
 .. versionadded:: 4.4.0
 
 If the controller method corresponding to the URI segment of the method name
-does not exist, and if the default method is defined, the URI segments are
-passed to the default method for execution.
+does not exist, and if the default method is defined, the remaining URI segments
+are passed to the default method for execution.
 
 .. literalinclude:: controllers/024.php
 

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -279,6 +279,40 @@ Your method will be passed URI segments 3 and 4 (``'sandals'`` and ``'123'``):
 
 .. literalinclude:: controllers/022.php
 
+Default Controller
+==================
+
+The Default Controller is a special controller that is used when a URI ends with
+a directory name or when a URI is not present, as will be the case when only your
+site root URL is requested.
+
+Defining a Default Controller
+-----------------------------
+
+Let's try it with the ``Helloworld`` controller.
+
+To specify a default controller open your **app/Config/Routes.php**
+file and set this variable:
+
+.. literalinclude:: controllers/015.php
+
+Where ``Helloworld`` is the name of the controller class you want to be used.
+
+A few lines further down **Routes.php** in the "Route Definitions" section, comment out the line:
+
+.. literalinclude:: controllers/016.php
+
+If you now browse to your site without specifying any URI segments you'll
+see the "Hello World" message.
+
+.. important:: When you use Auto Routing (Improved), you must remove the line
+    ``$routes->get('/', 'Home::index');``. Because defined routes take
+    precedence over Auto Routing, and controllers defined in the defined routes
+    are denied access by Auto Routing (Improved) for security reasons.
+
+For more information, please refer to the :ref:`routes-configuration-options` section of the
+:ref:`URI Routing <routing-auto-routing-improved-configuration-options>` documentation.
+
 .. _controller-default-method-fallback:
 
 Default Method Fallback
@@ -326,40 +360,6 @@ So the default method will be passed URI segments 2 (``'101'``):
 .. note:: If there are more parameters in the URI than the method parameters,
     Auto Routing (Improved) does not execute the method, and it results in 404
     Not Found.
-
-Default Controller
-==================
-
-The Default Controller is a special controller that is used when a URI ends with
-a directory name or when a URI is not present, as will be the case when only your
-site root URL is requested.
-
-Defining a Default Controller
------------------------------
-
-Let's try it with the ``Helloworld`` controller.
-
-To specify a default controller open your **app/Config/Routes.php**
-file and set this variable:
-
-.. literalinclude:: controllers/015.php
-
-Where ``Helloworld`` is the name of the controller class you want to be used.
-
-A few lines further down **Routes.php** in the "Route Definitions" section, comment out the line:
-
-.. literalinclude:: controllers/016.php
-
-If you now browse to your site without specifying any URI segments you'll
-see the "Hello World" message.
-
-.. important:: When you use Auto Routing (Improved), you must remove the line
-    ``$routes->get('/', 'Home::index');``. Because defined routes take
-    precedence over Auto Routing, and controllers defined in the defined routes
-    are denied access by Auto Routing (Improved) for security reasons.
-
-For more information, please refer to the :ref:`routes-configuration-options` section of the
-:ref:`URI Routing <routing-auto-routing-improved-configuration-options>` documentation.
 
 Organizing Your Controllers into Sub-directories
 ================================================

--- a/user_guide_src/source/incoming/controllers/025.php
+++ b/user_guide_src/source/incoming/controllers/025.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controllers\News;
+
+use App\Controllers\BaseController;
+
+class Home extends BaseController
+{
+    public function getList()
+    {
+        // ...
+    }
+
+    public function getIndex($id = null)
+    {
+        // ...
+    }
+}

--- a/user_guide_src/source/incoming/controllers/025.php
+++ b/user_guide_src/source/incoming/controllers/025.php
@@ -6,11 +6,6 @@ use App\Controllers\BaseController;
 
 class Home extends BaseController
 {
-    public function getList()
-    {
-        // ...
-    }
-
     public function getIndex($id = null)
     {
         // ...


### PR DESCRIPTION
**Description**
Related #7162

You can pass arguments to the default method of the default controller.

When you have `News\Home` and `public function getIndex($id = null)` in it:
  - `GET /news/101`
    - → `News` not found
    - → `News\101` not found (invalid)
    - → `News\101\Home` not found (invalid)
    - → `News\Home` found
    - → `News\Home::getIndex()` found
    - → run `News\Home::getIndex('101')`

This PR makes it possible that one controller one URI.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
