### PR TITLE
fix: [Validation] DBGroup is ignored when checking the value of a placeholder

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -190,6 +190,9 @@ class Validation implements ValidationInterface
      * Runs the validation process, returning true or false
      * determining whether validation was successful or not.
      *
+     * @TODO the method signature is not good. Should make the checkValue()
+     *      method this method.
+     *
      * @param array|bool|float|int|object|string|null $value
      * @param string[]                                $errors
      */
@@ -198,6 +201,31 @@ class Validation implements ValidationInterface
         $this->reset();
 
         return $this->setRule('check', null, $rule, $errors)->run(['check' => $value]);
+    }
+
+    /**
+     * Runs the validation process, returning true or false determining whether
+     * validation was successful or not.
+     *
+     * @param array|bool|float|int|object|string|null $value
+     * @param array|string                            $rules
+     * @param string[]                                $errors
+     * @param string|null                             $dbGroup The database group to use.
+     */
+    private function checkValue($value, $rules, array $errors = [], $dbGroup = null): bool
+    {
+        $this->reset();
+
+        return $this->setRule(
+            'check',
+            null,
+            $rules,
+            $errors
+        )->run(
+            ['check' => $value],
+            null,
+            $dbGroup
+        );
     }
 
     /**
@@ -682,6 +710,7 @@ class Validation implements ValidationInterface
 
                     foreach ($placeholderFields as $field) {
                         $validator ??= Services::validation(null, false);
+                        assert($validator instanceof Validation);
 
                         $placeholderRules = $rules[$field]['rules'] ?? null;
 
@@ -702,7 +731,8 @@ class Validation implements ValidationInterface
                         }
 
                         // Validate the placeholder field
-                        if (! $validator->check($data[$field], implode('|', $placeholderRules))) {
+                        $dbGroup = $data['DBGroup'] ?? null;
+                        if (! $validator->checkValue($data[$field], $placeholderRules, [], $dbGroup)) {
                             // if fails, do nothing
                             continue;
                         }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -116,6 +116,9 @@ class Validation implements ValidationInterface
      * @param array|null  $data    The array of data to validate.
      * @param string|null $group   The predefined group of rules to apply.
      * @param string|null $dbGroup The database group to use.
+     *
+     * @TODO Type ?string for $dbGroup should be removed.
+     *      See https://github.com/codeigniter4/CodeIgniter4/issues/6723
      */
     public function run(?array $data = null, ?string $group = null, ?string $dbGroup = null): bool
     {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -124,7 +124,7 @@ class Validation implements ValidationInterface
     {
         $data ??= $this->data;
 
-        // i.e. is_unique
+        // `DBGroup` is a reserved name. For is_unique and is_not_unique
         $data['DBGroup'] = $dbGroup;
 
         $this->loadRuleSets();

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -187,23 +187,6 @@ class Validation implements ValidationInterface
     }
 
     /**
-     * Runs the validation process, returning true or false
-     * determining whether validation was successful or not.
-     *
-     * @TODO the method signature is not good. Should make the checkValue()
-     *      method this method.
-     *
-     * @param array|bool|float|int|object|string|null $value
-     * @param string[]                                $errors
-     */
-    public function check($value, string $rule, array $errors = []): bool
-    {
-        $this->reset();
-
-        return $this->setRule('check', null, $rule, $errors)->run(['check' => $value]);
-    }
-
-    /**
      * Runs the validation process, returning true or false determining whether
      * validation was successful or not.
      *
@@ -212,7 +195,7 @@ class Validation implements ValidationInterface
      * @param string[]                                $errors
      * @param string|null                             $dbGroup The database group to use.
      */
-    private function checkValue($value, $rules, array $errors = [], $dbGroup = null): bool
+    public function check($value, $rules, array $errors = [], $dbGroup = null): bool
     {
         $this->reset();
 
@@ -732,7 +715,7 @@ class Validation implements ValidationInterface
 
                         // Validate the placeholder field
                         $dbGroup = $data['DBGroup'] ?? null;
-                        if (! $validator->checkValue($data[$field], $placeholderRules, [], $dbGroup)) {
+                        if (! $validator->check($data[$field], $placeholderRules, [], $dbGroup)) {
                             // if fails, do nothing
                             continue;
                         }

--- a/system/Validation/ValidationInterface.php
+++ b/system/Validation/ValidationInterface.php
@@ -32,12 +32,14 @@ interface ValidationInterface
      * Check; runs the validation process, returning true or false
      * determining whether or not validation was successful.
      *
-     * @param array|bool|float|int|object|string|null $value  Value to validate.
+     * @param array|bool|float|int|object|string|null $value   Value to validate.
+     * @param array|string                            $rules
      * @param string[]                                $errors
+     * @param string|null                             $dbGroup The database group to use.
      *
      * @return bool True if valid, else false.
      */
-    public function check($value, string $rule, array $errors = []): bool;
+    public function check($value, $rules, array $errors = [], $dbGroup = null): bool;
 
     /**
      * Takes a Request object and grabs the input data to use from its

--- a/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
+++ b/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
@@ -16,6 +16,7 @@ use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Validation\Validation;
 use Config\Database;
 use Config\Services;
+use InvalidArgumentException;
 use Tests\Support\Validation\TestRules;
 
 /**
@@ -80,6 +81,16 @@ class DatabaseRelatedRulesTest extends CIUnitTestCase
         $data = ['email' => 'derek@world.co.uk'];
         $this->validation->setRules(['email' => 'is_unique[user.email]']);
         $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testIsUniqueWithInvalidDBGroup(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalidGroup is not a valid database connection group');
+
+        $this->validation->setRules(['email' => 'is_unique[user.email]']);
+        $data = ['email' => 'derek@world.co.uk'];
+        $this->assertTrue($this->validation->run($data, null, 'invalidGroup'));
     }
 
     public function testIsUniqueWithIgnoreValue(): void

--- a/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
+++ b/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
@@ -82,7 +82,7 @@ class DatabaseRelatedRulesTest extends CIUnitTestCase
         $this->assertTrue($this->validation->run($data));
     }
 
-    public function testIsUniqueIgnoresParams(): void
+    public function testIsUniqueWithIgnoreValue(): void
     {
         $db = Database::connect();
         $db
@@ -102,7 +102,7 @@ class DatabaseRelatedRulesTest extends CIUnitTestCase
         $this->assertTrue($this->validation->run($data));
     }
 
-    public function testIsUniqueIgnoresParamsPlaceholders(): void
+    public function testIsUniqueWithIgnoreValuePlaceholder(): void
     {
         $this->hasInDatabase('user', [
             'name'    => 'Derek',

--- a/user_guide_src/source/changelogs/v4.3.6.rst
+++ b/user_guide_src/source/changelogs/v4.3.6.rst
@@ -12,6 +12,28 @@ Release Date: Unreleased
 BREAKING
 ********
 
+Interface Changes
+=================
+
+.. note:: As long as you have not extended the relevant CodeIgniter core classes
+    or implemented these interfaces, all these changes are backward compatible
+    and require no intervention.
+
+ValidationInterface::check()
+----------------------------
+
+- The second parameter has changed from ``string $rule`` to ``$rules``.
+- The optional fourth parameter ``$dbGroup = null`` has been added.
+
+Method Signature Changes
+========================
+
+Validation::check()
+-------------------
+
+- The second parameter has changed from ``string $rule`` to ``$rules``.
+- The optional fourth parameter ``$dbGroup = null`` has been added.
+
 Message Changes
 ***************
 
@@ -23,6 +45,11 @@ Deprecations
 
 Bugs Fixed
 **********
+
+- **Validation:** Fixed a bug that ``$DBGroup`` is ignored when checking
+  the value of a placeholder.
+- **Validation:** Fixed a bug that ``check()`` cannot specify non-default
+  database group.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/installation/upgrade_436.rst
+++ b/user_guide_src/source/installation/upgrade_436.rst
@@ -21,6 +21,9 @@ Breaking Changes
 Breaking Enhancements
 *********************
 
+- The method signatures of ``ValidationInterface::check()`` and ``Validation::check()``
+  have been changed. If you implement or extend them, update the signatures.
+
 Project Files
 *************
 


### PR DESCRIPTION
**Description**
Fixes #7547

- fix that ``$DBGroup`` is ignored when checking the value of a placeholder
- fix that ``check()`` cannot specify non-default database group
- fix ``ValidationInterface::check()``

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
