### PR TITLE
fix: `spark routes` shows invalid routes with Auto Routing Improved

### DIFF
--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -79,7 +79,7 @@ final class ControllerMethodReader
                         if ($routeForDefaultController !== []) {
                             // The controller is the default controller. It only
                             // has a route for the default method. Other methods
-                            // will be routed even if they exist.
+                            // will not be routed even if they exist.
                             $output = [...$output, ...$routeForDefaultController];
 
                             continue;

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -161,6 +161,8 @@ final class ControllerMethodReader
 
     /**
      * Gets a route for the default controller.
+     *
+     * @phpstan-return list<array>
      */
     private function getRouteForDefaultController(
         string $classShortname,

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -65,8 +65,9 @@ final class ControllerMethodReader
                     // Remove HTTP verb prefix.
                     $methodInUri = lcfirst(substr($methodName, strlen($httpVerb)));
 
+                    // Check if it is the default method.
                     if ($methodInUri === $defaultMethod) {
-                        $routeWithoutController = $this->getRouteWithoutController(
+                        $routeForDefaultController = $this->getRouteForDefaultController(
                             $classShortname,
                             $defaultController,
                             $classInUri,
@@ -75,8 +76,11 @@ final class ControllerMethodReader
                             $httpVerb
                         );
 
-                        if ($routeWithoutController !== []) {
-                            $output = [...$output, ...$routeWithoutController];
+                        if ($routeForDefaultController !== []) {
+                            // The controller is the default controller. It only
+                            // has a route for the default method. Other methods
+                            // will be routed even if they exist.
+                            $output = [...$output, ...$routeForDefaultController];
 
                             continue;
                         }
@@ -93,7 +97,7 @@ final class ControllerMethodReader
                         continue;
                     }
 
-                    // Skip the default controller.
+                    // If it is the default controller, no more routes exists.
                     if ($classShortname === $defaultController) {
                         continue;
                     }
@@ -156,9 +160,9 @@ final class ControllerMethodReader
     }
 
     /**
-     * Gets a route without default controller.
+     * Gets a route for the default controller.
      */
-    private function getRouteWithoutController(
+    private function getRouteForDefaultController(
         string $classShortname,
         string $defaultController,
         string $uriByClass,

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -93,6 +93,11 @@ final class ControllerMethodReader
                         continue;
                     }
 
+                    // Skip the default controller.
+                    if (class_basename($class) === $defaultController) {
+                        continue;
+                    }
+
                     $route = $classInUri . '/' . $methodInUri;
 
                     $params      = [];

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -94,7 +94,7 @@ final class ControllerMethodReader
                     }
 
                     // Skip the default controller.
-                    if (class_basename($class) === $defaultController) {
+                    if ($classShortname === $defaultController) {
                         continue;
                     }
 

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 
+use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home;
 use CodeIgniter\Test\CIUnitTestCase;
 use Tests\Support\Controllers\Newautorouting;
 use Tests\Support\Controllers\Remap;
@@ -22,13 +23,13 @@ use Tests\Support\Controllers\Remap;
  */
 final class ControllerMethodReaderTest extends CIUnitTestCase
 {
-    private function createControllerMethodReader(): ControllerMethodReader
-    {
+    private function createControllerMethodReader(
+        string $namespace = 'Tests\Support\Controllers'
+    ): ControllerMethodReader {
         $methods = [
             'get',
             'post',
         ];
-        $namespace = 'Tests\Support\Controllers';
 
         return new ControllerMethodReader($namespace, $methods);
     }
@@ -57,6 +58,34 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
                     'b' => true,
                     'c' => false,
                 ],
+            ],
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    public function testReadDefaultController()
+    {
+        $reader = $this->createControllerMethodReader(
+            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers'
+        );
+
+        $routes = $reader->read(Home::class);
+
+        $expected = [
+            0 => [
+                'method'       => 'get',
+                'route'        => '/',
+                'route_params' => '',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home::getIndex',
+                'params'       => [],
+            ],
+            [
+                'method'       => 'post',
+                'route'        => '/',
+                'route_params' => '',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home::postIndex',
+                'params'       => [],
             ],
         ];
 

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/Home.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/Home.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers;
+
+use CodeIgniter\Controller;
+
+/**
+ * The default controller for Auto Routing (Improved)
+ */
+class Home extends Controller
+{
+    public function getIndex()
+    {
+    }
+
+    public function postIndex()
+    {
+    }
+
+    /**
+     * This method cannot be accessible.
+     */
+    public function getFoo()
+    {
+    }
+}


### PR DESCRIPTION
**Description**
Fixes #7415

- fix the `spark routes` shows the default controller's method routes that cannot be accessible.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
