### PR TITLE
docs: improve sample code in Database Configuration

### DIFF
--- a/user_guide_src/source/database/configuration/008.php
+++ b/user_guide_src/source/database/configuration/008.php
@@ -4,14 +4,20 @@ namespace Config;
 
 use CodeIgniter\Database\Config;
 
+/**
+ * Database Configuration
+ */
 class Database extends Config
 {
+    // ...
     public $development = [/* ... */];
     public $test        = [/* ... */];
     public $production  = [/* ... */];
 
     public function __construct()
     {
+        // ...
+
         $this->defaultGroup = ENVIRONMENT;
     }
 }


### PR DESCRIPTION
**Description**
If devs copy and paste the constructor, it won't work becaseu `parent::__construct();` is missing.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
