### PR TITLE
fix: add missing 'make:cell' in app/Config/Generators.php

### DIFF
--- a/app/Config/Generators.php
+++ b/app/Config/Generators.php
@@ -26,6 +26,7 @@ class Generators extends BaseConfig
      * @var array<string, string>
      */
     public array $views = [
+        'make:cell'         => 'CodeIgniter\Commands\Generators\Views\cell.tpl.php',
         'make:command'      => 'CodeIgniter\Commands\Generators\Views\command.tpl.php',
         'make:config'       => 'CodeIgniter\Commands\Generators\Views\config.tpl.php',
         'make:controller'   => 'CodeIgniter\Commands\Generators\Views\controller.tpl.php',


### PR DESCRIPTION
**Description**
> ErrorException: Undefined array key "make:cell" in .../CodeIgniter4/system/CLI/GeneratorTrait.php:270

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
