### PR TITLE
fix: change Services::session() config param type

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -661,19 +661,16 @@ class Services extends BaseService
      * Return the session manager.
      *
      * @return Session
-     *
-     * @TODO replace the first parameter type `?App` with `?SessionConfig`
      */
-    public static function session(?App $config = null, bool $getShared = true)
+    public static function session(?SessionConfig $config = null, bool $getShared = true)
     {
         if ($getShared) {
             return static::getSharedInstance('session', $config);
         }
 
-        $logger = AppServices::logger();
+        $config ??= config(SessionConfig::class);
 
-        $config = config(SessionConfig::class);
-        assert($config instanceof SessionConfig, 'Missing "Config/Session.php".');
+        $logger = AppServices::logger();
 
         $driverName = $config->driver;
 

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -54,7 +54,6 @@ use Tests\Support\Config\Services;
  */
 final class ServicesTest extends CIUnitTestCase
 {
-    private App $config;
     private array $original;
 
     protected function setUp(): void
@@ -62,7 +61,6 @@ final class ServicesTest extends CIUnitTestCase
         parent::setUp();
 
         $this->original = $_SERVER;
-        $this->config   = new App();
     }
 
     protected function tearDown(): void

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -243,7 +243,7 @@ final class ServicesTest extends CIUnitTestCase
      */
     public function testNewSession()
     {
-        $actual = Services::session($this->config);
+        $actual = Services::session();
         $this->assertInstanceOf(Session::class, $actual);
     }
 

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -50,8 +50,11 @@ Method Signature Changes
 Parameter Type Changes
 ----------------------
 
-- **Services:** The first parameter of ``Services::security()`` has been
-  changed from ``Config\App`` to ``Config\Security``.
+- **Services:**
+    - The first parameter of ``Services::security()`` has been changed from
+      ``Config\App`` to ``Config\Security``.
+    - The first parameter of ``Services::session()`` has been changed from
+      ``Config\App`` to ``Config\Session``.
 - **Session:**
     - The second parameter of ``Session::__construct()`` has been changed from
       ``Config\App`` to ``Config\Session``.


### PR DESCRIPTION
**Description**
#7630 changed the config param type for `Services::security()`.
So this PR changes the config param type for `Services::session()`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
