### PR TITLE
docs: remove incorrect @property in ResponseTrait

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\API;
 
 use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
 
@@ -21,9 +20,6 @@ use Config\Services;
  * Provides common, more readable, methods to provide
  * consistent HTTP responses under a variety of common
  * situations when working as an API.
- *
- * @property RequestInterface  $request
- * @property ResponseInterface $response
  */
 trait ResponseTrait
 {


### PR DESCRIPTION
**Description**
Fixes #7486

`@property` is used for magic properties.
See https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/property.html#property-property-read-property-write

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
