### PR TITLE
fix: number_to_roman() param type

### DIFF
--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -173,9 +173,9 @@ if (! function_exists('number_to_roman')) {
     /**
      * Convert a number to a roman numeral.
      *
-     * @param string $num it will convert to int
+     * @param int|string $num it will convert to int
      */
-    function number_to_roman(string $num): ?string
+    function number_to_roman($num): ?string
     {
         static $map = [
             'M'  => 1000,

--- a/user_guide_src/source/helpers/number_helper.rst
+++ b/user_guide_src/source/helpers/number_helper.rst
@@ -92,7 +92,7 @@ The following functions are available:
 
 .. php:function:: number_to_roman($num)
 
-    :param string $num: The number want to convert
+    :param int|string $num: The number want to convert
     :returns: The roman number converted from given parameter
     :rtype: string|null
 
@@ -101,4 +101,4 @@ The following functions are available:
     .. literalinclude:: number_helper/009.php
 
     This function only handles numbers in the range 1 through 3999.
-    It will return null for any value outside that range.
+    It will return ``null`` for any value outside that range.

--- a/user_guide_src/source/helpers/number_helper/009.php
+++ b/user_guide_src/source/helpers/number_helper/009.php
@@ -1,5 +1,5 @@
 <?php
 
-echo number_to_roman(23);  // Returns XXIII
-echo number_to_roman(324);  // Returns CCCXXIV
+echo number_to_roman(23);    // Returns XXIII
+echo number_to_roman(324);   // Returns CCCXXIV
 echo number_to_roman(2534);  // Returns MMDXXXIV


### PR DESCRIPTION
**Description**
- fix param type for `$num`

```php
<?php
declare(strict_types=1);
namespace App\Controllers;
class Home extends BaseController
{
    public function index()
    {
        helper('number');
        echo number_to_roman(23);
    }
}
```
The above code causes the type error:
```
TypeError
number_to_roman(): Argument #1 ($num) must be of type string, int given
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
