### PR TITLE
[4.4] refactor: a single point of sending the Response.

### DIFF
--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -142,11 +142,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
-        ob_start();
-        $this->codeigniter->run($routes);
-        $output = ob_get_clean();
+        $response = $this->codeigniter->run($routes, true);
 
-        $this->assertStringContainsString('Oops', $output);
+        $this->assertStringContainsString('Oops', $response->getBody());
+        $this->assertSame(567, $response->getStatusCode());
     }
 
     public function testRun404OverrideReturnResponse()

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -138,6 +138,7 @@ Deprecations
   are deprecated. Because these methods have been moved to ``BaseExceptionHandler`` or
   ``ExceptionHandler``.
 - **Autoloader:** ``Autoloader::sanitizeFilename()`` is deprecated.
+- **CodeIgniter:** ``CodeIgniter::$returnResponse`` property is deprecated. no longer used.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -138,7 +138,7 @@ Deprecations
   are deprecated. Because these methods have been moved to ``BaseExceptionHandler`` or
   ``ExceptionHandler``.
 - **Autoloader:** ``Autoloader::sanitizeFilename()`` is deprecated.
-- **CodeIgniter:** ``CodeIgniter::$returnResponse`` property is deprecated. no longer used.
+- **CodeIgniter:** ``CodeIgniter::$returnResponse`` property is deprecated. No longer used.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
This PR refactors the CodeIgniter class code so that all successful responses, except those caused by exceptions, are sent from one place.

- The ``CodeIgniter::handleRequest()`` method now always returns a Response.
- Moved HTTP cli check and page cache check to ``CodeIgniter::handleRequest()`` method. Because these methods generate a Response and are actually part of the request processing.
- Event call ``Events::trigger('pre_system')`` moved to method ``CodeIgniter::handleRequest()`` and is now on the same "level" as ``Events::trigger('post_system')``
- The ``CodeIgniter::$returnResponse`` property has been deprecated as it is no longer used.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
