### PR TITLE
docs: fix @var in BaseModel

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -63,8 +63,8 @@ abstract class BaseModel
      * The Database connection group that
      * should be instantiated.
      *
-     * @var string
-     * @phpstan-var non-empty-string
+     * @var string|null
+     * @phpstan-var non-empty-string|null
      */
     protected $DBGroup;
 


### PR DESCRIPTION
**Description**
`$DBGroup` is nullable.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
