### PR TITLE
refactor: [Entity] fix incorrect return value

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -465,7 +465,7 @@ class Entity implements JsonSerializable
         if (method_exists($this, '_' . $method)) {
             $this->{'_' . $method}($value);
 
-            return $this;
+            return;
         }
 
         // If a "`set` + $key" method exists, it is also a setter.


### PR DESCRIPTION
**Description**
Related #7542

```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   system/Entity/Entity.php                                                                                                                  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  468    Method CodeIgniter\Entity\Entity::__set() with return type void returns $this(CodeIgniter\Entity\Entity) but should not return anything.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
