### PR TITLE
[4.4] fix: Typed property CodeIgniter::$bufferLevel must not be accessed before initialization

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -331,7 +331,8 @@ class CodeIgniter
             );
         }
 
-        static::$cacheTTL = 0;
+        static::$cacheTTL  = 0;
+        $this->bufferLevel = ob_get_level();
 
         $this->startBenchmark();
 


### PR DESCRIPTION
**Description**
The `CodeIgniter::$bufferLevel` property is undefined by default.
If an exception is thrown in the `CodeIgniter::handleRequest()` method before the value is assigned to the property, an error occurs when the `CodeIgniter::outputBufferingEnd()` method is called. 
`Typed property CodeIgniter\CodeIgniter::$bufferLevel must not be accessed before initialization`.

This PR sets the `CodeIgniter::$bufferLevel` property in the `CodeIgniter::run()` method to prevent this error.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
