### PR TITLE
docs: add config() in Global Functions

### DIFF
--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -99,10 +99,12 @@ Convenience Functions
 
 Two shortcut functions for Factories have been provided. These functions are always available.
 
+.. _factories-config:
+
 config()
 ========
 
-The first is ``config()`` which returns a new instance of a Config class. The only required parameter is the class name:
+The first is :php:func:`config()` which returns a new instance of a Config class. The only required parameter is the class name:
 
 .. literalinclude:: factories/008.php
 

--- a/user_guide_src/source/general/common_functions.rst
+++ b/user_guide_src/source/general/common_functions.rst
@@ -30,6 +30,21 @@ Service Accessors
 
     .. literalinclude:: common_functions/001.php
 
+.. php:function:: config(string $name[, bool $getShared = true])
+
+    :param string $name: The config classname.
+    :param bool $getShared: Whether to return a shared instance.
+    :returns: The config instances.
+    :rtype: object|null
+
+    More simple way of getting config instances from Factories.
+
+    See :ref:`Configuration <configuration-config>` and
+    :ref:`Factories <factories-config>` for details.
+
+    The ``config()`` uses ``Factories::config()`` internally.
+    See :ref:`factories-loading-class` for details on the first parameter ``$name``.
+
 .. php:function:: cookie(string $name[, string $value = ''[, array $options = []]])
 
     :param string $name: Cookie name

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -30,10 +30,12 @@ By using the ``new`` keyword to create an instance:
 
 .. literalinclude:: configuration/001.php
 
+.. _configuration-config:
+
 config()
 --------
 
-By using the ``config()`` function:
+By using the :php:func:`config()` function:
 
 .. literalinclude:: configuration/002.php
 

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -187,7 +187,7 @@ with the ``new`` command:
 
 .. literalinclude:: modules/008.php
 
-Config files are automatically discovered whenever using the ``config()`` function that is always available.
+Config files are automatically discovered whenever using the :php:func:`config()` function that is always available.
 
 .. note:: We don't recommend you use the same short classname in modules.
     Modules that need to override or add to known configurations in **app/Config/** should use :ref:`registrars`.


### PR DESCRIPTION
**Description**
`config()` description in multiple places, but keyword search is difficult.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
