### PR TITLE
fix: [Validation] required_with may return incorrect result

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -263,7 +263,6 @@ class Rules
         // If the field is present we can safely assume that
         // the field is here, no matter whether the corresponding
         // search field is present or not.
-        $fields  = explode(',', $fields);
         $present = $this->required($str ?? '');
 
         if ($present) {
@@ -272,10 +271,10 @@ class Rules
 
         // Still here? Then we fail this test if
         // any of the fields are present in $data
-        // as $fields is the lis
+        // as $fields is the list
         $requiredFields = [];
 
-        foreach ($fields as $field) {
+        foreach (explode(',', $fields) as $field) {
             if (
                 (array_key_exists($field, $data) && ! empty($data[$field]))
                 || (strpos($field, '.') !== false && ! empty(dot_array_search($field, $data)))
@@ -308,8 +307,7 @@ class Rules
         // If the field is present we can safely assume that
         // the field is here, no matter whether the corresponding
         // search field is present or not.
-        $otherFields = explode(',', $otherFields);
-        $present     = $this->required($str ?? '');
+        $present = $this->required($str ?? '');
 
         if ($present) {
             return true;
@@ -317,7 +315,7 @@ class Rules
 
         // Still here? Then we fail this test if
         // any of the fields are not present in $data
-        foreach ($otherFields as $otherField) {
+        foreach (explode(',', $otherFields) as $otherField) {
             if ((strpos($otherField, '.') === false) && (! array_key_exists($otherField, $data) || empty($data[$otherField]))) {
                 return false;
             }

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -276,7 +276,10 @@ class Rules
         $requiredFields = [];
 
         foreach ($fields as $field) {
-            if ((array_key_exists($field, $data) && ! empty($data[$field])) || (strpos($field, '.') !== false && ! empty(dot_array_search($field, $data)))) {
+            if (
+                (array_key_exists($field, $data) && ! empty($data[$field]))
+                || (strpos($field, '.') !== false && ! empty(dot_array_search($field, $data)))
+            ) {
                 $requiredFields[] = $field;
             }
         }

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -316,9 +316,13 @@ class Rules
         // Still here? Then we fail this test if
         // any of the fields are not present in $data
         foreach (explode(',', $otherFields) as $otherField) {
-            if ((strpos($otherField, '.') === false) && (! array_key_exists($otherField, $data) || empty($data[$otherField]))) {
+            if (
+                (strpos($otherField, '.') === false)
+                && (! array_key_exists($otherField, $data) || empty($data[$otherField]))
+            ) {
                 return false;
             }
+
             if (strpos($otherField, '.') !== false) {
                 if ($field === null) {
                     throw new InvalidArgumentException('You must supply the parameters: field.');

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -278,12 +278,12 @@ class Rules
     /**
      * Is the field required for required_with?
      *
-     * @params string|null $fields
+     * @params string $fields Comma separated field names
      *
      * @used-by required_with(), Validation::processRequiredWith()
      * @internal
      */
-    public function isRequiredForRequiredWith(?string $fields, array $data): bool
+    public function isRequiredForRequiredWith(string $fields, array $data): bool
     {
         $requiredFields = [];
 

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -272,6 +272,19 @@ class Rules
         // Still here? Then we fail this test if
         // any of the fields are present in $data
         // as $fields is the list
+        return ! $this->isRequiredForRequiredWith($fields, $data);
+    }
+
+    /**
+     * Is the field required for required_with?
+     *
+     * @params string|null $fields
+     *
+     * @used-by required_with(), Validation::processRequiredWith()
+     * @internal
+     */
+    public function isRequiredForRequiredWith(?string $fields, array $data): bool
+    {
         $requiredFields = [];
 
         foreach (explode(',', $fields) as $field) {
@@ -283,7 +296,7 @@ class Rules
             }
         }
 
-        return empty($requiredFields);
+        return ! empty($requiredFields);
     }
 
     /**

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -347,6 +347,19 @@ class Rules
     }
 
     /**
+     * Is the field required for required_with?
+     *
+     * @params string|null $fields
+     *
+     * @used-by required_with(), Validation::processRequiredWith()
+     * @internal
+     */
+    public function isRequiredForRequiredWith(?string $fields, array $data): bool
+    {
+        return $this->nonStrictRules->isRequiredForRequiredWith($fields, $data);
+    }
+
+    /**
      * The field is required when all of the other fields are present
      * in the data but not required.
      *

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -349,12 +349,12 @@ class Rules
     /**
      * Is the field required for required_with?
      *
-     * @params string|null $fields
+     * @params string $fields Comma separated field names
      *
      * @used-by required_with(), Validation::processRequiredWith()
      * @internal
      */
-    public function isRequiredForRequiredWith(?string $fields, array $data): bool
+    public function isRequiredForRequiredWith(string $fields, array $data): bool
     {
         return $this->nonStrictRules->isRequiredForRequiredWith($fields, $data);
     }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -218,16 +218,16 @@ class Validation implements ValidationInterface
      * so that we can collect all of the first errors.
      *
      * @param array|string $value
-     * @param array|null   $rules
-     * @param array|null   $data          The array of data to validate, with `DBGroup`.
+     * @param array        $rules
+     * @param array        $data          The array of data to validate, with `DBGroup`.
      * @param string|null  $originalField The original asterisk field name like "foo.*.bar".
      */
     protected function processRules(
         string $field,
         ?string $label,
         $value,
-        $rules = null,
-        ?array $data = null,
+        $rules = null,       // @TODO remove `= null`
+        ?array $data = null, // @TODO remove `= null`
         ?string $originalField = null
     ): bool {
         if ($data === null) {
@@ -318,12 +318,11 @@ class Validation implements ValidationInterface
     }
 
     /**
-     * @param array|null $rules
-     * @param array|null $data  The array of data to validate, with `DBGroup`.
+     * @param array|null $data The array of data to validate, with `DBGroup`.
      *
      * @return array|true The modified rules or true if we return early
      */
-    private function processIfExist(string $field, $rules, ?array $data)
+    private function processIfExist(string $field, array $rules, ?array $data)
     {
         if (in_array('if_exist', $rules, true)) {
             $flattenedData = array_flatten_with_dots($data);
@@ -359,12 +358,11 @@ class Validation implements ValidationInterface
 
     /**
      * @param array|string $value
-     * @param array|null   $rules
      * @param array|null   $data  The array of data to validate, with `DBGroup`.
      *
      * @return array|true The modified rules or true if we return early
      */
-    private function processPermitEmpty($value, $rules = null, ?array $data = null)
+    private function processPermitEmpty($value, array $rules, ?array $data = null)
     {
         if (in_array('permit_empty', $rules, true)) {
             if (

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -345,8 +345,6 @@ class Validation implements ValidationInterface
                 $dataIsExisting = array_key_exists($ifExistField, $flattenedData);
             }
 
-            unset($ifExistField, $flattenedData);
-
             if (! $dataIsExisting) {
                 // we return early if `if_exist` is not satisfied. we have nothing to do here.
                 return true;

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -323,11 +323,11 @@ class Validation implements ValidationInterface
     }
 
     /**
-     * @param array|null $data The array of data to validate, with `DBGroup`.
+     * @param array $data The array of data to validate, with `DBGroup`.
      *
      * @return array|true The modified rules or true if we return early
      */
-    private function processRequiredWith(array $rules, ?array $data)
+    private function processRequiredWith(array $rules, array $data)
     {
         foreach ($rules as $rule) {
             if (! $this->isClosure($rule) && preg_match('/(.*?)\[(.*)\]/', $rule, $match)) {
@@ -354,11 +354,11 @@ class Validation implements ValidationInterface
     }
 
     /**
-     * @param array|null $data The array of data to validate, with `DBGroup`.
+     * @param array $data The array of data to validate, with `DBGroup`.
      *
      * @return array|true The modified rules or true if we return early
      */
-    private function processIfExist(string $field, array $rules, ?array $data)
+    private function processIfExist(string $field, array $rules, array $data)
     {
         if (in_array('if_exist', $rules, true)) {
             $flattenedData = array_flatten_with_dots($data);
@@ -394,11 +394,11 @@ class Validation implements ValidationInterface
 
     /**
      * @param array|string $value
-     * @param array|null   $data  The array of data to validate, with `DBGroup`.
+     * @param array        $data  The array of data to validate, with `DBGroup`.
      *
      * @return array|true The modified rules or true if we return early
      */
-    private function processPermitEmpty($value, array $rules, ?array $data = null)
+    private function processPermitEmpty($value, array $rules, array $data)
     {
         if (in_array('permit_empty', $rules, true)) {
             if (

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -234,71 +234,14 @@ class Validation implements ValidationInterface
             throw new InvalidArgumentException('You must supply the parameter: data.');
         }
 
-        if (in_array('if_exist', $rules, true)) {
-            $flattenedData = array_flatten_with_dots($data);
-            $ifExistField  = $field;
-
-            if (strpos($field, '.*') !== false) {
-                // We'll change the dot notation into a PCRE pattern that can be used later
-                $ifExistField   = str_replace('\.\*', '\.(?:[^\.]+)', preg_quote($field, '/'));
-                $dataIsExisting = false;
-                $pattern        = sprintf('/%s/u', $ifExistField);
-
-                foreach (array_keys($flattenedData) as $item) {
-                    if (preg_match($pattern, $item) === 1) {
-                        $dataIsExisting = true;
-                        break;
-                    }
-                }
-            } else {
-                $dataIsExisting = array_key_exists($ifExistField, $flattenedData);
-            }
-
-            unset($ifExistField, $flattenedData);
-
-            if (! $dataIsExisting) {
-                // we return early if `if_exist` is not satisfied. we have nothing to do here.
-                return true;
-            }
-
-            // Otherwise remove the if_exist rule and continue the process
-            $rules = array_filter($rules, static fn ($rule) => $rule instanceof Closure || $rule !== 'if_exist');
+        $rules = $this->processIfExist($field, $rules, $data);
+        if ($rules === true) {
+            return true;
         }
 
-        if (in_array('permit_empty', $rules, true)) {
-            if (
-                ! in_array('required', $rules, true)
-                && (is_array($value) ? $value === [] : trim((string) $value) === '')
-            ) {
-                $passed = true;
-
-                foreach ($rules as $rule) {
-                    if (! $this->isClosure($rule) && preg_match('/(.*?)\[(.*)\]/', $rule, $match)) {
-                        $rule  = $match[1];
-                        $param = $match[2];
-
-                        if (! in_array($rule, ['required_with', 'required_without'], true)) {
-                            continue;
-                        }
-
-                        // Check in our rulesets
-                        foreach ($this->ruleSetInstances as $set) {
-                            if (! method_exists($set, $rule)) {
-                                continue;
-                            }
-
-                            $passed = $passed && $set->{$rule}($value, $param, $data);
-                            break;
-                        }
-                    }
-                }
-
-                if ($passed === true) {
-                    return true;
-                }
-            }
-
-            $rules = array_filter($rules, static fn ($rule) => $rule instanceof Closure || $rule !== 'permit_empty');
+        $rules = $this->processPermitEmpty($value, $rules, $data);
+        if ($rules === true) {
+            return true;
         }
 
         foreach ($rules as $i => $rule) {
@@ -372,6 +315,96 @@ class Validation implements ValidationInterface
         }
 
         return true;
+    }
+
+    /**
+     * @param array|null $rules
+     * @param array|null $data  The array of data to validate, with `DBGroup`.
+     *
+     * @return array|true The modified rules or true if we return early
+     */
+    private function processIfExist(string $field, $rules, ?array $data)
+    {
+        if (in_array('if_exist', $rules, true)) {
+            $flattenedData = array_flatten_with_dots($data);
+            $ifExistField  = $field;
+
+            if (strpos($field, '.*') !== false) {
+                // We'll change the dot notation into a PCRE pattern that can be used later
+                $ifExistField   = str_replace('\.\*', '\.(?:[^\.]+)', preg_quote($field, '/'));
+                $dataIsExisting = false;
+                $pattern        = sprintf('/%s/u', $ifExistField);
+
+                foreach (array_keys($flattenedData) as $item) {
+                    if (preg_match($pattern, $item) === 1) {
+                        $dataIsExisting = true;
+                        break;
+                    }
+                }
+            } else {
+                $dataIsExisting = array_key_exists($ifExistField, $flattenedData);
+            }
+
+            unset($ifExistField, $flattenedData);
+
+            if (! $dataIsExisting) {
+                // we return early if `if_exist` is not satisfied. we have nothing to do here.
+                return true;
+            }
+
+            // Otherwise remove the if_exist rule and continue the process
+            $rules = array_filter($rules, static fn ($rule) => $rule instanceof Closure || $rule !== 'if_exist');
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @param array|string $value
+     * @param array|null   $rules
+     * @param array|null   $data  The array of data to validate, with `DBGroup`.
+     *
+     * @return array|true The modified rules or true if we return early
+     */
+    private function processPermitEmpty($value, $rules = null, ?array $data = null)
+    {
+        if (in_array('permit_empty', $rules, true)) {
+            if (
+                ! in_array('required', $rules, true)
+                && (is_array($value) ? $value === [] : trim((string) $value) === '')
+            ) {
+                $passed = true;
+
+                foreach ($rules as $rule) {
+                    if (! $this->isClosure($rule) && preg_match('/(.*?)\[(.*)\]/', $rule, $match)) {
+                        $rule  = $match[1];
+                        $param = $match[2];
+
+                        if (! in_array($rule, ['required_with', 'required_without'], true)) {
+                            continue;
+                        }
+
+                        // Check in our rulesets
+                        foreach ($this->ruleSetInstances as $set) {
+                            if (! method_exists($set, $rule)) {
+                                continue;
+                            }
+
+                            $passed = $passed && $set->{$rule}($value, $param, $data);
+                            break;
+                        }
+                    }
+                }
+
+                if ($passed === true) {
+                    return true;
+                }
+            }
+
+            $rules = array_filter($rules, static fn ($rule) => $rule instanceof Closure || $rule !== 'permit_empty');
+        }
+
+        return $rules;
     }
 
     /**

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -615,6 +615,33 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
+     * @dataProvider RequiredWithAndOtherRuleProvider
+     */
+    public function testRequiredWithAndOtherRule(bool $expected, array $data): void
+    {
+        $this->validation->setRules([
+            'testField' => 'required_with[otherField]|valid_date',
+        ]);
+
+        $result = $this->validation->run($data);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function RequiredWithAndOtherRuleProvider(): Generator
+    {
+        yield from [
+            [true, []],
+            [true, ['testField' => '2023-06-12']],
+            [true, ['testField' => '2023-06-12', 'otherField' => 'yes']],
+            [true, ['testField' => '2023-06-12', 'otherField' => '']],
+            [true, ['testField' => '', 'otherField' => '']],
+            [false, ['testField' => '', 'otherField' => 'yes']],
+            [false, ['otherField' => 'yes']],
+        ];
+    }
+
+    /**
      * @dataProvider requiredWithoutProvider
      */
     public function testRequiredWithout(?string $field, ?string $check, bool $expected): void


### PR DESCRIPTION
**Description**
Fixes #7557

When you specify `required_with` and other rules like `'required_with[otherField]|valid_date'`,
even if the field is not required (the `otherField` field is not present in the data), 
Validation processes other rules (`valid_date`) and returns incorrect result (`false`).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
