### PR TITLE
docs: fix incorrect comments in query_builder

### DIFF
--- a/user_guide_src/source/database/query_builder/098.php
+++ b/user_guide_src/source/database/query_builder/098.php
@@ -1,6 +1,6 @@
 <?php
 
-// Note that the second parameter of the ``get_compiled_select`` method is false
+// Note that the parameter of the `getCompiledSelect()` method is false
 $sql = $builder->select(['field1', 'field2'])
     ->where('field3', 5)
     ->getCompiledSelect(false);
@@ -13,5 +13,5 @@ $sql = $builder->select(['field1', 'field2'])
 $data = $builder->get()->getResultArray();
 /*
  * Would execute and return an array of results of the following query:
- * SELECT field1, field1 from mytable where field3 = 5;
+ * SELECT field1, field2 FROM mytable WHERE field3 = 5;
  */


### PR DESCRIPTION
**Description**
- fix incorrect comments

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
