### PR TITLE
refactor: remove unneeded code in IncomingRequest

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -121,11 +121,6 @@ parameters:
 			path: system/HTTP/Files/UploadedFile.php
 
 		-
-			message: "#^Property CodeIgniter\\\\HTTP\\\\IncomingRequest\\:\\:\\$locale \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: system/HTTP/IncomingRequest.php
-
-		-
 			message: "#^Property CodeIgniter\\\\HTTP\\\\Message\\:\\:\\$protocolVersion \\(string\\) on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: system/HTTP/Message.php

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -554,7 +554,7 @@ class IncomingRequest extends Request
      */
     public function getLocale(): string
     {
-        return $this->locale ?? $this->defaultLocale;
+        return $this->locale;
     }
 
     /**


### PR DESCRIPTION
**Description**
`$this->locale` is set in the `detectLocale()` method called in the constructor.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
