### PR TITLE
fix: PHPDoc @template and @return in database

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -46,8 +46,8 @@ use Throwable;
  * @property bool       $transFailure
  * @property bool       $transStatus
  *
- * @template TConnection of object|resource
- * @template TResult of object|resource
+ * @template TConnection
+ * @template TResult
  *
  * @implements ConnectionInterface<TConnection, TResult>
  */

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -18,8 +18,6 @@ use CodeIgniter\Events\Events;
 use ErrorException;
 
 /**
- *
- * @implements PreparedQueryInterface<TConnection, TStatement, TResult>
  * @template TConnection
  * @template TStatement
  * @template TResult
@@ -111,7 +109,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      * prepared query. Upon success, will return a Results object.
      *
      * @return bool|ResultInterface
-     * @phpstan-return bool|ResultInterface<TConnection, TResult>
+     * @phpstan-return bool|ResultInterface
      *
      * @throws DatabaseException
      */

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -21,6 +21,8 @@ use ErrorException;
  * @template TConnection
  * @template TStatement
  * @template TResult
+ *
+ * @implements PreparedQueryInterface<TConnection, TStatement, TResult>
  */
 abstract class BasePreparedQuery implements PreparedQueryInterface
 {
@@ -109,7 +111,7 @@ abstract class BasePreparedQuery implements PreparedQueryInterface
      * prepared query. Upon success, will return a Results object.
      *
      * @return bool|ResultInterface
-     * @phpstan-return bool|ResultInterface
+     * @phpstan-return bool|ResultInterface<TConnection, TResult>
      *
      * @throws DatabaseException
      */

--- a/system/Database/BasePreparedQuery.php
+++ b/system/Database/BasePreparedQuery.php
@@ -18,11 +18,11 @@ use CodeIgniter\Events\Events;
 use ErrorException;
 
 /**
- * @template TConnection of object|resource
- * @template TStatement of object|resource
- * @template TResult of object|resource
  *
  * @implements PreparedQueryInterface<TConnection, TStatement, TResult>
+ * @template TConnection
+ * @template TStatement
+ * @template TResult
  */
 abstract class BasePreparedQuery implements PreparedQueryInterface
 {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -17,6 +17,8 @@ use stdClass;
 /**
  * @template TConnection
  * @template TResult
+ *
+ * @implements ResultInterface<TConnection, TResult>
  */
 abstract class BaseResult implements ResultInterface
 {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -15,10 +15,10 @@ use CodeIgniter\Entity\Entity;
 use stdClass;
 
 /**
- * @template TConnection of object|resource
- * @template TResult of object|resource
  *
  * @implements ResultInterface<TConnection, TResult>
+ * @template TConnection
+ * @template TResult
  */
 abstract class BaseResult implements ResultInterface
 {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -15,8 +15,6 @@ use CodeIgniter\Entity\Entity;
 use stdClass;
 
 /**
- *
- * @implements ResultInterface<TConnection, TResult>
  * @template TConnection
  * @template TResult
  */

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -497,6 +497,8 @@ abstract class BaseResult implements ResultInterface
 
     /**
      * Frees the current result.
+     *
+     * @return void
      */
     abstract public function freeResult();
 
@@ -523,7 +525,7 @@ abstract class BaseResult implements ResultInterface
      *
      * Overridden by child classes.
      *
-     * @return object
+     * @return Entity|false|object|stdClass
      */
     abstract protected function fetchObject(string $className = 'stdClass');
 }

--- a/system/Database/ConnectionInterface.php
+++ b/system/Database/ConnectionInterface.php
@@ -12,8 +12,8 @@
 namespace CodeIgniter\Database;
 
 /**
- * @template TConnection of object|resource
- * @template TResult of object|resource
+ * @template TConnection
+ * @template TResult
  */
 interface ConnectionInterface
 {

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -103,6 +103,8 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
+     *
+     * @return void
      */
     public function freeResult()
     {

--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Database\OCI8;
 
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Entity\Entity;
+use stdClass;
 
 /**
  * Result for OCI8

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -69,6 +69,8 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
+     *
+     * @return void
      */
     public function freeResult()
     {

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -13,6 +13,11 @@ namespace CodeIgniter\Database;
 
 use BadMethodCallException;
 
+/**
+ * @template TConnection
+ * @template TStatement
+ * @template TResult
+ */
 interface PreparedQueryInterface
 {
     /**
@@ -20,7 +25,7 @@ interface PreparedQueryInterface
      * prepared query. Upon success, will return a Results object.
      *
      * @return bool|ResultInterface
-     * @phpstan-return bool|ResultInterface
+     * @phpstan-return bool|ResultInterface<TConnection, TResult>
      */
     public function execute(...$data);
 

--- a/system/Database/PreparedQueryInterface.php
+++ b/system/Database/PreparedQueryInterface.php
@@ -13,11 +13,6 @@ namespace CodeIgniter\Database;
 
 use BadMethodCallException;
 
-/**
- * @template TConnection of object|resource
- * @template TStatement of object|resource
- * @template TResult of object|resource
- */
 interface PreparedQueryInterface
 {
     /**
@@ -25,7 +20,7 @@ interface PreparedQueryInterface
      * prepared query. Upon success, will return a Results object.
      *
      * @return bool|ResultInterface
-     * @phpstan-return bool|ResultInterface<TConnection, TResult>
+     * @phpstan-return bool|ResultInterface
      */
     public function execute(...$data);
 

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -13,6 +13,10 @@ namespace CodeIgniter\Database;
 
 use stdClass;
 
+/**
+ * @template TConnection
+ * @template TResult
+ */
 interface ResultInterface
 {
     /**

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -13,10 +13,6 @@ namespace CodeIgniter\Database;
 
 use stdClass;
 
-/**
- * @template TConnection of object|resource
- * @template TResult of object|resource
- */
 interface ResultInterface
 {
     /**

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -103,6 +103,8 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
+     *
+     * @return void
      */
     public function freeResult()
     {

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -80,6 +80,8 @@ class Result extends BaseResult
 
     /**
      * Frees the current result.
+     *
+     * @return void
      */
     public function freeResult()
     {

--- a/system/Test/Mock/MockResult.php
+++ b/system/Test/Mock/MockResult.php
@@ -46,7 +46,7 @@ class MockResult extends BaseResult
     /**
      * Frees the current result.
      *
-     * @return mixed
+     * @return void
      */
     public function freeResult()
     {
@@ -59,7 +59,7 @@ class MockResult extends BaseResult
      *
      * @param int $n
      *
-     * @return mixed
+     * @return bool
      */
     public function dataSeek($n = 0)
     {

--- a/system/Test/Mock/MockResult.php
+++ b/system/Test/Mock/MockResult.php
@@ -63,6 +63,7 @@ class MockResult extends BaseResult
      */
     public function dataSeek($n = 0)
     {
+        return true;
     }
 
     /**


### PR DESCRIPTION
**Description**
To fix this error: https://github.com/codeigniter4/shield/pull/195#issuecomment-1508037593

It seems Psalm does not allow to use `resource` in @template type.
See
- https://github.com/codeigniter4/settings/pull/60#issuecomment-1414894845
- https://github.com/codeigniter4/shield/pull/195#issuecomment-1508037593
    
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
