### PR TITLE
fix: PostgreSQL getVersion() output

### DIFF
--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -133,7 +133,9 @@ class Connection extends BaseConnection
         }
 
         $pgVersion                  = pg_version($this->connID);
-        $this->dataCache['version'] = $pgVersion['server'] ?? '';
+        $this->dataCache['version'] = isset($pgVersion['server']) ?
+            (preg_match('/^(\d+\.\d+)/', $pgVersion['server'], $matches) ? $matches[1] : '') :
+            '';
 
         return $this->dataCache['version'];
     }

--- a/tests/system/Database/Live/GetVersionTest.php
+++ b/tests/system/Database/Live/GetVersionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+
+/**
+ * @group DatabaseLive
+ *
+ * @internal
+ */
+final class GetVersionTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $migrate = false;
+
+    public function testGetVersion()
+    {
+        $version = $this->db->getVersion();
+
+        $this->assertMatchesRegularExpression('/\A\d+(\.\d+)*\z/', $version);
+    }
+}


### PR DESCRIPTION
**Description**
Follow-up #7488

- add test for getVersion()
- fix output version string

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
