### PR TITLE
docs: remove unneeded @throws in CodeIgniter

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -310,8 +310,6 @@ class CodeIgniter
      * makes all of the pieces work together.
      *
      * @return ResponseInterface|void
-     *
-     * @throws RedirectException
      */
     public function run(?RouteCollectionInterface $routes = null, bool $returnResponse = false)
     {

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -148,9 +148,6 @@ class FeatureTestCase extends CIUnitTestCase
      * instance that can be used to run many assertions against.
      *
      * @return FeatureResponse
-     *
-     * @throws Exception
-     * @throws RedirectException
      */
     public function call(string $method, string $path, ?array $params = null)
     {

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -138,9 +138,6 @@ trait FeatureTestTrait
      * instance that can be used to run many assertions against.
      *
      * @return TestResponse
-     *
-     * @throws RedirectException
-     * @throws Exception
      */
     public function call(string $method, string $path, ?array $params = null)
     {


### PR DESCRIPTION
**Description**
Closes #7434
See https://github.com/codeigniter4/CodeIgniter4/issues/7434#issuecomment-1507972531

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
