### PR TITLE
docs: remove sending PR to FriendsOfPHP/security-advisories

### DIFF
--- a/admin/RELEASE.md
+++ b/admin/RELEASE.md
@@ -149,14 +149,6 @@ the existing content.
   * Create **user_guide_src/source/installation/upgrade_{next_version}.rst** and add it to
     **upgrading.rst** (See **next-upgrading-guide.rst**)
 
-## After Publishing Security Advisory
-
-* Send a PR to [PHP Security Advisories Database](https://github.com/FriendsOfPHP/security-advisories).
-  * E.g. https://github.com/FriendsOfPHP/security-advisories/pull/606
-  * See https://github.com/FriendsOfPHP/security-advisories#contributing
-  * Don't forget to run `php -d memory_limit=-1 validator.php`, before
-    submitting the PR
-
 ## Appendix
 
 ### Sphinx Installation


### PR DESCRIPTION
**Description**
`composer audit` uses GitHub Security Advisory Database.
https://github.com/advisories?query=codeigniter4
So now we don't need to send PR to FriendsOfPHP/security-advisories.

```console
$ php spark | head -2

CodeIgniter v4.3.4 Command Line Tool - Server Time: 2023-05-23 23:59:12 UTC+00:00
```
```console
$ composer audit
Info from https://repo.packagist.org: #StandWithUkraine
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | codeigniter4/framework                                                           |
| CVE               | CVE-2023-32692                                                                   |
| Title             | Remote Code Execution Vulnerability in Validation Placeholders in CodeIgniter4   |
| URL               | https://github.com/advisories/GHSA-m6m8-6gq8-c9fj                                |
| Affected versions | <4.3.5                                                                           |
| Reported at       | 2023-05-22T19:49:11+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
