### PR TITLE
config: change default value of CURLRequest::$shareOptions

### DIFF
--- a/app/Config/CURLRequest.php
+++ b/app/Config/CURLRequest.php
@@ -16,5 +16,5 @@ class CURLRequest extends BaseConfig
      * If true, all the options won't be reset between requests.
      * It may cause an error request with unnecessary headers.
      */
-    public bool $shareOptions = true;
+    public bool $shareOptions = false;
 }

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -153,6 +153,8 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
+- app/Config/CURLRequest.php
+    - The default value of :ref:`$shareOptions <curlrequest-sharing-options>` has been change to ``false``.
 - app/Config/Exceptions.php
     - Added the new method ``handler()`` that define custom Exception Handlers.
       See :ref:`custom-exception-handlers`.

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -23,16 +23,22 @@ to change very little to move over to use Guzzle.
 Config for CURLRequest
 **********************
 
+.. _curlrequest-sharing-options:
+
 Sharing Options
 ===============
 
-Due to historical reasons, by default, the CURLRequest shares all the options between requests.
-If you send more than one request with an instance of the class,
-this behavior may cause an error request with unnecessary headers and body.
+.. note:: Since v4.4.0, the default value has been changed to ``false``. This
+    setting exists only for backward compatibility. New users do not need to
+    change the setting.
 
-You can change the behavior by editing the following config parameter value in **app/Config/CURLRequest.php** to ``false``:
+If you want to share all the options between requests, set ``$shareOptions`` to
+``true`` in **app/Config/CURLRequest.php**:
 
 .. literalinclude:: curlrequest/001.php
+
+If you send more than one request with an instance of the class, this behavior
+may cause an error request with unnecessary headers and body.
 
 .. note:: Before v4.2.0, the request body is not reset even if ``$shareOptions`` is false due to a bug.
 

--- a/user_guide_src/source/libraries/curlrequest/001.php
+++ b/user_guide_src/source/libraries/curlrequest/001.php
@@ -6,7 +6,6 @@ use CodeIgniter\Config\BaseConfig;
 
 class CURLRequest extends BaseConfig
 {
-    public $shareOptions = false;
-
     // ...
+    public bool $shareOptions = true;
 }


### PR DESCRIPTION
**Description**
This should be `false`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
