### PR TITLE
docs: [4.4] fix Rector's incorrect refactoring

### DIFF
--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -46,6 +46,8 @@ final class AutoRouterImproved implements AutoRouterInterface
 
     /**
      * An array of params to the controller method.
+     *
+     * @phpstan-var list<string>
      */
     private array $params = [];
 
@@ -72,6 +74,8 @@ final class AutoRouterImproved implements AutoRouterInterface
 
     /**
      * The URI segments.
+     *
+     * @phpstan-var list<string>
      */
     private array $segments = [];
 
@@ -279,6 +283,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         }
 
         // The first item may be a method name.
+        /** @phpstan-var list<string> $params */
         $params = $this->params;
 
         $methodParam = array_shift($params);


### PR DESCRIPTION
**Description**
Related #7649

The following refactoring will break the code. 

Two tests will fail:
- AutoRouterImprovedTest::testFindsControllerAndMethodAndParam()
- AutoRouterImprovedTest::testPermitsURIWithUnderscoreParam()

```diff
1) system/Router/AutoRouterImproved.php:294

    ---------- begin diff ----------
@@ @@

             // Update the positions.
             $this->methodPos = $this->paramPos;
-            if ($params === []) {
-                $this->paramPos = null;
-            }
+            $this->paramPos = null;
             if ($this->paramPos !== null) {
                 $this->paramPos++;
             }
    ----------- end diff -----------

Applied rules:
 * RemoveAlwaysTrueIfConditionRector
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/5449192482/jobs/9913186865

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
