### PR TITLE
added `UploadedFile::getClientPath()`

### DIFF
--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -180,6 +180,7 @@ class FileCollection
         return new UploadedFile(
             $array['tmp_name'] ?? null,
             $array['name'] ?? null,
+            $array['full_path'] ?? null,
             $array['type'] ?? null,
             $array['size'] ?? null,
             $array['error'] ?? null

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -42,6 +42,13 @@ class UploadedFile extends File implements UploadedFileInterface
     protected $originalName;
 
     /**
+     * The webkit relative path of the file as provided by the client for directory uploads.
+     * 
+     * @var string
+     */
+    protected $clientPath;
+
+    /**
      * The filename given to a file during a move.
      *
      * @var string
@@ -75,15 +82,17 @@ class UploadedFile extends File implements UploadedFileInterface
      *
      * @param string $path         The temporary location of the uploaded file.
      * @param string $originalName The client-provided filename.
+     * @param string $clientPath   The webkit relative path as provided by the client for directory uploads.
      * @param string $mimeType     The type of file as provided by PHP
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null)
+    public function __construct(string $path, string $originalName, ?string $clientPath = null, ?string $mimeType = null, ?int $size = null, ?int $error = null)
     {
         $this->path             = $path;
         $this->name             = $originalName;
         $this->originalName     = $originalName;
+        $this->clientPath       = $clientPath;
         $this->originalMimeType = $mimeType;
         $this->size             = $size;
         $this->error            = $error;
@@ -265,6 +274,17 @@ class UploadedFile extends File implements UploadedFileInterface
     public function getClientName(): string
     {
         return $this->originalName;
+    }
+
+    /**
+     * PHP 8.1+  
+     * Gets the webkit relative path of the file as provided by the client during directory upload.
+     * 
+     * @return string The webkit relative path of the file as provided by the client during directory upload, or none if PHP version is below 8.1
+     */
+    public function getClientPath(): string
+    {
+        return $this->clientPath;
     }
 
     /**

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -28,11 +28,12 @@ interface UploadedFileInterface
      *
      * @param string $path         The temporary location of the uploaded file.
      * @param string $originalName The client-provided filename.
+     * @param string $webkitPath   The webkit relative path as provided by the client.
      * @param string $mimeType     The type of file as provided by PHP
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null);
+    public function __construct(string $path, string $originalName, ?string $webkitPath = null, ?string $mimeType = null, ?int $size = null, ?int $error = null);
 
     /**
      * Move the uploaded file to a new location.
@@ -108,6 +109,13 @@ interface UploadedFileInterface
      * Gets the temporary filename where the file was uploaded to.
      */
     public function getTempName(): string;
+
+    /**
+     * Returns the webkit relative path of the file as provided by the client during directory upload.
+     *   
+     * @return string The webkit relative path of the file as provided by the client during directory upload, or null if PHP version is below 8.1
+     */
+    public function getClientPath(): string | null;
 
     /**
      * Returns the original file extension, based on the file name that

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -42,6 +42,7 @@ final class FileCollectionTest extends CIUnitTestCase
                 'type'     => 'text/plain',
                 'size'     => '124',
                 'tmp_name' => '/tmp/myTempFile.txt',
+                'full_path' => '/tmp/myTempFile.txt',
                 'error'    => 0,
             ],
         ];
@@ -54,6 +55,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertInstanceOf(UploadedFile::class, $file);
 
         $this->assertSame('someFile.txt', $file->getName());
+        $this->assertSame('/tmp/myTempFile.txt', $file->getClientPath());
         $this->assertSame(124, $file->getSize());
     }
 


### PR DESCRIPTION
Enables access to the `full_path` index (added in PHP 8.1)  for files in directory uploads.

**Description**
Add the file's `full_path` value to  `UploadedFile`, accessible via `UploadedFile::getClientPath()`.
If PHP version is below 8.1 then `UploadedFile::getClientPath()` returns null.


**Checklist:**
- [ ] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
