### PR TITLE
fix: `url_to()` error message

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1239,6 +1239,11 @@ class RouteCollection implements RouteCollectionInterface
         // Build our resulting string, inserting the $params in
         // the appropriate places.
         foreach ($matches[0] as $index => $pattern) {
+            if (! isset($params[$index])) {
+                throw new InvalidArgumentException(
+                    'Missing argument for "' . $pattern . '" in route "' . $from . '".'
+                );
+            }
             if (! preg_match('#^' . $pattern . '$#u', $params[$index])) {
                 throw RouterException::forInvalidParameterType();
             }

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\HTTP\URI;
 use CodeIgniter\Router\Exceptions\RouterException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use InvalidArgumentException;
 
 /**
  * @backupGlobals enabled
@@ -899,5 +900,21 @@ final class MiscUrlTest extends CIUnitTestCase
             'http://example.com/index.php/en/path/string/to/13',
             url_to('path-to', 'string', 13, 'en')
         );
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/7651
+     */
+    public function testUrlToMissingArgument()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing argument for "([a-zA-Z]+)" in route "([a-zA-Z]+)/login".');
+
+        $routes = Services::routes();
+        $routes->group('(:alpha)', static function ($routes) {
+            $routes->match(['get'], 'login', 'Common\LoginController::loginView', ['as' => 'loginURL']);
+        });
+
+        url_to('loginURL');
     }
 }


### PR DESCRIPTION
**Description**
Fixes #7651

Before:
> Undefined array key 0

After:
> Missing argument for "([a-zA-Z]+)" in route "([a-zA-Z]+)/login".

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
