### PR TITLE
fix: change assertion on CLITest::testWaitZero

### DIFF
--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -73,7 +73,7 @@ final class CLITest extends CIUnitTestCase
         $time = time();
         CLI::wait(0);
 
-        $this->assertSame(0, time() - $time);
+        $this->assertCloseEnough(0, time() - $time);
 
         PhpStreamWrapper::restore();
     }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Fixes #7536 

`time()` is volatile. It may be called on the edges causing difference to be at least 1.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
