### PR TITLE
refactor: [Entity] fix incorrect return value

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -429,7 +429,7 @@ class Entity implements JsonSerializable
      *
      * @param array|bool|float|int|object|string|null $value
      *
-     * @return $this
+     * @return void
      *
      * @throws Exception
      */
@@ -452,7 +452,7 @@ class Entity implements JsonSerializable
         if (method_exists($this, $method)) {
             $this->{$method}($value);
 
-            return $this;
+            return;
         }
 
         // Otherwise, just the value. This allows for creation of new
@@ -460,8 +460,6 @@ class Entity implements JsonSerializable
         // saved. Useful for grabbing values through joins, assigning
         // relationships, etc.
         $this->attributes[$dbColumn] = $value;
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
**Description**
```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   system/Entity/Entity.php                                                                                                                  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  455    Method CodeIgniter\Entity\Entity::__set() with return type void returns $this(CodeIgniter\Entity\Entity) but should not return anything.  
  464    Method CodeIgniter\Entity\Entity::__set() with return type void returns $this(CodeIgniter\Entity\Entity) but should not return anything.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
