### PR TITLE
[Rector] Remove findParentType() on UnderscoreToCamelCaseVariableNameRector

### DIFF
--- a/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -111,7 +111,10 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
         return null;
     }
 
-    private function processRenameVariable(FunctionLike|Variable $node): ?Variable
+    /**
+     * @param FunctionLike|Variable $node
+     */
+    private function processRenameVariable(Node $node): ?Variable
     {
         if ($node instanceof FunctionLike) {
             if ($node instanceof Closure) {

--- a/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -15,10 +15,14 @@ namespace Utils\Rector;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Namespace_;
 use Rector\Core\Php\ReservedKeywordAnalyzer;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -35,6 +39,7 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
     private const PARAM_NAME_REGEX = '#(?<paramPrefix>@param\s.*\s+\$)(?<paramName>%s)#ms';
 
     private ReservedKeywordAnalyzer $reservedKeywordAnalyzer;
+    private bool $hasChanged = false;
 
     public function __construct(
         ReservedKeywordAnalyzer $reservedKeywordAnalyzer
@@ -74,14 +79,59 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
      */
     public function getNodeTypes(): array
     {
-        return [Variable::class];
+        return [FileWithoutNamespace::class, Namespace_::class];
     }
 
     /**
-     * @param Variable $node
+     * @param ClassMethod|Closure|FileWithoutNamespace|Function_|Namespace_ $node
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->stmts === null) {
+            return null;
+        }
+
+        $this->hasChanged = false;
+
+        $this->traverseNodesWithCallable(
+            $node->stmts,
+            function (Node $subNode) {
+                if ($subNode instanceof Variable || $subNode instanceof ClassMethod || $subNode instanceof Function_ || $subNode instanceof Closure) {
+                    $this->processRenameVariable($subNode);
+                }
+
+                return null;
+            }
+        );
+
+        if ($this->hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function processRenameVariable(FunctionLike|Variable $node): ?Variable
+    {
+        if ($node instanceof FunctionLike) {
+            if ($node instanceof Closure) {
+                foreach ($node->uses as $closureUse) {
+                    $this->processRenameVariable($closureUse->var);
+                }
+            }
+
+            foreach ($node->params as $key => $param) {
+                $originalVariableName = $param->var->name;
+                $variable             = $this->processRenameVariable($param->var);
+                if ($variable instanceof Variable) {
+                    $node->params[$key]->var = $variable;
+                    $this->updateDocblock($originalVariableName, $variable->name, $node);
+                }
+            }
+
+            return null;
+        }
+
         $nodeName = $this->getName($node);
         if ($nodeName === null) {
             return null;
@@ -105,24 +155,19 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
             return null;
         }
 
-        $node->name = $camelCaseName;
-        $this->updateDocblock($node, $nodeName, $camelCaseName);
+        $node->name       = $camelCaseName;
+        $this->hasChanged = true;
 
         return $node;
     }
 
-    private function updateDocblock(Variable $variable, string $variableName, string $camelCaseName): void
+    private function updateDocblock(string $variableName, string $camelCaseName, ?FunctionLike $functionLike): void
     {
-        $parentFunctionLike = $this->betterNodeFinder->findParentType($variable, ClassMethod::class);
-
-        if ($parentFunctionLike === null) {
-            $parentFunctionLike = $this->betterNodeFinder->findParentType($variable, Function_::class);
-            if ($parentFunctionLike === null) {
-                return;
-            }
+        if ($functionLike === null) {
+            return;
         }
 
-        $docComment = $parentFunctionLike->getDocComment();
+        $docComment = $functionLike->getDocComment();
         if ($docComment === null) {
             return;
         }
@@ -136,7 +181,7 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
             return;
         }
 
-        $phpDocInfo         = $this->phpDocInfoFactory->createFromNodeOrEmpty($parentFunctionLike);
+        $phpDocInfo         = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
         $paramTagValueNodes = $phpDocInfo->getParamTagValueNodes();
 
         foreach ($paramTagValueNodes as $paramTagValueNode) {
@@ -146,6 +191,6 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
             }
         }
 
-        $parentFunctionLike->setDocComment(new Doc($phpDocInfo->getPhpDocNode()->__toString()));
+        $functionLike->setDocComment(new Doc($phpDocInfo->getPhpDocNode()->__toString()));
     }
 }


### PR DESCRIPTION

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

Prepare for next Rector release, as `findParentType()` removed on rector/rector:dev-main.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
