### PR TITLE
feat: add ValidationInterface::getValidated()

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -212,7 +212,7 @@ class Validation implements ValidationInterface
     }
 
     /**
-     * Returns actually validated data.
+     * Returns the actual validated data.
      */
     public function getValidated(): array
     {

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -148,4 +148,9 @@ interface ValidationInterface
      * Displays a single error in formatted HTML as defined in the $template view.
      */
     public function showError(string $field, string $template = 'single'): string;
+
+    /**
+     * Returns the actual validated data.
+     */
+    public function getValidated(): array;
 }

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -29,12 +29,16 @@ or more was specified. See :ref:`upgrade-440-uri-setsegment`.
 
 The next segment (``+1``) of the current last segment can be set as before.
 
+.. _v440-interface-changes:
+
 Interface Changes
 =================
 
 .. note:: As long as you have not extended the relevant CodeIgniter core classes
     or implemented these interfaces, all these changes are backward compatible
     and require no intervention.
+
+- **Validation:** Added the ``getValidated()`` method in ``ValidationInterface``.
 
 Method Signature Changes
 ========================

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -60,6 +60,12 @@ by defining your own exception handler.
 
 See :ref:`custom-exception-handlers` for the detail.
 
+Interface Changes
+=================
+
+Some interface changes have been made. Classes that implement them should update
+their APIs to reflect the changes. See :ref:`v440-interface-changes` for details.
+
 Mandatory File Changes
 **********************
 


### PR DESCRIPTION
**Description**
Follow-up #7420

PHPStan reports when using `$this->validator->getValidated()` in `Controller`:
> Call to an undefined method CodeIgniter\Validation\ValidationInterface::getValidated().

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
