### PR TITLE
refactor: use ::class to config() param

### DIFF
--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\CLI;
 
+use Config\Exceptions;
 use Psr\Log\LoggerInterface;
 use ReflectionException;
 use Throwable;
@@ -121,7 +122,7 @@ abstract class BaseCommand
     {
         $exception = $e;
         $message   = $e->getMessage();
-        $config    = config('Exceptions');
+        $config    = config(Exceptions::class);
 
         require $config->errorViewPath . '/cli/error_exception.php';
     }

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\CLI;
 
+use Config\Generators;
 use Config\Services;
 use Throwable;
 
@@ -267,7 +268,7 @@ trait GeneratorTrait
     protected function renderTemplate(array $data = []): string
     {
         try {
-            return view(config('Generators')->views[$this->name], $data, ['debug' => false]);
+            return view(config(Generators::class)->views[$this->name], $data, ['debug' => false]);
         } catch (Throwable $e) {
             log_message('error', (string) $e);
 

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use Closure;
 use CodeIgniter\Cache\CacheInterface;
+use Config\Cache;
 use Exception;
 use InvalidArgumentException;
 
@@ -61,7 +62,7 @@ abstract class BaseHandler implements CacheInterface
             throw new InvalidArgumentException('Cache key cannot be empty.');
         }
 
-        $reserved = config('Cache')->reservedCharacters ?? self::RESERVED_CHARACTERS;
+        $reserved = config(Cache::class)->reservedCharacters ?? self::RESERVED_CHARACTERS;
         if ($reserved && strpbrk($key, $reserved) !== false) {
             throw new InvalidArgumentException('Cache key contains reserved characters ' . $reserved);
         }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -28,6 +28,7 @@ use CodeIgniter\Router\RouteCollectionInterface;
 use CodeIgniter\Router\Router;
 use Config\App;
 use Config\Cache;
+use Config\Feature;
 use Config\Kint as KintConfig;
 use Config\Services;
 use Exception;
@@ -268,7 +269,6 @@ class CodeIgniter
 
     private function configureKint(): void
     {
-        /** @var \Config\Kint $config */
         $config = config(KintConfig::class);
 
         Kint::$depth_limit         = $config->maxDepth;
@@ -455,7 +455,7 @@ class CodeIgniter
             // If any filters were specified within the routes file,
             // we need to ensure it's active for the current request
             if ($routeFilter !== null) {
-                $multipleFiltersEnabled = config('Feature')->multipleFilters ?? false;
+                $multipleFiltersEnabled = config(Feature::class)->multipleFilters ?? false;
                 if ($multipleFiltersEnabled) {
                     $filters->enableFilters($routeFilter, 'before');
                     $filters->enableFilters($routeFilter, 'after');
@@ -822,7 +822,7 @@ class CodeIgniter
         $this->benchmark->stop('routing');
 
         // for backward compatibility
-        $multipleFiltersEnabled = config('Feature')->multipleFilters ?? false;
+        $multipleFiltersEnabled = config(Feature::class)->multipleFilters ?? false;
         if (! $multipleFiltersEnabled) {
             return $this->router->getFilter();
         }

--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Commands\Cache;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use Config\Cache;
 
 /**
  * Clears current cache.
@@ -62,7 +63,7 @@ class ClearCache extends BaseCommand
      */
     public function run(array $params)
     {
-        $config  = config('Cache');
+        $config  = config(Cache::class);
         $handler = $params[0] ?? $config->handler;
 
         if (! array_key_exists($handler, $config->validHandlers)) {

--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -15,6 +15,7 @@ use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
+use Config\Cache;
 
 /**
  * Shows information on the cache.
@@ -54,7 +55,7 @@ class InfoCache extends BaseCommand
      */
     public function run(array $params)
     {
-        $config = config('Cache');
+        $config = config(Cache::class);
         helper('number');
 
         if ($config->handler !== 'file') {

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -82,10 +82,7 @@ class CreateDatabase extends BaseCommand
         }
 
         try {
-            /**
-             * @var Database $config
-             */
-            $config = config('Database');
+            $config = config(Database::class);
 
             // Set to an empty database to prevent connection errors.
             $group = ENVIRONMENT === 'testing' ? 'tests' : $config->defaultGroup;

--- a/system/Commands/Generators/MigrationGenerator.php
+++ b/system/Commands/Generators/MigrationGenerator.php
@@ -15,6 +15,8 @@ use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\GeneratorTrait;
 use Config\App as AppConfig;
+use Config\Database;
+use Config\Migrations;
 use Config\Session as SessionConfig;
 
 /**
@@ -107,12 +109,11 @@ class MigrationGenerator extends BaseCommand
             $data['session']  = true;
             $data['table']    = is_string($table) ? $table : 'ci_sessions';
             $data['DBGroup']  = is_string($DBGroup) ? $DBGroup : 'default';
-            $data['DBDriver'] = config('Database')->{$data['DBGroup']}['DBDriver'];
+            $data['DBDriver'] = config(Database::class)->{$data['DBGroup']}['DBDriver'];
 
-            /** @var AppConfig $config */
-            $config = config('App');
+            $config = config(AppConfig::class);
             /** @var SessionConfig|null $session */
-            $session = config('Session');
+            $session = config(SessionConfig::class);
 
             $data['matchIP'] = ($session instanceof SessionConfig)
                 ? $session->matchIP : $config->sessionMatchIP;
@@ -126,6 +127,6 @@ class MigrationGenerator extends BaseCommand
      */
     protected function basename(string $filename): string
     {
-        return gmdate(config('Migrations')->timestampFormat) . basename($filename);
+        return gmdate(config(Migrations::class)->timestampFormat) . basename($filename);
     }
 }

--- a/system/Commands/Generators/SessionMigrationGenerator.php
+++ b/system/Commands/Generators/SessionMigrationGenerator.php
@@ -14,6 +14,8 @@ namespace CodeIgniter\Commands\Generators;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\GeneratorTrait;
+use Config\App;
+use Config\Migrations;
 
 /**
  * Generates a migration file for database sessions.
@@ -93,7 +95,7 @@ class SessionMigrationGenerator extends BaseCommand
         $data['session'] = true;
         $data['table']   = $this->getOption('t');
         $data['DBGroup'] = $this->getOption('g');
-        $data['matchIP'] = config('App')->sessionMatchIP ?? false;
+        $data['matchIP'] = config(App::class)->sessionMatchIP ?? false;
 
         $data['table']   = is_string($data['table']) ? $data['table'] : 'ci_sessions';
         $data['DBGroup'] = is_string($data['DBGroup']) ? $data['DBGroup'] : 'default';
@@ -106,6 +108,6 @@ class SessionMigrationGenerator extends BaseCommand
      */
     protected function basename(string $filename): string
     {
-        return gmdate(config('Migrations')->timestampFormat) . basename($filename);
+        return gmdate(config(Migrations::class)->timestampFormat) . basename($filename);
     }
 }

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -18,6 +18,7 @@ use CodeIgniter\Commands\Utilities\Routes\AutoRouteCollector;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\AutoRouteCollector as AutoRouteCollectorImproved;
 use CodeIgniter\Commands\Utilities\Routes\FilterCollector;
 use CodeIgniter\Commands\Utilities\Routes\SampleURIGenerator;
+use Config\Feature;
 use Config\Services;
 
 /**
@@ -124,7 +125,7 @@ class Routes extends BaseCommand
         }
 
         if ($collection->shouldAutoRoute()) {
-            $autoRoutesImproved = config('Feature')->autoRoutesImproved ?? false;
+            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved ?? false;
 
             if ($autoRoutesImproved) {
                 $autoRouteCollector = new AutoRouteCollectorImproved(

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -15,6 +15,7 @@ use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Router;
+use Config\Filters as FiltersConfig;
 
 /**
  * Collects filters for a route.
@@ -72,7 +73,7 @@ final class FilterCollector
 
     private function createFilters(Request $request): Filters
     {
-        $config = config('Filters');
+        $config = config(FiltersConfig::class);
 
         return new Filters($config, $request, Services::response());
     }

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -15,6 +15,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\Router;
+use Config\Feature;
 use Config\Services;
 
 /**
@@ -35,7 +36,7 @@ final class FilterFinder
     {
         $this->router->handle($uri);
 
-        $multipleFiltersEnabled = config('Feature')->multipleFilters ?? false;
+        $multipleFiltersEnabled = config(Feature::class)->multipleFilters ?? false;
         if (! $multipleFiltersEnabled) {
             $filter = $this->router->getFilter();
 

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -59,7 +59,7 @@ class BaseConfig
      */
     public function __construct()
     {
-        static::$moduleConfig = config('Modules');
+        static::$moduleConfig = config(Modules::class);
 
         $this->registerProperties();
 

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -318,7 +318,7 @@ class BaseService
     protected static function discoverServices(string $name, array $arguments)
     {
         if (! static::$discovered) {
-            $config = config('Modules');
+            $config = config(Modules::class);
 
             if ($config->shouldDiscover('services')) {
                 $locator = static::locator();
@@ -360,7 +360,7 @@ class BaseService
     protected static function buildServicesCache(): void
     {
         if (! static::$discovered) {
-            $config = config('Modules');
+            $config = config(Modules::class);
 
             if ($config->shouldDiscover('services')) {
                 $locator = static::locator();

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -230,7 +230,7 @@ class Factories
             // Handle Config as a special case to prevent logic loops
             ? self::$configOptions
             // Load values from the best Factory configuration (will include Registrars)
-            : config('Factory')->{$component} ?? [];
+            : config(Factory::class)->{$component} ?? [];
 
         return self::setOptions($component, $values);
     }

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -61,6 +61,7 @@ use CodeIgniter\View\RendererInterface;
 use CodeIgniter\View\View;
 use Config\App;
 use Config\Cache;
+use Config\ContentSecurityPolicy as ContentSecurityPolicyConfig;
 use Config\ContentSecurityPolicy as CSPConfig;
 use Config\Database;
 use Config\Email as EmailConfig;
@@ -70,8 +71,11 @@ use Config\Filters as FiltersConfig;
 use Config\Format as FormatConfig;
 use Config\Honeypot as HoneypotConfig;
 use Config\Images;
+use Config\Logger as LoggerConfig;
 use Config\Migrations;
+use Config\Modules;
 use Config\Pager as PagerConfig;
+use Config\Paths;
 use Config\Services as AppServices;
 use Config\Session as SessionConfig;
 use Config\Toolbar as ToolbarConfig;
@@ -129,7 +133,7 @@ class Services extends BaseService
             return static::getSharedInstance('clirequest', $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
 
         return new CLIRequest($config);
     }
@@ -145,7 +149,7 @@ class Services extends BaseService
             return static::getSharedInstance('codeigniter', $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
 
         return new CodeIgniter($config);
     }
@@ -175,7 +179,7 @@ class Services extends BaseService
             return static::getSharedInstance('csp', $config);
         }
 
-        $config ??= config('ContentSecurityPolicy');
+        $config ??= config(ContentSecurityPolicyConfig::class);
 
         return new ContentSecurityPolicy($config);
     }
@@ -192,7 +196,7 @@ class Services extends BaseService
             return static::getSharedInstance('curlrequest', $options, $response, $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
         $response ??= new Response($config);
 
         return new CURLRequest(
@@ -217,7 +221,7 @@ class Services extends BaseService
         }
 
         if (empty($config) || ! (is_array($config) || $config instanceof EmailConfig)) {
-            $config = config('Email');
+            $config = config(EmailConfig::class);
         }
 
         return new Email($config);
@@ -236,7 +240,7 @@ class Services extends BaseService
             return static::getSharedInstance('encrypter', $config);
         }
 
-        $config ??= config('Encryption');
+        $config ??= config(EncryptionConfig::class);
         $encryption = new Encryption($config);
 
         return $encryption->initialize($config);
@@ -261,7 +265,7 @@ class Services extends BaseService
             return static::getSharedInstance('exceptions', $config, $request, $response);
         }
 
-        $config ??= config('Exceptions');
+        $config ??= config(ExceptionsConfig::class);
         $request ??= AppServices::request();
         $response ??= AppServices::response();
 
@@ -282,7 +286,7 @@ class Services extends BaseService
             return static::getSharedInstance('filters', $config);
         }
 
-        $config ??= config('Filters');
+        $config ??= config(FiltersConfig::class);
 
         return new Filters($config, AppServices::request(), AppServices::response());
     }
@@ -298,7 +302,7 @@ class Services extends BaseService
             return static::getSharedInstance('format', $config);
         }
 
-        $config ??= config('Format');
+        $config ??= config(FormatConfig::class);
 
         return new Format($config);
     }
@@ -315,7 +319,7 @@ class Services extends BaseService
             return static::getSharedInstance('honeypot', $config);
         }
 
-        $config ??= config('Honeypot');
+        $config ??= config(HoneypotConfig::class);
 
         return new Honeypot($config);
     }
@@ -332,7 +336,7 @@ class Services extends BaseService
             return static::getSharedInstance('image', $handler, $config);
         }
 
-        $config ??= config('Images');
+        $config ??= config(Images::class);
         assert($config instanceof Images);
 
         $handler = $handler ?: $config->defaultHandler;
@@ -392,7 +396,7 @@ class Services extends BaseService
             return static::getSharedInstance('logger');
         }
 
-        return new Logger(config('Logger'));
+        return new Logger(config(LoggerConfig::class));
     }
 
     /**
@@ -406,7 +410,7 @@ class Services extends BaseService
             return static::getSharedInstance('migrations', $config, $db);
         }
 
-        $config ??= config('Migrations');
+        $config ??= config(Migrations::class);
 
         return new MigrationRunner($config, $db);
     }
@@ -440,7 +444,7 @@ class Services extends BaseService
             return static::getSharedInstance('pager', $config, $view);
         }
 
-        $config ??= config('Pager');
+        $config ??= config(PagerConfig::class);
         $view ??= AppServices::renderer();
 
         return new Pager($config, $view);
@@ -457,8 +461,8 @@ class Services extends BaseService
             return static::getSharedInstance('parser', $viewPath, $config);
         }
 
-        $viewPath = $viewPath ?: config('Paths')->viewDirectory;
-        $config ??= config('View');
+        $viewPath = $viewPath ?: config(Paths::class)->viewDirectory;
+        $config ??= config(ViewConfig::class);
 
         return new Parser($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
     }
@@ -476,8 +480,8 @@ class Services extends BaseService
             return static::getSharedInstance('renderer', $viewPath, $config);
         }
 
-        $viewPath = $viewPath ?: config('Paths')->viewDirectory;
-        $config ??= config('View');
+        $viewPath = $viewPath ?: config(Paths::class)->viewDirectory;
+        $config ??= config(ViewConfig::class);
 
         return new View($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
     }
@@ -536,7 +540,7 @@ class Services extends BaseService
             return static::getSharedInstance('request', $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
 
         return new IncomingRequest(
             $config,
@@ -557,7 +561,7 @@ class Services extends BaseService
             return static::getSharedInstance('response', $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
 
         return new Response($config);
     }
@@ -573,7 +577,7 @@ class Services extends BaseService
             return static::getSharedInstance('redirectresponse', $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
         $response = new RedirectResponse($config);
         $response->setProtocolVersion(AppServices::request()->getProtocolVersion());
 
@@ -592,7 +596,7 @@ class Services extends BaseService
             return static::getSharedInstance('routes');
         }
 
-        return new RouteCollection(AppServices::locator(), config('Modules'));
+        return new RouteCollection(AppServices::locator(), config(Modules::class));
     }
 
     /**
@@ -625,7 +629,7 @@ class Services extends BaseService
             return static::getSharedInstance('security', $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
 
         return new Security($config);
     }
@@ -641,13 +645,13 @@ class Services extends BaseService
             return static::getSharedInstance('session', $config);
         }
 
-        $config ??= config('App');
+        $config ??= config(App::class);
         assert($config instanceof App);
 
         $logger = AppServices::logger();
 
         /** @var SessionConfig|null $sessionConfig */
-        $sessionConfig = config('Session');
+        $sessionConfig = config(SessionConfig::class);
 
         $driverName = $sessionConfig->driver ?? $config->sessionDriver;
 
@@ -718,7 +722,7 @@ class Services extends BaseService
             return static::getSharedInstance('toolbar', $config);
         }
 
-        $config ??= config('Toolbar');
+        $config ??= config(ToolbarConfig::class);
 
         return new Toolbar($config);
     }
@@ -750,7 +754,7 @@ class Services extends BaseService
             return static::getSharedInstance('validation', $config);
         }
 
-        $config ??= config('Validation');
+        $config ??= config(ValidationConfig::class);
 
         return new Validation($config, AppServices::renderer());
     }

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Services;
+use Config\Validation;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -164,7 +165,7 @@ class Controller
 
         // If you replace the $rules array with the name of the group
         if (is_string($rules)) {
-            $validation = config('Validation');
+            $validation = config(Validation::class);
 
             // If the rule wasn't found in the \Config\Validation, we
             // should throw an exception so the developer can find it.

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -57,8 +57,7 @@ class Config extends BaseConfig
             $config = $group;
             $group  = 'custom-' . md5(json_encode($config));
         } else {
-            /** @var DbConfig $dbConfig */
-            $dbConfig = config('Database');
+            $dbConfig = config(DbConfig::class);
 
             if ($group === null) {
                 $group = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
@@ -132,7 +131,7 @@ class Config extends BaseConfig
      */
     public static function seeder(?string $group = null)
     {
-        $config = config('Database');
+        $config = config(DbConfig::class);
 
         return new Seeder($config, static::connect($group));
     }

--- a/system/Database/Migration.php
+++ b/system/Database/Migration.php
@@ -46,7 +46,7 @@ abstract class Migration
      */
     public function __construct(?Forge $forge = null)
     {
-        $this->forge = $forge ?? Database::forge($this->DBGroup ?? config('Database')->defaultGroup);
+        $this->forge = $forge ?? Database::forge($this->DBGroup ?? config(Database::class)->defaultGroup);
 
         $this->db = $this->forge->getConnection();
     }

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -142,7 +142,7 @@ class MigrationRunner
         $this->namespace = APP_NAMESPACE;
 
         // get default database group
-        $config      = config('Database');
+        $config      = config(Database::class);
         $this->group = $config->defaultGroup;
         unset($config);
 
@@ -844,7 +844,7 @@ class MigrationRunner
         }
 
         $instance = new $class();
-        $group    = $instance->getDBGroup() ?? config('Database')->defaultGroup;
+        $group    = $instance->getDBGroup() ?? config(Database::class)->defaultGroup;
 
         if (ENVIRONMENT !== 'testing' && $group === 'tests' && $this->groupFilter !== 'tests') {
             // @codeCoverageIgnoreStart

--- a/system/Debug/Toolbar/Collectors/Config.php
+++ b/system/Debug/Toolbar/Collectors/Config.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
 use CodeIgniter\CodeIgniter;
+use Config\App;
 use Config\Services;
 
 /**
@@ -24,7 +25,7 @@ class Config
      */
     public static function display(): array
     {
-        $config = config('App');
+        $config = config(App::class);
 
         return [
             'ciVersion'   => CodeIgniter::CI_VERSION,

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Debug\Toolbar\Collectors;
 
 use CodeIgniter\Database\Query;
 use CodeIgniter\I18n\Time;
+use Config\Toolbar;
 
 /**
  * Collector for the Database tab of the Debug Toolbar.
@@ -78,7 +79,7 @@ class Database extends BaseCollector
      */
     public static function collect(Query $query)
     {
-        $config = config('Toolbar');
+        $config = config(Toolbar::class);
 
         // Provide default in case it's not set
         $max = $config->maxQueries ?: 100;

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -24,7 +24,7 @@ abstract class BaseHandler implements EncrypterInterface
      */
     public function __construct(?Encryption $config = null)
     {
-        $config ??= config('Encryption');
+        $config ??= config(Encryption::class);
 
         // make the parameters conveniently accessible
         foreach (get_object_vars($config) as $key => $value) {

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -71,8 +71,7 @@ class Events
             return;
         }
 
-        /** @var Modules $config */
-        $config = config('Modules');
+        $config = config(Modules::class);
         $events = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php';
         $files  = [];
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -106,7 +106,7 @@ class Filters
         $this->request = &$request;
         $this->setResponse($response);
 
-        $this->modules = $modules ?? config('Modules');
+        $this->modules = $modules ?? config(Modules::class);
 
         if ($this->modules->shouldDiscover('filters')) {
             $this->discoverFilters();

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -112,12 +112,12 @@ class CURLRequest extends OutgoingRequest
 
         parent::__construct('GET', $uri);
 
-        $this->responseOrig   = $response ?? new Response(config('App'));
+        $this->responseOrig   = $response ?? new Response(config(App::class));
         $this->baseURI        = $uri->useRawQueryString();
         $this->defaultOptions = $options;
 
         /** @var ConfigCURLRequest|null $configCURLRequest */
-        $configCURLRequest  = config('CURLRequest');
+        $configCURLRequest  = config(ConfigCURLRequest::class);
         $this->shareOptions = $configCURLRequest->shareOptions ?? true;
 
         $this->config = $this->defaultConfig;

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use Config\App;
 use Config\ContentSecurityPolicy as ContentSecurityPolicyConfig;
 
 /**
@@ -241,7 +242,7 @@ class ContentSecurityPolicy
      */
     public function __construct(ContentSecurityPolicyConfig $config)
     {
-        $appConfig        = config('App');
+        $appConfig        = config(App::class);
         $this->CSPEnabled = $appConfig->CSPEnabled;
 
         foreach (get_object_vars($config) as $setting => $value) {

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Exceptions\DownloadException;
 use CodeIgniter\Files\File;
+use Config\App;
 use Config\Mimes;
 
 /**
@@ -64,7 +65,7 @@ class DownloadResponse extends Response
      */
     public function __construct(string $filename, bool $setMime)
     {
-        parent::__construct(config('App'));
+        parent::__construct(config(App::class));
 
         $this->filename = $filename;
         $this->setMime  = $setMime;

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Validation\FormatRules;
+use Config\App;
 
 /**
  * Request Trait
@@ -63,7 +64,7 @@ trait RequestTrait
          * @deprecated $this->proxyIPs property will be removed in the future
          */
         // @phpstan-ignore-next-line
-        $proxyIPs = $this->proxyIPs ?? config('App')->proxyIPs;
+        $proxyIPs = $this->proxyIPs ?? config(App::class)->proxyIPs;
         // @phpstan-ignore-next-line
         if (! empty($proxyIPs) && (! is_array($proxyIPs) || is_int(array_key_first($proxyIPs)))) {
             throw new ConfigException(

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -16,6 +16,7 @@ use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
+use Config\Cookie as CookieConfig;
 use Config\Services;
 
 /**
@@ -172,7 +173,7 @@ class Response extends Message implements ResponseInterface
         }
 
         $this->cookieStore = new CookieStore([]);
-        Cookie::setDefaults(config('Cookie') ?? [
+        Cookie::setDefaults(config(CookieConfig::class) ?? [
             // @todo Remove this fallback when deprecated `App` members are removed
             'prefix'   => $config->cookiePrefix,
             'path'     => $config->cookiePath,

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -582,7 +582,7 @@ trait ResponseTrait
         }
 
         /** @var CookieConfig|null $cookieConfig */
-        $cookieConfig = config('Cookie');
+        $cookieConfig = config(CookieConfig::class);
 
         if ($cookieConfig instanceof CookieConfig) {
             $secure ??= $cookieConfig->secure;

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\HTTP;
 
 use BadMethodCallException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use Config\App;
 
 /**
  * Abstraction for a uniform resource identifier (URI).
@@ -622,7 +623,7 @@ class URI
     private function changeSchemeAndPath(string $scheme, string $path): array
     {
         // Check if this is an internal URI
-        $config  = config('App');
+        $config  = config(App::class);
         $baseUri = new self($config->baseURL);
 
         if (

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -69,10 +69,10 @@ if (! function_exists('get_cookie')) {
     {
         if ($prefix === '') {
             /** @var Cookie|null $cookie */
-            $cookie = config('Cookie');
+            $cookie = config(Cookie::class);
 
             // @TODO Remove Config\App fallback when deprecated `App` members are removed.
-            $prefix = $cookie instanceof Cookie ? $cookie->prefix : config('App')->cookiePrefix;
+            $prefix = $cookie instanceof Cookie ? $cookie->prefix : config(App::class)->cookiePrefix;
         }
 
         $request = Services::request();

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -10,7 +10,9 @@
  */
 
 use CodeIgniter\Validation\Exceptions\ValidationException;
+use Config\App;
 use Config\Services;
+use Config\Validation;
 
 // CodeIgniter Form Helpers
 
@@ -50,7 +52,7 @@ if (! function_exists('form_open')) {
             $attributes .= ' method="post"';
         }
         if (stripos($attributes, 'accept-charset=') === false) {
-            $config = config('App');
+            $config = config(App::class);
             $attributes .= ' accept-charset="' . strtolower($config->charset) . '"';
         }
 
@@ -718,7 +720,7 @@ if (! function_exists('validation_list_errors')) {
      */
     function validation_list_errors(string $template = 'list'): string
     {
-        $config = config('Validation');
+        $config = config(Validation::class);
         $view   = Services::renderer();
 
         if (! array_key_exists($template, $config->templates)) {
@@ -738,7 +740,7 @@ if (! function_exists('validation_show_error')) {
      */
     function validation_show_error(string $field, string $template = 'single'): string
     {
-        $config = config('Validation');
+        $config = config(Validation::class);
         $view   = Services::renderer();
 
         $errors = array_filter(validation_errors(), static fn ($key) => preg_match(

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -38,7 +38,7 @@ if (! function_exists('_get_uri')) {
         $appConfig = null;
         if ($config === null) {
             /** @var App $appConfig */
-            $appConfig = config('App');
+            $appConfig = config(App::class);
 
             if ($appConfig->baseURL === '') {
                 throw new InvalidArgumentException(
@@ -145,7 +145,7 @@ if (! function_exists('base_url')) {
     function base_url($relativePath = '', ?string $scheme = null): string
     {
         /** @var App $config */
-        $config = clone config('App');
+        $config = clone config(App::class);
 
         // Use the current baseURL for multiple domain support
         $request         = Services::request();
@@ -238,7 +238,7 @@ if (! function_exists('index_page')) {
     function index_page(?App $altConfig = null): string
     {
         // use alternate config if provided, else default one
-        $config = $altConfig ?? config('App');
+        $config = $altConfig ?? config(App::class);
 
         return $config->indexPage;
     }
@@ -258,7 +258,7 @@ if (! function_exists('anchor')) {
     function anchor($uri = '', string $title = '', $attributes = '', ?App $altConfig = null): string
     {
         // use alternate config if provided, else default one
-        $config = $altConfig ?? config('App');
+        $config = $altConfig ?? config(App::class);
 
         $siteUrl = is_array($uri) ? site_url($uri, null, $config) : (preg_match('#^(\w+:)?//#i', $uri) ? $uri : site_url($uri, null, $config));
         // eliminate trailing slash
@@ -291,7 +291,7 @@ if (! function_exists('anchor_popup')) {
     function anchor_popup($uri = '', string $title = '', $attributes = false, ?App $altConfig = null): string
     {
         // use alternate config if provided, else default one
-        $config = $altConfig ?? config('App');
+        $config = $altConfig ?? config(App::class);
 
         $siteUrl = preg_match('#^(\w+:)?//#i', $uri) ? $uri : site_url($uri, null, $config);
         $siteUrl = rtrim($siteUrl, '/');

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -15,6 +15,7 @@ use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Files\FileCollection;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Publisher\Exceptions\PublisherException;
+use Config\Publisher as PublisherConfig;
 use RuntimeException;
 use Throwable;
 
@@ -162,7 +163,7 @@ class Publisher extends FileCollection
         $this->replacer = new ContentReplacer();
 
         // Restrictions are intentionally not injected to prevent overriding
-        $this->restrictions = config('Publisher')->restrictions;
+        $this->restrictions = config(PublisherConfig::class)->restrictions;
 
         // Make sure the destination is allowed
         foreach (array_keys($this->restrictions) as $directory) {

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1265,8 +1265,7 @@ class RouteCollection implements RouteCollectionInterface
 
         // Check invalid locale
         if ($locale !== null) {
-            /** @var App $config */
-            $config = config('App');
+            $config = config(App::class);
             if (! in_array($locale, $config->supportedLocales, true)) {
                 $locale = null;
             }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -16,6 +16,8 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\Exceptions\RouterException;
+use Config\App;
+use Config\Feature;
 
 /**
  * Request router.
@@ -131,7 +133,7 @@ class Router implements RouterInterface
         $this->translateURIDashes = $this->collection->shouldTranslateURIDashes();
 
         if ($this->collection->shouldAutoRoute()) {
-            $autoRoutesImproved = config('Feature')->autoRoutesImproved ?? false;
+            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved ?? false;
             if ($autoRoutesImproved) {
                 $this->autoRouter = new AutoRouterImproved(
                     $this->collection->getRegisteredControllers('*'),
@@ -181,7 +183,7 @@ class Router implements RouterInterface
         // Checks defined routes
         if ($this->checkRoutes($uri)) {
             if ($this->collection->isFiltered($this->matchedRoute[0])) {
-                $multipleFiltersEnabled = config('Feature')->multipleFilters ?? false;
+                $multipleFiltersEnabled = config(Feature::class)->multipleFilters ?? false;
                 if ($multipleFiltersEnabled) {
                     $this->filtersInfo = $this->collection->getFiltersForRoute($this->matchedRoute[0]);
                 } else {
@@ -441,7 +443,7 @@ class Router implements RouterInterface
                     );
 
                     if ($this->collection->shouldUseSupportedLocalesOnly()
-                        && ! in_array($matched['locale'], config('App')->supportedLocales, true)) {
+                        && ! in_array($matched['locale'], config(App::class)->supportedLocales, true)) {
                         // Throw exception to prevent the autorouter, if enabled,
                         // from trying to find a route
                         throw PageNotFoundException::forLocaleNotSupported($matched['locale']);

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -172,7 +172,7 @@ class Security implements SecurityInterface
     public function __construct(App $config)
     {
         /** @var SecurityConfig|null $security */
-        $security = config('Security');
+        $security = config(SecurityConfig::class);
 
         // Store CSRF-related configurations
         if ($security instanceof SecurityConfig) {
@@ -223,7 +223,7 @@ class Security implements SecurityInterface
     private function configureCookie(App $config): void
     {
         /** @var CookieConfig|null $cookie */
-        $cookie = config('Cookie');
+        $cookie = config(CookieConfig::class);
 
         if ($cookie instanceof CookieConfig) {
             $cookiePrefix     = $cookie->prefix;

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -108,7 +108,7 @@ abstract class BaseHandler implements SessionHandlerInterface
     public function __construct(AppConfig $config, string $ipAddress)
     {
         /** @var SessionConfig|null $session */
-        $session = config('Session');
+        $session = config(SessionConfig::class);
 
         // Store Session configurations
         if ($session instanceof SessionConfig) {
@@ -123,7 +123,7 @@ abstract class BaseHandler implements SessionHandlerInterface
         }
 
         /** @var CookieConfig|null $cookie */
-        $cookie = config('Cookie');
+        $cookie = config(CookieConfig::class);
 
         if ($cookie instanceof CookieConfig) {
             // Session cookies have no prefix.

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -74,7 +74,7 @@ class DatabaseHandler extends BaseHandler
         parent::__construct($config, $ipAddress);
 
         /** @var SessionConfig|null $session */
-        $session = config('Session');
+        $session = config(SessionConfig::class);
 
         // Store Session configurations
         if ($session instanceof SessionConfig) {

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -59,7 +59,7 @@ class MemcachedHandler extends BaseHandler
         parent::__construct($config, $ipAddress);
 
         /** @var SessionConfig|null $session */
-        $session = config('Session');
+        $session = config(SessionConfig::class);
 
         $this->sessionExpiration = ($session instanceof SessionConfig)
             ? $session->expiration : $config->sessionExpiration;

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -72,7 +72,7 @@ class RedisHandler extends BaseHandler
         parent::__construct($config, $ipAddress);
 
         /** @var SessionConfig|null $session */
-        $session = config('Session');
+        $session = config(SessionConfig::class);
 
         // Store Session configurations
         if ($session instanceof SessionConfig) {

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -166,7 +166,7 @@ class Session implements SessionInterface
         $this->driver = $driver;
 
         /** @var SessionConfig|null $session */
-        $session = config('Session');
+        $session = config(SessionConfig::class);
 
         // Store Session configurations
         if ($session instanceof SessionConfig) {
@@ -195,7 +195,7 @@ class Session implements SessionInterface
         $this->cookieSameSite = $config->cookieSameSite ?? $this->cookieSameSite;
 
         /** @var CookieConfig $cookie */
-        $cookie = config('Cookie');
+        $cookie = config(CookieConfig::class);
 
         $this->cookie = (new Cookie($this->sessionCookieName, '', [
             'expires'  => $this->sessionExpiration === 0 ? 0 : Time::now()->getTimestamp() + $this->sessionExpiration,

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -25,6 +25,7 @@ use CodeIgniter\Test\Mock\MockEmail;
 use CodeIgniter\Test\Mock\MockSession;
 use Config\App;
 use Config\Autoload;
+use Config\Email;
 use Config\Modules;
 use Config\Services;
 use Exception;
@@ -323,7 +324,7 @@ abstract class CIUnitTestCase extends TestCase
      */
     protected function mockEmail()
     {
-        Services::injectMock('email', new MockEmail(config('Email')));
+        Services::injectMock('email', new MockEmail(config(Email::class)));
     }
 
     /**
@@ -333,7 +334,7 @@ abstract class CIUnitTestCase extends TestCase
     {
         $_SESSION = [];
 
-        $config  = config('App');
+        $config  = config(App::class);
         $session = new MockSession(new ArrayHandler($config, '0.0.0.0'), $config);
 
         Services::injectMock('session', $session);

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -96,7 +96,7 @@ trait ControllerTestTrait
         helper('url');
 
         if (empty($this->appConfig)) {
-            $this->appConfig = config('App');
+            $this->appConfig = config(App::class);
         }
 
         if (! $this->uri instanceof URI) {

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -96,7 +96,7 @@ trait ControllerTester
     protected function setUpControllerTester(): void
     {
         if (empty($this->appConfig)) {
-            $this->appConfig = config('App');
+            $this->appConfig = config(App::class);
         }
 
         if (! $this->uri instanceof URI) {

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Test;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Model;
+use Config\App;
 use Faker\Factory;
 use Faker\Generator;
 use InvalidArgumentException;
@@ -114,7 +115,7 @@ class Fabricator
 
         // If no locale was specified then use the App default
         if ($locale === null) {
-            $locale = config('App')->defaultLocale;
+            $locale = config(App::class)->defaultLocale;
         }
 
         // There is no easy way to retrieve the locale from Faker so we will store it

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -18,6 +18,7 @@ use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\RouteCollection;
+use Config\App;
 use Config\Services;
 use Exception;
 use ReflectionException;
@@ -291,7 +292,7 @@ class FeatureTestCase extends CIUnitTestCase
      */
     protected function setupRequest(string $method, ?string $path = null): IncomingRequest
     {
-        $config = config('App');
+        $config = config(App::class);
         $uri    = new URI(rtrim($config->baseURL, '/') . '/' . trim($path, '/ '));
 
         $request      = new IncomingRequest($config, clone $uri, null, new UserAgent());

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -98,7 +98,7 @@ trait FilterTestTrait
         $this->response ??= clone Services::response();
 
         // Create our config and Filters instance to reuse for performance
-        $this->filtersConfig ??= config('Filters');
+        $this->filtersConfig ??= config(FiltersConfig::class);
         $this->filters ??= new Filters($this->filtersConfig, $this->request, $this->response);
 
         if ($this->collection === null) {

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -11,6 +11,8 @@
 
 namespace CodeIgniter\Typography;
 
+use Config\DocTypes;
+
 /**
  * Typography Class
  */
@@ -324,7 +326,7 @@ class Typography
         $newstr = '';
 
         for ($ex = explode('pre>', $str), $ct = count($ex), $i = 0; $i < $ct; $i++) {
-            $xhtml = ! (config('DocTypes')->html5 ?? false);
+            $xhtml = ! (config(DocTypes::class)->html5 ?? false);
             $newstr .= (($i % 2) === 0) ? nl2br($ex[$i], $xhtml) : $ex[$i];
 
             if ($ct - 1 !== $i) {

--- a/system/View/ViewDecoratorTrait.php
+++ b/system/View/ViewDecoratorTrait.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\View;
 
 use CodeIgniter\View\Exceptions\ViewException;
+use Config\View as ViewConfig;
 
 trait ViewDecoratorTrait
 {
@@ -21,7 +22,7 @@ trait ViewDecoratorTrait
      */
     protected function decorateOutput(string $html): string
     {
-        $decorators = \config('View')->decorators;
+        $decorators = \config(ViewConfig::class)->decorators;
 
         foreach ($decorators as $decorator) {
             if (! is_subclass_of($decorator, ViewDecoratorInterface::class)) {


### PR DESCRIPTION
**Description**
`::class` keyword is better than string for IDE or static analysis.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
