### PR TITLE
refactor: remove uneeded `if` in Commands\Utilities\Routes

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -11,7 +11,6 @@
 
 namespace CodeIgniter\Commands\Utilities;
 
-use Closure;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouteCollector;
@@ -119,21 +118,19 @@ class Routes extends BaseCommand
         $definedRouteCollector = new DefinedRouteCollector($collection);
 
         foreach ($definedRouteCollector->collect() as $route) {
-            if (is_string($route['handler']) || $route['handler'] instanceof Closure) {
-                $sampleUri = $uriGenerator->get($route['route']);
-                $filters   = $filterCollector->get($route['method'], $sampleUri);
+            $sampleUri = $uriGenerator->get($route['route']);
+            $filters   = $filterCollector->get($route['method'], $sampleUri);
 
-                $routeName = ($route['route'] === $route['name']) ? '»' : $route['name'];
+            $routeName = ($route['route'] === $route['name']) ? '»' : $route['name'];
 
-                $tbody[] = [
-                    strtoupper($route['method']),
-                    $route['route'],
-                    $routeName,
-                    $route['handler'],
-                    implode(' ', array_map('class_basename', $filters['before'])),
-                    implode(' ', array_map('class_basename', $filters['after'])),
-                ];
-            }
+            $tbody[] = [
+                strtoupper($route['method']),
+                $route['route'],
+                $routeName,
+                $route['handler'],
+                implode(' ', array_map('class_basename', $filters['before'])),
+                implode(' ', array_map('class_basename', $filters['after'])),
+            ];
         }
 
         if ($collection->shouldAutoRoute()) {


### PR DESCRIPTION
**Description**
Follow-up #7653

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
