### PR TITLE
fix: [ViewCells] when there are cells with the same short name, only the first cell is loaded

### DIFF
--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -178,7 +178,8 @@ class Cell
         }
 
         // locate and return an instance of the cell
-        $object = Factories::cells($class);
+        // @TODO extend Factories to be able to load classes with the same short name.
+        $object = class_exists($class) ? new $class() : Factories::cells($class);
 
         if (! is_object($object)) {
             throw ViewException::forInvalidCellClass($class);

--- a/tests/_support/View/OtherCells/SampleClass.php
+++ b/tests/_support/View/OtherCells/SampleClass.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\View\OtherCells;
+
+/**
+ * Two classes with the same short name.
+ *
+ * - Tests\Support\View\SampleClass
+ * - Tests\Support\View\OtherCells\SampleClass
+ */
+class SampleClass
+{
+    public function hello()
+    {
+        return 'Good-bye!';
+    }
+}

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -113,6 +113,17 @@ final class CellTest extends CIUnitTestCase
         $this->assertSame($expected, $this->cell->render('\Tests\Support\View\SampleClass::hello'));
     }
 
+    public function testDisplayRendersTwoCellsWithSameShortName()
+    {
+        $output = $this->cell->render('\Tests\Support\View\SampleClass::hello');
+
+        $this->assertSame('Hello', $output);
+
+        $output = $this->cell->render('\Tests\Support\View\OtherCells\SampleClass::hello');
+
+        $this->assertSame('Good-bye!', $output);
+    }
+
     public function testDisplayRendersWithValidParamString()
     {
         $params   = 'one=two,three=four';


### PR DESCRIPTION
**Description**
Fixes #7684

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
