### PR TITLE
docs: Suppress phpstan error in AutoRouterImproved

### DIFF
--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -298,7 +298,7 @@ final class AutoRouterImproved implements AutoRouterInterface
             if ($params === []) {
                 $this->paramPos = null;
             }
-            if ($this->paramPos !== null) {
+            if ($this->paramPos !== null) { // @phpstan-ignore-line
                 $this->paramPos++;
             }
 


### PR DESCRIPTION
**Description**
The following error is a false positive.
See AutoRouterImprovedTest::testFindsControllerAndMethodAndParam().
    
      ------ ---------------------------------------------------------------
      Line   system/Router/AutoRouterImproved.php
     ------ ---------------------------------------------------------------
      301    Strict comparison using !== between null and null will always
             evaluate to false.
     ------ ---------------------------------------------------------------
https://github.com/codeigniter4/CodeIgniter4/actions/runs/5449192482/jobs/9913186865

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
