### PR TITLE
fix: button's type should not default to button

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -420,11 +420,11 @@ if (! function_exists('form_button')) {
      * @param array|string        $data
      * @param array|object|string $extra string, array, object that can be cast to array
      */
-    function form_button($data = '', string $content = '', $extra = ''): string
+    function form_button($data = '', string $content = '', $extra = '', string $type = null): string
     {
         $defaults = [
             'name' => is_array($data) ? '' : $data,
-            'type' => 'button',
+            'type' => $type ?? 'submit',
         ];
 
         if (is_array($data) && isset($data['content'])) {


### PR DESCRIPTION
An html button's default type is submit. The form helper form_button creates a button which exclusively allows a "button" type. However, there are certain scenarios where the value of the submit button should be different from its content. The current option is to use an form_submit with a form_hidden to reproduce the same result.