### PR TITLE
[Rector] Refactor UnderscoreToCamelCaseVariableNameRector as removed findParentByType()

### DIFF
--- a/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -113,13 +113,16 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
 
     private function updateDocblock(Variable $variable, string $variableName, string $camelCaseName): void
     {
-        $parentClassMethodOrFunction = $this->betterNodeFinder->findParentByTypes($variable, [ClassMethod::class, Function_::class]);
+        $parentFunctionLike = $this->betterNodeFinder->findParentType($variable, ClassMethod::class);
 
-        if ($parentClassMethodOrFunction === null) {
-            return;
+        if ($parentFunctionLike === null) {
+            $parentFunctionLike = $this->betterNodeFinder->findParentType($variable, Function_::class);
+            if ($parentFunctionLike === null) {
+                return;
+            }
         }
 
-        $docComment = $parentClassMethodOrFunction->getDocComment();
+        $docComment = $parentFunctionLike->getDocComment();
         if ($docComment === null) {
             return;
         }
@@ -133,7 +136,7 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
             return;
         }
 
-        $phpDocInfo         = $this->phpDocInfoFactory->createFromNodeOrEmpty($parentClassMethodOrFunction);
+        $phpDocInfo         = $this->phpDocInfoFactory->createFromNodeOrEmpty($parentFunctionLike);
         $paramTagValueNodes = $phpDocInfo->getParamTagValueNodes();
 
         foreach ($paramTagValueNodes as $paramTagValueNode) {
@@ -143,6 +146,6 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
             }
         }
 
-        $parentClassMethodOrFunction->setDocComment(new Doc($phpDocInfo->getPhpDocNode()->__toString()));
+        $parentFunctionLike->setDocComment(new Doc($phpDocInfo->getPhpDocNode()->__toString()));
     }
 }


### PR DESCRIPTION

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

`findParentByType()` is removed in latest rector dev-main:

- https://github.com/rectorphp/rector-src/pull/4429/files#diff-a658c135f88f0c6bfdd6a0dc7c25761a25747c595ce47a701fb6f7dc2859c74e

We can now temporary use `findParentType()` instead before it actually gone. This PR is ensure it keep up to date with latest change on rector to ensure no huge change when dependabot trigger on next rector new release.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
