### PR TITLE
docs: add note for custom command generator template

### DIFF
--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -308,3 +308,14 @@ GeneratorTrait
 
 All generator commands must use the ``GeneratorTrait`` to fully utilize its methods that are used in code
 generation.
+
+*************************************
+Accessing a Custom Generator Template
+*************************************
+
+By default, all generator templates will be looked up at the ``CodeIgniter\Commands\Generators\Views`` namespace.
+To declare a custom location for your custom generator template, you will need to add it to the ``app/Config/Generators.php``
+file. For example, if you have a command ``make:awesome-command`` and your generator template is located within your *app*
+directory ``app/Commands/Generators/Views/awesomecommand.tpl.php``, you would update the config file like so:
+
+.. literalinclude:: cli_generators/001.php

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -313,8 +313,8 @@ generation.
 Declaring the Location of a Custom Generator Command Template
 *************************************************************
 
-The default order of lookup for generator templates is first, the template defined in the **app/Config/Generators.php** file,
-and if not found, the template will be looked up at the ``CodeIgniter\Commands\Generators\Views`` namespace.
+The default order of lookup for generator templates is (1) the template defined in the **app/Config/Generators.php** file,
+and (2) if not found, the template found at the ``CodeIgniter\Commands\Generators\Views`` namespace.
 
 To declare the template location for your custom generator command, you will need to add it to the **app/Config/Generators.php**
 file. For example, if you have a command ``make:awesome-command`` and your generator template is located within your *app*

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -309,13 +309,15 @@ GeneratorTrait
 All generator commands must use the ``GeneratorTrait`` to fully utilize its methods that are used in code
 generation.
 
-*************************************
-Accessing a Custom Generator Template
-*************************************
+*************************************************************
+Declaring the Location of a Custom Generator Command Template
+*************************************************************
 
-By default, all generator templates will be looked up at the ``CodeIgniter\Commands\Generators\Views`` namespace.
-To declare a custom location for your custom generator template, you will need to add it to the ``app/Config/Generators.php``
+The default order of lookup for generator templates is first, the template defined in the **app/Config/Generators.php** file,
+and if not found, the template will be looked up at the ``CodeIgniter\Commands\Generators\Views`` namespace.
+
+To declare the template location for your custom generator command, you will need to add it to the **app/Config/Generators.php**
 file. For example, if you have a command ``make:awesome-command`` and your generator template is located within your *app*
-directory ``app/Commands/Generators/Views/awesomecommand.tpl.php``, you would update the config file like so:
+directory **app/Commands/Generators/Views/awesomecommand.tpl.php**, you would update the config file like so:
 
 .. literalinclude:: cli_generators/001.php

--- a/user_guide_src/source/cli/cli_generators/001.php
+++ b/user_guide_src/source/cli/cli_generators/001.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class Generators extends BaseConfig
+{
+    public array $views = [
+        // ..
+        'make:awesome-command' => 'App\Commands\Generators\awesomecommand.tpl.php',
+    ];
+}

--- a/user_guide_src/source/cli/cli_generators/001.php
+++ b/user_guide_src/source/cli/cli_generators/001.php
@@ -8,6 +8,6 @@ class Generators extends BaseConfig
 {
     public array $views = [
         // ..
-        'make:awesome-command' => 'App\Commands\Generators\awesomecommand.tpl.php',
+        'make:awesome-command' => 'App\Commands\Generators\Views\awesomecommand.tpl.php',
     ];
 }


### PR DESCRIPTION
**Description**
Added explanation on how to locate the view template of a custom generator command. Fixes #7405.

**Checklist:**
* [x]  Securely signed commits
* [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
* [ ] Unit testing, with >80% coverage
* [x]  User guide updated
* [ ] Conforms to style guide
