### PR TITLE
fix: feature test with validation

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -175,6 +175,9 @@ trait FeatureTestTrait
         // Make sure filters are reset between tests
         Services::injectMock('filters', Services::filters(null, false));
 
+        // Make sure validation is reset between tests
+        Services::injectMock('validation', Services::validation(null, false));
+
         $response = $this->app
             ->setContext('web')
             ->setRequest($request)

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -102,6 +102,36 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $response->assertSee('Hello Mars!');
     }
 
+    public function testCallValidationTwice()
+    {
+        $this->withRoutes([
+            [
+                'post',
+                'section/create',
+                static function () {
+                    $validation = Services::validation();
+                    $validation->setRule('title', 'title', 'required|min_length[3]');
+
+                    $post = Services::request()->getPost();
+
+                    if ($validation->run($post)) {
+                        return 'Okay';
+                    }
+
+                    return 'Invalid';
+                },
+            ],
+        ]);
+
+        $response = $this->post('section/create', ['foo' => 'Mars']);
+
+        $response->assertSee('Invalid');
+
+        $response = $this->post('section/create', ['title' => 'Section Title']);
+
+        $response->assertSee('Okay');
+    }
+
     public function testCallPut()
     {
         $this->withRoutes([


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=87844

Feature testing shares the Validation object between requests.
So the validation result is incorrect after a failed validation.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
