### PR TITLE
fix: [Auto Routing Improved] one controller method has more than one URI when $translateURIDashes is true

### DIFF
--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -373,10 +373,10 @@ final class AutoRouterImproved implements AutoRouterInterface
         return (bool) preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $segment);
     }
 
-    private function translateURIDashes(string $classname): string
+    private function translateURIDashes(string $segment): string
     {
         return $this->translateURIDashes
-            ? str_replace('-', '_', $classname)
-            : $classname;
+            ? str_replace('-', '_', $segment)
+            : $segment;
     }
 }

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -324,6 +324,10 @@ final class AutoRouterImproved implements AutoRouterInterface
         // Ensure the controller does not have _remap() method.
         $this->checkRemap();
 
+        // Ensure the URI segments for the controller and method do not contain
+        // underscores when $translateURIDashes is true.
+        $this->checkUnderscore($uri);
+
         // Check parameter count
         try {
             $this->checkParameters($uri);
@@ -430,6 +434,28 @@ final class AutoRouterImproved implements AutoRouterInterface
             );
         } catch (ReflectionException $e) {
             // Do nothing.
+        }
+    }
+
+    private function checkUnderscore(string $uri): void
+    {
+        if ($this->translateURIDashes === false) {
+            return;
+        }
+
+        $paramPos = $this->paramPos ?? count($this->segments);
+
+        for ($i = 0; $i < $paramPos; $i++) {
+            if (strpos($this->segments[$i], '_') !== false) {
+                throw new PageNotFoundException(
+                    'AutoRouterImproved prohibits access to the URI'
+                    . ' containing underscores ("' . $this->segments[$i] . '")'
+                    . ' when $translateURIDashes is enabled.'
+                    . ' Please use the dash.'
+                    . ' Handler:' . $this->controller . '::' . $this->method
+                    . ', URI:' . $uri
+                );
+            }
         }
     }
 

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -202,7 +202,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                 $this->controller = $controller;
                 $this->params     = $params;
 
-                if ($params !== []) { // @phpstan-ignore-line
+                if ($params !== []) {
                     $this->paramPos = $paramPos;
                 }
 
@@ -221,7 +221,7 @@ final class AutoRouterImproved implements AutoRouterInterface
             $this->controller = $controller;
             $this->params     = $params;
 
-            if ($params !== []) { // @phpstan-ignore-line
+            if ($params !== []) {
                 $this->paramPos = 0;
             }
 

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -65,6 +65,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . Index::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
+        $this->assertSame([
+            'controller' => null,
+            'method'     => null,
+            'params'     => null,
+        ], $router->getPos());
     }
 
     public function testAutoRouteFindsModuleDefaultControllerAndMethodGet()
@@ -114,6 +119,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
+        $this->assertSame([
+            'controller' => 0,
+            'method'     => 1,
+            'params'     => null,
+        ], $router->getPos());
     }
 
     public function testFindsControllerAndMethodAndParam()
@@ -127,6 +137,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame(['a'], $params);
+        $this->assertSame([
+            'controller' => 0,
+            'method'     => 1,
+            'params'     => 2,
+        ], $router->getPos());
     }
 
     public function testUriParamCountIsGreaterThanMethodParams()
@@ -165,6 +180,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
+        $this->assertSame([
+            'controller' => 1,
+            'method'     => 2,
+            'params'     => null,
+        ], $router->getPos());
     }
 
     public function testAutoRouteFindsControllerWithSubSubfolder()
@@ -246,6 +266,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . Index::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame(['15'], $params);
+        $this->assertSame([
+            'controller' => 0,
+            'method'     => null,
+            'params'     => 1,
+        ], $router->getPos());
     }
 
     public function testAutoRouteFallbackToDefaultControllerOneParam()
@@ -259,6 +284,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame(['15'], $params);
+        $this->assertSame([
+            'controller' => null,
+            'method'     => null,
+            'params'     => 1,
+        ], $router->getPos());
     }
 
     public function testAutoRouteFallbackToDefaultControllerTwoParams()
@@ -272,6 +302,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame(['15', '20'], $params);
+        $this->assertSame([
+            'controller' => null,
+            'method'     => null,
+            'params'     => 1,
+        ], $router->getPos());
     }
 
     public function testAutoRouteFallbackToDefaultControllerNoParams()
@@ -285,6 +320,11 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
         $this->assertSame('getIndex', $method);
         $this->assertSame([], $params);
+        $this->assertSame([
+            'controller' => null,
+            'method'     => null,
+            'params'     => null,
+        ], $router->getPos());
     }
 
     public function testAutoRouteRejectsSingleDot()

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -402,7 +402,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash_folder');
+        $router->getRoute('dash_folder', 'get');
     }
 
     public function testRejectsURIWithUnderscoreController()
@@ -414,7 +414,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash-folder/dash_controller/dash-method');
+        $router->getRoute('dash-folder/dash_controller/dash-method', 'get');
     }
 
     public function testRejectsURIWithUnderscoreMethod()
@@ -426,7 +426,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash-folder/dash-controller/dash_method');
+        $router->getRoute('dash-folder/dash-controller/dash_method', 'get');
     }
 
     public function testPermitsURIWithUnderscoreParam()
@@ -434,7 +434,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a_b');
+            = $router->getRoute('mycontroller/somemethod/a_b', 'get');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -447,7 +447,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a-b');
+            = $router->getRoute('mycontroller/somemethod/a-b', 'get');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -352,4 +352,66 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router->getRoute('remap/test', 'get');
     }
+
+    public function testRejectsURIWithUnderscoreFolder()
+    {
+        $this->expectException(PageNotFoundException::class);
+        $this->expectExceptionMessage(
+            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_folder")'
+        );
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('dash_folder');
+    }
+
+    public function testRejectsURIWithUnderscoreController()
+    {
+        $this->expectException(PageNotFoundException::class);
+        $this->expectExceptionMessage(
+            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_controller")'
+        );
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('dash-folder/dash_controller/dash-method');
+    }
+
+    public function testRejectsURIWithUnderscoreMethod()
+    {
+        $this->expectException(PageNotFoundException::class);
+        $this->expectExceptionMessage(
+            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_method")'
+        );
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute('dash-folder/dash-controller/dash_method');
+    }
+
+    public function testPermitsURIWithUnderscoreParam()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('mycontroller/somemethod/a_b');
+
+        $this->assertNull($directory);
+        $this->assertSame('\\' . Mycontroller::class, $controller);
+        $this->assertSame('getSomemethod', $method);
+        $this->assertSame(['a_b'], $params);
+    }
+
+    public function testDoesNotTranslateDashInParam()
+    {
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('mycontroller/somemethod/a-b');
+
+        $this->assertNull($directory);
+        $this->assertSame('\\' . Mycontroller::class, $controller);
+        $this->assertSame('getSomemethod', $method);
+        $this->assertSame(['a-b'], $params);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -151,6 +151,10 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Auto Routing (Improved)**: In previous versions, when ``$translateURIDashes``
+  is true, two URIs correspond to a single controller method, one URI for dashes
+  (e.g., **foo-bar**) and one URI for underscores (e.g., **foo_bar**). This bug
+  has been fixed. Now the URI for underscores (**foo_bar**) is not accessible.
 - **Output Buffering:** Bug fix with output buffering.
 
 See the repo's

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -607,6 +607,12 @@ URI segments when used in Auto Routing, thus saving you additional route entries
 
 .. literalinclude:: routing/049.php
 
+.. note:: When using Auto Routing (Improved), prior to v4.4.0, if
+    ``$translateURIDashes`` is true, two URIs correspond to a single controller
+    method, one URI for dashes (e.g., **foo-bar**) and one URI for underscores
+    (e.g., **foo_bar**). This was incorrect behavior. Since v4.4.0, the URI for
+    underscores (**foo_bar**) is not accessible.
+
 .. _use-defined-routes-only:
 
 Use Defined Routes Only

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -60,6 +60,19 @@ by defining your own exception handler.
 
 See :ref:`custom-exception-handlers` for the detail.
 
+Auto Routing (Improved) and translateURIDashes
+==============================================
+
+When using Auto Routing (Improved) and ``$translateURIDashes`` is true
+(``$routes->setTranslateURIDashes(true)``), in previous versions due to a bug
+two URIs correspond to a single controller method, one URI for dashes
+(e.g., **foo-bar**) and one URI for underscores (e.g., **foo_bar**).
+
+This bug was fixed and now URIs for underscores (**foo_bar**) is not accessible.
+
+If you have links to URIs for underscores (**foo_bar**), update them with URIs
+for dashes (**foo-bar**).
+
 Interface Changes
 =================
 


### PR DESCRIPTION
~~Needs #7406~~

**Description**
When `$translateURIDashes` is true, two URIs correspond to a single controller method,
one URI for dashes (`foo-bar`) and one URI for underscores (`foo_bar`). 
This is incorrect behavior, contrary to the design philosophy.

This PR prohibits the URI for underscores (`foo_bar`) when `$translateURIDashes` is true.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
