### PR TITLE
Normalize data provider names

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,6 +44,10 @@ $finder = Finder::create()
     ]);
 
 $overrides = [
+    'php_unit_data_provider_name' => [
+        'prefix' => 'provide',
+        'suffix' => '',
+    ],
     'php_unit_data_provider_return_type' => true,
     'no_extra_blank_lines'               => [
         'tokens' => [

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -30,6 +30,10 @@ $finder = Finder::create()
     ]);
 
 $overrides = [
+    'php_unit_data_provider_name' => [
+        'prefix' => 'provide',
+        'suffix' => '',
+    ],
     'php_unit_data_provider_return_type' => true,
     'no_extra_blank_lines'               => [
         'tokens' => [

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -53,6 +53,10 @@ $overrides = [
             'use',
         ],
     ],
+    'php_unit_data_provider_name' => [
+        'prefix' => 'provide',
+        'suffix' => '',
+    ],
 ];
 
 $options = [

--- a/tests/system/AutoReview/FrameworkCodeTest.php
+++ b/tests/system/AutoReview/FrameworkCodeTest.php
@@ -39,7 +39,7 @@ final class FrameworkCodeTest extends TestCase
     ];
 
     /**
-     * @dataProvider provideTestClassCases
+     * @dataProvider provideEachTestClassHasCorrectGroupAnnotation
      *
      * @phpstan-param class-string $class
      */
@@ -73,7 +73,7 @@ final class FrameworkCodeTest extends TestCase
         ));
     }
 
-    public function provideTestClassCases(): iterable
+    public function provideEachTestClassHasCorrectGroupAnnotation(): iterable
     {
         foreach ($this->getTestClasses() as $class) {
             yield $class => [$class];

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -450,7 +450,7 @@ final class CLITest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider tableProvider
+     * @dataProvider provideTable
      *
      * @param array $tbody
      * @param array $thead
@@ -463,7 +463,7 @@ final class CLITest extends CIUnitTestCase
         $this->assertSame($this->getStreamFilterBuffer(), $expected);
     }
 
-    public function tableProvider(): iterable
+    public function provideTable(): iterable
     {
         $head = [
             'ID',

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -23,7 +23,7 @@ use Tests\Support\Cache\RestrictiveHandler;
 final class BaseHandlerTest extends CIUnitTestCase
 {
     /**
-     * @dataProvider invalidTypeProvider
+     * @dataProvider provideValidateKeyInvalidType
      *
      * @param mixed $input
      */
@@ -35,7 +35,7 @@ final class BaseHandlerTest extends CIUnitTestCase
         BaseHandler::validateKey($input);
     }
 
-    public function invalidTypeProvider(): iterable
+    public function provideValidateKeyInvalidType(): iterable
     {
         return [
             [true],

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -273,7 +273,7 @@ final class FileHandlerTest extends AbstractHandlerTest
     }
 
     /**
-     * @dataProvider modeProvider
+     * @dataProvider provideSaveMode
      *
      * permissions given on Windows are fixed to `0666`
      *
@@ -296,7 +296,7 @@ final class FileHandlerTest extends AbstractHandlerTest
         $this->assertSame($string, $mode);
     }
 
-    public function modeProvider(): iterable
+    public function provideSaveMode(): iterable
     {
         return [
             [

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -731,7 +731,7 @@ final class CodeIgniterTest extends CIUnitTestCase
     /**
      * @param array|bool $cacheQueryStringValue
      *
-     * @dataProvider cacheQueryStringProvider
+     * @dataProvider providePageCacheWithCacheQueryString
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/pull/6410
      */
@@ -789,7 +789,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         CITestStreamFilter::removeErrorFilter();
     }
 
-    public function cacheQueryStringProvider(): iterable
+    public function providePageCacheWithCacheQueryString(): iterable
     {
         $testingUrls = [
             'test', // URL #1

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -128,7 +128,7 @@ final class CommandTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider commandArgsProvider
+     * @dataProvider provideCommandParsesArgsCorrectly
      */
     public function testCommandParsesArgsCorrectly(string $input, array $expected): void
     {
@@ -138,7 +138,7 @@ final class CommandTest extends CIUnitTestCase
         $this->assertSame($expected, ParamsReveal::$args);
     }
 
-    public function commandArgsProvider(): iterable
+    public function provideCommandParsesArgsCorrectly(): iterable
     {
         return [
             [

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -22,7 +22,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 final class SampleURIGeneratorTest extends CIUnitTestCase
 {
     /**
-     * @dataProvider routeKeyProvider
+     * @dataProvider provideGet
      */
     public function testGet(string $routeKey, string $expected): void
     {
@@ -33,7 +33,7 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
         $this->assertSame($expected, $uri);
     }
 
-    public function routeKeyProvider(): iterable
+    public function provideGet(): iterable
     {
         yield from [
             'root'                => ['/', '/'],

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -594,7 +594,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider dirtyPathsProvider
+     * @dataProvider provideCleanPathActuallyCleaningThePaths
      *
      * @param mixed $input
      * @param mixed $expected
@@ -604,7 +604,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->assertSame($expected, clean_path($input));
     }
 
-    public function dirtyPathsProvider(): iterable
+    public function provideCleanPathActuallyCleaningThePaths(): iterable
     {
         $ds = DIRECTORY_SEPARATOR;
 

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -27,7 +27,7 @@ use ReflectionMethod;
 final class CommonSingleServiceTest extends CIUnitTestCase
 {
     /**
-     * @dataProvider serviceNamesProvider
+     * @dataProvider provideServiceNames
      */
     public function testSingleServiceWithNoParamsSupplied(string $service): void
     {
@@ -43,7 +43,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider serviceNamesProvider
+     * @dataProvider provideServiceNames
      */
     public function testSingleServiceWithAtLeastOneParamSupplied(string $service): void
     {
@@ -99,7 +99,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
         $this->assertNull(single_service('timers'));
     }
 
-    public static function serviceNamesProvider(): iterable
+    public static function provideServiceNames(): iterable
     {
         static $services = [];
         static $excl     = [

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -56,7 +56,7 @@ final class DotEnvTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideLoadVars
+     * @dataProvider provideLoadsVars
      */
     public function testLoadsVars(string $expected, string $varname): void
     {
@@ -66,7 +66,7 @@ final class DotEnvTest extends CIUnitTestCase
         $this->assertSame($expected, getenv($varname));
     }
 
-    public function provideLoadVars(): iterable
+    public function provideLoadsVars(): iterable
     {
         yield from [
             ['bar', 'FOO'],

--- a/tests/system/Config/MimesTest.php
+++ b/tests/system/Config/MimesTest.php
@@ -21,7 +21,7 @@ use Config\Mimes;
  */
 final class MimesTest extends CIUnitTestCase
 {
-    public function extensionsList(): iterable
+    public function provideGuessExtensionFromType(): iterable
     {
         return [
             'null' => [
@@ -48,14 +48,14 @@ final class MimesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider extensionsList
+     * @dataProvider provideGuessExtensionFromType
      */
     public function testGuessExtensionFromType(?string $expected, string $mime): void
     {
         $this->assertSame($expected, Mimes::guessExtensionFromType($mime));
     }
 
-    public function mimesList(): iterable
+    public function provideGuessTypeFromExtension(): iterable
     {
         return [
             'null' => [
@@ -82,7 +82,7 @@ final class MimesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider mimesList
+     * @dataProvider provideGuessTypeFromExtension
      */
     public function testGuessTypeFromExtension(?string $expected, string $ext): void
     {

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -79,7 +79,7 @@ final class CookieTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider prefixProvider
+     * @dataProvider provideConfigPrefix
      */
     public function testConfigPrefix(string $configPrefix, string $optionPrefix, string $expected): void
     {
@@ -98,7 +98,7 @@ final class CookieTest extends CIUnitTestCase
         $this->assertSame($expected, $cookie->getPrefixedName());
     }
 
-    public function prefixProvider(): iterable
+    public function provideConfigPrefix(): iterable
     {
         yield from [
             ['prefix_', '', 'prefix_test'],
@@ -165,7 +165,7 @@ final class CookieTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider invalidExpiresProvider
+     * @dataProvider provideInvalidExpires
      *
      * @param bool|float|string $expires
      */
@@ -175,7 +175,7 @@ final class CookieTest extends CIUnitTestCase
         new Cookie('test', 'value', ['expires' => $expires]);
     }
 
-    public static function invalidExpiresProvider(): iterable
+    public static function provideInvalidExpires(): iterable
     {
         $cases = [
             'non-numeric-string' => ['yes'],
@@ -189,7 +189,7 @@ final class CookieTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider setCookieHeaderProvider
+     * @dataProvider provideSetCookieHeaderCreation
      */
     public function testSetCookieHeaderCreation(string $header, array $changed): void
     {
@@ -198,7 +198,7 @@ final class CookieTest extends CIUnitTestCase
         $this->assertSame(array_merge($cookie, $changed), $cookie);
     }
 
-    public static function setCookieHeaderProvider(): iterable
+    public static function provideSetCookieHeaderCreation(): iterable
     {
         yield 'basic' => [
             'test=value',

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -167,7 +167,7 @@ final class BaseConnectionTest extends CIUnitTestCase
      * These tests are intended to confirm the current behavior.
      * We do not know if all of these are the correct behavior.
      *
-     * @dataProvider identifiersProvider
+     * @dataProvider provideProtectIdentifiers
      */
     public function testProtectIdentifiers(
         bool $prefixSingle,
@@ -183,7 +183,7 @@ final class BaseConnectionTest extends CIUnitTestCase
         $this->assertSame($expected, $return);
     }
 
-    public function identifiersProvider(): iterable
+    public function provideProtectIdentifiers(): iterable
     {
         yield from [
             // $prefixSingle, $protectIdentifiers, $fieldExists, $item, $expected

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -104,7 +104,7 @@ final class BaseQueryTest extends CIUnitTestCase
         $this->assertSame($newSQL, $query->getQuery());
     }
 
-    public function queryTypes(): iterable
+    public function provideIsWriteType(): iterable
     {
         return [
             'select' => [
@@ -183,7 +183,7 @@ final class BaseQueryTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider queryTypes
+     * @dataProvider provideIsWriteType
      *
      * @param mixed $expected
      * @param mixed $sql
@@ -577,7 +577,7 @@ final class BaseQueryTest extends CIUnitTestCase
         $this->assertSame($expected, $query->getQuery());
     }
 
-    public function queryKeywords(): iterable
+    public function provideHighlightQueryKeywords(): iterable
     {
         return [
             'highlightKeyWords' => [
@@ -596,7 +596,7 @@ final class BaseQueryTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider queryKeywords
+     * @dataProvider provideHighlightQueryKeywords
      *
      * @param mixed $expected
      * @param mixed $sql

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -392,7 +392,7 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
-    public function provideInvalidKeys(): iterable
+    public function provideWhereInvalidKeyThrowInvalidArgumentException(): iterable
     {
         return [
             'null'         => [null],
@@ -401,7 +401,7 @@ final class WhereTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideInvalidKeys
+     * @dataProvider provideWhereInvalidKeyThrowInvalidArgumentException
      *
      * @param mixed $key
      */
@@ -413,7 +413,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->whereIn($key, ['Politician', 'Accountant']);
     }
 
-    public function provideInvalidValues(): iterable
+    public function provideWhereInEmptyValuesThrowInvalidArgumentException(): iterable
     {
         return [
             'null'                    => [null],
@@ -423,7 +423,7 @@ final class WhereTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideInvalidValues
+     * @dataProvider provideWhereInEmptyValuesThrowInvalidArgumentException
      *
      * @param mixed $values
      */

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -192,7 +192,7 @@ final class ConfigTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider convertDSNProvider
+     * @dataProvider provideConvertDSN
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/7550
      */
@@ -208,7 +208,7 @@ final class ConfigTest extends CIUnitTestCase
         $this->assertSame($expected, $this->getPrivateProperty($conn, 'DSN'));
     }
 
-    public function convertDSNProvider(): iterable
+    public function provideConvertDSN(): iterable
     {
         yield from [
             [

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -32,7 +32,7 @@ final class EmailTest extends CIUnitTestCase
         $this->assertStringContainsString('Invalid email address: "invalid"', $email->printDebugger());
     }
 
-    public function autoClearProvider(): iterable
+    public function provideEmailSendWithClearance(): iterable
     {
         return [
             'autoclear'     => [true],
@@ -41,7 +41,7 @@ final class EmailTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider autoClearProvider
+     * @dataProvider provideEmailSendWithClearance
      *
      * @param mixed $autoClear
      */

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -208,7 +208,7 @@ final class FiltersTest extends CIUnitTestCase
         $this->assertSame($expected, $filters->initialize()->getFilters());
     }
 
-    public function provideExcept(): iterable
+    public function provideProcessMethodProcessGlobalsWithExcept(): iterable
     {
         return [
             [
@@ -221,7 +221,7 @@ final class FiltersTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideExcept
+     * @dataProvider provideProcessMethodProcessGlobalsWithExcept
      */
     public function testProcessMethodProcessGlobalsWithExcept(array $except): void
     {

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -115,7 +115,7 @@ final class InvalidCharsTest extends CIUnitTestCase
     /**
      * @doesNotPerformAssertions
      *
-     * @dataProvider stringWithLineBreakAndTabProvider
+     * @dataProvider provideCheckControlStringWithLineBreakAndTabReturnsTheString
      */
     public function testCheckControlStringWithLineBreakAndTabReturnsTheString(string $input): void
     {
@@ -124,7 +124,7 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
-    public function stringWithLineBreakAndTabProvider(): iterable
+    public function provideCheckControlStringWithLineBreakAndTabReturnsTheString(): iterable
     {
         yield from [
             ["String contains \n line break."],
@@ -136,7 +136,7 @@ final class InvalidCharsTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider stringWithControlCharsProvider
+     * @dataProvider provideCheckControlStringWithControlCharsCausesException
      */
     public function testCheckControlStringWithControlCharsCausesException(string $input): void
     {
@@ -148,7 +148,7 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
-    public function stringWithControlCharsProvider(): iterable
+    public function provideCheckControlStringWithControlCharsCausesException(): iterable
     {
         yield from [
             ["String contains null char.\0"],

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -102,7 +102,7 @@ final class XMLFormatterTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider invalidTagsProvider
+     * @dataProvider provideValidatingInvalidTags
      */
     public function testValidatingInvalidTags(string $expected, array $input): void
     {
@@ -115,7 +115,7 @@ final class XMLFormatterTest extends CIUnitTestCase
         $this->assertSame($expectedXML, $this->xmlFormatter->format($input));
     }
 
-    public function invalidTagsProvider(): iterable
+    public function provideValidatingInvalidTags(): iterable
     {
         return [
             [

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -517,7 +517,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->fetchGlobal('post', 'clients[]'));
     }
 
-    public function ipAddressChecks(): iterable
+    public function provideValidIPAddress(): iterable
     {
         return [
             'empty' => [
@@ -564,7 +564,7 @@ final class CLIRequestTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider ipAddressChecks
+     * @dataProvider provideValidIPAddress
      *
      * @param mixed      $expected
      * @param mixed      $address

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -518,7 +518,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame($expected, $request->getRawInput());
     }
 
-    public function provideRawInputVarChecks(): iterable
+    public function provideCanGrabGetRawInputVar(): iterable
     {
         return [
             [
@@ -598,7 +598,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideRawInputVarChecks
+     * @dataProvider provideCanGrabGetRawInputVar
      *
      * @param string $rawstring
      * @param mixed  $var
@@ -839,7 +839,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertNull($this->request->getGetPost('gc'));
     }
 
-    public function providePathChecks(): iterable
+    public function provideExtensionPHP(): iterable
     {
         return [
             'not /index.php' => [
@@ -854,7 +854,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider providePathChecks
+     * @dataProvider provideExtensionPHP
      *
      * @param mixed $path
      * @param mixed $detectPath

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -532,7 +532,7 @@ final class RequestTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->fetchGlobal('post', 'people[0]', FILTER_VALIDATE_INT));
     }
 
-    public function ipAddressChecks(): iterable
+    public function provideValidIPAddress(): iterable
     {
         return [
             'empty' => [
@@ -579,7 +579,7 @@ final class RequestTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider ipAddressChecks
+     * @dataProvider provideValidIPAddress
      *
      * @param mixed      $expected
      * @param mixed      $address

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -270,7 +270,7 @@ final class ResponseTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideForRedirect
+     * @dataProvider provideRedirect
      */
     public function testRedirect(
         string $server,
@@ -291,7 +291,7 @@ final class ResponseTest extends CIUnitTestCase
         $this->assertSame($expectedCode, $response->getStatusCode());
     }
 
-    public function provideForRedirect(): iterable
+    public function provideRedirect(): iterable
     {
         yield from [
             ['Apache/2.4.17', 'HTTP/1.1', 'GET', null, 302],
@@ -316,7 +316,7 @@ final class ResponseTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideForRedirectWithIIS
+     * @dataProvider provideRedirectWithIIS
      */
     public function testRedirectWithIIS(
         string $protocol,
@@ -337,7 +337,7 @@ final class ResponseTest extends CIUnitTestCase
         unset($_SERVER['SERVER_SOFTWARE']);
     }
 
-    public function provideForRedirectWithIIS(): iterable
+    public function provideRedirectWithIIS(): iterable
     {
         yield from [
             ['HTTP/1.1', 'GET', null, 302],

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -126,7 +126,7 @@ final class URITest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideURLs
+     * @dataProvider provideSimpleUri
      */
     public function testSimpleUri(string $url, string $expectedURL, string $expectedPath): void
     {
@@ -136,7 +136,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expectedPath, $uri->getPath());
     }
 
-    public function provideURLs(): iterable
+    public function provideSimpleUri(): iterable
     {
         return [
             '' => [
@@ -362,7 +362,7 @@ final class URITest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider providePaths
+     * @dataProvider provideSetPath
      */
     public function testSetPath(string $path, string $expectedURL, string $expectedPath): void
     {
@@ -375,7 +375,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expectedPath, $uri->getPath());
     }
 
-    public function providePaths(): iterable
+    public function provideSetPath(): iterable
     {
         return [
             '' => [
@@ -431,7 +431,7 @@ final class URITest extends CIUnitTestCase
         ];
     }
 
-    public function invalidPaths(): iterable
+    public function providePathGetsFiltered(): iterable
     {
         return [
             'dot-segment' => [
@@ -462,7 +462,7 @@ final class URITest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider invalidPaths
+     * @dataProvider providePathGetsFiltered
      *
      * @param string $path
      * @param string $expected
@@ -555,7 +555,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame('', $uri->getQuery());
     }
 
-    public function authorityInfo(): iterable
+    public function provideAuthorityReturnsExceptedValues(): iterable
     {
         return [
             'host-only' => [
@@ -578,7 +578,7 @@ final class URITest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider authorityInfo
+     * @dataProvider provideAuthorityReturnsExceptedValues
      *
      * @param string $url
      * @param string $expected
@@ -590,7 +590,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expected, $uri->getAuthority());
     }
 
-    public function defaultPorts(): iterable
+    public function provideAuthorityRemovesDefaultPorts(): iterable
     {
         return [
             'http' => [
@@ -605,7 +605,7 @@ final class URITest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider defaultPorts
+     * @dataProvider provideAuthorityRemovesDefaultPorts
      *
      * @param string $scheme
      * @param int    $port
@@ -629,7 +629,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($authority, $uri->getAuthority());
     }
 
-    public function defaultDots(): iterable
+    public function provideRemoveDotSegments(): iterable
     {
         return [
             [
@@ -728,7 +728,7 @@ final class URITest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider defaultDots
+     * @dataProvider provideRemoveDotSegments
      *
      * @param string $path
      * @param string $expected

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -209,7 +209,7 @@ final class ArrayHelperTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider deepSearchProvider
+     * @dataProvider provideArrayDeepSearch
      *
      * @param int|string        $key
      * @param array|string|null $expected
@@ -320,7 +320,7 @@ final class ArrayHelperTest extends CIUnitTestCase
         array_sort_by_multiple_keys($data, $sortColumns);
     }
 
-    public static function deepSearchProvider(): iterable
+    public static function provideArrayDeepSearch(): iterable
     {
         return [
             [
@@ -400,14 +400,14 @@ final class ArrayHelperTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider arrayFlattenProvider
+     * @dataProvider provideArrayFlattening
      */
     public function testArrayFlattening(array $input, array $expected): void
     {
         $this->assertSame($expected, array_flatten_with_dots($input));
     }
 
-    public function arrayFlattenProvider(): iterable
+    public function provideArrayFlattening(): iterable
     {
         yield 'normal' => [
             [

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -248,7 +248,7 @@ final class ArrayHelperTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider sortByMultipleKeysProvider
+     * @dataProvider provideSortByMultipleKeys
      */
     public function testArraySortByMultipleKeysWithArray(array $data, array $sortColumns, array $expected): void
     {
@@ -259,7 +259,7 @@ final class ArrayHelperTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider sortByMultipleKeysProvider
+     * @dataProvider provideSortByMultipleKeys
      */
     public function testArraySortByMultipleKeysWithObjects(array $data, array $sortColumns, array $expected): void
     {
@@ -275,7 +275,7 @@ final class ArrayHelperTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider sortByMultipleKeysProvider
+     * @dataProvider provideSortByMultipleKeys
      */
     public function testArraySortByMultipleKeysFailsEmptyParameter(array $data, array $sortColumns, array $expected): void
     {
@@ -297,7 +297,7 @@ final class ArrayHelperTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider sortByMultipleKeysProvider
+     * @dataProvider provideSortByMultipleKeys
      *
      * @param mixed $data
      */
@@ -346,7 +346,7 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
     }
 
-    public static function sortByMultipleKeysProvider(): iterable
+    public static function provideSortByMultipleKeys(): iterable
     {
         $seed = [
             0 => [

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -235,7 +235,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $this->assertSame('assets/image.jpg', uri_string());
     }
 
-    public function urlIsProvider(): iterable
+    public function provideUrlIs(): iterable
     {
         return [
             [
@@ -277,7 +277,7 @@ final class CurrentUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider urlIsProvider
+     * @dataProvider provideUrlIs
      */
     public function testUrlIs(string $currentPath, string $testPath, bool $expected): void
     {
@@ -291,7 +291,7 @@ final class CurrentUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider urlIsProvider
+     * @dataProvider provideUrlIs
      */
     public function testUrlIsNoIndex(string $currentPath, string $testPath, bool $expected): void
     {
@@ -307,7 +307,7 @@ final class CurrentUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider urlIsProvider
+     * @dataProvider provideUrlIs
      */
     public function testUrlIsWithSubfolder(string $currentPath, string $testPath, bool $expected): void
     {

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -112,7 +112,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test anchor
 
-    public function anchorNormalPatterns(): iterable
+    public function provideAnchor(): iterable
     {
         return [
             'normal01' => [
@@ -156,7 +156,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider anchorNormalPatterns
+     * @dataProvider provideAnchor
      *
      * @param mixed $expected
      * @param mixed $uri
@@ -171,7 +171,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
-    public function anchorNoindexPatterns(): iterable
+    public function provideAnchorNoindex(): iterable
     {
         return [
             'noindex01' => [
@@ -221,7 +221,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider anchorNoindexPatterns
+     * @dataProvider provideAnchorNoindex
      *
      * @param mixed $expected
      * @param mixed $uri
@@ -238,7 +238,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
-    public function anchorSubpagePatterns(): iterable
+    public function provideAnchorTargetted(): iterable
     {
         return [
             'subpage01' => [
@@ -278,7 +278,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider anchorSubpagePatterns
+     * @dataProvider provideAnchorTargetted
      *
      * @param mixed $expected
      * @param mixed $uri
@@ -295,7 +295,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
-    public function anchorExamplePatterns(): iterable
+    public function provideAnchorExamples(): iterable
     {
         return [
             'egpage01' => [
@@ -324,7 +324,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider anchorExamplePatterns
+     * @dataProvider provideAnchorExamples
      *
      * @param mixed $expected
      * @param mixed $uri
@@ -341,7 +341,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test anchor_popup
 
-    public function anchorPopupPatterns(): iterable
+    public function provideAnchorPopup(): iterable
     {
         return [
             'normal01' => [
@@ -382,7 +382,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider anchorPopupPatterns
+     * @dataProvider provideAnchorPopup
      *
      * @param mixed $expected
      * @param mixed $uri
@@ -399,7 +399,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test mailto
 
-    public function mailtoPatterns(): iterable
+    public function provideMailto(): iterable
     {
         return [
             'page01' => [
@@ -421,7 +421,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider mailtoPatterns
+     * @dataProvider provideMailto
      *
      * @param mixed $expected
      * @param mixed $email
@@ -438,7 +438,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test safe_mailto
 
-    public function safeMailtoPatterns(): iterable
+    public function provideSafeMailto(): iterable
     {
         return [
             'page01' => [
@@ -460,7 +460,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider safeMailtoPatterns
+     * @dataProvider provideSafeMailto
      *
      * @param mixed $expected
      * @param mixed $email
@@ -487,7 +487,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test auto_link
 
-    public function autolinkUrls(): iterable
+    public function provideAutoLinkUrl(): iterable
     {
         return [
             'test01' => [
@@ -526,7 +526,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider autolinkUrls
+     * @dataProvider provideAutoLinkUrl
      *
      * @param mixed $in
      * @param mixed $out
@@ -536,7 +536,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($out, auto_link($in, 'url'));
     }
 
-    public function autolinkEmails(): iterable
+    public function provideAutoLinkEmail(): iterable
     {
         return [
             'test01' => [
@@ -575,7 +575,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider autolinkEmails
+     * @dataProvider provideAutoLinkEmail
      *
      * @param mixed $in
      * @param mixed $out
@@ -585,7 +585,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($out, auto_link($in, 'email'));
     }
 
-    public function autolinkBoth(): iterable
+    public function provideAutolinkBoth(): iterable
     {
         return [
             'test01' => [
@@ -624,7 +624,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider autolinkBoth
+     * @dataProvider provideAutolinkBoth
      *
      * @param mixed $in
      * @param mixed $out
@@ -634,7 +634,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($out, auto_link($in));
     }
 
-    public function autolinkPopup(): iterable
+    public function provideAutoLinkPopup(): iterable
     {
         return [
             'test01' => [
@@ -673,7 +673,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider autolinkPopup
+     * @dataProvider provideAutoLinkPopup
      *
      * @param mixed $in
      * @param mixed $out
@@ -685,7 +685,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test prep_url
 
-    public function prepUrlProvider(): iterable
+    public function providePrepUrl(): iterable
     {
         // input, expected, secure
         return [
@@ -763,7 +763,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider prepUrlProvider
+     * @dataProvider providePrepUrl
      */
     public function testPrepUrl(string $input, string $expected, bool $secure): void
     {
@@ -829,7 +829,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider urlToProvider
+     * @dataProvider provideUrlTo
      */
     public function testUrlTo(string $expected, string $input, ...$args): void
     {
@@ -845,7 +845,7 @@ final class MiscUrlTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider urlToMissingRoutesProvider
+     * @dataProvider provideUrlToThrowsOnEmptyOrMissingRoute
      */
     public function testUrlToThrowsOnEmptyOrMissingRoute(string $route): void
     {
@@ -854,7 +854,7 @@ final class MiscUrlTest extends CIUnitTestCase
         url_to($route);
     }
 
-    public function urlToProvider(): iterable
+    public function provideUrlTo(): iterable
     {
         $page = config('App')->indexPage !== '' ? config('App')->indexPage . '/' : '';
 
@@ -874,7 +874,7 @@ final class MiscUrlTest extends CIUnitTestCase
         ];
     }
 
-    public function urlToMissingRoutesProvider(): iterable
+    public function provideUrlToThrowsOnEmptyOrMissingRoute(): iterable
     {
         return [
             [

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -61,7 +61,7 @@ final class SiteUrlTest extends CIUnitTestCase
      * @param string      $expectedSiteUrl
      * @param string      $expectedBaseUrl
      *
-     * @dataProvider configProvider
+     * @dataProvider provideUrls
      */
     public function testUrls(
         $baseURL,
@@ -81,7 +81,7 @@ final class SiteUrlTest extends CIUnitTestCase
         $this->assertSame($expectedBaseUrl, base_url($path, $scheme));
     }
 
-    public function configProvider(): iterable
+    public function provideUrls(): iterable
     {
         // baseURL, indexPage, scheme, secure, path, expectedSiteUrl, expectedBaseUrl
         return [

--- a/tests/system/I18n/TimeLegacyTest.php
+++ b/tests/system/I18n/TimeLegacyTest.php
@@ -1147,7 +1147,7 @@ final class TimeLegacyTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideLocales
+     * @dataProvider provideToStringDoesNotDependOnLocale
      */
     public function testToStringDoesNotDependOnLocale(string $locale): void
     {
@@ -1158,7 +1158,7 @@ final class TimeLegacyTest extends CIUnitTestCase
         $this->assertSame('2017-03-10 12:00:00', (string) $time);
     }
 
-    public function provideLocales(): iterable
+    public function provideToStringDoesNotDependOnLocale(): iterable
     {
         yield from [
             ['en'],

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1159,7 +1159,7 @@ final class TimeTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideLocales
+     * @dataProvider provideToStringDoesNotDependOnLocale
      */
     public function testToStringDoesNotDependOnLocale(string $locale): void
     {
@@ -1170,7 +1170,7 @@ final class TimeTest extends CIUnitTestCase
         $this->assertSame('2017-03-10 12:00:00', (string) $time);
     }
 
-    public function provideLocales(): iterable
+    public function provideToStringDoesNotDependOnLocale(): iterable
     {
         yield from [
             ['en'],

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -213,7 +213,7 @@ final class LanguageTest extends CIUnitTestCase
         $this->assertSame('billions and billions', lang('Core.bazillion', [], 'en'));
     }
 
-    public function MessageBundles(): iterable
+    public function provideBundleUniqueKeys(): iterable
     {
         return [
             ['CLI'],
@@ -244,7 +244,7 @@ final class LanguageTest extends CIUnitTestCase
      * There's not a whole lot that can be done with message bundles,
      * but we can at least try loading them ... more accurate code coverage?
      *
-     * @dataProvider MessageBundles
+     * @dataProvider provideBundleUniqueKeys
      *
      * @param mixed $bundle
      */

--- a/tests/system/Models/FindModelTest.php
+++ b/tests/system/Models/FindModelTest.php
@@ -157,7 +157,7 @@ final class FindModelTest extends LiveModelTestCase
     }
 
     /**
-     * @dataProvider provideGroupBy
+     * @dataProvider provideFirstAggregate
      *
      * @param mixed $groupBy
      * @param mixed $total
@@ -184,7 +184,7 @@ final class FindModelTest extends LiveModelTestCase
         $this->assertSame($total, (int) $user->total);
     }
 
-    public static function provideGroupBy(): iterable
+    public static function provideFirstAggregate(): iterable
     {
         return [
             [true, 3],

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -382,7 +382,7 @@ final class UpdateModelTest extends LiveModelTestCase
     }
 
     /**
-     * @dataProvider provideInvalidIds
+     * @dataProvider provideUpdateThrowDatabaseExceptionWithoutWhereClause
      *
      * @param false|null $id
      */
@@ -397,7 +397,7 @@ final class UpdateModelTest extends LiveModelTestCase
         $this->model->update($id, ['name' => 'Foo Bar']);
     }
 
-    public function provideInvalidIds(): iterable
+    public function provideUpdateThrowDatabaseExceptionWithoutWhereClause(): iterable
     {
         yield from [
             [

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -47,7 +47,7 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider fileProvider
+     * @dataProvider provideDefaultPublicRestrictions
      */
     public function testDefaultPublicRestrictions(string $path): void
     {
@@ -69,7 +69,7 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
         $this->assertSame($expected, $errors[$file]->getMessage());
     }
 
-    public function fileProvider(): iterable
+    public function provideDefaultPublicRestrictions(): iterable
     {
         yield from [
             'php'  => ['index.php'],
@@ -79,7 +79,7 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider destinationProvider
+     * @dataProvider provideDestinations
      */
     public function testDestinations(string $destination, bool $allowed): void
     {
@@ -99,7 +99,7 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
         $this->assertInstanceOf(Publisher::class, $publisher);
     }
 
-    public function destinationProvider(): iterable
+    public function provideDestinations(): iterable
     {
         return [
             'explicit' => [

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -120,7 +120,7 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
         $this->assertSame('/en/contact', $routes->reverseRoute('myController::goto'));
     }
 
-    public function reverseRoutingHandlerProvider(): iterable
+    public function provideReverseRoutingDefaultNamespaceAppController(): iterable
     {
         return yield from [
             'Omit namespace'                  => ['Galleries::showUserGallery'],
@@ -130,7 +130,7 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider reverseRoutingHandlerProvider
+     * @dataProvider provideReverseRoutingDefaultNamespaceAppController
      */
     public function testReverseRoutingDefaultNamespaceAppController(string $controller): void
     {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -380,7 +380,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider groupProvider
+     * @dataProvider provideNestedGroupingWorksWithRootPrefix
      */
     public function testNestedGroupingWorksWithRootPrefix(
         string $group,
@@ -405,7 +405,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutes());
     }
 
-    public function groupProvider(): iterable
+    public function provideNestedGroupingWorksWithRootPrefix(): iterable
     {
         yield from [
             ['admin', '/', [
@@ -1218,7 +1218,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider optionsProvider
+     * @dataProvider provideRoutesOptionsWithSameFromTwoRoutes
      */
     public function testRoutesOptionsWithSameFromTwoRoutes(array $options1, array $options2): void
     {
@@ -1242,7 +1242,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($options, $options1);
     }
 
-    public function optionsProvider(): iterable
+    public function provideRoutesOptionsWithSameFromTwoRoutes(): iterable
     {
         yield from [
             [

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -847,7 +847,7 @@ final class RouterTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideRedirectCase
+     * @dataProvider provideRedirectRoute
      */
     public function testRedirectRoute(
         string $route,
@@ -870,7 +870,7 @@ final class RouterTest extends CIUnitTestCase
         $router->handle($url);
     }
 
-    public function provideRedirectCase(): iterable
+    public function provideRedirectRoute(): iterable
     {
         // [$route, $redirectFrom, $redirectTo, $url, $expectedPath, $alias]
         return [

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -284,7 +284,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->get('0');
     }
 
-    public function provideRoutesData(): iterable
+    public function provideOpenCliRoutesFromHttpGot404(): iterable
     {
         return [
             'non parameterized cli' => [
@@ -316,7 +316,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideRoutesData
+     * @dataProvider provideOpenCliRoutesFromHttpGot404
      *
      * @param mixed $from
      * @param mixed $to

--- a/tests/system/Test/TestLoggerTest.php
+++ b/tests/system/Test/TestLoggerTest.php
@@ -21,7 +21,7 @@ use Config\Logger;
 final class TestLoggerTest extends CIUnitTestCase
 {
     /**
-     * @dataProvider provideDidLogCases
+     * @dataProvider provideDidLogMethod
      */
     public function testDidLogMethod(bool $expected, string $level, string $message, bool $exact): void
     {
@@ -33,7 +33,7 @@ final class TestLoggerTest extends CIUnitTestCase
         );
     }
 
-    public function provideDidLogCases(): iterable
+    public function provideDidLogMethod(): iterable
     {
         yield 'exact' => [
             true,

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -33,7 +33,7 @@ final class TestResponseTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider statusCodeProvider
+     * @dataProvider provideHttpStatusCodes
      */
     public function testIsOK(int $code, bool $isOk): void
     {
@@ -46,7 +46,7 @@ final class TestResponseTest extends CIUnitTestCase
     /**
      * Provides status codes and their expected "OK"
      */
-    public function statusCodeProvider(): iterable
+    public function provideHttpStatusCodes(): iterable
     {
         return [
             [
@@ -223,7 +223,7 @@ final class TestResponseTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider statusCodeProvider
+     * @dataProvider provideHttpStatusCodes
      */
     public function testAssertIsOK(int $code, bool $isOk): void
     {

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -189,7 +189,7 @@ final class ThrottleTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider tokenTimeUsecases
+     * @dataProvider provideTokenTimeCalculationUCs
      */
     public function testTokenTimeCalculationUCs(int $capacity, int $seconds, array $checkInputs): void
     {
@@ -208,7 +208,7 @@ final class ThrottleTest extends CIUnitTestCase
         }
     }
 
-    public function tokenTimeUsecases(): iterable
+    public function provideTokenTimeCalculationUCs(): iterable
     {
         return [
             '2 capacity / 200 seconds (100s refresh, 0.01 tokens/s) -> 5 checks, 1 cost each' => [

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -49,7 +49,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider creditCardProvider
+     * @dataProvider provideValidCCNumber
      */
     public function testValidCCNumber(string $type, ?string $number, bool $expected): void
     {
@@ -63,7 +63,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
      *
      * @see https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
      */
-    public function creditCardProvider(): iterable
+    public function provideValidCCNumber(): iterable
     {
         yield from [
             'null_test' => [

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -85,7 +85,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider urlProvider
+     * @dataProvider provideValidUrl
      */
     public function testValidURL(?string $url, bool $isLoose, bool $isStrict): void
     {
@@ -101,7 +101,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider urlProvider
+     * @dataProvider provideValidUrl
      */
     public function testValidURLStrict(?string $url, bool $isLoose, bool $isStrict): void
     {
@@ -129,7 +129,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
     }
 
-    public function urlProvider(): iterable
+    public function provideValidUrl(): iterable
     {
         yield from [
             [
@@ -802,7 +802,7 @@ class FormatRulesTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
      *
-     * @dataProvider integerInvalidTypeDataProvider
+     * @dataProvider provideInvalidIntegerType
      *
      * @param mixed $value
      */
@@ -821,7 +821,7 @@ class FormatRulesTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
      *
-     * @dataProvider integerInvalidTypeDataProvider
+     * @dataProvider provideInvalidIntegerType
      *
      * @param mixed $value
      */
@@ -837,7 +837,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertsame($expected, $this->validation->run($data));
     }
 
-    public function integerInvalidTypeDataProvider(): iterable
+    public function provideInvalidIntegerType(): iterable
     {
         // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
         // yield 'array with int' => [

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -229,7 +229,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider emailProviderSingle
+     * @dataProvider provideValidEmail
      */
     public function testValidEmail(?string $email, bool $expected): void
     {
@@ -245,7 +245,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider emailsProvider
+     * @dataProvider provideValidEmails
      */
     public function testValidEmails(?string $email, bool $expected): void
     {
@@ -260,7 +260,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function emailProviderSingle(): iterable
+    public function provideValidEmail(): iterable
     {
         yield from [
             [
@@ -278,7 +278,7 @@ class FormatRulesTest extends CIUnitTestCase
         ];
     }
 
-    public function emailsProvider(): iterable
+    public function provideValidEmails(): iterable
     {
         yield from [
             [
@@ -309,7 +309,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider ipProvider
+     * @dataProvider provideValidIP
      */
     public function testValidIP(?string $ip, ?string $which, bool $expected): void
     {
@@ -324,7 +324,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function ipProvider(): iterable
+    public function provideValidIP(): iterable
     {
         yield from [
             [
@@ -376,7 +376,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider stringProvider
+     * @dataProvider provideString
      *
      * @param int|string $str
      */
@@ -393,7 +393,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function stringProvider(): iterable
+    public function provideString(): iterable
     {
         yield from [
             [
@@ -412,7 +412,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider alphaProvider
+     * @dataProvider provideAlpha
      */
     public function testAlpha(?string $str, bool $expected): void
     {
@@ -427,7 +427,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaProvider(): iterable
+    public function provideAlpha(): iterable
     {
         yield from [
             [
@@ -454,7 +454,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider alphaSpaceProvider
+     * @dataProvider provideAlphaSpace
      */
     public function testAlphaSpace(?string $value, bool $expected): void
     {
@@ -469,7 +469,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaSpaceProvider(): iterable
+    public function provideAlphaSpace(): iterable
     {
         yield from [
             [
@@ -538,7 +538,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider alphaNumericPunctProvider
+     * @dataProvider provideAlphaNumericPunct
      */
     public function testAlphaNumericPunct(?string $str, bool $expected): void
     {
@@ -553,7 +553,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaNumericPunctProvider(): iterable
+    public function provideAlphaNumericPunct(): iterable
     {
         yield from [
             [
@@ -670,7 +670,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider alphaDashProvider
+     * @dataProvider provideAlphaDash
      */
     public function testAlphaDash(?string $str, bool $expected): void
     {
@@ -685,7 +685,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaDashProvider(): iterable
+    public function provideAlphaDash(): iterable
     {
         yield from [
             [
@@ -708,7 +708,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider hexProvider
+     * @dataProvider provideHex
      */
     public function testHex(?string $str, bool $expected): void
     {
@@ -723,7 +723,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function hexProvider(): iterable
+    public function provideHex(): iterable
     {
         yield from [
             [
@@ -746,7 +746,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider numericProvider
+     * @dataProvider provideNumeric
      */
     public function testNumeric(?string $str, bool $expected): void
     {
@@ -761,7 +761,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function numericProvider(): iterable
+    public function provideNumeric(): iterable
     {
         yield from [
             [
@@ -868,7 +868,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider integerProvider
+     * @dataProvider provideInteger
      */
     public function testInteger(?string $str, bool $expected): void
     {
@@ -883,7 +883,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function integerProvider(): iterable
+    public function provideInteger(): iterable
     {
         yield from [
             [
@@ -922,7 +922,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider decimalProvider
+     * @dataProvider provideDecimal
      */
     public function testDecimal(?string $str, bool $expected): void
     {
@@ -937,7 +937,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function decimalProvider(): iterable
+    public function provideDecimal(): iterable
     {
         yield from [
             [
@@ -980,7 +980,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider naturalProvider
+     * @dataProvider provideNatural
      */
     public function testNatural(?string $str, bool $expected): void
     {
@@ -995,7 +995,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function naturalProvider(): iterable
+    public function provideNatural(): iterable
     {
         yield from [
             [
@@ -1022,7 +1022,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider naturalZeroProvider
+     * @dataProvider provideNaturalNoZero
      */
     public function testNaturalNoZero(?string $str, bool $expected): void
     {
@@ -1037,7 +1037,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function naturalZeroProvider(): iterable
+    public function provideNaturalNoZero(): iterable
     {
         yield from [
             [
@@ -1064,7 +1064,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider base64Provider
+     * @dataProvider provideBase64
      */
     public function testBase64(?string $str, bool $expected): void
     {
@@ -1079,7 +1079,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function base64Provider(): iterable
+    public function provideBase64(): iterable
     {
         yield from [
             [
@@ -1098,7 +1098,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider jsonProvider
+     * @dataProvider provideJson
      */
     public function testJson(?string $str, bool $expected): void
     {
@@ -1113,7 +1113,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function jsonProvider(): iterable
+    public function provideJson(): iterable
     {
         yield from [
             [
@@ -1156,7 +1156,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider timezoneProvider
+     * @dataProvider provideTimeZone
      */
     public function testTimeZone(?string $str, bool $expected): void
     {
@@ -1171,7 +1171,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function timezoneProvider(): iterable
+    public function provideTimeZone(): iterable
     {
         yield from [
             [
@@ -1194,7 +1194,7 @@ class FormatRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider validDateProvider
+     * @dataProvider provideValidDate
      */
     public function testValidDate(?string $str, ?string $format, bool $expected): void
     {
@@ -1209,7 +1209,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function validDateProvider(): iterable
+    public function provideValidDate(): iterable
     {
         yield from [
             [

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -52,7 +52,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideRequiredCases
+     * @dataProvider provideRequired
      */
     public function testRequired(array $data, bool $expected): void
     {
@@ -60,7 +60,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideRequiredCases(): iterable
+    public function provideRequired(): iterable
     {
         yield from [
             [['foo' => null], false],
@@ -73,7 +73,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider ifExistProvider
+     * @dataProvider provideIfExist
      */
     public function testIfExist(array $rules, array $data, bool $expected): void
     {
@@ -81,7 +81,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function ifExistProvider(): iterable
+    public function provideIfExist(): iterable
     {
         yield from [
             [
@@ -126,7 +126,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider providePermitEmptyCases
+     * @dataProvider providePermitEmpty
      */
     public function testPermitEmpty(array $rules, array $data, bool $expected): void
     {
@@ -134,7 +134,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function providePermitEmptyCases(): iterable
+    public function providePermitEmpty(): iterable
     {
         yield from [
             // If the rule is only `permit_empty`, any value will pass.
@@ -343,7 +343,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideEqualsCases
+     * @dataProvider provideEquals
      */
     public function testEquals(array $data, string $param, bool $expected): void
     {
@@ -351,7 +351,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideEqualsCases(): iterable
+    public function provideEquals(): iterable
     {
         yield from [
             'null'   => [['foo' => null], '', false],
@@ -397,7 +397,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideExactLengthCases
+     * @dataProvider provideExactLength
      */
     public function testExactLength(?string $data, bool $expected): void
     {
@@ -405,7 +405,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run(['foo' => $data]));
     }
 
-    public function provideExactLengthCases(): iterable
+    public function provideExactLength(): iterable
     {
         yield from [
             'null'    => [null, false],
@@ -423,7 +423,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider greaterThanProvider
+     * @dataProvider provideGreaterThan
      */
     public function testGreaterThan(?string $first, ?string $second, bool $expected): void
     {
@@ -432,7 +432,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function greaterThanProvider(): iterable
+    public function provideGreaterThan(): iterable
     {
         yield from [
             ['-10', '-11', true],
@@ -448,7 +448,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider greaterThanEqualProvider
+     * @dataProvider provideGreaterThanEqual
      */
     public function testGreaterThanEqual(?string $first, ?string $second, bool $expected): void
     {
@@ -457,7 +457,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function greaterThanEqualProvider(): iterable
+    public function provideGreaterThanEqual(): iterable
     {
         yield from [
             ['0', '0', true],
@@ -474,7 +474,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider lessThanProvider
+     * @dataProvider provideLessThan
      */
     public function testLessThan(?string $first, ?string $second, bool $expected): void
     {
@@ -483,7 +483,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function lessThanProvider(): iterable
+    public function provideLessThan(): iterable
     {
         yield from [
             ['-10', '-11', false],
@@ -500,7 +500,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider lessThanEqualProvider
+     * @dataProvider provideLessThanEqual
      */
     public function testLessThanEqual(?string $first, ?string $second, bool $expected): void
     {
@@ -509,7 +509,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function lessThanEqualProvider(): iterable
+    public function provideLessThanEqual(): iterable
     {
         yield from [
             ['0', '0', true],
@@ -561,7 +561,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider requiredWithProvider
+     * @dataProvider provideRequiredWith
      */
     public function testRequiredWith(?string $field, ?string $check, bool $expected): void
     {
@@ -581,7 +581,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function requiredWithProvider(): iterable
+    public function provideRequiredWith(): iterable
     {
         yield from [
             ['nope', 'bar', false],
@@ -616,7 +616,7 @@ class RulesTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/7557
      *
-     * @dataProvider RequiredWithAndOtherRulesProvider
+     * @dataProvider provideRequiredWithAndOtherRules
      */
     public function testRequiredWithAndOtherRules(bool $expected, array $data): void
     {
@@ -629,7 +629,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $result);
     }
 
-    public function RequiredWithAndOtherRulesProvider(): iterable
+    public function provideRequiredWithAndOtherRules(): iterable
     {
         yield from [
             // `otherField` and `mustBeADate` do not exist
@@ -652,7 +652,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider RequiredWithAndOtherRuleWithValueZeroProvider
+     * @dataProvider provideRequiredWithAndOtherRuleWithValueZero
      */
     public function testRequiredWithAndOtherRuleWithValueZero(bool $expected, array $data): void
     {
@@ -666,7 +666,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $result);
     }
 
-    public function RequiredWithAndOtherRuleWithValueZeroProvider(): iterable
+    public function provideRequiredWithAndOtherRuleWithValueZero(): iterable
     {
         yield from [
             [true, ['married' => '0', 'partner_name' => '']],
@@ -676,7 +676,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider requiredWithoutProvider
+     * @dataProvider provideRequiredWithout
      */
     public function testRequiredWithout(?string $field, ?string $check, bool $expected): void
     {
@@ -696,7 +696,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function requiredWithoutProvider(): iterable
+    public function provideRequiredWithout(): iterable
     {
         yield from [
             ['nope', 'bars', false],
@@ -728,7 +728,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider requiredWithoutMultipleProvider
+     * @dataProvider provideRequiredWithoutMultiple
      */
     public function testRequiredWithoutMultiple(string $foo, string $bar, string $baz, bool $result): void
     {
@@ -742,7 +742,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($result, $this->validation->run($data));
     }
 
-    public function requiredWithoutMultipleProvider(): iterable
+    public function provideRequiredWithoutMultiple(): iterable
     {
         yield from [
             'all empty' => [
@@ -779,7 +779,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider requiredWithoutMultipleWithoutFieldsProvider
+     * @dataProvider provideRequiredWithoutMultipleWithoutFields
      */
     public function testRequiredWithoutMultipleWithoutFields(array $data, bool $result): void
     {
@@ -788,7 +788,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($result, $this->validation->run($data));
     }
 
-    public function requiredWithoutMultipleWithoutFieldsProvider(): iterable
+    public function provideRequiredWithoutMultipleWithoutFields(): iterable
     {
         yield from [
             'baz is missing' => [

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -526,7 +526,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider inListProvider
+     * @dataProvider provideInList
      */
     public function testInList(?string $first, ?string $second, bool $expected): void
     {
@@ -536,7 +536,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider inListProvider
+     * @dataProvider provideInList
      */
     public function testNotInList(?string $first, ?string $second, bool $expected): void
     {
@@ -545,7 +545,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame(! $expected, $this->validation->run($data));
     }
 
-    public function inListProvider(): iterable
+    public function provideInList(): iterable
     {
         yield from [
             ['red', 'red,Blue,123', true],

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -50,7 +50,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider creditCardProvider
+     * @dataProvider provideValidCCNumber
      */
     public function testValidCCNumber(string $type, ?string $number, bool $expected): void
     {
@@ -64,7 +64,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
      *
      * @see https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
      */
-    public function creditCardProvider(): iterable
+    public function provideValidCCNumber(): iterable
     {
         yield from [
             'null_test' => [

--- a/tests/system/Validation/StrictRules/FormatRulesTest.php
+++ b/tests/system/Validation/StrictRules/FormatRulesTest.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Validation\StrictRules;
 
 use CodeIgniter\Validation\FormatRulesTest as TraditionalFormatRulesTest;
-use Generator;
 use Tests\Support\Validation\TestRules;
 
 /**
@@ -40,7 +39,7 @@ final class FormatRulesTest extends TraditionalFormatRulesTest
         ],
     ];
 
-    public function alphaSpaceProvider(): Generator
+    public function provideAlphaSpace(): iterable
     {
         yield from [
             [
@@ -70,7 +69,7 @@ final class FormatRulesTest extends TraditionalFormatRulesTest
         ];
     }
 
-    public function integerInvalidTypeDataProvider(): Generator
+    public function provideInvalidIntegerType(): iterable
     {
         yield 'array with int' => [
             [555],

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -42,7 +42,7 @@ final class RulesTest extends TraditionalRulesTest
     ];
 
     /**
-     * @dataProvider providePermitEmptyCasesStrict
+     * @dataProvider providePermitEmptyStrict
      */
     public function testPermitEmptyStrict(array $rules, array $data, bool $expected): void
     {
@@ -50,7 +50,7 @@ final class RulesTest extends TraditionalRulesTest
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function providePermitEmptyCasesStrict(): iterable
+    public function providePermitEmptyStrict(): iterable
     {
         yield from [
             [
@@ -174,7 +174,7 @@ final class RulesTest extends TraditionalRulesTest
     }
 
     /**
-     * @dataProvider provideLessThanEqualStrict
+     * @dataProvider provideLessEqualThanStrict
      *
      * @param int $value
      */
@@ -186,7 +186,7 @@ final class RulesTest extends TraditionalRulesTest
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideLessThanEqualStrict(): iterable
+    public function provideLessEqualThanStrict(): iterable
     {
         yield from [
             [0, '0', true],

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -186,7 +186,7 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider setRuleRulesFormatCaseProvider
+     * @dataProvider provideSetRuleRulesFormat
      *
      * @param mixed $rules
      */
@@ -201,7 +201,7 @@ class ValidationTest extends CIUnitTestCase
         $this->addToAssertionCount(1);
     }
 
-    public function setRuleRulesFormatCaseProvider(): iterable
+    public function provideSetRuleRulesFormat(): iterable
     {
         yield 'fail-simple-object' => [
             false,
@@ -325,7 +325,7 @@ class ValidationTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/5368
      *
-     * @dataProvider arrayDataProvider
+     * @dataProvider provideCanValidatetArrayData
      *
      * @param mixed $value
      */
@@ -338,7 +338,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function arrayDataProvider(): iterable
+    public function provideCanValidatetArrayData(): iterable
     {
         yield 'list array' => [
             [1, 2, 3, 4, 5],
@@ -378,7 +378,7 @@ class ValidationTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/5374
      *
-     * @dataProvider isIntInvalidTypeDataProvider
+     * @dataProvider provideIsIntWithInvalidTypeData
      *
      * @param mixed $value
      */
@@ -390,7 +390,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function isIntInvalidTypeDataProvider(): iterable
+    public function provideIsIntWithInvalidTypeData(): iterable
     {
         yield 'array with int' => [
             [555],
@@ -608,7 +608,7 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider rulesSetupProvider
+     * @dataProvider provideRulesSetup
      *
      * @param string|string[] $rules
      * @param string          $expected
@@ -622,7 +622,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->getError('foo'));
     }
 
-    public function rulesSetupProvider(): iterable
+    public function provideRulesSetup(): iterable
     {
         yield from [
             [
@@ -956,7 +956,7 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider arrayFieldDataProvider
+     * @dataProvider provideRulesForArrayField
      */
     public function testRulesForArrayField(array $body, array $rules, array $results): void
     {
@@ -970,7 +970,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($results, $this->validation->getErrors());
     }
 
-    public function arrayFieldDataProvider(): iterable
+    public function provideRulesForArrayField(): iterable
     {
         yield from [
             'all_rules_should_pass' => [
@@ -1195,7 +1195,7 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider dotNotationForIfExistProvider
+     * @dataProvider provideDotNotationOnIfExistRule
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4521
      */
@@ -1205,7 +1205,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function dotNotationForIfExistProvider(): iterable
+    public function provideDotNotationOnIfExistRule(): iterable
     {
         yield 'dot-on-end-fail' => [
             false,
@@ -1265,7 +1265,7 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider validationArrayDataCaseProvider
+     * @dataProvider provideValidationOfArrayData
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4510
      */
@@ -1275,7 +1275,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function validationArrayDataCaseProvider(): iterable
+    public function provideValidationOfArrayData(): iterable
     {
         yield 'fail-empty-string' => [
             false,
@@ -1321,7 +1321,7 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideStringRulesCases
+     * @dataProvider provideSplittingOfComplexStringRules
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4929
      */
@@ -1331,7 +1331,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $splitter($input));
     }
 
-    public function provideStringRulesCases(): iterable
+    public function provideSplittingOfComplexStringRules(): iterable
     {
         yield [
             'required',

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -418,7 +418,7 @@ final class ParserTest extends CIUnitTestCase
         $this->assertSame($result, $this->parser->renderString($template));
     }
 
-    public function escValueTypes(): iterable
+    public function provideEscHandling(): iterable
     {
         return [
             'scalar'     => [42],
@@ -473,7 +473,7 @@ final class ParserTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider escValueTypes
+     * @dataProvider provideEscHandling
      *
      * @param mixed      $value
      * @param mixed|null $expected


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
In php-cs-fixer v3.19, a new fixer `php_unit_data_provider_name` is released that aims to normalize data provider names _used only **ONCE**_.

<details>
    <summary>Description of <code>php_unit_data_provider_name</code></summary>

```console
$ vendor/bin/php-cs-fixer describe php_unit_data_provider_name
Description of php_unit_data_provider_name rule.
Data provider names must match the name of the test.

Fixer applying this rule is risky.
Fixer could be risky if one is calling data provider by name as function.

Fixer is configurable using following options:
* prefix (string): prefix that replaces "test"; defaults to 'provide'
* suffix (string): suffix to be present at the end; defaults to 'Cases'

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,8 @@
    <?php
    class FooTest extends TestCase {
        /**
   -     * @dataProvider dataProvider
   +     * @dataProvider provideSomethingCases
         */
        public function testSomething($expected, $actual) {}
   -    public function dataProvider() {}
   +    public function provideSomethingCases() {}
    }

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['prefix' => 'data_', 'suffix' => ''].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,8 @@
    <?php
    class FooTest extends TestCase {
        /**
   -     * @dataProvider dt_prvdr_ftr
   +     * @dataProvider data_feature
         */
        public function test_feature($expected, $actual) {}
   -    public function dt_prvdr_ftr() {}
   +    public function data_feature() {}
    }

   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['prefix' => 'provides', 'suffix' => 'Data'].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,25 +1,25 @@
    <?php
    class FooTest extends TestCase {
        /**
         * @dataProvider dataProviderUsedInMultipleTests
         */
        public function testA($expected, $actual) {}
        /**
         * @dataProvider dataProviderUsedInMultipleTests
         */
        public function testB($expected, $actual) {}
        /**
   -     * @dataProvider dataProviderUsedInSingleTest
   +     * @dataProvider providesCData
         */
        public function testC($expected, $actual) {}
        /**
         * @dataProvider dataProviderUsedAsFirstInTest
         * @dataProvider dataProviderUsedAsSecondInTest
         */
        public function testD($expected, $actual) {}

        public function dataProviderUsedInMultipleTests() {}
   -    public function dataProviderUsedInSingleTest() {}
   +    public function providesCData() {}
        public function dataProviderUsedAsFirstInTest() {}
        public function dataProviderUsedAsSecondInTest() {}
    }

   ----------- end diff -----------


```
</details>

~Based on the existing naming we have,~ I used the setting:
```
'php_unit_data_provider_name' => [
    'prefix' => 'provide',
    'suffix' => '',
],
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
