### PR TITLE
Fix generics signature of `config()` and `model()`

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -10,7 +10,6 @@
  */
 
 use CodeIgniter\Cache\CacheInterface;
-use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
@@ -27,7 +26,6 @@ use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\URI;
-use CodeIgniter\Model;
 use CodeIgniter\Session\Session;
 use CodeIgniter\Test\TestLogger;
 use Config\App;
@@ -202,16 +200,15 @@ if (! function_exists('command')) {
 
 if (! function_exists('config')) {
     /**
-     * More simple way of getting config instances from Factories
+     * Simpler way of getting config instances from Factories
      *
-     * @template ConfigTemplate of BaseConfig
+     * @template T of object
      *
-     * @param class-string<ConfigTemplate>|string $name
+     * @param class-string<T>|non-empty-string $name
      *
-     * @return ConfigTemplate|null
-     * @phpstan-return ($name is class-string<ConfigTemplate> ? ConfigTemplate : object|null)
+     * @phpstan-return ($name is class-string<T> ? T : null)
      */
-    function config(string $name, bool $getShared = true)
+    function config(string $name, bool $getShared = true): ?object
     {
         return Factories::config($name, ['getShared' => $getShared]);
     }
@@ -811,16 +808,15 @@ if (! function_exists('log_message')) {
 
 if (! function_exists('model')) {
     /**
-     * More simple way of getting model instances from Factories
+     * Simpler way of getting model instances from Factories
      *
-     * @template ModelTemplate of Model
+     * @template T of object
      *
-     * @param class-string<ModelTemplate>|string $name
+     * @param class-string<T>|non-empty-string $name
      *
-     * @return ModelTemplate|null
-     * @phpstan-return ($name is class-string<ModelTemplate> ? ModelTemplate : object|null)
+     * @phpstan-return ($name is class-string<T> ? T : null)
      */
-    function model(string $name, bool $getShared = true, ?ConnectionInterface &$conn = null)
+    function model(string $name, bool $getShared = true, ?ConnectionInterface &$conn = null): ?object
     {
         return Factories::models($name, ['getShared' => $getShared], $conn);
     }

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -365,7 +365,7 @@ class Toolbar
                 return;
             }
 
-            $toolbar = Services::toolbar(config(self::class));
+            $toolbar = Services::toolbar(config(ToolbarConfig::class));
             $stats   = $app->getPerformanceStats();
             $data    = $toolbar->run(
                 $stats['startTime'],


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Since the current _undocumented_ behavior of `config()` and `model()` is to allow any class string as name input and return their respective instances, then I believe we should change the generics signature to account this fact.

**How to test**
1. Create a test file: `test.php`
```php
<?php

use function PHPStan\dumpType;

dumpType(config(stdClass::class));
dumpType(config('Config\App'));
dumpType(config('App'));

```
2. Run `vendor/bin/phpstan analyse -v test.php`
3. The dumped types would be:
```
------ ------------------------- 
  Line   test.php
 ------ -------------------------
  :5     Dumped type: stdClass
  :6     Dumped type: Config\App
  :7     Dumped type: App|null
 ------ -------------------------

```

In line 7, PHPStan gives the inferred type as `App|null` since it does not know if `App` is a valid class string or not. In PHPStan parlance, this is a "maybe" class string, thus it can be `App` or `null`. More precise type inference will come once our own phpstan extension is out, which is currently in development.

This PR also fixes the resulting error in code in Toolbar.
```
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   system\Debug\Toolbar.php
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------   
  :368   Parameter #1 $config of static method CodeIgniter\Config\BaseService::toolbar() expects Config\Toolbar|null, CodeIgniter\Debug\Toolbar given.
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------   
```

Related: #7224 #7254 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
