### PR TITLE
fix: validation error when a closure is used in combination with permit_empty or if_exist rules

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -239,7 +239,7 @@ class Validation implements ValidationInterface
             }
 
             // Otherwise remove the if_exist rule and continue the process
-            $rules = array_diff($rules, ['if_exist']);
+            $rules = array_filter($rules, static fn ($rule) => $rule instanceof Closure || $rule !== 'if_exist');
         }
 
         if (in_array('permit_empty', $rules, true)) {
@@ -250,7 +250,7 @@ class Validation implements ValidationInterface
                 $passed = true;
 
                 foreach ($rules as $rule) {
-                    if (preg_match('/(.*?)\[(.*)\]/', $rule, $match)) {
+                    if (! $this->isClosure($rule) && preg_match('/(.*?)\[(.*)\]/', $rule, $match)) {
                         $rule  = $match[1];
                         $param = $match[2];
 
@@ -275,7 +275,7 @@ class Validation implements ValidationInterface
                 }
             }
 
-            $rules = array_diff($rules, ['permit_empty']);
+            $rules = array_filter($rules, static fn ($rule) => $rule instanceof Closure || $rule !== 'permit_empty');
         }
 
         foreach ($rules as $i => $rule) {

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -117,6 +117,12 @@ class RulesTest extends CIUnitTestCase
                 ['foo' => []],
                 true,
             ],
+            // Testing with closure
+            [
+                ['foo' => ['if_exist', static fn ($value) => true]],
+                ['foo' => []],
+                true,
+            ],
         ];
     }
 
@@ -273,6 +279,12 @@ class RulesTest extends CIUnitTestCase
             [
                 ['foo' => 'permit_empty|required_without[bar]'],
                 ['foo' => '', 'bar' => 1],
+                true,
+            ],
+            // Testing with closure
+            [
+                ['foo' => ['permit_empty', static fn ($value) => true]],
+                ['foo' => ''],
                 true,
             ],
         ];

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -84,6 +84,12 @@ final class RulesTest extends TraditionalRulesTest
                 ['foo' => false],
                 true,
             ],
+            // Testing with closure
+            [
+                ['foo' => ['permit_empty', static fn ($value) => true]],
+                ['foo' => ''],
+                true,
+            ],
         ];
     }
 

--- a/user_guide_src/source/changelogs/v4.3.5.rst
+++ b/user_guide_src/source/changelogs/v4.3.5.rst
@@ -24,6 +24,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Validation:** Fixed a bug where a closure used in combination with ``permit_empty`` or ``if_exist`` rules was causing an error.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
Fixes: #7490

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
