### PR TITLE
docs: improve doc comment and tests for locateFile()

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -33,8 +33,13 @@ class FileLocator
      * Attempts to locate a file by examining the name for a namespace
      * and looking through the PSR-4 namespaced files that we know about.
      *
-     * @param string      $file   The namespaced file to locate
-     * @param string|null $folder The folder within the namespace that we should look for the file.
+     * @param string      $file   The relative file path or namespaced file to
+     *                            locate. If not namespaced, search in the app
+     *                            folder.
+     * @param string|null $folder The folder within the namespace that we should
+     *                            look for the file. If $file does not contain
+     *                            this value, it will be appended to the namespace
+     *                            folder.
      * @param string      $ext    The file extension the file should have.
      *
      * @return false|string The path to the file, or false if not found.

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -53,7 +53,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testLocateFileWorksWithLegacyStructure()
     {
-        $file = 'Controllers/Home';
+        $file = 'Controllers/Home'; // not namespaced
 
         $expected = APPPATH . 'Controllers/Home.php';
 
@@ -62,14 +62,14 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testLocateFileWithLegacyStructureNotFound()
     {
-        $file = 'Unknown';
+        $file = 'Unknown'; // not namespaced
 
         $this->assertFalse($this->locator->locateFile($file));
     }
 
     public function testLocateFileWorksInAppDirectory()
     {
-        $file = 'welcome_message';
+        $file = 'welcome_message'; // not namespaced
 
         $expected = APPPATH . 'Views/welcome_message.php';
 
@@ -78,7 +78,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testLocateFileWorksInAppDirectoryWithoutFolder()
     {
-        $file = 'Common';
+        $file = 'Common'; // not namespaced
 
         $expected = APPPATH . 'Common.php';
 
@@ -87,7 +87,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testLocateFileWorksInNestedAppDirectory()
     {
-        $file = 'Controllers/Home';
+        $file = 'Controllers/Home'; // not namespaced
 
         $expected = APPPATH . 'Controllers/Home.php';
 
@@ -105,7 +105,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testLocateFileReplacesFolderNameLegacy()
     {
-        $file = 'Views/welcome_message.php';
+        $file = 'Views/welcome_message.php'; // not namespaced
 
         $expected = APPPATH . 'Views/welcome_message.php';
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -94,21 +94,23 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertSame($expected, $this->locator->locateFile($file, 'Controllers'));
     }
 
-    public function testLocateFileReplacesFolderName()
+    public function testLocateFileWithFolderNameInFile()
     {
         $file = '\App\Views/errors/html/error_404.php';
 
         $expected = APPPATH . 'Views/errors/html/error_404.php';
 
+        // This works because $file contains `Views`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
-    public function testLocateFileReplacesFolderNameLegacy()
+    public function testLocateFileNotNamespacedWithFolderNameInFile()
     {
         $file = 'Views/welcome_message.php'; // not namespaced
 
         $expected = APPPATH . 'Views/welcome_message.php';
 
+        // This works because $file contains `Views`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -67,7 +67,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertFalse($this->locator->locateFile($file));
     }
 
-    public function testLocateFileWorksInApplicationDirectory()
+    public function testLocateFileWorksInAppDirectory()
     {
         $file = 'welcome_message';
 
@@ -76,7 +76,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
-    public function testLocateFileWorksInApplicationDirectoryWithoutFolder()
+    public function testLocateFileWorksInAppDirectoryWithoutFolder()
     {
         $file = 'Common';
 
@@ -85,7 +85,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertSame($expected, $this->locator->locateFile($file));
     }
 
-    public function testLocateFileWorksInNestedApplicationDirectory()
+    public function testLocateFileWorksInNestedAppDirectory()
     {
         $file = 'Controllers/Home';
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -91,6 +91,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Controllers/Home.php';
 
+        // This works because $file contains `Controllers`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Controllers'));
     }
 
@@ -120,6 +121,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $expected = APPPATH . 'Views/errors/html/error_404.php';
 
+        // The namespace `Errors` (APPPATH . 'Views/errors') + the folder (`html`) + `error_404`
         $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
     }
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -51,7 +51,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->locator = new FileLocator($autoloader);
     }
 
-    public function testLocateFileNotNamespacedWorks()
+    public function testLocateFileNotNamespacedFindsInAppDirectory()
     {
         $file = 'Controllers/Home'; // not namespaced
 
@@ -67,7 +67,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertFalse($this->locator->locateFile($file));
     }
 
-    public function testLocateFileNotNamespacedWorksInAppDirectory()
+    public function testLocateFileNotNamespacedFindsWithFolderInAppDirectory()
     {
         $file = 'welcome_message'; // not namespaced
 
@@ -76,7 +76,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
-    public function testLocateFileNotNamespacedWorksInAppDirectoryWithoutFolder()
+    public function testLocateFileNotNamespacedFindesWithoutFolderInAppDirectory()
     {
         $file = 'Common'; // not namespaced
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -51,7 +51,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->locator = new FileLocator($autoloader);
     }
 
-    public function testLocateFileWorksWithLegacyStructure()
+    public function testLocateFileNotNamespacedWorks()
     {
         $file = 'Controllers/Home'; // not namespaced
 
@@ -60,14 +60,14 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertSame($expected, $this->locator->locateFile($file));
     }
 
-    public function testLocateFileWithLegacyStructureNotFound()
+    public function testLocateFileNotNamespacedNotFound()
     {
         $file = 'Unknown'; // not namespaced
 
         $this->assertFalse($this->locator->locateFile($file));
     }
 
-    public function testLocateFileWorksInAppDirectory()
+    public function testLocateFileNotNamespacedWorksInAppDirectory()
     {
         $file = 'welcome_message'; // not namespaced
 
@@ -76,7 +76,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
-    public function testLocateFileWorksInAppDirectoryWithoutFolder()
+    public function testLocateFileNotNamespacedWorksInAppDirectoryWithoutFolder()
     {
         $file = 'Common'; // not namespaced
 
@@ -85,7 +85,7 @@ final class FileLocatorTest extends CIUnitTestCase
         $this->assertSame($expected, $this->locator->locateFile($file));
     }
 
-    public function testLocateFileWorksInNestedAppDirectory()
+    public function testLocateFileNotNamespacedWorksInNestedAppDirectory()
     {
         $file = 'Controllers/Home'; // not namespaced
 


### PR DESCRIPTION
**Description**
Because the behavior of locateFile() is difficult to understand.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
