### PR TITLE
chore: add Composer\Config::disableProcessTimeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,11 +83,13 @@
         "sa": "@analyze",
         "test": "phpunit",
         "cs": [
+            "Composer\\Config::disableProcessTimeout",
             "php-cs-fixer fix --ansi --verbose --dry-run --diff --config=.php-cs-fixer.user-guide.php",
             "php-cs-fixer fix --ansi --verbose --dry-run --diff --config=.php-cs-fixer.no-header.php",
             "php-cs-fixer fix --ansi --verbose --dry-run --diff"
         ],
         "cs-fix": [
+            "Composer\\Config::disableProcessTimeout",
             "php-cs-fixer fix --ansi --verbose --diff --config=.php-cs-fixer.user-guide.php",
             "php-cs-fixer fix --ansi --verbose --diff --config=.php-cs-fixer.no-header.php",
             "php-cs-fixer fix --ansi --verbose --diff"


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Occasionally, `cs-fix` fails with process time out error. This removes the 5-minute timeout for the code style fixes.

See https://getcomposer.org/doc/06-config.md#process-timeout

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
