### PR TITLE
fix: directory separator from routing file.

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -264,6 +264,11 @@ class RouteCollection implements RouteCollectionInterface
         $this->autoRoute          = $routing->autoRoute;
         $this->routeFiles         = $routing->routeFiles;
         $this->prioritize         = $routing->prioritize;
+
+        // Normalize the path string in routeFiles array.
+        foreach ($this->routeFiles as $routeKey => $routesFile) {
+            $this->routeFiles[$routeKey] = realpath($routesFile) ?: $routesFile;
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**
Fixes #7474 

Normalize the route path.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
