### PR TITLE
fix: FeatureTestTrait may change $params values passed to call(), and a few bug fixes

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -371,6 +371,10 @@ trait FeatureTestTrait
      */
     protected function setRequestBody(Request $request, ?array $params = null): Request
     {
+        if ($this->requestBody !== '') {
+            $request->setBody($this->requestBody);
+        }
+
         if ($this->bodyFormat !== '') {
             $formatMime = '';
             if ($this->bodyFormat === 'json') {
@@ -385,13 +389,9 @@ trait FeatureTestTrait
 
             if ($params !== null && $formatMime !== '') {
                 $formatted = Services::format()->getFormatter($formatMime)->format($params);
+                // "withBodyFormat() and $params of call()" has higher priority than withBody().
                 $request->setBody($formatted);
             }
-        }
-
-        // withBody() has higher priority than $params of withBodyFormat().
-        if ($this->requestBody !== '') {
-            $request->setBody($this->requestBody);
         }
 
         return $request;

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -137,6 +137,8 @@ trait FeatureTestTrait
      * Calls a single URI, executes it, and returns a TestResponse
      * instance that can be used to run many assertions against.
      *
+     * @param string $method HTTP verb
+     *
      * @return TestResponse
      */
     public function call(string $method, string $path, ?array $params = null)
@@ -281,6 +283,8 @@ trait FeatureTestTrait
     /**
      * Setup a Request object to use so that CodeIgniter
      * won't try to auto-populate some of the items.
+     *
+     * @param string $method HTTP verb
      */
     protected function setupRequest(string $method, ?string $path = null): IncomingRequest
     {
@@ -324,6 +328,8 @@ trait FeatureTestTrait
      * relevant to the request, like $_POST data.
      *
      * Always populate the GET vars based on the URI.
+     *
+     * @param string $method HTTP verb
      *
      * @return Request
      *

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -344,11 +344,18 @@ trait FeatureTestTrait
             : $this->getPrivateProperty($request->getUri(), 'query');
 
         $request->setGlobal('get', $get);
-        if ($method !== 'get') {
-            $request->setGlobal($method, $params);
+
+        if ($method === 'get') {
+            $request->setGlobal('request', $request->fetchGlobal('get'));
         }
 
-        $request->setGlobal('request', $params);
+        if ($method === 'post') {
+            $request->setGlobal($method, $params);
+            $request->setGlobal(
+                'request',
+                $request->fetchGlobal('post') + $request->fetchGlobal('get')
+            );
+        }
 
         $_SESSION = $this->session ?? [];
 

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -110,7 +110,7 @@ trait FeatureTestTrait
     /**
      * Set the raw body for the request
      *
-     * @param mixed $body
+     * @param string $body
      *
      * @return $this
      */

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -371,7 +371,7 @@ trait FeatureTestTrait
      */
     protected function setRequestBody(Request $request, ?array $params = null): Request
     {
-        if (isset($this->bodyFormat) && $this->bodyFormat !== '') {
+        if ($this->bodyFormat !== '') {
             $formatMime = '';
             if ($this->bodyFormat === 'json') {
                 $formatMime = 'application/json';
@@ -390,7 +390,7 @@ trait FeatureTestTrait
         }
 
         // withBody() has higher priority than $params of withBodyFormat().
-        if (isset($this->requestBody) && $this->requestBody !== '') {
+        if ($this->requestBody !== '') {
             $request->setBody($this->requestBody);
         }
 

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -156,7 +156,7 @@ trait FeatureTestTrait
         $request = $this->setupRequest($method, $path);
         $request = $this->setupHeaders($request);
         $request = $this->populateGlobals($method, $request, $params);
-        $request = $this->setRequestBody($request);
+        $request = $this->setRequestBody($request, $params);
 
         // Initialize the RouteCollection
         if (! $routes = $this->routes) {
@@ -369,12 +369,14 @@ trait FeatureTestTrait
             if (empty($params)) {
                 $params = $request->fetchGlobal('request');
             }
+
             $formatMime = '';
             if ($this->bodyFormat === 'json') {
                 $formatMime = 'application/json';
             } elseif ($this->bodyFormat === 'xml') {
                 $formatMime = 'application/xml';
             }
+
             if (! empty($formatMime) && ! empty($params)) {
                 $formatted = Services::format()->getFormatter($formatMime)->format($params);
                 $request->setBody($formatted);

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -339,7 +339,7 @@ trait FeatureTestTrait
     {
         // $params should set the query vars if present,
         // otherwise set it from the URL.
-        $get = ! empty($params) && $method === 'get'
+        $get = (! empty($params) && $method === 'get')
             ? $params
             : $this->getPrivateProperty($request->getUri(), 'query');
 

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -358,6 +358,60 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertTrue($response->isOK());
     }
 
+    public function testCallGetWithParams()
+    {
+        $this->withRoutes([
+            [
+                'get',
+                'home',
+                static fn () => json_encode(Services::request()->getGet()),
+            ],
+        ]);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->get('home', $data);
+
+        $response->assertOK();
+        $this->assertStringContainsString(
+            // All GET values will be strings.
+            '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
+            $response->getBody()
+        );
+    }
+
+    public function testCallPostWithParams()
+    {
+        $this->withRoutes([
+            [
+                'post',
+                'home',
+                static fn () => json_encode(Services::request()->getPost()),
+            ],
+        ]);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->post('home', $data);
+
+        $response->assertOK();
+        $this->assertStringContainsString(
+            // All POST values will be strings.
+            '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
+            $response->getBody()
+        );
+    }
+
     public function testCallWithJsonRequest()
     {
         $this->withRoutes([

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -421,9 +421,19 @@ final class FeatureTestTraitTest extends CIUnitTestCase
                 '\Tests\Support\Controllers\Popcorn::echoJson',
             ],
         ]);
-        $response = $this->withBodyFormat('json')->call('post', 'home', ['foo' => 'bar']);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->withBodyFormat('json')
+            ->call('post', 'home', $data);
+
         $response->assertOK();
-        $response->assertJSONExact(['foo' => 'bar']);
+        $response->assertJSONExact($data);
     }
 
     public function testSetupRequestBodyWithParams()
@@ -440,10 +450,18 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $request = $this->setupRequest('post', 'home');
 
-        $request = $this->withBodyFormat('xml')->setRequestBody($request, ['foo' => 'bar']);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $request = $this->withBodyFormat('xml')->setRequestBody($request, $data);
 
         $expectedXml = '<?xml version="1.0"?>
-<response><foo>bar</foo></response>
+<response><true>1</true><false/><int>2</int><null/><float>1.23</float><string>foo</string></response>
 ';
 
         $this->assertSame($expectedXml, $request->getBody());

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -548,6 +548,23 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertSame('application/json', $request->header('Content-Type')->getValue());
     }
 
+    public function testSetupJSONRequestBodyWithBody()
+    {
+        $request = $this->setupRequest('post', 'home');
+        $request = $this->withBodyFormat('json')
+            ->withBody(json_encode(['foo1' => 'bar1']))
+            ->setRequestBody($request);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(['foo1' => 'bar1']),
+            $request->getBody()
+        );
+        $this->assertSame(
+            'application/json',
+            $request->header('Content-Type')->getValue()
+        );
+    }
+
     public function testSetupRequestBodyWithXml()
     {
         $request = $this->setupRequest('post', 'home');

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -466,6 +466,54 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         );
     }
 
+    public function testCallPutWithJsonRequest()
+    {
+        $this->withRoutes([
+            [
+                'put',
+                'home',
+                '\Tests\Support\Controllers\Popcorn::echoJson',
+            ],
+        ]);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->withBodyFormat('json')
+            ->call('put', 'home', $data);
+
+        $response->assertOK();
+        $response->assertJSONExact($data);
+    }
+
+    public function testCallPutWithJsonRequestAndREQUEST()
+    {
+        $this->withRoutes([
+            [
+                'put',
+                'home',
+                static fn () => json_encode(Services::request()->fetchGlobal('request')),
+            ],
+        ]);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->withBodyFormat('json')
+            ->call('put', 'home', $data);
+
+        $response->assertOK();
+        $this->assertStringContainsString('[]', $response->getBody());
+    }
+
     public function testCallWithJsonRequest()
     {
         $this->withRoutes([

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -385,6 +385,33 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         );
     }
 
+    public function testCallGetWithParamsAndREQEST()
+    {
+        $this->withRoutes([
+            [
+                'get',
+                'home',
+                static fn () => json_encode(Services::request()->fetchGlobal('request')),
+            ],
+        ]);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->get('home', $data);
+
+        $response->assertOK();
+        $this->assertStringContainsString(
+            // All GET values will be strings.
+            '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
+            $response->getBody()
+        );
+    }
+
     public function testCallPostWithParams()
     {
         $this->withRoutes([
@@ -392,6 +419,33 @@ final class FeatureTestTraitTest extends CIUnitTestCase
                 'post',
                 'home',
                 static fn () => json_encode(Services::request()->getPost()),
+            ],
+        ]);
+        $data = [
+            'true'   => true,
+            'false'  => false,
+            'int'    => 2,
+            'null'   => null,
+            'float'  => 1.23,
+            'string' => 'foo',
+        ];
+        $response = $this->post('home', $data);
+
+        $response->assertOK();
+        $this->assertStringContainsString(
+            // All POST values will be strings.
+            '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
+            $response->getBody()
+        );
+    }
+
+    public function testCallPostWithParamsAndREQUEST()
+    {
+        $this->withRoutes([
+            [
+                'post',
+                'home',
+                static fn () => json_encode(Services::request()->fetchGlobal('request')),
             ],
         ]);
         $data = [

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -385,7 +385,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         );
     }
 
-    public function testCallGetWithParamsAndREQEST()
+    public function testCallGetWithParamsAndREQUEST()
     {
         $this->withRoutes([
             [

--- a/user_guide_src/source/changelogs/v4.3.7.rst
+++ b/user_guide_src/source/changelogs/v4.3.7.rst
@@ -12,6 +12,10 @@ Release Date: Unreleased
 BREAKING
 ********
 
+- **FeatureTestTrait:** When using :ref:`withBodyFormat() <feature-formatting-the-request>`,
+  the priority of the request body has been changed.
+  See :ref:`Upgrading Guide <upgrade-437-feature-testing>` for details.
+
 Message Changes
 ***************
 

--- a/user_guide_src/source/installation/upgrade_437.rst
+++ b/user_guide_src/source/installation/upgrade_437.rst
@@ -18,6 +18,27 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+.. _upgrade-437-feature-testing:
+
+Feature Testing Request Body
+============================
+
+If you call:
+
+1. :ref:`withBody() <feature-setting-the-body>`
+2. and :ref:`withBodyFormat() <feature-formatting-the-request>`
+3. and pass the ``$params`` to :ref:`call() <feature-requesting-a-page>` (or shorthand methods)
+
+the priority for a Request body has been changed. In the unlikely event that you
+have test code affected by this change, modify it.
+
+For example, now the ``$params`` is used to build the request body, and the ``$body``
+is not used::
+
+    $this->withBody($body)->withBodyFormat('json')->call('post', $params)
+
+Previously, the ``$body`` was used for the request body.
+
 Breaking Enhancements
 *********************
 

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -21,22 +21,30 @@ are called if you implement your own methods.
 
 .. literalinclude:: feature/001.php
 
-Requesting A Page
+Requesting a Page
 =================
 
 Essentially, feature tests simply allows you to call an endpoint on your application and get the results back.
-to do this, you use the ``call()`` method. The first parameter is the HTTP method to use (most frequently either GET or POST).
-The second parameter is the path on your site to test. The third parameter accepts an array that is used to populate the
-superglobal variables for the HTTP verb you are using. So, a method of **GET** would have the **$_GET** variable
-populated, while a **post** request would have the **$_POST** array populated.
+To do this, you use the ``call()`` method.
+
+1. The first parameter is the HTTP method to use (most frequently either GET or POST).
+2. The second parameter is the URI path on your site to test.
+3. The third parameter ``$params`` accepts an array that is used to populate the
+   superglobal variables for the HTTP verb you are using. So, a method of **GET**
+   would have the **$_GET** variable populated, while a **POST** request would
+   have the **$_POST** array populated.
+
+   .. note:: The ``$params`` array does not make sense for every HTTP verb, but is
+      included for consistency.
 
 .. literalinclude:: feature/002.php
+
+Shorthand Methods
+-----------------
 
 Shorthand methods for each of the HTTP verbs exist to ease typing and make things clearer:
 
 .. literalinclude:: feature/003.php
-
-.. note:: The ``$params`` array does not make sense for every HTTP verb, but is included for consistency.
 
 Setting Different Routes
 ------------------------
@@ -74,13 +82,17 @@ to send out emails. You can tell the system to skip any event handling with the 
 
 .. literalinclude:: feature/007.php
 
-Formatting The Request
+Formatting the Request
 -----------------------
 
 You can set the format of your request's body using the ``withBodyFormat()`` method. Currently this supports either
-`json` or `xml`. This will take the parameters passed into ``call()``, ``post()``, ``get()``... and assign them to the
-body of the request in the given format. This will also set the `Content-Type` header for your request accordingly.
+``json`` or ``xml``.
 This is useful when testing JSON or XML APIs so that you can set the request in the form that the controller will expect.
+
+This will take the parameters passed into ``call()``, ``post()``, ``get()``... and assign them to the
+body of the request in the given format.
+
+This will also set the `Content-Type` header for your request accordingly.
 
 .. literalinclude:: feature/008.php
 
@@ -88,8 +100,10 @@ Setting the Body
 ----------------
 
 You can set the body of your request with the ``withBody()`` method. This allows you to format the body how you want
-to format it. It is recommended that you use this if you have more complicated XMLs to test. This will also not set
-the Content-Type header for you so if you need that, you can set it with the ``withHeaders()`` method.
+to format it. It is recommended that you use this if you have more complicated XMLs to test.
+
+This will not set
+the `Content-Type` header for you. If you need that, you can set it with the ``withHeaders()`` method.
 
 Checking the Response
 =====================

--- a/user_guide_src/source/testing/feature.rst
+++ b/user_guide_src/source/testing/feature.rst
@@ -21,6 +21,8 @@ are called if you implement your own methods.
 
 .. literalinclude:: feature/001.php
 
+.. _feature-requesting-a-page:
+
 Requesting a Page
 =================
 
@@ -32,7 +34,8 @@ To do this, you use the ``call()`` method.
 3. The third parameter ``$params`` accepts an array that is used to populate the
    superglobal variables for the HTTP verb you are using. So, a method of **GET**
    would have the **$_GET** variable populated, while a **POST** request would
-   have the **$_POST** array populated.
+   have the **$_POST** array populated. The ``$params`` is also used in
+   :ref:`feature-formatting-the-request`.
 
    .. note:: The ``$params`` array does not make sense for every HTTP verb, but is
       included for consistency.
@@ -82,6 +85,8 @@ to send out emails. You can tell the system to skip any event handling with the 
 
 .. literalinclude:: feature/007.php
 
+.. _feature-formatting-the-request:
+
 Formatting the Request
 -----------------------
 
@@ -95,6 +100,8 @@ body of the request in the given format.
 This will also set the `Content-Type` header for your request accordingly.
 
 .. literalinclude:: feature/008.php
+
+.. _feature-setting-the-body:
 
 Setting the Body
 ----------------


### PR DESCRIPTION
**Description**
Fixes #7593

- fix: when you call `withBodyFormat('json')` and pass `$params` to `call()`,  the values in  `$params` is converted to string.
- fix: REQUEST global is set with a JSON/XML request
   - $_REQUEST = $_POST + $_GET. It should be empty if it is a JSON/XML request.
- fix: when calling `withBody()` and `withBodyFormat()`, `Content-Type` is not set
- fix: [BC] change priority for request body
   - When you call `withBody($body)->withBodyFormat('json')->call('post', $param)`, `$param` is used for the request body from now on. Previously, `$body` was used.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
