### PR TITLE
docs: fix sample code of Config\Validation

### DIFF
--- a/user_guide_src/source/libraries/validation/003.php
+++ b/user_guide_src/source/libraries/validation/003.php
@@ -2,7 +2,9 @@
 
 namespace Config;
 
-class Validation
+// ...
+
+class Validation extends BaseConfig
 {
     // ...
 

--- a/user_guide_src/source/libraries/validation/013.php
+++ b/user_guide_src/source/libraries/validation/013.php
@@ -2,9 +2,13 @@
 
 namespace Config;
 
-class Validation
+// ...
+
+class Validation extends BaseConfig
 {
-    public $signup = [
+    // ...
+
+    public array $signup = [
         'username'     => 'required|max_length[30]',
         'password'     => 'required|max_length[255]',
         'pass_confirm' => 'required|max_length[255]|matches[password]',

--- a/user_guide_src/source/libraries/validation/015.php
+++ b/user_guide_src/source/libraries/validation/015.php
@@ -2,16 +2,20 @@
 
 namespace Config;
 
-class Validation
+// ...
+
+class Validation extends BaseConfig
 {
-    public $signup = [
+    // ...
+
+    public array $signup = [
         'username'     => 'required|max_length[30]',
         'password'     => 'required|max_length[255]',
         'pass_confirm' => 'required|max_length[255]|matches[password]',
         'email'        => 'required|max_length[254]|valid_email',
     ];
 
-    public $signup_errors = [
+    public array $signup_errors = [
         'username' => [
             'required' => 'You must choose a username.',
         ],

--- a/user_guide_src/source/libraries/validation/016.php
+++ b/user_guide_src/source/libraries/validation/016.php
@@ -2,9 +2,13 @@
 
 namespace Config;
 
-class Validation
+// ...
+
+class Validation extends BaseConfig
 {
-    public $signup = [
+    // ...
+
+    public array $signup = [
         'username' => [
             'rules'  => 'required|max_length[30]',
             'errors' => [
@@ -18,5 +22,6 @@ class Validation
             ],
         ],
     ];
+
     // ...
 }

--- a/user_guide_src/source/libraries/validation/032.php
+++ b/user_guide_src/source/libraries/validation/032.php
@@ -2,9 +2,13 @@
 
 namespace Config;
 
-class Validation
+// ...
+
+class Validation extends BaseConfig
 {
-    public $templates = [
+    // ...
+
+    public array $templates = [
         'list'    => 'CodeIgniter\Validation\Views\list',
         'single'  => 'CodeIgniter\Validation\Views\single',
         'my_list' => '_errors_list',

--- a/user_guide_src/source/libraries/validation/033.php
+++ b/user_guide_src/source/libraries/validation/033.php
@@ -2,12 +2,13 @@
 
 namespace Config;
 
+use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Validation\CreditCardRules;
 use CodeIgniter\Validation\FileRules;
 use CodeIgniter\Validation\FormatRules;
 use CodeIgniter\Validation\Rules;
 
-class Validation
+class Validation extends BaseConfig
 {
     // ...
 


### PR DESCRIPTION
**Description**
- add missing `extends BaseConfig`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
