### PR TITLE
docs: fix incorrect PHPDoc types in TestResponse

### DIFF
--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -350,7 +350,7 @@ class TestResponse extends TestCase
     /**
      * Returns the response's body as JSON
      *
-     * @return false|string|null
+     * @return false|string
      */
     public function getJSON()
     {
@@ -385,7 +385,7 @@ class TestResponse extends TestCase
      * Asserts that the JSON exactly matches the passed in data.
      * If the value being passed in is a string, it must be a json_encoded string.
      *
-     * @param array|string $test
+     * @param array|object|string $test
      *
      * @throws Exception
      */


### PR DESCRIPTION
**Description**
- fix incorrect PHPDoc types

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
