### PR TITLE
[Rector] Remove NodeConnectingVisitor from phpstan config

### DIFF
--- a/.github/workflows/test-rector.yml
+++ b/.github/workflows/test-rector.yml
@@ -15,6 +15,7 @@ on:
       - '.github/workflows/test-rector.yml'
       - composer.json
       - rector.php
+      - '**.neon.dist'
 
   push:
     branches:
@@ -28,6 +29,7 @@ on:
       - '.github/workflows/test-rector.yml'
       - composer.json
       - rector.php
+      - '**.neon.dist'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,3 @@
-conditionalTags:
-	PhpParser\NodeVisitor\NodeConnectingVisitor:
-		phpstan.parser.richParserNodeVisitor: true
-
 services:
 	-
 		class: Utils\PHPStan\CheckUseStatementsAfterLicenseRule


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

Rector is removing parent connecting node, and the config itself removed at PR:

- https://github.com/rectorphp/rector-src/pull/4415#pullrequestreview-1512291349

in rector-src dev-main, I think it can be removed in here as well already.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
