### PR TITLE
fix: wrong classname in exception message in Cell

### DIFF
--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -175,9 +175,9 @@ class Cell
         }
 
         // locate and return an instance of the cell
-        $class = Factories::cells($class);
+        $object = Factories::cells($class);
 
-        if (! is_object($class)) {
+        if (! is_object($object)) {
             throw ViewException::forInvalidCellClass($class);
         }
 
@@ -186,7 +186,7 @@ class Cell
         }
 
         return [
-            $class,
+            $object,
             $method,
         ];
     }


### PR DESCRIPTION
**Description**
- fix the exception message: `CodeIgniter\View\Exceptions\ViewException: Unable to locate view cell class: "".`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
