### PR TITLE
fix: [4.4] merge conflict in RouteCollection

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1328,7 +1328,7 @@ class RouteCollection implements RouteCollectionInterface
         foreach ($matches[0] as $index => $pattern) {
             if (! isset($params[$index])) {
                 throw new InvalidArgumentException(
-                    'Missing argument for "' . $pattern . '" in route "' . $from . '".'
+                    'Missing argument for "' . $pattern . '" in route "' . $routeKey . '".'
                 );
             }
             if (! preg_match('#^' . $pattern . '$#u', $params[$index])) {


### PR DESCRIPTION
**Description**
4.4 is broken now. 

- fix merge conflicts from #7652 by https://github.com/codeigniter4/CodeIgniter4/commit/37449d3d3d958c84a506067fd655336a21a7dfa4

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
