### PR TITLE
fix: Session::stop() does not destroy session

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -272,21 +272,13 @@ class Session implements SessionInterface
     }
 
     /**
-     * Does a full stop of the session:
+     * Destroys the current session.
      *
-     * - destroys the session
-     * - unsets the session id
-     * - destroys the session cookie
+     * @deprecated Use destroy() instead.
      */
     public function stop()
     {
-        setcookie(
-            $this->sessionCookieName,
-            session_id(),
-            ['expires' => 1, 'path' => $this->cookie->getPath(), 'domain' => $this->cookie->getDomain(), 'secure' => $this->cookie->isSecure(), 'httponly' => true]
-        );
-
-        session_regenerate_id(true);
+        $this->destroy();
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.3.5.rst
+++ b/user_guide_src/source/changelogs/v4.3.5.rst
@@ -9,6 +9,12 @@ Release Date: Unreleased
     :local:
     :depth: 3
 
+SECURITY
+********
+
+- Fixed that ``Session::stop()`` did not destroy the session.
+  See :ref:`Session Library <session-stop>` for details.
+
 BREAKING
 ********
 
@@ -20,6 +26,9 @@ Changes
 
 Deprecations
 ************
+
+- **Session:** The :ref:`Session::stop() <session-stop>` method is deprecated.
+  Use the :ref:`Session::destroy() <session-destroy>` instead.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/installation/upgrade_435.rst
+++ b/user_guide_src/source/installation/upgrade_435.rst
@@ -18,6 +18,18 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+Session::stop()
+===============
+
+Prior to v4.3.5, the ``Session::stop()`` method did not destroy the session due
+to a bug. This method has been modified to destroy the session, and now deprecated
+because it is exactly the same as the ``Session::destroy()`` method. So use the
+:ref:`Session::destroy <session-destroy>` method instead.
+
+If you have code to depend on the bug, replace it with ``session_regenerate_id(true)``.
+
+See also :ref:`Session Library <session-stop>`.
+
 Breaking Enhancements
 *********************
 

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -345,6 +345,11 @@ intend to reuse that same key in the same request, you'd want to use
 Destroying a Session
 ====================
 
+.. _session-destroy:
+
+destroy()
+---------
+
 To clear the current session (for example, during a logout), you may
 simply use either PHP's `session_destroy() <https://www.php.net/session_destroy>`_
 function, or the library's ``destroy()`` method. Both will work in exactly the
@@ -357,11 +362,20 @@ same way:
     tempdata) will be destroyed permanently and functions will be
     unusable during the same request after you destroy the session.
 
-You may also use the ``stop()`` method to completely kill the session
-by removing the old session ID, destroying all data, and destroying
-the cookie that contained the session ID:
+.. _session-stop:
 
-.. literalinclude:: sessions/038.php
+stop()
+------
+
+.. deprecated:: 4.3.5
+
+The session class also has the ``stop()`` method.
+
+.. warning:: Prior to v4.3.5, this method did not destroy the session due to a bug.
+
+Starting with v4.3.5, this method has been modified to destroy the session.
+However, it is deprecated because it is exactly the same as the ``destroy()``
+method. Use the ``destroy()`` method instead.
 
 Accessing Session Metadata
 ==========================

--- a/user_guide_src/source/libraries/sessions/038.php
+++ b/user_guide_src/source/libraries/sessions/038.php
@@ -1,3 +1,0 @@
-<?php
-
-$session->stop();


### PR DESCRIPTION
**Description**
Closes #7501

See https://github.com/codeigniter4/CodeIgniter4/issues/7501#issuecomment-1549005952

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
