### PR TITLE
fix: sqlsrv default port cause connection refuse

### DIFF
--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -121,7 +121,7 @@ class Connection extends BaseConnection
             unset($connection['UID'], $connection['PWD']);
         }
 
-        if (strpos($this->hostname, ',') === false && $this->port !== '') {
+        if (strpos($this->hostname, ',') === false && $this->port !== '' && (int)$this->port !== 1433) {
             $this->hostname .= ', ' . $this->port;
         }
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -121,7 +121,7 @@ class Connection extends BaseConnection
             unset($connection['UID'], $connection['PWD']);
         }
 
-        if (strpos($this->hostname, ',') === false && $this->port !== '' && (int) $this->port !== 1433) {
+        if (strpos($this->hostname, ',') === false && $this->port !== '') {
             $this->hostname .= ', ' . $this->port;
         }
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -121,7 +121,7 @@ class Connection extends BaseConnection
             unset($connection['UID'], $connection['PWD']);
         }
 
-        if (strpos($this->hostname, ',') === false && $this->port !== '' && (int)$this->port !== 1433) {
+        if (strpos($this->hostname, ',') === false && $this->port !== '' && (int) $this->port !== 1433) {
             $this->hostname .= ', ' . $this->port;
         }
 

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -174,7 +174,7 @@ Explanation of Values:
 **compress**    Whether or not to use client compression (``MySQLi`` only).
 **strictOn**    true/false (boolean) - Whether to force "Strict Mode" connections, good for ensuring strict SQL
                 while developing an application (``MySQLi`` only).
-**port**        The database port number - Empty for default port (or dynamic port with ``SQLSRV``)
+**port**        The database port number - Empty string ``''`` for default port (or dynamic port with ``SQLSRV``).
 **foreignKeys** true/false (boolean) - Whether or not to enable Foreign Key constraint (``SQLite3`` only).
 
                 .. important:: SQLite3 Foreign Key constraint is disabled by default.

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -174,7 +174,7 @@ Explanation of Values:
 **compress**    Whether or not to use client compression (``MySQLi`` only).
 **strictOn**    true/false (boolean) - Whether to force "Strict Mode" connections, good for ensuring strict SQL
                 while developing an application (``MySQLi`` only).
-**port**        The database port number.
+**port**        The database port number - Empty for default port (or dynamic port with ``SQLSRV``)
 **foreignKeys** true/false (boolean) - Whether or not to enable Foreign Key constraint (``SQLite3`` only).
 
                 .. important:: SQLite3 Foreign Key constraint is disabled by default.


### PR DESCRIPTION
**Description**
database connection is refused when using sqlsrv driver with default port. 
fixed by ignoring the default port ( 1433 )

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide

Fixes: https://github.com/codeigniter4/CodeIgniter4/issues/6165