### PR TITLE
refactor: drop support for `Config\App::$proxyIPs = ''`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -92,6 +92,8 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/system/Debug/Exceptions.php',
             // @TODO remove if deprecated $httpVerb is removed
             __DIR__ . '/system/Router/AutoRouterImproved.php',
+            // @TODO remove if deprecated $config is removed
+            __DIR__ . '/system/HTTP/Request.php',
         ],
 
         // check on constant compare

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -22,6 +22,15 @@ class Request extends OutgoingRequest implements RequestInterface
     use RequestTrait;
 
     /**
+     * Proxy IPs
+     *
+     * @var array<string, string>
+     *
+     * @deprecated 4.0.5 No longer used. Check the App config directly
+     */
+    protected $proxyIPs;
+
+    /**
      * Constructor.
      *
      * @param App $config

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -35,7 +35,7 @@ class Request extends OutgoingRequest implements RequestInterface
      *
      * @param App $config
      *
-     * @deprecated The $config is no longer needed and will be removed in a future version
+     * @deprecated 4.0.5 The $config is no longer needed and will be removed in a future version
      */
     public function __construct($config = null) // @phpstan-ignore-line
     {
@@ -54,7 +54,7 @@ class Request extends OutgoingRequest implements RequestInterface
      * @param string $ip    IP Address
      * @param string $which IP protocol: 'ipv4' or 'ipv6'
      *
-     * @deprecated Use Validation instead
+     * @deprecated 4.0.5 Use Validation instead
      *
      * @codeCoverageIgnore
      */
@@ -68,7 +68,7 @@ class Request extends OutgoingRequest implements RequestInterface
      *
      * @param bool $upper Whether to return in upper or lower case.
      *
-     * @deprecated The $upper functionality will be removed and this will revert to its PSR-7 equivalent
+     * @deprecated 4.0.5 The $upper functionality will be removed and this will revert to its PSR-7 equivalent
      *
      * @codeCoverageIgnore
      */
@@ -82,7 +82,7 @@ class Request extends OutgoingRequest implements RequestInterface
      *
      * @return $this
      *
-     * @deprecated Use withMethod() instead for immutability
+     * @deprecated 4.0.5 Use withMethod() instead for immutability
      *
      * @codeCoverageIgnore
      */

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -22,28 +22,14 @@ class Request extends OutgoingRequest implements RequestInterface
     use RequestTrait;
 
     /**
-     * Proxy IPs
-     *
-     * @var array<string, string>
-     *
-     * @deprecated Check the App config directly
-     */
-    protected $proxyIPs;
-
-    /**
      * Constructor.
      *
      * @param App $config
      *
      * @deprecated The $config is no longer needed and will be removed in a future version
      */
-    public function __construct($config = null)
+    public function __construct($config = null) // @phpstan-ignore-line
     {
-        /**
-         * @deprecated $this->proxyIps property will be removed in the future
-         */
-        $this->proxyIPs = $config->proxyIPs;
-
         if (empty($this->method)) {
             $this->method = $this->getServer('REQUEST_METHOD') ?? 'GET';
         }

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -60,17 +60,8 @@ trait RequestTrait
             'valid_ip',
         ];
 
-        /**
-         * @deprecated $this->proxyIPs property will be removed in the future
-         */
-        // @phpstan-ignore-next-line
-        $proxyIPs = $this->proxyIPs ?? config(App::class)->proxyIPs;
-        // @phpstan-ignore-next-line
+        $proxyIPs = config(App::class)->proxyIPs;
 
-        // Workaround for old Config\App file. App::$proxyIPs may be empty string.
-        if ($proxyIPs === '') {
-            $proxyIPs = [];
-        }
         if (! empty($proxyIPs) && (! is_array($proxyIPs) || is_int(array_key_first($proxyIPs)))) {
             throw new ConfigException(
                 'You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.'

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\Files\UploadedFile;
@@ -973,7 +974,8 @@ final class IncomingRequestTest extends CIUnitTestCase
             '10.0.1.200'     => 'X-Forwarded-For',
             '192.168.5.0/24' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
+        Factories::injectMock('config', App::class, $config);
+        $this->request = new Request();
         $this->request->populateHeaders();
 
         // we should see the original forwarded address
@@ -990,7 +992,8 @@ final class IncomingRequestTest extends CIUnitTestCase
         $config->proxyIPs = [
             '2001:db8::2:1' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
+        Factories::injectMock('config', App::class, $config);
+        $this->request = new Request();
         $this->request->populateHeaders();
 
         // we should see the original forwarded address
@@ -1075,7 +1078,8 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $config           = new App();
         $config->proxyIPs = ['192.168.5.0/24' => 'X-Forwarded-For'];
-        $this->request    = new Request($config);
+        Factories::injectMock('config', App::class, $config);
+        $this->request = new Request();
         $this->request->populateHeaders();
 
         // we should see the original forwarded address
@@ -1090,7 +1094,8 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $config           = new App();
         $config->proxyIPs = ['2001:db8:1234::/48' => 'X-Forwarded-For'];
-        $this->request    = new Request($config);
+        Factories::injectMock('config', App::class, $config);
+        $this->request = new Request();
         $this->request->populateHeaders();
 
         // we should see the original forwarded address
@@ -1166,7 +1171,8 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $config           = new App();
         $config->proxyIPs = ['192.168.5.0/28'];
-        $this->request    = new Request($config);
+        Factories::injectMock('config', App::class, $config);
+        $this->request = new Request();
         $this->request->populateHeaders();
 
         $this->request->getIPAddress();

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 
@@ -616,7 +617,8 @@ final class RequestTest extends CIUnitTestCase
             '10.0.1.200'     => 'X-Forwarded-For',
             '192.168.5.0/24' => 'X-Forwarded-For',
         ];
-        $this->request = new Request($config);
+        Factories::injectMock('config', App::class, $config);
+        $this->request = new Request();
         $this->request->populateHeaders();
 
         // we should see the original forwarded address
@@ -667,7 +669,8 @@ final class RequestTest extends CIUnitTestCase
 
         $config           = new App();
         $config->proxyIPs = ['192.168.5.0/24' => 'X-Forwarded-For'];
-        $this->request    = new Request($config);
+        Factories::injectMock('config', App::class, $config);
+        $this->request = new Request();
         $this->request->populateHeaders();
 
         // we should see the original forwarded address

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -137,6 +137,7 @@ Changes
 - **Config:** The deprecated Session items in **app/Config/App.php** has been removed.
 - **Config:** Routing settings have been moved to **app/Config/Routing.php** config file.
   See :ref:`Upgrading Guide <upgrade-440-config-routing>`.
+- **Request:** The deprecated property ``$proxyIPs`` has been removed.
 - **DownloadResponse:** When generating response headers, does not replace the ``Content-Disposition`` header if it was previously specified.
 - **Autoloader:** Before v4.4.0, CodeIgniter autoloader did not allow special
   characters that are illegal in filenames on certain operating systems.

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -137,7 +137,6 @@ Changes
 - **Config:** The deprecated Session items in **app/Config/App.php** has been removed.
 - **Config:** Routing settings have been moved to **app/Config/Routing.php** config file.
   See :ref:`Upgrading Guide <upgrade-440-config-routing>`.
-- **Request:** The deprecated property ``$proxyIPs`` has been removed.
 - **DownloadResponse:** When generating response headers, does not replace the ``Content-Disposition`` header if it was previously specified.
 - **Autoloader:** Before v4.4.0, CodeIgniter autoloader did not allow special
   characters that are illegal in filenames on certain operating systems.

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -72,6 +72,12 @@ Mandatory File Changes
 Config Files
 ============
 
+app/Config/App.php
+------------------
+
+- The property ``$proxyIPs`` must be an array. If you don't use proxy servers,
+  it must be ``public array $proxyIPs = [];``.
+
 .. _upgrade-440-config-routing:
 
 app/Config/Routing.php


### PR DESCRIPTION
~~Needs #7620~~

**Description**
- ~~remove `Request::$proxyIPs`~~
- drop support for `Config\App::$proxyIPs = ''` (old Config file)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
