### PR TITLE
docs: add @phpstan-ignore-next-line in number_to_size()

### DIFF
--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -24,8 +24,10 @@ if (! function_exists('number_to_size')) {
     {
         // Strip any formatting & ensure numeric input
         try {
+            // @phpstan-ignore-next-line
             $num = 0 + str_replace(',', '', $num);
         } catch (ErrorException $ee) {
+            // Catch "Warning:  A non-numeric value encountered"
             return false;
         }
 


### PR DESCRIPTION
**Description**
phpstan 1.10.22

```
 ------ ------------------------------------------------------------------------------------- 
  Line   system/Helpers/number_helper.php                                                     
 ------ ------------------------------------------------------------------------------------- 
  27     Binary operation "+" between 0 and (array<int, string>|string) results in an error.  
 ------ ------------------------------------------------------------------------------------- 
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
