### PR TITLE
refactor: [Auto Routing Improved] ensure $httpVerb is lower case

### DIFF
--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -104,7 +104,9 @@ final class AutoRouterImproved implements AutoRouterInterface
      */
     public function getRoute(string $uri, string $httpVerb): array
     {
-        $defaultMethod = strtolower($httpVerb) . ucfirst($this->defaultMethod);
+        $httpVerb = strtolower($httpVerb);
+
+        $defaultMethod = $httpVerb . ucfirst($this->defaultMethod);
         $this->method  = $defaultMethod;
 
         $segments = explode('/', $uri);


### PR DESCRIPTION
**Description**
Follow-up #7543

`$httpVerb` is used later in the method. So the value should be lower case.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
