### PR TITLE
fix: auto routing legacy and $route->add()

### DIFF
--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -197,16 +197,11 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRegisteredControllers\\(.*\\)\\.$#"
-			count: 2
-			path: system/Router/Router.php
-
-		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: system/Router/Router.php
 
 		-
-			message: "#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutes\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: system/Router/Router.php
 

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -20,7 +20,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 final class AutoRouter implements AutoRouterInterface
 {
     /**
-     * List of CLI routes.
+     * List of CLI routes that do not contain '*' routes.
      *
      * @var array<string, Closure|string> [routeKey => handler]
      */

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Router;
 
+use Closure;
 use CodeIgniter\Exceptions\PageNotFoundException;
 
 /**
@@ -19,11 +20,11 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 final class AutoRouter implements AutoRouterInterface
 {
     /**
-     * List of controllers registered for the CLI verb that should not be accessed in the web.
+     * List of CLI routes.
      *
-     * @var class-string[]
+     * @var array<string, Closure|string> [routeKey => handler]
      */
-    private array $protectedControllers;
+    private array $cliRoutes;
 
     /**
      * Sub-directory that contains the requested controller class.
@@ -58,17 +59,17 @@ final class AutoRouter implements AutoRouterInterface
     private string $defaultNamespace;
 
     public function __construct(
-        array $protectedControllers,
+        array $cliRoutes,
         string $defaultNamespace,
         string $defaultController,
         string $defaultMethod,
         bool $translateURIDashes,
         string $httpVerb
     ) {
-        $this->protectedControllers = $protectedControllers;
-        $this->defaultNamespace     = $defaultNamespace;
-        $this->translateURIDashes   = $translateURIDashes;
-        $this->httpVerb             = $httpVerb;
+        $this->cliRoutes          = $cliRoutes;
+        $this->defaultNamespace   = $defaultNamespace;
+        $this->translateURIDashes = $translateURIDashes;
+        $this->httpVerb           = $httpVerb;
 
         $this->controller = $defaultController;
         $this->method     = $defaultMethod;
@@ -126,18 +127,24 @@ final class AutoRouter implements AutoRouterInterface
             $controller .= $controllerName;
 
             $controller = strtolower($controller);
+            $methodName = strtolower($this->methodName());
 
-            foreach ($this->protectedControllers as $controllerInRoute) {
-                if (! is_string($controllerInRoute)) {
-                    continue;
-                }
-                if (strtolower($controllerInRoute) !== $controller) {
-                    continue;
-                }
+            foreach ($this->cliRoutes as $handler) {
+                if (is_string($handler)) {
+                    $handler = strtolower($handler);
 
-                throw new PageNotFoundException(
-                    'Cannot access the controller in a CLI Route. Controller: ' . $controllerInRoute
-                );
+                    if (strpos($handler, $controller . '::' . $methodName) === 0) {
+                        throw new PageNotFoundException(
+                            'Cannot access CLI Route: ' . $uri
+                        );
+                    }
+
+                    if ($handler === $controller) {
+                        throw new PageNotFoundException(
+                            'Cannot access CLI Route: ' . $uri
+                        );
+                    }
+                }
             }
         }
 

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -133,6 +133,13 @@ final class AutoRouter implements AutoRouterInterface
                 if (is_string($handler)) {
                     $handler = strtolower($handler);
 
+                    // Like $routes->cli('hello/(:segment)', 'Home::$1')
+                    if (strpos($handler, '::$') !== false) {
+                        throw new PageNotFoundException(
+                            'Cannot access CLI Route: ' . $uri
+                        );
+                    }
+
                     if (strpos($handler, $controller . '::' . $methodName) === 0) {
                         throw new PageNotFoundException(
                             'Cannot access CLI Route: ' . $uri

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -485,9 +485,9 @@ class RouteCollection implements RouteCollectionInterface
     /**
      * Returns the raw array of available routes.
      *
-     * @param bool $only Whether to return without '*' routes.
+     * @param bool $includeWildcard Whether to include '*' routes.
      */
-    public function getRoutes(?string $verb = null, bool $only = false): array
+    public function getRoutes(?string $verb = null, bool $includeWildcard = true): array
     {
         if (empty($verb)) {
             $verb = $this->getHTTPVerb();
@@ -503,7 +503,7 @@ class RouteCollection implements RouteCollectionInterface
         if (isset($this->routes[$verb])) {
             // Keep current verb's routes at the beginning, so they're matched
             // before any of the generic, "add" routes.
-            $collection = ! $only ? $this->routes[$verb] + ($this->routes['*'] ?? []) : $this->routes[$verb];
+            $collection = $includeWildcard ? $this->routes[$verb] + ($this->routes['*'] ?? []) : $this->routes[$verb];
 
             foreach ($collection as $r) {
                 $key          = key($r['route']);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -503,11 +503,7 @@ class RouteCollection implements RouteCollectionInterface
         if (isset($this->routes[$verb])) {
             // Keep current verb's routes at the beginning, so they're matched
             // before any of the generic, "add" routes.
-            if (! $only) {
-                $collection = $this->routes[$verb] + ($this->routes['*'] ?? []);
-            } else {
-                $collection = $this->routes[$verb];
-            }
+            $collection = ! $only ? $this->routes[$verb] + ($this->routes['*'] ?? []) : $this->routes[$verb];
 
             foreach ($collection as $r) {
                 $key          = key($r['route']);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -484,8 +484,10 @@ class RouteCollection implements RouteCollectionInterface
 
     /**
      * Returns the raw array of available routes.
+     *
+     * @param bool $only Whether to return without '*' routes.
      */
-    public function getRoutes(?string $verb = null): array
+    public function getRoutes(?string $verb = null, bool $only = false): array
     {
         if (empty($verb)) {
             $verb = $this->getHTTPVerb();
@@ -501,7 +503,11 @@ class RouteCollection implements RouteCollectionInterface
         if (isset($this->routes[$verb])) {
             // Keep current verb's routes at the beginning, so they're matched
             // before any of the generic, "add" routes.
-            $collection = $this->routes[$verb] + ($this->routes['*'] ?? []);
+            if (! $only) {
+                $collection = $this->routes[$verb] + ($this->routes['*'] ?? []);
+            } else {
+                $collection = $this->routes[$verb];
+            }
 
             foreach ($collection as $r) {
                 $key          = key($r['route']);

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -145,7 +145,7 @@ class Router implements RouterInterface
                 );
             } else {
                 $this->autoRouter = new AutoRouter(
-                    $this->collection->getRoutes('cli', true), // @phpstan-ignore-line
+                    $this->collection->getRoutes('cli', false), // @phpstan-ignore-line
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -145,7 +145,7 @@ class Router implements RouterInterface
                 );
             } else {
                 $this->autoRouter = new AutoRouter(
-                    $this->collection->getRoutes('cli'), // @phpstan-ignore-line
+                    $this->collection->getRoutes('cli', true), // @phpstan-ignore-line
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -145,7 +145,7 @@ class Router implements RouterInterface
                 );
             } else {
                 $this->autoRouter = new AutoRouter(
-                    $this->collection->getRegisteredControllers('cli'),
+                    $this->collection->getRoutes('cli'), // @phpstan-ignore-line
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),
@@ -393,6 +393,7 @@ class Router implements RouterInterface
      */
     protected function checkRoutes(string $uri): bool
     {
+        // @phpstan-ignore-next-line
         $routes = $this->collection->getRoutes($this->collection->getHTTPVerb());
 
         // Don't waste any time

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -325,7 +325,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     public function testOpenCliRoutesFromHttpGot404($from, $to, $httpGet)
     {
         $this->expectException(PageNotFoundException::class);
-        $this->expectExceptionMessage('Cannot access the controller in a CLI Route.');
+        $this->expectExceptionMessage('Cannot access CLI Route: ');
 
         $collection = Services::routes();
         $collection->setAutoRoute(true);

--- a/user_guide_src/source/changelogs/v4.3.7.rst
+++ b/user_guide_src/source/changelogs/v4.3.7.rst
@@ -12,6 +12,10 @@ Release Date: Unreleased
 BREAKING
 ********
 
+- **RouteCollection:** The second parameter ``bool $only = false`` has been added
+  to the ``RouteCollection::getRoutes()`` method.
+- **AutoRouting Legacy:** The first parameter of the ``AutoRouter::__construct()``
+  has been changed from ``$protectedControllers`` to ``$cliRoutes``.
 - **FeatureTestTrait:** When using :ref:`withBodyFormat() <feature-formatting-the-request>`,
   the priority of the request body has been changed.
   See :ref:`Upgrading Guide <upgrade-437-feature-testing>` for details.
@@ -27,6 +31,10 @@ Deprecations
 
 Bugs Fixed
 **********
+
+- **AutoRouting Legacy:** Fixed a bug that when you added a route with
+  ``$routes->add()``, the controller's other methods were inaccessible from the
+  web browser.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.3.7.rst
+++ b/user_guide_src/source/changelogs/v4.3.7.rst
@@ -12,8 +12,8 @@ Release Date: Unreleased
 BREAKING
 ********
 
-- **RouteCollection:** The second parameter ``bool $only = false`` has been added
-  to the ``RouteCollection::getRoutes()`` method.
+- **RouteCollection:** The second parameter ``bool $includeWildcard = true`` has
+  been added to the ``RouteCollection::getRoutes()`` method.
 - **AutoRouting Legacy:** The first parameter of the ``AutoRouter::__construct()``
   has been changed from ``$protectedControllers`` to ``$cliRoutes``.
 - **FeatureTestTrait:** When using :ref:`withBodyFormat() <feature-formatting-the-request>`,

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -324,10 +324,12 @@ Command-Line Only Routes
 .. note:: It is recommended to use Spark Commands for CLI scripts instead of calling controllers via CLI.
     See the :doc:`../cli/cli_commands` page for detailed information.
 
-You can create routes that work only from the command-line, and are inaccessible from the web browser, with the
-``cli()`` method. Any route created by any of the HTTP-verb-based
+Any route created by any of the HTTP-verb-based
 route methods will also be inaccessible from the CLI, but routes created by the ``add()`` method will still be
-available from the command line:
+available from the command line.
+
+You can create routes that work only from the command-line, and are inaccessible from the web browser, with the
+``cli()`` method:
 
 .. literalinclude:: routing/032.php
 


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=86977

There is a bug:
- When you enable Auto Routing Legacy, if you `$route->add()`, the controller's other methods are inaccessible from the web browser.

**How to Test**
```diff
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -19,7 +19,7 @@ $routes->set404Override();
 // where controller filters or CSRF protection are bypassed.
 // If you don't want to define all routes, please use the Auto Routing (Improved).
 // Set `$autoRoutesImproved` to true in `app/Config/Feature.php` and set the following to true.
-// $routes->setAutoRoute(false);
+$routes->setAutoRoute(true);
 
 /*
  * --------------------------------------------------------------------
@@ -31,6 +31,8 @@ $routes->set404Override();
 // route since we don't have to scan directories.
 $routes->get('/', 'Home::index');
 
+$routes->add('instructor/login', 'Instructor::login');
+
 /*
  * --------------------------------------------------------------------
  * Additional Routing
```
```php
<?php

namespace App\Controllers;

class Instructor extends BaseController
{
    public function login()
    {
        return __METHOD__;
    }

    public function logout()
    {
        return __METHOD__;
    }
}
```

Navigate to:
- http://localhost:8080/instructor/login
- http://localhost:8080/instructor/logout

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
