### PR TITLE
fix: remove instantiation of Response in `Services::exceptions()`

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -101,7 +101,7 @@ use Config\View as ConfigView;
  * @method static CURLRequest                curlrequest($options = [], ResponseInterface $response = null, App $config = null, $getShared = true)
  * @method static Email                      email($config = null, $getShared = true)
  * @method static EncrypterInterface         encrypter(Encryption $config = null, $getShared = false)
- * @method static Exceptions                 exceptions(ConfigExceptions $config = null, IncomingRequest $request = null, ResponseInterface $response = null, $getShared = true)
+ * @method static Exceptions                 exceptions(ConfigExceptions $config = null, $getShared = true)
  * @method static Filters                    filters(ConfigFilters $config = null, $getShared = true)
  * @method static Format                     format(ConfigFormat $config = null, $getShared = true)
  * @method static Honeypot                   honeypot(ConfigHoneyPot $config = null, $getShared = true)

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -257,25 +257,18 @@ class Services extends BaseService
      *  - register_shutdown_function
      *
      * @return Exceptions
-     *
-     * @deprecated The parameter $request and $response are deprecated.
      */
     public static function exceptions(
         ?ExceptionsConfig $config = null,
-        ?IncomingRequest $request = null,
-        ?ResponseInterface $response = null,
         bool $getShared = true
     ) {
         if ($getShared) {
-            return static::getSharedInstance('exceptions', $config, $request, $response);
+            return static::getSharedInstance('exceptions', $config);
         }
 
         $config ??= config(ExceptionsConfig::class);
 
-        // @TODO remove instantiation of Response in the future.
-        $response ??= AppServices::response();
-
-        return new Exceptions($config, $request, $response);
+        return new Exceptions($config);
     }
 
     /**

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -37,7 +37,7 @@ class Exceptions
      *
      * @var int
      *
-     * @deprecated No longer used. Moved to BaseExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     public $ob_level;
 
@@ -47,7 +47,7 @@ class Exceptions
      *
      * @var string
      *
-     * @deprecated No longer used. Moved to BaseExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     protected $viewPath;
 
@@ -235,7 +235,7 @@ class Exceptions
      *
      * @return string The path and filename of the view file to use
      *
-     * @deprecated No longer used. Moved to ExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to ExceptionHandler.
      */
     protected function determineView(Throwable $exception, string $templatePath): string
     {
@@ -263,7 +263,7 @@ class Exceptions
     /**
      * Given an exception and status code will display the error to the client.
      *
-     * @deprecated No longer used. Moved to BaseExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     protected function render(Throwable $exception, int $statusCode)
     {
@@ -305,7 +305,7 @@ class Exceptions
     /**
      * Gathers the variables that will be made available to the view.
      *
-     * @deprecated No longer used. Moved to BaseExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     protected function collectVars(Throwable $exception, int $statusCode): array
     {
@@ -466,7 +466,7 @@ class Exceptions
      * Describes memory usage in real-world units. Intended for use
      * with memory_get_usage, etc.
      *
-     * @deprecated No longer used. Moved to BaseExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     public static function describeMemory(int $bytes): string
     {
@@ -486,7 +486,7 @@ class Exceptions
      *
      * @return bool|string
      *
-     * @deprecated No longer used. Moved to BaseExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     public static function highlightFile(string $file, int $lineNumber, int $lines = 15)
     {

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -74,12 +74,7 @@ class Exceptions
 
     private ?Throwable $exceptionCaughtByExceptionHandler = null;
 
-    /**
-     * @param RequestInterface|null $request
-     *
-     * @deprecated The parameter $request and $response are deprecated. No longer used.
-     */
-    public function __construct(ExceptionsConfig $config, $request, ResponseInterface $response) /** @phpstan-ignore-line */
+    public function __construct(ExceptionsConfig $config)
     {
         // For backward compatibility
         $this->ob_level = ob_get_level();

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -127,13 +127,13 @@ final class ServicesTest extends CIUnitTestCase
 
     public function testNewExceptions(): void
     {
-        $actual = Services::exceptions(new Exceptions(), Services::request(), Services::response());
+        $actual = Services::exceptions(new Exceptions());
         $this->assertInstanceOf(\CodeIgniter\Debug\Exceptions::class, $actual);
     }
 
     public function testNewExceptionsWithNullConfig(): void
     {
-        $actual = Services::exceptions(null, null, null, false);
+        $actual = Services::exceptions(null, false);
         $this->assertInstanceOf(\CodeIgniter\Debug\Exceptions::class, $actual);
     }
 

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -19,7 +19,6 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
 use Config\Exceptions as ExceptionsConfig;
-use Config\Services;
 use ErrorException;
 use RuntimeException;
 
@@ -52,7 +51,7 @@ final class ExceptionsTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->exception = new Exceptions(new ExceptionsConfig(), Services::request(), Services::response());
+        $this->exception = new Exceptions(new ExceptionsConfig());
     }
 
     /**
@@ -65,7 +64,7 @@ final class ExceptionsTest extends CIUnitTestCase
         $config->logDeprecations     = true;
         $config->deprecationLogLevel = 'error';
 
-        $this->exception = new Exceptions($config, Services::request(), Services::response());
+        $this->exception = new Exceptions($config);
         $this->exception->initialize();
 
         // this is only needed for IDEs not to complain that strlen does not accept explicit null
@@ -89,7 +88,7 @@ final class ExceptionsTest extends CIUnitTestCase
         $config->logDeprecations     = true;
         $config->deprecationLogLevel = 'error';
 
-        $this->exception = new Exceptions($config, Services::request(), Services::response());
+        $this->exception = new Exceptions($config);
         $this->exception->initialize();
 
         @trigger_error('Hello! I am a deprecation!', E_USER_DEPRECATED);

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -109,6 +109,14 @@ Added Parameters
 - **Routing:** The third parameter ``Routing $routing`` has been added to
   ``RouteCollection::__construct()``.
 
+Removed Parameters
+------------------
+
+- **Services:** The second parameter ``$request`` and the third parameter
+  ``$response`` in ``Services::exceptions()`` have been removed.
+- **Error Handling:** The second parameter ``$request`` and the third parameter
+  ``$response`` in ``CodeIgniter\Debug\Exceptions::__construct()`` have been removed.
+
 Return Type Changes
 -------------------
 


### PR DESCRIPTION
**Description**
In 4.3 or before, Request and Response objects are created in `Services::exceptions()` in `CodeIgniter::initialize()`. It is too early, and it created bug #7668.

In 4.4 branch, we have already removed instantiation of Request in `Services::exceptions()`.
This PR removes the instantiation of Response, and both Request and Response objects will be created in `CodeIgniter::run()`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
