### PR TITLE
fix: typo in log message in Session

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -232,7 +232,7 @@ class Session implements SessionInterface
         }
 
         if (session_status() === PHP_SESSION_ACTIVE) {
-            $this->logger->warning('Session: Sessions is enabled, and one exists.Please don\'t $session->start();');
+            $this->logger->warning('Session: Sessions is enabled, and one exists. Please don\'t $session->start();');
 
             return;
         }


### PR DESCRIPTION
**Description**
- typo in log message

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
