### PR TITLE
docs: fix phpstan errors

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -61,11 +61,6 @@ parameters:
 			path: system/Database/Migration.php
 
 		-
-			message: "#^Property CodeIgniter\\\\Database\\\\BaseConnection\\<mysqli,mysqli_result\\>\\:\\:\\$strictOn \\(bool\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: system/Database/MySQLi/Connection.php
-
-		-
 			message: "#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\<mysqli, mysqli_result\\>\\:\\:\\$mysqli\\.$#"
 			count: 3
 			path: system/Database/MySQLi/PreparedQuery.php

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\API;
 
 use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
 
@@ -21,7 +22,7 @@ use Config\Services;
  * consistent HTTP responses under a variety of common
  * situations when working as an API.
  *
- * @property IncomingRequest   $request
+ * @property RequestInterface  $request
  * @property ResponseInterface $response
  */
 trait ResponseTrait

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -30,8 +30,6 @@ use InvalidArgumentException;
  * Additional methods to make a PSR-7 Response class
  * compliant with the framework's own ResponseInterface.
  *
- * @property array $statusCodes
- *
  * @see https://github.com/php-fig/http-message/blob/master/src/ResponseInterface.php
  */
 trait ResponseTrait


### PR DESCRIPTION
**Description**
phpstan (1.10.13) reports the following errors:
```
 ------ ------------------------------------------------------------------------------------------------------------------------ 
  Line   system/Database/MySQLi/Connection.php                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------------ 
         Ignored error pattern #^Property CodeIgniter\\Database\\BaseConnection<mysqli,mysqli_result>\:\:\$strictOn \(bool\) in  
         isset\(\) is not nullable\.$# in path                                                                                   
         /Users/kenji/work/codeigniter/official/CodeIgniter4/system/Database/MySQLi/Connection.php was not matched in reported   
         errors.                                                                                                                 
 ------ ------------------------------------------------------------------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------------- 
  Line   system/HTTP/Response.php                                                     
 ------ ----------------------------------------------------------------------------- 
  255    Static access to instance property CodeIgniter\HTTP\Response::$statusCodes.  
 ------ ----------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   system/HTTP/ResponseTrait.php (in context of class CodeIgniter\HTTP\Response)  
 ------ ------------------------------------------------------------------------------- 
  161    Static access to instance property CodeIgniter\HTTP\Response::$statusCodes.    
  167    Static access to instance property CodeIgniter\HTTP\Response::$statusCodes.    
 ------ ------------------------------------------------------------------------------- 
```

In `4.4` branch, the following error is reported:
```
 ------ ---------------------------------------------------------------------------------------------------------- 
  Line   system/Debug/ExceptionHandler.php                                                                         
 ------ ---------------------------------------------------------------------------------------------------------- 
  48     Property CodeIgniter\Debug\ExceptionHandler::$request (CodeIgniter\HTTP\IncomingRequest) does not accept  
         CodeIgniter\HTTP\RequestInterface.                                                                        
 ------ ---------------------------------------------------------------------------------------------------------- 
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
