### PR TITLE
fix: Validation::check() does not accept array rules

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -200,9 +200,9 @@ class Validation implements ValidationInterface
      * Runs the validation process, returning true or false
      * determining whether validation was successful or not.
      *
-     * @param array|bool|float|int|object|string|null $value
-     * @param array|string                            $rule
-     * @param string[]                                $errors
+     * @param array|bool|float|int|object|string|null $value  The data to validate.
+     * @param array|string                            $rule   The validation rules.
+     * @param string[]                                $errors The custom error message.
      */
     public function check($value, $rule, array $errors = []): bool
     {
@@ -451,7 +451,8 @@ class Validation implements ValidationInterface
      *        'rule' => 'message',
      *    ]
      *
-     * @param array|string $rules
+     * @param array|string $rules  The validation rules.
+     * @param array        $errors The custom error message.
      *
      * @return $this
      *

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -201,9 +201,10 @@ class Validation implements ValidationInterface
      * determining whether validation was successful or not.
      *
      * @param array|bool|float|int|object|string|null $value
+     * @param array|string                            $rule
      * @param string[]                                $errors
      */
-    public function check($value, string $rule, array $errors = []): bool
+    public function check($value, $rule, array $errors = []): bool
     {
         $this->reset();
 

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -39,7 +39,10 @@ Interface Changes
 Method Signature Changes
 ========================
 
-- The third parameter ``Routing $routing`` has been added to ``RouteCollection::__construct()``.
+- **Routing:** The third parameter ``Routing $routing`` has been added to
+  ``RouteCollection::__construct()``.
+- **Validation:** The method signature of ``Validation::check()`` has been changed.
+  The ``string`` typehint on the ``$rule`` parameter was removed.
 
 Enhancements
 ************

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -78,9 +78,12 @@ The Cookie config items in **app/Config/App.php** are no longer used.
 Breaking Enhancements
 *********************
 
-- The method signature of ``RouteCollection::__construct()`` has been changed.
+- **Routing:** The method signature of ``RouteCollection::__construct()`` has been changed.
   The third parameter ``Routing $routing`` has been added. Extending classes
   should likewise add the parameter so as not to break LSP.
+- **Validation:** The method signature of ``Validation::check()`` has been changed.
+  The ``string`` typehint on the ``$rule`` parameter was removed. Extending classes
+  should likewise remove the typehint so as not to break LSP.
 
 Project Files
 *************

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -376,9 +376,15 @@ you previously set, so ``setRules()``, ``setRuleGroup()`` etc. need to be repeat
 Validating 1 Value
 ==================
 
-Validate one value against a rule:
+Validate one value against the rules:
 
 .. literalinclude:: validation/012.php
+
+.. note:: Prior to v4.4.0, this method's second parameter, ``$rule``, was
+    typehinted to accept ``string``. In v4.4.0 and after, the typehint was
+    removed to allow arrays, too.
+
+.. note:: This method calls the ``setRule()`` method to set the rules internally.
 
 .. _validation-getting-validated-data:
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -376,7 +376,10 @@ you previously set, so ``setRules()``, ``setRuleGroup()`` etc. need to be repeat
 Validating 1 Value
 ==================
 
-Validate one value against the rules:
+The ``check()`` method validates one value against the rules.
+The first parameter ``$value`` is the value to validate. The second parameter
+``$rule`` is the validation rules.
+The optional third parameter ``$errors`` is the the custom error message.
 
 .. literalinclude:: validation/012.php
 

--- a/user_guide_src/source/libraries/validation/012.php
+++ b/user_guide_src/source/libraries/validation/012.php
@@ -1,3 +1,5 @@
 <?php
 
-$validation->check($value, 'required');
+if ($validation->check($value, 'required')) {
+    // $value is valid.
+}


### PR DESCRIPTION
**Description**
`Validation::check()` should accept array rules.
In #5545, `string` for `$rules` in `setRule()` was removed.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
