### PR TITLE
chore: [Psalm] workarround for Tests\Support\Controllers\Hello does not exist

### DIFF
--- a/psalm_autoload.php
+++ b/psalm_autoload.php
@@ -23,4 +23,23 @@ foreach ($helperDirs as $dir) {
     }
 }
 
+$dirs = [
+    'tests/_support/Controllers',
+];
+
+foreach ($dirs as $dir) {
+    $dir = __DIR__ . '/' . $dir;
+    if (! is_dir($dir)) {
+        continue;
+    }
+
+    chdir($dir);
+
+    foreach (glob('*.php') as $filename) {
+        $filePath = realpath($dir . '/' . $filename);
+
+        require_once $filePath;
+    }
+}
+
 chdir(__DIR__);


### PR DESCRIPTION
**Description**
- scan tests/_support/Controllers for Psalm

I don't know why these errors are reported.

```
ERROR: UndefinedClass - tests/system/CodeIgniterTest.php:114:33 - Class, interface or enum named Tests\Support\Controllers\Hello does not exist (see https://psalm.dev/019)
        $routes->set404Override('Tests\Support\Controllers\Hello::index');


ERROR: UndefinedClass - tests/system/CodeIgniterTest.php:133:33 - Class, interface or enum named Tests\Support\Controllers\Popcorn does not exist (see https://psalm.dev/019)
        $routes->set404Override('Tests\Support\Controllers\Popcorn::pop');


ERROR: UndefinedClass - tests/system/CodeIgniterTest.php:152:33 - Class, interface or enum named Tests\Support\Controllers\Popcorn does not exist (see https://psalm.dev/019)
        $routes->set404Override('Tests\Support\Controllers\Popcorn::pop');
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/5276222376/jobs/9542644621

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
