### PR TITLE
fix: skip http proxy added header

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -387,6 +387,10 @@ class CURLRequest extends OutgoingRequest
             $output = substr($output, strpos($output, $breakString) + 4);
         }
 
+        if (strpos($output, 'HTTP/1.1 200 Connection established') === 0) {
+            $output = substr($output, strpos($output, $breakString) + 4);
+        }
+
         // If request and response have Digest
         if (isset($this->config['auth'][2]) && $this->config['auth'][2] === 'digest' && strpos($output, 'WWW-Authenticate: Digest') !== false) {
             $output = substr($output, strpos($output, $breakString) + 4);

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -725,7 +725,7 @@ final class CURLRequestTest extends CIUnitTestCase
             'delay'    => 100,
         ]);
 
-        $request->setOutput("HTTP/1.1 200 Connection established:\x0d\x0a\x0d\x0aHi there");
+        $request->setOutput("HTTP/1.1 200 Connection established\x0d\x0a\x0d\x0aHi there");
         $response = $request->get('answer');
         $this->assertSame('Hi there', $response->getBody());
     }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -718,6 +718,18 @@ final class CURLRequestTest extends CIUnitTestCase
         $this->assertSame('Hi there', $response->getBody());
     }
 
+    public function testSendProxied()
+    {
+        $request = $this->getRequest([
+            'base_uri' => 'http://www.foo.com/api/v1/',
+            'delay'    => 100,
+        ]);
+
+        $request->setOutput("HTTP/1.1 200 Connection established:\x0d\x0a\x0d\x0aHi there");
+        $response = $request->get('answer');
+        $this->assertSame('Hi there', $response->getBody());
+    }
+
     /**
      * See: https://github.com/codeigniter4/CodeIgniter4/issues/3261
      */

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -718,18 +718,6 @@ final class CURLRequestTest extends CIUnitTestCase
         $this->assertSame('Hi there', $response->getBody());
     }
 
-    public function testSendProxied()
-    {
-        $request = $this->getRequest([
-            'base_uri' => 'http://www.foo.com/api/v1/',
-            'delay'    => 100,
-        ]);
-
-        $request->setOutput("HTTP/1.1 200 Connection established\x0d\x0a\x0d\x0aHi there");
-        $response = $request->get('answer');
-        $this->assertSame('Hi there', $response->getBody());
-    }
-
     /**
      * See: https://github.com/codeigniter4/CodeIgniter4/issues/3261
      */
@@ -775,6 +763,21 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
 
         $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testSendProxied()
+    {
+        $request = $this->getRequest([
+            'base_uri' => 'http://www.foo.com/api/v1/',
+            'delay'    => 100,
+        ]);
+
+        $output = "HTTP/1.1 200 Connection established
+Proxy-Agent: Fortinet-Proxy/1.0\x0d\x0a\x0d\x0aHTTP/1.1 200 OK\x0d\x0a\x0d\x0aHi there";
+        $request->setOutput($output);
+
+        $response = $request->get('answer');
+        $this->assertSame('Hi there', $response->getBody());
     }
 
     /**


### PR DESCRIPTION
**Description**

This pull request addresses the HTTP proxy problem by adding a new conditional statement to the code. Specifically, the code checks if the output string begins with `HTTP/1.1 200 Connection established`.


For example, when the output string contains the following header:


```sh
HTTP/1.1 200 Connection established
Proxy-Agent: Fortinet-Proxy/1.0
```

If it does, then the code uses `substr` function to remove the initial part of the string up to the specified `$breakString`, which helps in handling the HTTP proxy issue. The added code segment is as follows:

```php
if (strpos($output, 'HTTP/1.1 200 Connection established') === 0) {
    $output = substr($output, strpos($output, $breakString) + 4);
}
```

This change ensures that the HTTP proxy connection is handled properly and the code runs smoothly without any errors.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
