### PR TITLE
fix: failed tests on Windows and optimization.

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -323,12 +323,7 @@ class RouteCollection implements RouteCollectionInterface
             $files = $this->fileLocator->search('Config/Routes.php');
 
             foreach ($files as $file) {
-                // Don't include our main file again...
-                if (in_array($file, $this->routeFiles, true)) {
-                    continue;
-                }
-
-                include $file;
+                include_once $file;
             }
         }
 


### PR DESCRIPTION
**Description**
Because of the different directory separator characters on Windows and Unix, some routing tests fail on Windows.
Details https://github.com/codeigniter4/CodeIgniter4/issues/7474

PR also optimizes the code.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
