### PR TITLE
fix: [Auto Routing Improved] feature testing may use incorrect param count

### DIFF
--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -106,6 +106,9 @@ final class AutoRouterImproved implements AutoRouterInterface
     {
         $httpVerb = strtolower($httpVerb);
 
+        // Reset Controller method params.
+        $this->params = [];
+
         $defaultMethod = $httpVerb . ucfirst($this->defaultMethod);
         $this->method  = $defaultMethod;
 

--- a/tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
+++ b/tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
@@ -72,4 +72,13 @@ final class FeatureTestAutoRoutingImprovedTest extends CIUnitTestCase
 
         $response->assertSee('Saved');
     }
+
+    public function testCallParamsCount()
+    {
+        $response = $this->post('newautorouting/save/1/a/b');
+        $response->assertSee('Saved');
+
+        $response = $this->get('newautorouting');
+        $response->assertSee('Hello');
+    }
 }


### PR DESCRIPTION
**Description**
Follow-up #7543 
See https://forum.codeigniter.com/showthread.php?tid=87818&pid=410558#pid410558

- fix a bug that `$this->params` is not reset for a new HTTP request

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
