### PR TITLE
fix: [Auto Routing Improved] spark routes shows invalid routes

### DIFF
--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -117,6 +117,12 @@ final class ControllerMethodReader
                         $params[$param->getName()] = $required;
                     }
 
+                    // If it is the default controller, the method will not be
+                    // routed.
+                    if ($classShortname === $defaultController) {
+                        $route = 'x ' . $route;
+                    }
+
                     $output[] = [
                         'method'       => $httpVerb,
                         'route'        => $route,

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -65,8 +65,9 @@ final class ControllerMethodReader
                     // Remove HTTP verb prefix.
                     $methodInUri = lcfirst(substr($methodName, strlen($httpVerb)));
 
+                    // Check if it is the default method.
                     if ($methodInUri === $defaultMethod) {
-                        $routeWithoutController = $this->getRouteWithoutController(
+                        $routeForDefaultController = $this->getRouteForDefaultController(
                             $classShortname,
                             $defaultController,
                             $classInUri,
@@ -75,8 +76,11 @@ final class ControllerMethodReader
                             $httpVerb
                         );
 
-                        if ($routeWithoutController !== []) {
-                            $output = [...$output, ...$routeWithoutController];
+                        if ($routeForDefaultController !== []) {
+                            // The controller is the default controller. It only
+                            // has a route for the default method. Other methods
+                            // will not be routed even if they exist.
+                            $output = [...$output, ...$routeForDefaultController];
 
                             continue;
                         }
@@ -151,9 +155,11 @@ final class ControllerMethodReader
     }
 
     /**
-     * Gets a route without default controller.
+     * Gets a route for the default controller.
+     *
+     * @phpstan-return list<array>
      */
-    private function getRouteWithoutController(
+    private function getRouteForDefaultController(
         string $classShortname,
         string $defaultController,
         string $uriByClass,

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 
+use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home;
 use CodeIgniter\Test\CIUnitTestCase;
 use Tests\Support\Controllers\Newautorouting;
 use Tests\Support\Controllers\Remap;
@@ -22,13 +23,13 @@ use Tests\Support\Controllers\Remap;
  */
 final class ControllerMethodReaderTest extends CIUnitTestCase
 {
-    private function createControllerMethodReader(): ControllerMethodReader
-    {
+    private function createControllerMethodReader(
+        string $namespace = 'Tests\Support\Controllers'
+    ): ControllerMethodReader {
         $methods = [
             'get',
             'post',
         ];
-        $namespace = 'Tests\Support\Controllers';
 
         return new ControllerMethodReader($namespace, $methods);
     }
@@ -57,6 +58,41 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
                     'b' => true,
                     'c' => false,
                 ],
+            ],
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    public function testReadDefaultController()
+    {
+        $reader = $this->createControllerMethodReader(
+            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers'
+        );
+
+        $routes = $reader->read(Home::class);
+
+        $expected = [
+            0 => [
+                'method'       => 'get',
+                'route'        => '/',
+                'route_params' => '',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home::getIndex',
+                'params'       => [],
+            ],
+            [
+                'method'       => 'post',
+                'route'        => '/',
+                'route_params' => '',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home::postIndex',
+                'params'       => [],
+            ],
+            [
+                'method'       => 'get',
+                'route'        => 'x home/foo',
+                'route_params' => '',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home::getFoo',
+                'params'       => [],
             ],
         ];
 

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/Home.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/Home.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers;
+
+use CodeIgniter\Controller;
+
+/**
+ * The default controller for Auto Routing (Improved)
+ */
+class Home extends Controller
+{
+    public function getIndex()
+    {
+    }
+
+    public function postIndex()
+    {
+    }
+
+    /**
+     * This method cannot be accessible.
+     */
+    public function getFoo()
+    {
+    }
+}

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -829,6 +829,25 @@ The *Method* will be like ``GET(auto)``.
 
 ``/..`` in the *Route* column indicates one segment. ``[/..]`` indicates it is optional.
 
+If you see a route starting with ``x`` like the following, it indicates an invalid
+route that won't be routed, but the controller has a public method for routing.
+
+.. code-block:: none
+
+    +-----------+----------------+------+-------------------------------------+----------------+---------------+
+    | Method    | Route          | Name | Handler                             | Before Filters | After Filters |
+    +-----------+----------------+------+-------------------------------------+----------------+---------------+
+    | GET(auto) | x home/foo     |      | \App\Controllers\Home::getFoo       | <unknown>      | <unknown>     |
+    +-----------+----------------+------+-------------------------------------+----------------+---------------+
+
+The above example shows you have the ``\App\Controllers\Home::getFoo()`` method,
+but it is not routed because it is the default controller (``Home`` by default)
+and the default controller name must be omitted in the URI. You should delete
+the ``getFoo()`` method.
+
+.. note:: Prior to v4.3.4, the invalid route is displayed as a normal route
+    due to a bug.
+
 Auto Routing (Legacy)
 ---------------------
 


### PR DESCRIPTION
**Description**
Supersedes #7417
Fixes #7415

Methods that are not routed should be removed. 
So the command shows them with `x` so that developers know.

Before:
```
+-----------+--------------+------+-------------------------------------+----------------+---------------+
| Method    | Route        | Name | Handler                             | Before Filters | After Filters |
+-----------+--------------+------+-------------------------------------+----------------+---------------+
| GET(auto) | dir          |      | \App\Controllers\Dir\Home::getIndex |                | toolbar       |
| GET(auto) | dir/home/foo |      | \App\Controllers\Dir\Home::getFoo   | <unknown>      | <unknown>     |
| GET(auto) | /            |      | \App\Controllers\Home::getIndex     |                | toolbar       |
| GET(auto) | home/foo     |      | \App\Controllers\Home::getFoo       | <unknown>      | <unknown>     |
+-----------+--------------+------+-------------------------------------+----------------+---------------+
```

After:
```
+-----------+----------------+------+-------------------------------------+----------------+---------------+
| Method    | Route          | Name | Handler                             | Before Filters | After Filters |
+-----------+----------------+------+-------------------------------------+----------------+---------------+
| GET(auto) | dir            |      | \App\Controllers\Dir\Home::getIndex |                | toolbar       |
| GET(auto) | x dir/home/foo |      | \App\Controllers\Dir\Home::getFoo   | <unknown>      | <unknown>     |
| GET(auto) | /              |      | \App\Controllers\Home::getIndex     |                | toolbar       |
| GET(auto) | x home/foo     |      | \App\Controllers\Home::getFoo       | <unknown>      | <unknown>     |
+-----------+----------------+------+-------------------------------------+----------------+---------------+
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
