### PR TITLE
chore: add `.htaccess` in project root

### DIFF
--- a/.github/scripts/deploy-appstarter
+++ b/.github/scripts/deploy-appstarter
@@ -20,7 +20,7 @@ git checkout master
 rm -rf *
 
 # Copy common files
-releasable='app public writable env LICENSE spark preload.php'
+releasable='app public writable env LICENSE spark preload.php .htaccess'
 for fff in $releasable;
 do
     cp -Rf ${SOURCE}/$fff ./

--- a/.github/scripts/deploy-framework
+++ b/.github/scripts/deploy-framework
@@ -20,7 +20,7 @@ git checkout master
 rm -rf *
 
 # Copy common files
-releasable='app public writable env LICENSE spark system preload.php'
+releasable='app public writable env LICENSE spark system preload.php .htaccess'
 for fff in $releasable;
 do
     cp -Rf ${SOURCE}/$fff ./

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,13 @@
+# It is recommended that the "public" folder be pointed as the document root.
+# However, this file will work (but not perfect) if you have no other choice
+# but to place your CI4 project folder in the document root on a shared server.
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteRule ^(.*)$ public/$1 [L]
+</IfModule>
+
+<FilesMatch "^\.">
+    Require all denied
+    Satisfy All
+</FilesMatch>


### PR DESCRIPTION
**Description**
Currently, if the baseURL contains a subfolder, it is difficult to deploy, e.g., on shared servers that you can't edit httpd.conf.

E.g.
```
└── htdocs
    └── ci436 (project folder)
        └── public
```

Before:
![Screenshot 2023-07-07 17 31 17](https://github.com/codeigniter4/CodeIgniter4/assets/87955/44325220-3e85-4f04-bd78-258a3fd00c9c)

After:
![Screenshot 2023-07-07 17 31 26](https://github.com/codeigniter4/CodeIgniter4/assets/87955/bf30414b-5496-4d34-b5a4-134e0fbe358d)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [ ] User guide updated
- [] Conforms to style guide
