### PR TITLE
Remove `parallel.processTimeout`

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,8 +36,6 @@ parameters:
 		- system/Test/Filters/CITestStreamFilter.php
 		- system/ThirdParty/*
 		- system/Validation/Views/single.php
-	parallel:
-		processTimeout: 300.0
 	scanDirectories:
 		- system/Helpers
 	dynamicConstantNames:


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Default PHPStan parallel process timeout is 600.0 seconds so we should take advantage of the longer time.
https://github.com/phpstan/phpstan-src/blob/2861699cdd2d522ae3062559db6f11335844e3fe/conf/config.neon#L116-L121

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
