### PR TITLE
fix: remove $insertID in make:model template

### DIFF
--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -10,7 +10,6 @@ class {class} extends Model
     protected $table            = '{table}';
     protected $primaryKey       = 'id';
     protected $useAutoIncrement = true;
-    protected $insertID         = 0;
     protected $returnType       = {return};
     protected $useSoftDeletes   = false;
     protected $protectFields    = true;


### PR DESCRIPTION
**Description**
Fixes #7440

We should not use `$insertID` in Model.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
