### PR TITLE
Double // in url in URI Routing example (Using Named Routes) 

### DIFF
--- a/user_guide_src/source/incoming/routing/030.php
+++ b/user_guide_src/source/incoming/routing/030.php
@@ -7,4 +7,4 @@ $routes->get('users/(:num)/gallery/(:num)', 'Galleries::showUserGallery/$1/$2', 
 
 <!-- Generate the URI to link to user ID 15, gallery 12: -->
 <a href="<?= url_to('user_gallery', 15, 12) ?>">View Gallery</a>
-<!-- Result: 'http://example.com//users/15/gallery/12' -->
+<!-- Result: 'http://example.com/users/15/gallery/12' -->

--- a/user_guide_src/source/incoming/routing/047.php
+++ b/user_guide_src/source/incoming/routing/047.php
@@ -1,4 +1,4 @@
 <?php
 
-// example.com routes to app/Controllers/Welcome.php
-$routes->setDefaultController('Welcome');
+// example.com routes to app/Controllers/Home.php
+$routes->setDefaultController('Home');


### PR DESCRIPTION
This is a very stupid edit, just a typo in the url of example.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide