### PR TITLE
Add access to `full_path` index of uploaded files

### DIFF
--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -180,6 +180,7 @@ class FileCollection
         return new UploadedFile(
             $array['tmp_name'] ?? null,
             $array['name'] ?? null,
+            $array['full_path'] ?? null,
             $array['type'] ?? null,
             $array['size'] ?? null,
             $array['error'] ?? null

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -180,10 +180,10 @@ class FileCollection
         return new UploadedFile(
             $array['tmp_name'] ?? null,
             $array['name'] ?? null,
-            $array['full_path'] ?? null,
             $array['type'] ?? null,
             $array['size'] ?? null,
-            $array['error'] ?? null
+            $array['error'] ?? null,
+            $array['full_path'] ?? null
         );
     }
 

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -82,10 +82,10 @@ class UploadedFile extends File implements UploadedFileInterface
      *
      * @param string $path         The temporary location of the uploaded file.
      * @param string $originalName The client-provided filename.
-     * @param string $clientPath   The webkit relative path of the uploaded file.
      * @param string $mimeType     The type of file as provided by PHP
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param string $clientPath   The webkit relative path of the uploaded file.
      */
     public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null)
     {

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -90,12 +90,12 @@ class UploadedFile extends File implements UploadedFileInterface
     public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null)
     {
         $this->path             = $path;
-        $this->clientPath       = $clientPath;
         $this->name             = $originalName;
         $this->originalName     = $originalName;
         $this->originalMimeType = $mimeType;
         $this->size             = $size;
         $this->error            = $error;
+        $this->clientPath       = $clientPath;
 
         parent::__construct($path, false);
     }

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -280,7 +280,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * (PHP 8.1+)
      * Returns the webkit relative path of the uploaded file on directory uploads.
      */
-    public function getClientPath(): string
+    public function getClientPath(): string|null
     {
         return $this->clientPath;
     }

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -87,7 +87,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $clientPath, ?string $mimeType = null, ?int $size = null, ?int $error = null)
+    public function __construct(string $path, string $originalName, ?string $clientPath = null, ?string $mimeType = null, ?int $size = null, ?int $error = null)
     {
         $this->path             = $path;
         $this->clientPath       = $clientPath;

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -87,7 +87,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $clientPath = null, ?string $mimeType = null, ?int $size = null, ?int $error = null)
+    public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null)
     {
         $this->path             = $path;
         $this->clientPath       = $clientPath;

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -280,7 +280,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * (PHP 8.1+)
      * Returns the webkit relative path of the uploaded file on directory uploads.
      */
-    public function getClientPath(): string|null
+    public function getClientPath(): ?string
     {
         return $this->clientPath;
     }

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -35,6 +35,13 @@ class UploadedFile extends File implements UploadedFileInterface
     protected $path;
 
     /**
+     * The webkit relative path of the file.
+     *
+     * @var string
+     */
+    protected $clientPath;
+
+    /**
      * The original filename as provided by the client.
      *
      * @var string
@@ -75,13 +82,15 @@ class UploadedFile extends File implements UploadedFileInterface
      *
      * @param string $path         The temporary location of the uploaded file.
      * @param string $originalName The client-provided filename.
+     * @param string $clientPath   The webkit relative path of the uploaded file.
      * @param string $mimeType     The type of file as provided by PHP
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null)
+    public function __construct(string $path, string $originalName, ?string $clientPath, ?string $mimeType = null, ?int $size = null, ?int $error = null)
     {
         $this->path             = $path;
+        $this->clientPath       = $clientPath;
         $this->name             = $originalName;
         $this->originalName     = $originalName;
         $this->originalMimeType = $mimeType;
@@ -265,6 +274,15 @@ class UploadedFile extends File implements UploadedFileInterface
     public function getClientName(): string
     {
         return $this->originalName;
+    }
+
+    /**
+     * (PHP 8.1+)
+     * Returns the webkit relative path of the uploaded file on directory uploads.
+     */
+    public function getClientPath(): string
+    {
+        return $this->clientPath;
     }
 
     /**

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -114,7 +114,7 @@ interface UploadedFileInterface
      * (PHP 8.1+)
      * Returns the webkit relative path of the uploaded file on directory uploads.
      */
-    public function getClientPath(): string;
+    public function getClientPath(): string|null;
 
     /**
      * Returns the original file extension, based on the file name that

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -28,11 +28,12 @@ interface UploadedFileInterface
      *
      * @param string $path         The temporary location of the uploaded file.
      * @param string $originalName The client-provided filename.
+     * @param string $clientPath   The webkit relative path of the uploaded file.
      * @param string $mimeType     The type of file as provided by PHP
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null);
+    public function __construct(string $path, string $originalName, ?string $clientPath, ?string $mimeType = null, ?int $size = null, ?int $error = null);
 
     /**
      * Move the uploaded file to a new location.
@@ -108,6 +109,12 @@ interface UploadedFileInterface
      * Gets the temporary filename where the file was uploaded to.
      */
     public function getTempName(): string;
+
+    /**
+     * (PHP 8.1+)
+     * Returns the webkit relative path of the uploaded file on directory uploads.
+     */
+    public function getClientPath(): string;
 
     /**
      * Returns the original file extension, based on the file name that

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -114,7 +114,7 @@ interface UploadedFileInterface
      * (PHP 8.1+)
      * Returns the webkit relative path of the uploaded file on directory uploads.
      */
-    public function getClientPath(): string|null;
+    public function getClientPath(): ?string;
 
     /**
      * Returns the original file extension, based on the file name that

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -33,7 +33,7 @@ interface UploadedFileInterface
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $clientPath, ?string $mimeType = null, ?int $size = null, ?int $error = null);
+    public function __construct(string $path, string $originalName, ?string $clientPath = null, ?string $mimeType = null, ?int $size = null, ?int $error = null);
 
     /**
      * Move the uploaded file to a new location.

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -28,10 +28,10 @@ interface UploadedFileInterface
      *
      * @param string $path         The temporary location of the uploaded file.
      * @param string $originalName The client-provided filename.
-     * @param string $clientPath   The webkit relative path of the uploaded file.
      * @param string $mimeType     The type of file as provided by PHP
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param string $clientPath   The webkit relative path of the uploaded file.
      */
     public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null);
 

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -33,7 +33,7 @@ interface UploadedFileInterface
      * @param int    $size         The size of the file, in bytes
      * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
      */
-    public function __construct(string $path, string $originalName, ?string $clientPath = null, ?string $mimeType = null, ?int $size = null, ?int $error = null);
+    public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null);
 
     /**
      * Move the uploaded file to a new location.

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -42,7 +42,7 @@ final class FileCollectionTest extends CIUnitTestCase
                 'type'      => 'text/plain',
                 'size'      => '124',
                 'tmp_name'  => '/tmp/myTempFile.txt',
-                'full_path' => 'tmp/myTempFile.txt',
+                'full_path' => 'someDir/someFile.txt',
                 'error'     => 0,
             ],
         ];
@@ -55,7 +55,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertInstanceOf(UploadedFile::class, $file);
 
         $this->assertSame('someFile.txt', $file->getName());
-        $this->assertSame('tmp/myTempFile.txt', $file->getClientPath());
+        $this->assertSame('someDir/someFile.txt', $file->getClientPath());
         $this->assertSame(124, $file->getSize());
     }
 

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -55,8 +55,13 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertInstanceOf(UploadedFile::class, $file);
 
         $this->assertSame('someFile.txt', $file->getName());
-        $this->assertSame('someDir/someFile.txt', $file->getClientPath());
         $this->assertSame(124, $file->getSize());
+
+        if (version_compare(PHP_VERSION, '8.1', '>=')) {
+            $this->assertSame('someDir/someFile.txt', $file->getClientPath());
+        } else {
+            $this->assertNull($file->getClientPath());
+        }
     }
 
     public function testAllReturnsValidMultipleFilesSameName()

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -38,11 +38,12 @@ final class FileCollectionTest extends CIUnitTestCase
     {
         $_FILES = [
             'userfile' => [
-                'name'     => 'someFile.txt',
-                'type'     => 'text/plain',
-                'size'     => '124',
-                'tmp_name' => '/tmp/myTempFile.txt',
-                'error'    => 0,
+                'name'      => 'someFile.txt',
+                'type'      => 'text/plain',
+                'size'      => '124',
+                'tmp_name'  => '/tmp/myTempFile.txt',
+                'full_path' => 'tmp/myTempFile.txt',
+                'error'     => 0,
             ],
         ];
 
@@ -54,6 +55,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertInstanceOf(UploadedFile::class, $file);
 
         $this->assertSame('someFile.txt', $file->getName());
+        $this->assertSame('tmp/myTempFile.txt', $file->getClientPath());
         $this->assertSame(124, $file->getSize());
     }
 

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -38,12 +38,11 @@ final class FileCollectionTest extends CIUnitTestCase
     {
         $_FILES = [
             'userfile' => [
-                'name'      => 'someFile.txt',
-                'type'      => 'text/plain',
-                'size'      => '124',
-                'tmp_name'  => '/tmp/myTempFile.txt',
-                'full_path' => 'someDir/someFile.txt',
-                'error'     => 0,
+                'name'     => 'someFile.txt',
+                'type'     => 'text/plain',
+                'size'     => '124',
+                'tmp_name' => '/tmp/myTempFile.txt',
+                'error'    => 0,
             ],
         ];
 
@@ -56,12 +55,6 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $this->assertSame('someFile.txt', $file->getName());
         $this->assertSame(124, $file->getSize());
-
-        if (version_compare(PHP_VERSION, '8.1', '>=')) {
-            $this->assertSame('someDir/someFile.txt', $file->getClientPath());
-        } else {
-            $this->assertNull($file->getClientPath());
-        }
     }
 
     public function testAllReturnsValidMultipleFilesSameName()
@@ -458,6 +451,41 @@ final class FileCollectionTest extends CIUnitTestCase
         $file       = $collection->getFile('userfile');
 
         $this->assertSame(UPLOAD_ERR_OK, $file->getError());
+    }
+
+    public function testClientPathReturnsValidFullPath()
+    {
+        $_FILES = [
+            'userfile' => [
+                'name'      => 'someFile.txt',
+                'type'      => 'text/plain',
+                'size'      => '124',
+                'tmp_name'  => '/tmp/myTempFile.txt',
+                'full_path' => 'someDir/someFile.txt',
+            ],
+        ];
+
+        $collection = new FileCollection();
+        $file       = $collection->getFile('userfile');
+
+        $this->assertSame('someDir/someFile.txt', $file->getClientPath());
+    }
+
+    public function testClientPathReturnsNullWhenFullPathIsNull()
+    {
+        $_FILES = [
+            'userfile' => [
+                'name'     => 'someFile.txt',
+                'type'     => 'text/plain',
+                'size'     => '124',
+                'tmp_name' => '/tmp/myTempFile.txt',
+            ],
+        ];
+
+        $collection = new FileCollection();
+        $file       = $collection->getFile('userfile');
+
+        $this->assertNull($file->getClientPath());
     }
 
     public function testFileReturnsValidSingleFile()

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -89,6 +89,9 @@ Libraries
   the actual validated data. See :ref:`validation-getting-validated-data` for details.
 - **Images:** The option ``$quality`` can now be used to compress WebP images.
 
+- **Uploaded Files:** Added ``UploadedFiles::getClientPath()`` method that returns
+  the value of the `full_path` index of the file if it was uploaded via directory upload.
+
 Helpers and Functions
 =====================
 

--- a/user_guide_src/source/libraries/uploaded_files.rst
+++ b/user_guide_src/source/libraries/uploaded_files.rst
@@ -304,6 +304,14 @@ version, use ``getMimeType()`` instead:
 
 .. literalinclude:: uploaded_files/015.php
 
+getClientPath()
+---------------
+
+Returns the `webkit relative path <https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath>`_ of the uploaded file when the client has uploaded files via directory upload.  
+In PHP versions below 8.1, this returns ``null``
+
+.. literalinclude:: uploaded_files/023.php
+
 Moving Files
 ============
 

--- a/user_guide_src/source/libraries/uploaded_files.rst
+++ b/user_guide_src/source/libraries/uploaded_files.rst
@@ -307,6 +307,8 @@ version, use ``getMimeType()`` instead:
 getClientPath()
 ---------------
 
+.. versionadded:: 4.4.0
+
 Returns the `webkit relative path <https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath>`_ of the uploaded file when the client has uploaded files via directory upload.  
 In PHP versions below 8.1, this returns ``null``
 

--- a/user_guide_src/source/libraries/uploaded_files/023.php
+++ b/user_guide_src/source/libraries/uploaded_files/023.php
@@ -1,0 +1,4 @@
+<?php
+
+$clientPath = $file->getClientPath();
+echo $clientPath; // dir/file.txt, or dir/sub_dir/file.txt


### PR DESCRIPTION
**Description**
Supersedes #7538

Added `UploadedFile::getClientPath()` method.  
This returns the `full_path` index of uploaded files (when uploaded via directory).  
This feature is only available in PHP 8.1+. If the method is called below that version then `null` is returned.  

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
