### PR TITLE
docs: fix incorrect description on RedirectException (2)

### DIFF
--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -109,7 +109,7 @@ forcing a redirect to a specific route or URL:
 
 .. literalinclude:: errors/010.php
 
-``$uri`` may be a URI path relative to baseURL, or a complete URL. You can also supply a
+``$uri`` is a URI path relative to baseURL. You can also supply a
 redirect code to use instead of the default (``302``, "temporary redirect"):
 
 .. literalinclude:: errors/011.php

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -105,7 +105,7 @@ RedirectException
 -----------------
 
 This exception is a special case allowing for overriding of all other response routing and
-forcing a redirect to a specific route or URL:
+forcing a redirect to a specific URI:
 
 .. literalinclude:: errors/010.php
 


### PR DESCRIPTION
**Description**
Follow-up #7629
Ref https://github.com/codeigniter4/CodeIgniter4/issues/7628#issuecomment-1610451937

A complete URL will be converted to baseURL by `base_url()`. So it cannot be used with RedirectException since v4.0.0.

```php
<?php

namespace App\Controllers;

use CodeIgniter\Router\Exceptions\RedirectException;

class Home extends BaseController
{
    public function index()
    {
        throw new RedirectException('https://codeigniter.com/foo/bar');
    }
}
```
```
$ curl -v http://localhost:8080/
*   Trying 127.0.0.1:8080...
* connect to 127.0.0.1 port 8080 failed: Connection refused
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.87.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Host: localhost:8080
< Date: Wed, 28 Jun 2023 01:33:53 GMT
< Connection: close
< X-Powered-By: PHP/8.1.20
< Cache-Control: no-store, max-age=0, no-cache
< Content-Type: text/html; charset=UTF-8
< Location: http://localhost:8080/foo/bar  <-- Look here
< 
* Closing connection 0
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
