### PR TITLE
docs: fix incorrect description on RedirectException

### DIFF
--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -109,7 +109,7 @@ forcing a redirect to a specific route or URL:
 
 .. literalinclude:: errors/010.php
 
-``$route`` may be a named route, relative URI, or a complete URL. You can also supply a
+``$uri`` may be a URI path relative to baseURL, or a complete URL. You can also supply a
 redirect code to use instead of the default (``302``, "temporary redirect"):
 
 .. literalinclude:: errors/011.php

--- a/user_guide_src/source/general/errors/010.php
+++ b/user_guide_src/source/general/errors/010.php
@@ -1,3 +1,3 @@
 <?php
 
-throw new \CodeIgniter\Router\Exceptions\RedirectException($route);
+throw new \CodeIgniter\Router\Exceptions\RedirectException($uri);

--- a/user_guide_src/source/general/errors/011.php
+++ b/user_guide_src/source/general/errors/011.php
@@ -1,3 +1,3 @@
 <?php
 
-throw new \CodeIgniter\Router\Exceptions\RedirectException($route, 301);
+throw new \CodeIgniter\Router\Exceptions\RedirectException($uri, 301);


### PR DESCRIPTION
**Description**
Fixes #7628

A named route cannot be used with RedirectException.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
