### PR TITLE
[4.4] Fix output buffering

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1154,7 +1154,7 @@ class CodeIgniter
         $buffer = '';
 
         while (ob_get_level() > $this->bufferLevel) {
-            $buffer = ob_get_contents();
+            $buffer .= ob_get_contents();
             ob_end_clean();
         }
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -36,6 +36,7 @@ use Kint\Renderer\CliRenderer;
 use Kint\Renderer\RichRenderer;
 use Locale;
 use LogicException;
+use Throwable;
 
 /**
  * This class is the core of the framework, and will analyse the
@@ -163,6 +164,11 @@ class CodeIgniter
      * Whether to return Response object or send response.
      */
     protected bool $returnResponse = false;
+
+    /**
+     * Application output buffering level
+     */
+    protected int $bufferLevel;
 
     /**
      * Constructor.
@@ -367,6 +373,7 @@ class CodeIgniter
         try {
             return $this->handleRequest($routes, $cacheConfig, $returnResponse);
         } catch (RedirectException $e) {
+            $this->outputBufferingEnd();
             $logger = Services::logger();
             $logger->info('REDIRECTED ROUTE at ' . $e->getMessage());
 
@@ -389,6 +396,10 @@ class CodeIgniter
             if ($return instanceof ResponseInterface) {
                 return $return;
             }
+        } catch (Throwable $e) {
+            $this->outputBufferingEnd();
+
+            throw $e;
         }
     }
 
@@ -810,7 +821,7 @@ class CodeIgniter
         $this->benchmark->stop('bootstrap');
         $this->benchmark->start('routing');
 
-        ob_start();
+        $this->outputBufferingStart();
 
         $this->controller = $this->router->handle($path);
         $this->method     = $this->router->methodName();
@@ -979,15 +990,8 @@ class CodeIgniter
         // Display 404 Errors
         $this->response->setStatusCode($e->getCode());
 
-        if (ENVIRONMENT !== 'testing') {
-            if (ob_get_level() > 0) {
-                ob_end_flush(); // @codeCoverageIgnore
-            }
-        }
-        // When testing, one is for phpunit, another is for test case.
-        elseif (ob_get_level() > 2) {
-            ob_end_flush(); // @codeCoverageIgnore
-        }
+        echo $this->outputBufferingEnd();
+        flush();
 
         // Throws new PageNotFoundException and remove exception message on production.
         throw PageNotFoundException::forPageNotFound(
@@ -1006,21 +1010,9 @@ class CodeIgniter
      */
     protected function gatherOutput(?Cache $cacheConfig = null, $returned = null)
     {
-        $this->output = ob_get_contents();
-        // If buffering is not null.
-        // Clean (erase) the output buffer and turn off output buffering
-        if (ob_get_length()) {
-            ob_end_clean();
-        }
+        $this->output = $this->outputBufferingEnd();
 
         if ($returned instanceof DownloadResponse) {
-            // Turn off output buffering completely, even if php.ini output_buffering is not off
-            if (ENVIRONMENT !== 'testing') {
-                while (ob_get_level() > 0) {
-                    ob_end_clean();
-                }
-            }
-
             $this->response = $returned;
 
             return;
@@ -1149,5 +1141,23 @@ class CodeIgniter
         $this->context = $context;
 
         return $this;
+    }
+
+    protected function outputBufferingStart(): void
+    {
+        $this->bufferLevel = ob_get_level();
+        ob_start();
+    }
+
+    protected function outputBufferingEnd(): string
+    {
+        $buffer = '';
+
+        while (ob_get_level() > $this->bufferLevel) {
+            $buffer = ob_get_contents();
+            ob_end_clean();
+        }
+
+        return $buffer;
     }
 }

--- a/system/Debug/BaseExceptionHandler.php
+++ b/system/Debug/BaseExceptionHandler.php
@@ -215,10 +215,6 @@ abstract class BaseExceptionHandler
             exit(1);
         }
 
-        if (ob_get_level() > $this->obLevel + 1) {
-            ob_end_clean();
-        }
-
         echo(function () use ($exception, $statusCode, $viewFile): string {
             $vars = $this->collectVars($exception, $statusCode);
             extract($vars, EXTR_SKIP);

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -296,10 +296,6 @@ class Exceptions
             exit(1);
         }
 
-        if (ob_get_level() > $this->ob_level + 1) {
-            ob_end_clean();
-        }
-
         echo(function () use ($exception, $statusCode, $viewFile): string {
             $vars = $this->collectVars($exception, $statusCode);
             extract($vars, EXTR_SKIP);

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -252,6 +252,13 @@ class DownloadResponse extends Response
      */
     public function send()
     {
+        // Turn off output buffering completely, even if php.ini output_buffering is not off
+        if (ENVIRONMENT !== 'testing') {
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+        }
+
         $this->buildHeaders();
         $this->sendHeaders();
         $this->sendBody();

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -144,14 +144,6 @@ trait FeatureTestTrait
      */
     public function call(string $method, string $path, ?array $params = null)
     {
-        $buffer = \ob_get_level();
-
-        // Clean up any open output buffers
-        // not relevant to unit testing
-        if (\ob_get_level() > 0 && (! isset($this->clean) || $this->clean === true)) {
-            \ob_end_clean(); // @codeCoverageIgnore
-        }
-
         // Simulate having a blank session
         $_SESSION                  = [];
         $_SERVER['REQUEST_METHOD'] = $method;
@@ -180,22 +172,8 @@ trait FeatureTestTrait
             ->setRequest($request)
             ->run($routes, true);
 
-        $output = \ob_get_contents();
-        if (empty($response->getBody()) && ! empty($output)) {
-            $response->setBody($output);
-        }
-
         // Reset directory if it has been set
         Services::router()->setDirectory(null);
-
-        // Ensure the output buffer is identical so no tests are risky
-        while (\ob_get_level() > $buffer) {
-            \ob_end_clean(); // @codeCoverageIgnore
-        }
-
-        while (\ob_get_level() < $buffer) {
-            \ob_start(); // @codeCoverageIgnore
-        }
 
         return new TestResponse($response);
     }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -54,10 +54,6 @@ final class CodeIgniterTest extends CIUnitTestCase
     {
         parent::tearDown();
 
-        if (ob_get_level() > 1) {
-            ob_end_clean();
-        }
-
         $this->resetServices();
     }
 
@@ -71,6 +67,16 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('Welcome to CodeIgniter', $output);
+    }
+
+    public function testOutputBufferingControl()
+    {
+        ob_start();
+        $this->codeigniter->run();
+        ob_get_clean();
+
+        // 1 phpunit output buffering level
+        $this->assertSame(1, ob_get_level());
     }
 
     public function testRunEmptyDefaultRouteReturnResponse()
@@ -828,10 +834,6 @@ final class CodeIgniterTest extends CIUnitTestCase
             $output = ob_get_clean();
 
             $this->assertSame($string, $output);
-
-            if (ob_get_level() > 1) {
-                ob_end_clean();
-            }
         }
 
         // Calculate how much cached items exist in the cache after the test requests

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -74,6 +74,24 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertSame(200, $response->response()->getStatusCode());
     }
 
+    public function testClosureWithEcho()
+    {
+        $this->withRoutes([
+            [
+                'get',
+                'home',
+                static function () { echo 'test echo'; },
+            ],
+        ]);
+
+        $response = $this->get('home');
+        $this->assertInstanceOf(TestResponse::class, $response);
+        $this->assertInstanceOf(Response::class, $response->response());
+        $this->assertTrue($response->isOK());
+        $this->assertSame('test echo', $response->response()->getBody());
+        $this->assertSame(200, $response->response()->getStatusCode());
+    }
+
     public function testCallPost()
     {
         $this->withRoutes([

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -142,6 +142,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Output Buffering:** Bug fix with output buffering.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
Fixes #7493

Work with output buffering was carried out incorrectly.

To bypass an existing bug in tests, a hack was used
https://github.com/codeigniter4/CodeIgniter4/blob/3b3cfb57ee564c84487729b3fd5459efa6733920/tests/system/CodeIgniterTest.php#L57-L59

In my opinion, this PR correctly completes output buffering, including for exceptions.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
