### PR TITLE
docs: [QueryBuilder] class without import. scrolling in examples.

### DIFF
--- a/user_guide_src/source/database/query_builder/028.php
+++ b/user_guide_src/source/database/query_builder/028.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->where('advance_amount <', static fn (BaseBuilder $builder) => $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->where('advance_amount <', static function (BaseBuilder $builder) {
+    $builder->select('MAX(advance_amount)', false)->from('orders')->where('id >', 2);
+});
 // Produces: WHERE "advance_amount" < (SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/031.php
+++ b/user_guide_src/source/database/query_builder/031.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->whereIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->whereIn('id', static function (BaseBuilder $builder) {
+    $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
+});
 // Produces: WHERE "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/033.php
+++ b/user_guide_src/source/database/query_builder/033.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->orWhereIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->orWhereIn('id', static function (BaseBuilder $builder) {
+    $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
+});
 // Produces: OR "id" IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/035.php
+++ b/user_guide_src/source/database/query_builder/035.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->whereNotIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->whereNotIn('id', static function (BaseBuilder $builder) {
+    $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
+});
 // Produces: WHERE "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/037.php
+++ b/user_guide_src/source/database/query_builder/037.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->orWhereNotIn('id', static fn (BaseBuilder $builder) => $builder->select('job_id')->from('users_jobs')->where('user_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->orWhereNotIn('id', static function (BaseBuilder $builder) {
+    $builder->select('job_id')->from('users_jobs')->where('user_id', 3);
+});
 // Produces: OR "id" NOT IN (SELECT "job_id" FROM "users_jobs" WHERE "user_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/041.php
+++ b/user_guide_src/source/database/query_builder/041.php
@@ -2,4 +2,8 @@
 
 $array = ['title' => $match, 'page1' => $match, 'page2' => $match];
 $builder->like($array);
-// WHERE `title` LIKE '%match%' ESCAPE '!' AND  `page1` LIKE '%match%' ESCAPE '!' AND  `page2` LIKE '%match%' ESCAPE '!'
+/*
+ * WHERE `title` LIKE '%match%' ESCAPE '!'
+ *     AND  `page1` LIKE '%match%' ESCAPE '!'
+ *     AND  `page2` LIKE '%match%' ESCAPE '!'
+ */

--- a/user_guide_src/source/database/query_builder/052.php
+++ b/user_guide_src/source/database/query_builder/052.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->havingIn('id', static fn (BaseBuilder $builder) => $builder->select('user_id')->from('users_jobs')->where('group_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->havingIn('id', static function (BaseBuilder $builder) {
+    $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+});
 // Produces: HAVING "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/054.php
+++ b/user_guide_src/source/database/query_builder/054.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->orHavingIn('id', static fn (BaseBuilder $builder) => $builder->select('user_id')->from('users_jobs')->where('group_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->orHavingIn('id', static function (BaseBuilder $builder) {
+    $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+});
 // Produces: OR "id" IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/056.php
+++ b/user_guide_src/source/database/query_builder/056.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->havingNotIn('id', static fn (BaseBuilder $builder) => $builder->select('user_id')->from('users_jobs')->where('group_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->havingNotIn('id', static function (BaseBuilder $builder) {
+    $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+});
 // Produces: HAVING "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/058.php
+++ b/user_guide_src/source/database/query_builder/058.php
@@ -1,7 +1,11 @@
 <?php
 
 // With closure
-$builder->orHavingNotIn('id', static fn (BaseBuilder $builder) => $builder->select('user_id')->from('users_jobs')->where('group_id', 3));
+use CodeIgniter\Database\BaseBuilder;
+
+$builder->orHavingNotIn('id', static function (BaseBuilder $builder) {
+    $builder->select('user_id')->from('users_jobs')->where('group_id', 3);
+});
 // Produces: OR "id" NOT IN (SELECT "user_id" FROM "users_jobs" WHERE "group_id" = 3)
 
 // With builder directly

--- a/user_guide_src/source/database/query_builder/062.php
+++ b/user_guide_src/source/database/query_builder/062.php
@@ -2,4 +2,8 @@
 
 $array = ['title' => $match, 'page1' => $match, 'page2' => $match];
 $builder->havingLike($array);
-// HAVING `title` LIKE '%match%' ESCAPE '!' AND  `page1` LIKE '%match%' ESCAPE '!' AND  `page2` LIKE '%match%' ESCAPE '!'
+/*
+ *  HAVING `title` LIKE '%match%' ESCAPE '!'
+ *     AND  `page1` LIKE '%match%' ESCAPE '!'
+ *      AND  `page2` LIKE '%match%' ESCAPE '!'
+ */

--- a/user_guide_src/source/database/query_builder/062.php
+++ b/user_guide_src/source/database/query_builder/062.php
@@ -4,6 +4,6 @@ $array = ['title' => $match, 'page1' => $match, 'page2' => $match];
 $builder->havingLike($array);
 /*
  *  HAVING `title` LIKE '%match%' ESCAPE '!'
- *     AND  `page1` LIKE '%match%' ESCAPE '!'
+ *      AND  `page1` LIKE '%match%' ESCAPE '!'
  *      AND  `page2` LIKE '%match%' ESCAPE '!'
  */

--- a/user_guide_src/source/database/query_builder/081.php
+++ b/user_guide_src/source/database/query_builder/081.php
@@ -14,4 +14,9 @@ $data = [
 ];
 
 $builder->insertBatch($data);
-// Produces: INSERT INTO mytable (title, name, date) VALUES ('My title', 'My name', 'My date'),  ('Another title', 'Another name', 'Another date')
+/*
+ * Produces:
+ * INSERT INTO mytable (title, name, date)
+ *      VALUES ('My title', 'My name', 'My date'),
+ *      ('Another title', 'Another name', 'Another date')
+ */


### PR DESCRIPTION
**Description**
This PR makes corrections in the Query Builder section.
- The subquery examples use the ``BaseBuilder`` type hint without importing the class itself.
- Some code examples are long and do not fit completely into the code display block, which causes a scrolling bar to appear.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
