### PR TITLE
feat: improve View route output

### DIFF
--- a/system/Router/DefinedRouteCollector.php
+++ b/system/Router/DefinedRouteCollector.php
@@ -51,7 +51,9 @@ final class DefinedRouteCollector
                 if (is_string($handler) || $handler instanceof Closure) {
 
                     if ($handler instanceof Closure) {
-                        $handler = '(Closure)';
+                        $view = $this->routeCollection->getRoutesOptions($route, $method)['view'] ?? false;
+
+                        $handler = $view ? '(View) ' . $view : '(Closure)';
                     }
 
                     $routeName = $this->routeCollection->getRoutesOptions($route)['as'] ?? $route;

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1101,7 +1101,10 @@ class RouteCollection implements RouteCollectionInterface
             ->setData(['segments' => $data], 'raw')
             ->render($view, $options);
 
-        $this->create('get', $from, $to, $options);
+        $routeOptions = $options ?? [];
+        $routeOptions = array_merge($routeOptions, ['view' => $view]);
+
+        $this->create('get', $from, $to, $routeOptions);
 
         return $this;
     }

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1649,7 +1649,7 @@ class RouteCollection implements RouteCollectionInterface
      *     array{
      *         filter?: string|list<string>, namespace?: string, hostname?: string,
      *         subdomain?: string, offset?: int, priority?: int, as?: string,
-     *         redirect?: string
+     *         redirect?: int
      *     }
      * >
      */

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -82,7 +82,7 @@ final class DefinedRouteCollectorTest extends CIUnitTestCase
                 'method'  => 'get',
                 'route'   => 'about',
                 'name'    => 'about',
-                'handler' => '(Closure)',
+                'handler' => '(View) pages/about',
             ],
         ];
         $this->assertSame($expected, $definedRoutes);

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -83,8 +83,17 @@ Enhancements
 Commands
 ========
 
-- Now ``spark routes`` command can specify the host in the request URL.
-  See :ref:`routing-spark-routes-specify-host`.
+- **spark routes:**
+    - Now you can specify the host in the request URL.
+      See :ref:`routing-spark-routes-specify-host`.
+    - It shows view files of :ref:`view-routes` in *Handler* like the following:
+
+        +---------+-------------+------+------------------------------+----------------+---------------+
+        | Method  | Route       | Name | Handler                      | Before Filters | After Filters |
+        +---------+-------------+------+------------------------------+----------------+---------------+
+        | GET     | about       | »    | (View) pages/about           |                | toolbar       |
+        +---------+-------------+------+------------------------------+----------------+---------------+
+
 
 Testing
 =======
@@ -151,6 +160,7 @@ Others
 - **Error Handling:** Now you can use :ref:`custom-exception-handlers`.
 - **RedirectException:** can also take an object that implements ResponseInterface as its first argument.
 - **RedirectException:** implements ResponsableInterface.
+- **DebugBar:** Now :ref:`view-routes` are displayed in *DEFINED ROUTES* on the *Routes* tab.
 
 Message Changes
 ***************


### PR DESCRIPTION
~~Needs #7653~~

**Description**
- improve `spark routes` output for View routes
- DebugBar shows View routes

```php
$routes->view('about', 'pages/about');
```

```
+---------+-------------+------+------------------------------+----------------+---------------+
| Method  | Route       | Name | Handler                      | Before Filters | After Filters |
+---------+-------------+------+------------------------------+----------------+---------------+
| GET     | about       | »    | (View) pages/about           |                | toolbar       |
+---------+-------------+------+------------------------------+----------------+---------------+
```

![Screenshot 2023-07-04 13 18 24](https://github.com/codeigniter4/CodeIgniter4/assets/87955/2658dcbf-b371-4145-bfc8-0fdc06fd3874)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
