### PR TITLE
fix: `imagecreatefrompng()` gd-png: libpng warning

### DIFF
--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -354,7 +354,7 @@ class GDHandler extends BaseHandler
                     throw ImageException::forInvalidImageCreate(lang('Images.pngNotSupported'));
                 }
 
-                return imagecreatefrompng($path);
+                return @imagecreatefrompng($path);
 
             case IMAGETYPE_WEBP:
                 if (! function_exists('imagecreatefromwebp')) {


### PR DESCRIPTION
**Description**
Fixes #7567.
It seems this is a bug of php.

Ref:
1. https://stackoverflow.com/questions/70569197/imagecreatefrompng-gd-png-libpng-warning-interlace-handling-should-be-turne
2. https://github.com/dompdf/dompdf/issues/2718

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
