### PR TITLE
feat: [Factories] Config caching

### DIFF
--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -77,17 +77,4 @@ class Paths
      * is used when no value is provided to `Services::renderer()`.
      */
     public string $viewDirectory = __DIR__ . '/../Views';
-
-    public static function __set_state(array $array)
-    {
-        $obj = new self();
-
-        $properties = array_keys(get_object_vars($obj));
-
-        foreach ($properties as $property) {
-            $obj->{$property} = $array[$property];
-        }
-
-        return $obj;
-    }
 }

--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -77,4 +77,17 @@ class Paths
      * is used when no value is provided to `Services::renderer()`.
      */
     public string $viewDirectory = __DIR__ . '/../Views';
+
+    public static function __set_state(array $array)
+    {
+        $obj = new self();
+
+        $properties = array_keys(get_object_vars($obj));
+
+        foreach ($properties as $property) {
+            $obj->{$property} = $array[$property];
+        }
+
+        return $obj;
+    }
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+  <file src="system/Cache/FactoriesCache/FileVarExportHandler.php">
+    <UndefinedVariable>
+      <code>$val</code>
+    </UndefinedVariable>
+  </file>
   <file src="system/Cache/Handlers/MemcachedHandler.php">
     <UndefinedClass>
       <code>Memcache</code>

--- a/public/index.php
+++ b/public/index.php
@@ -43,6 +43,11 @@ require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstra
 require_once SYSTEMPATH . 'Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv(ROOTPATH))->load();
 
+// Define ENVIRONMENT
+if (! defined('ENVIRONMENT')) {
+    define('ENVIRONMENT', env('CI_ENVIRONMENT', 'production'));
+}
+
 /*
  * ---------------------------------------------------------------
  * GRAB OUR CODEIGNITER INSTANCE

--- a/public/index.php
+++ b/public/index.php
@@ -48,6 +48,11 @@ if (! defined('ENVIRONMENT')) {
     define('ENVIRONMENT', env('CI_ENVIRONMENT', 'production'));
 }
 
+// Load Config Cache
+// $factoriesCache = new \CodeIgniter\Cache\FactoriesCache();
+// $factoriesCache->load('config');
+// ^^^ Uncomment these lines if you want to use Config Caching.
+
 /*
  * ---------------------------------------------------------------
  * GRAB OUR CODEIGNITER INSTANCE
@@ -72,6 +77,10 @@ $app->setContext($context);
  */
 
 $app->run();
+
+// Save Config Cache
+// $factoriesCache->save('config');
+// ^^^ Uncomment this line if you want to use Config Caching.
 
 // Exits the application, setting the exit code for CLI-based applications
 // that might be watching.

--- a/spark
+++ b/spark
@@ -78,6 +78,11 @@ require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstra
 require_once SYSTEMPATH . 'Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv(ROOTPATH))->load();
 
+// Define ENVIRONMENT
+if (! defined('ENVIRONMENT')) {
+    define('ENVIRONMENT', env('CI_ENVIRONMENT', 'production'));
+}
+
 // Grab our CodeIgniter
 $app = Config\Services::codeigniter();
 $app->initialize();

--- a/system/Cache/FactoriesCache.php
+++ b/system/Cache/FactoriesCache.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache;
+
+use CodeIgniter\Cache\FactoriesCache\FileVarExportHandler;
+use CodeIgniter\Config\Factories;
+
+final class FactoriesCache
+{
+    /**
+     * @var CacheInterface|FileVarExportHandler
+     */
+    private $cache;
+
+    /**
+     * @param CacheInterface|FileVarExportHandler $cache
+     */
+    public function __construct($cache = null)
+    {
+        $this->cache = $cache ?? new FileVarExportHandler();
+    }
+
+    public function save(string $component): void
+    {
+        if (! Factories::isUpdated($component)) {
+            return;
+        }
+
+        $data = Factories::getComponentInstances($component);
+
+        $this->cache->save($this->getCacheKey($component), $data, 3600 * 24);
+    }
+
+    private function getCacheKey(string $component)
+    {
+        return 'FactoriesCache_' . $component;
+    }
+
+    public function load(string $component): bool
+    {
+        $key = $this->getCacheKey($component);
+
+        if (! $data = $this->cache->get($key)) {
+            return false;
+        }
+
+        Factories::setComponentInstances($component, $data);
+
+        return true;
+    }
+
+    public function delete(string $component): void
+    {
+        $this->cache->delete($this->getCacheKey($component));
+    }
+}

--- a/system/Cache/FactoriesCache.php
+++ b/system/Cache/FactoriesCache.php
@@ -22,7 +22,7 @@ final class FactoriesCache
     private $cache;
 
     /**
-     * @param CacheInterface|FileVarExportHandler $cache
+     * @param CacheInterface|FileVarExportHandler|null $cache
      */
     public function __construct($cache = null)
     {

--- a/system/Cache/FactoriesCache.php
+++ b/system/Cache/FactoriesCache.php
@@ -40,7 +40,7 @@ final class FactoriesCache
         $this->cache->save($this->getCacheKey($component), $data, 3600 * 24);
     }
 
-    private function getCacheKey(string $component)
+    private function getCacheKey(string $component): string
     {
         return 'FactoriesCache_' . $component;
     }

--- a/system/Cache/FactoriesCache/FileVarExportHandler.php
+++ b/system/Cache/FactoriesCache/FileVarExportHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache\FactoriesCache;
+
+final class FileVarExportHandler
+{
+    private string $path = WRITEPATH . 'cache';
+
+    /**
+     * @param array|bool|float|int|object|string|null $val
+     */
+    public function save(string $key, $val): void
+    {
+        $val = var_export($val, true);
+
+        // Write to temp file first to ensure atomicity
+        $tmp = $this->path . "/{$key}." . uniqid('', true) . '.tmp';
+        file_put_contents($tmp, '<?php $val = ' . $val . ';', LOCK_EX);
+
+        rename($tmp, $this->path . "/{$key}");
+    }
+
+    public function delete(string $key): void
+    {
+        @unlink($this->path . "/{$key}");
+    }
+
+    /**
+     * @return array|bool|float|int|object|string|null
+     */
+    public function get(string $key)
+    {
+        @include $this->path . "/{$key}";
+
+        return $val ?? false; // @phpstan-ignore-line
+    }
+}

--- a/system/Cache/FactoriesCache/FileVarExportHandler.php
+++ b/system/Cache/FactoriesCache/FileVarExportHandler.php
@@ -24,7 +24,7 @@ final class FileVarExportHandler
 
         // Write to temp file first to ensure atomicity
         $tmp = $this->path . "/{$key}." . uniqid('', true) . '.tmp';
-        file_put_contents($tmp, '<?php $val = ' . $val . ';', LOCK_EX);
+        file_put_contents($tmp, '<?php return ' . $val . ';', LOCK_EX);
 
         rename($tmp, $this->path . "/{$key}");
     }
@@ -39,8 +39,6 @@ final class FileVarExportHandler
      */
     public function get(string $key)
     {
-        @include $this->path . "/{$key}";
-
-        return $val ?? false; // @phpstan-ignore-line
+        return @include $this->path . "/{$key}";
     }
 }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -200,7 +200,6 @@ class CodeIgniter
     public function initialize()
     {
         // Define environment variables
-        $this->detectEnvironment();
         $this->bootstrapEnvironment();
 
         // Setup Exception Handling
@@ -560,6 +559,8 @@ class CodeIgniter
      *     production
      *
      * @codeCoverageIgnore
+     *
+     * @deprecated 4.4.0 No longer used. Moved to index.php and spark.
      */
     protected function detectEnvironment()
     {

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -83,25 +83,27 @@ class BaseConfig
     {
         static::$moduleConfig = config(Modules::class);
 
-        if (static::$override) {
-            $this->registerProperties();
+        if (! static::$override) {
+            return;
+        }
 
-            $properties  = array_keys(get_object_vars($this));
-            $prefix      = static::class;
-            $slashAt     = strrpos($prefix, '\\');
-            $shortPrefix = strtolower(substr($prefix, $slashAt === false ? 0 : $slashAt + 1));
+        $this->registerProperties();
 
-            foreach ($properties as $property) {
-                $this->initEnvValue($this->{$property}, $property, $prefix, $shortPrefix);
+        $properties  = array_keys(get_object_vars($this));
+        $prefix      = static::class;
+        $slashAt     = strrpos($prefix, '\\');
+        $shortPrefix = strtolower(substr($prefix, $slashAt === false ? 0 : $slashAt + 1));
 
-                if ($this instanceof Encryption && $property === 'key') {
-                    if (strpos($this->{$property}, 'hex2bin:') === 0) {
-                        // Handle hex2bin prefix
-                        $this->{$property} = hex2bin(substr($this->{$property}, 8));
-                    } elseif (strpos($this->{$property}, 'base64:') === 0) {
-                        // Handle base64 prefix
-                        $this->{$property} = base64_decode(substr($this->{$property}, 7), true);
-                    }
+        foreach ($properties as $property) {
+            $this->initEnvValue($this->{$property}, $property, $prefix, $shortPrefix);
+
+            if ($this instanceof Encryption && $property === 'key') {
+                if (strpos($this->{$property}, 'hex2bin:') === 0) {
+                    // Handle hex2bin prefix
+                    $this->{$property} = hex2bin(substr($this->{$property}, 8));
+                } elseif (strpos($this->{$property}, 'base64:') === 0) {
+                    // Handle base64 prefix
+                    $this->{$property} = base64_decode(substr($this->{$property}, 7), true);
                 }
             }
         }

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -40,6 +40,11 @@ class BaseConfig
     public static $registrars = [];
 
     /**
+     * Whether to override properties by Env vars and Registrars.
+     */
+    public static bool $override = true;
+
+    /**
      * Has module discovery happened yet?
      *
      * @var bool
@@ -78,23 +83,25 @@ class BaseConfig
     {
         static::$moduleConfig = config(Modules::class);
 
-        $this->registerProperties();
+        if (static::$override) {
+            $this->registerProperties();
 
-        $properties  = array_keys(get_object_vars($this));
-        $prefix      = static::class;
-        $slashAt     = strrpos($prefix, '\\');
-        $shortPrefix = strtolower(substr($prefix, $slashAt === false ? 0 : $slashAt + 1));
+            $properties  = array_keys(get_object_vars($this));
+            $prefix      = static::class;
+            $slashAt     = strrpos($prefix, '\\');
+            $shortPrefix = strtolower(substr($prefix, $slashAt === false ? 0 : $slashAt + 1));
 
-        foreach ($properties as $property) {
-            $this->initEnvValue($this->{$property}, $property, $prefix, $shortPrefix);
+            foreach ($properties as $property) {
+                $this->initEnvValue($this->{$property}, $property, $prefix, $shortPrefix);
 
-            if ($this instanceof Encryption && $property === 'key') {
-                if (strpos($this->{$property}, 'hex2bin:') === 0) {
-                    // Handle hex2bin prefix
-                    $this->{$property} = hex2bin(substr($this->{$property}, 8));
-                } elseif (strpos($this->{$property}, 'base64:') === 0) {
-                    // Handle base64 prefix
-                    $this->{$property} = base64_decode(substr($this->{$property}, 7), true);
+                if ($this instanceof Encryption && $property === 'key') {
+                    if (strpos($this->{$property}, 'hex2bin:') === 0) {
+                        // Handle hex2bin prefix
+                        $this->{$property} = hex2bin(substr($this->{$property}, 8));
+                    } elseif (strpos($this->{$property}, 'base64:') === 0) {
+                        // Handle base64 prefix
+                        $this->{$property} = base64_decode(substr($this->{$property}, 7), true);
+                    }
                 }
             }
         }

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -26,6 +26,8 @@ use RuntimeException;
  * from the environment.
  *
  * These can be set within the .env file.
+ *
+ * @phpstan-consistent-constructor
  */
 class BaseConfig
 {
@@ -50,6 +52,21 @@ class BaseConfig
      * @var Modules
      */
     protected static $moduleConfig;
+
+    public static function __set_state(array $array)
+    {
+        static::$override = false;
+        $obj              = new static();
+        static::$override = true;
+
+        $properties = array_keys(get_object_vars($obj));
+
+        foreach ($properties as $property) {
+            $obj->{$property} = $array[$property];
+        }
+
+        return $obj;
+    }
 
     /**
      * Will attempt to get environment variables with names

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -81,6 +81,15 @@ class Factories
     protected static $instances = [];
 
     /**
+     * Whether the component instances are updated?
+     *
+     * @var array<string, true> [component => true]
+     *
+     * @internal For caching only
+     */
+    protected static $updated = [];
+
+    /**
      * Define the class to load. You can *override* the concrete class.
      *
      * @param string $component Lowercase, plural component name
@@ -153,6 +162,7 @@ class Factories
 
         self::$instances[$options['component']][$class] = new $class(...$arguments);
         self::$aliases[$options['component']][$alias]   = $class;
+        self::$updated[$options['component']]           = true;
 
         // If a short classname is specified, also register FQCN to share the instance.
         if (! isset(self::$aliases[$options['component']][$class])) {
@@ -383,7 +393,8 @@ class Factories
             unset(
                 static::$options[$component],
                 static::$aliases[$component],
-                static::$instances[$component]
+                static::$instances[$component],
+                static::$updated[$component]
             );
 
             return;
@@ -392,6 +403,7 @@ class Factories
         static::$options   = [];
         static::$aliases   = [];
         static::$instances = [];
+        static::$updated   = [];
     }
 
     /**
@@ -439,5 +451,49 @@ class Factories
         }
 
         return $alias;
+    }
+
+    /**
+     * Gets component data for caching.
+     *
+     * @internal For caching only
+     */
+    public static function getComponentInstances(string $component): array
+    {
+        if (! isset(static::$aliases[$component])) {
+            return [
+                'aliases'   => [],
+                'instances' => [],
+            ];
+        }
+
+        $data = [
+            'aliases'   => static::$aliases[$component],
+            'instances' => self::$instances[$component],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Sets component data
+     *
+     * @internal For caching only
+     */
+    public static function setComponentInstances(string $component, array $data)
+    {
+        static::$aliases[$component] = $data['aliases'];
+        self::$instances[$component] = $data['instances'];
+        unset(self::$updated[$component]);
+    }
+
+    /**
+     * Whether the component instances are updated?
+     *
+     * @internal For caching only
+     */
+    public static function isUpdated(string $component): bool
+    {
+        return isset(self::$updated[$component]) ? true : false;
     }
 }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -467,12 +467,10 @@ class Factories
             ];
         }
 
-        $data = [
+        return [
             'aliases'   => static::$aliases[$component],
             'instances' => self::$instances[$component],
         ];
-
-        return $data;
     }
 
     /**
@@ -494,6 +492,6 @@ class Factories
      */
     public static function isUpdated(string $component): bool
     {
-        return isset(self::$updated[$component]) ? true : false;
+        return isset(self::$updated[$component]);
     }
 }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -478,7 +478,7 @@ class Factories
      *
      * @internal For caching only
      */
-    public static function setComponentInstances(string $component, array $data)
+    public static function setComponentInstances(string $component, array $data): void
     {
         static::$aliases[$component] = $data['aliases'];
         self::$instances[$component] = $data['instances'];

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -117,7 +117,7 @@ class Services extends BaseService
             return static::getSharedInstance('cache', $config);
         }
 
-        $config ??= new Cache();
+        $config ??= config(Cache::class);
 
         return CacheFactory::getHandler($config);
     }

--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -102,7 +102,7 @@ class UserAgent
      */
     public function __construct(?UserAgents $config = null)
     {
-        $this->config = $config ?? new UserAgents();
+        $this->config = $config ?? config(UserAgents::class);
 
         if (isset($_SERVER['HTTP_USER_AGENT'])) {
             $this->agent = trim($_SERVER['HTTP_USER_AGENT']);

--- a/system/Modules/Modules.php
+++ b/system/Modules/Modules.php
@@ -15,6 +15,8 @@ namespace CodeIgniter\Modules;
  * Modules Class
  *
  * @see https://codeigniter.com/user_guide/general/modules.html
+ *
+ * @phpstan-consistent-constructor
  */
 class Modules
 {
@@ -39,6 +41,11 @@ class Modules
      */
     public $aliases = [];
 
+    public function __construct()
+    {
+        // For @phpstan-consistent-constructor
+    }
+
     /**
      * Should the application auto-discover the requested resource.
      */
@@ -49,5 +56,18 @@ class Modules
         }
 
         return in_array(strtolower($alias), $this->aliases, true);
+    }
+
+    public static function __set_state(array $array)
+    {
+        $obj = new static();
+
+        $properties = array_keys(get_object_vars($obj));
+
+        foreach ($properties as $property) {
+            $obj->{$property} = $array[$property];
+        }
+
+        return $obj;
     }
 }

--- a/tests/system/Cache/FactoriesCacheFileHandlerTest.php
+++ b/tests/system/Cache/FactoriesCacheFileHandlerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache;
+
+use Config\Cache as CacheConfig;
+
+/**
+ * @internal
+ *
+ * @group Others
+ */
+final class FactoriesCacheFileHandlerTest extends FactoriesCacheFileVarExportHandlerTest
+{
+    /**
+     * @var @var FileVarExportHandler|CacheInterface
+     */
+    protected $handler;
+
+    protected function createFactoriesCache(): void
+    {
+        $this->handler = CacheFactory::getHandler(new CacheConfig(), 'file');
+        $this->cache   = new FactoriesCache($this->handler);
+    }
+}

--- a/tests/system/Cache/FactoriesCacheFileVarExportHandlerTest.php
+++ b/tests/system/Cache/FactoriesCacheFileVarExportHandlerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Cache;
+
+use CodeIgniter\Cache\FactoriesCache\FileVarExportHandler;
+use CodeIgniter\Config\Factories;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
+
+/**
+ * @internal
+ * @no-final
+ *
+ * @group Others
+ */
+class FactoriesCacheFileVarExportHandlerTest extends CIUnitTestCase
+{
+    protected FactoriesCache $cache;
+
+    /**
+     * @var CacheInterface|FileVarExportHandler
+     */
+    protected $handler;
+
+    protected function createFactoriesCache(): void
+    {
+        $this->handler = new FileVarExportHandler();
+        $this->cache   = new FactoriesCache($this->handler);
+    }
+
+    public function testInstantiate()
+    {
+        $this->createFactoriesCache();
+
+        $this->assertInstanceOf(FactoriesCache::class, $this->cache);
+    }
+
+    public function testSave()
+    {
+        Factories::reset();
+        Factories::config('App');
+
+        $this->createFactoriesCache();
+
+        $this->cache->save('config');
+
+        $cachedData = $this->handler->get('FactoriesCache_config');
+
+        $this->assertArrayHasKey('basenames', $cachedData);
+        $this->assertArrayHasKey('instances', $cachedData);
+        $this->assertArrayHasKey('Modules', $cachedData['basenames']);
+        $this->assertArrayHasKey('App', $cachedData['basenames']);
+    }
+
+    public function testLoad()
+    {
+        Factories::reset();
+        /** @var App $appConfig */
+        $appConfig          = Factories::config('App');
+        $appConfig->baseURL = 'http://test.example.jp/this-is-test/';
+
+        $this->createFactoriesCache();
+        $this->cache->save('config');
+
+        Factories::reset();
+
+        $this->cache->load('config');
+
+        $appConfig = Factories::config('App');
+        $this->assertSame('http://test.example.jp/this-is-test/', $appConfig->baseURL);
+    }
+
+    public function testDelete()
+    {
+        $this->createFactoriesCache();
+
+        $this->cache->delete('config');
+
+        $this->assertFalse($this->cache->load('config'));
+    }
+}

--- a/tests/system/Cache/FactoriesCacheFileVarExportHandlerTest.php
+++ b/tests/system/Cache/FactoriesCacheFileVarExportHandlerTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\Cache\FactoriesCache\FileVarExportHandler;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use Config\Modules;
 
 /**
  * @internal
@@ -55,10 +56,10 @@ class FactoriesCacheFileVarExportHandlerTest extends CIUnitTestCase
 
         $cachedData = $this->handler->get('FactoriesCache_config');
 
-        $this->assertArrayHasKey('basenames', $cachedData);
+        $this->assertArrayHasKey('aliases', $cachedData);
         $this->assertArrayHasKey('instances', $cachedData);
-        $this->assertArrayHasKey('Modules', $cachedData['basenames']);
-        $this->assertArrayHasKey('App', $cachedData['basenames']);
+        $this->assertArrayHasKey(Modules::class, $cachedData['aliases']);
+        $this->assertArrayHasKey('App', $cachedData['aliases']);
     }
 
     public function testLoad()

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Config;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Database;
 use InvalidArgumentException;
 use ReflectionClass;
 use stdClass;
@@ -402,7 +403,7 @@ final class FactoriesTest extends CIUnitTestCase
     public function testGetComponentInstances()
     {
         Factories::config('App');
-        Factories::config(\Config\Database::class);
+        Factories::config(Database::class);
 
         $data = Factories::getComponentInstances('config');
 

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -398,4 +398,59 @@ final class FactoriesTest extends CIUnitTestCase
 
         $this->assertInstanceOf(EntityModel::class, $model);
     }
+
+    public function testGetComponentInstances()
+    {
+        Factories::config('App');
+        Factories::config(\Config\Database::class);
+
+        $data = Factories::getComponentInstances('config');
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('aliases', $data);
+        $this->assertArrayHasKey('instances', $data);
+
+        return $data;
+    }
+
+    /**
+     * @depends testGetComponentInstances
+     */
+    public function testSetComponentInstances(array $data)
+    {
+        $before = Factories::getComponentInstances('config');
+        $this->assertSame(['aliases' => [], 'instances' => []], $before);
+
+        Factories::setComponentInstances('config', $data);
+
+        $data = Factories::getComponentInstances('config');
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('aliases', $data);
+        $this->assertArrayHasKey('instances', $data);
+
+        return $data;
+    }
+
+    /**
+     * @depends testSetComponentInstances
+     */
+    public function testIsUpdated(array $data)
+    {
+        Factories::reset();
+
+        $updated = $this->getFactoriesStaticProperty('updated');
+
+        $this->assertSame([], $updated);
+        $this->assertFalse(Factories::isUpdated('config'));
+
+        Factories::config('App');
+
+        $this->assertTrue(Factories::isUpdated('config'));
+        $this->assertFalse(Factories::isUpdated('models'));
+
+        Factories::setComponentInstances('config', $data);
+
+        $this->assertFalse(Factories::isUpdated('config'));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -222,8 +222,10 @@ Others
     - It can also take an object that implements ``ResponseInterface`` as its first argument.
     - It implements ``ResponsableInterface``.
 - **DebugBar:** Now :ref:`view-routes` are displayed in *DEFINED ROUTES* on the *Routes* tab.
-- **Factories:** You can now define the classname that will actually be loaded.
-  See :ref:`factories-defining-classname-to-be-loaded`.
+- **Factories:**
+    - You can now define the classname that will actually be loaded.
+      See :ref:`factories-defining-classname-to-be-loaded`.
+    - The Config Caching implemented. See :ref:`factories-config-caching` for details.
 
 Message Changes
 ***************

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -225,7 +225,7 @@ Others
 - **Factories:**
     - You can now define the classname that will actually be loaded.
       See :ref:`factories-defining-classname-to-be-loaded`.
-    - The Config Caching implemented. See :ref:`factories-config-caching` for details.
+    - Config Caching implemented. See :ref:`factories-config-caching` for details.
 
 Message Changes
 ***************

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -262,3 +262,81 @@ that single call will return a new or shared instance:
 
 .. literalinclude:: factories/007.php
    :lines: 2-
+
+.. _factories-config-caching:
+
+Config Caching
+**************
+
+.. versionadded:: 4.4.0
+
+To improve performance, the Config Caching has been implemented.
+
+Prerequisite
+============
+
+.. important:: Using this feature when the prerequisites are not met will prevent
+    CodeIgniter from operating properly. Do not use this feature in such cases.
+
+- To use this feature, the properties of all Config objects instantiated in
+  Factories must not be modified after instantiation. Put another way, the Config
+  classes must be an immutable or readonly classes.
+- By default, every Config class that is cached must implement ``__set_state()``
+  method.
+
+How It Works
+============
+
+- Save the all Config instances in Factories into a cache file before shutdown,
+  if the state of the Config instances in Factories changes.
+- Restore cached Config instances before CodeIgniter initialization if a cache
+  is available.
+
+Simply put, all Config instances held by Factories are cached immediately prior
+to shutdown, and the cached instances are used permanently.
+
+How to Update Config Values
+===========================
+
+Once cached, the cache is never expired. Changing a existing Config file
+(or changing Environment Variables for it) will not update the cache nor the Config
+values.
+
+So if you want to update Config values, update Config files or Environment Variables
+for them, and you must manually delete the cache file.
+
+You can use the ``spark cache:clear`` command:
+
+.. code-block:: console
+
+    php spark cache:clear
+
+Or simply delete the **writable/cache/FactoriesCache_config** file.
+
+How to Enable Config Caching
+============================
+
+Uncomment the following code in **public/index.php**::
+
+    --- a/public/index.php
+    +++ b/public/index.php
+    @@ -49,8 +49,8 @@ if (! defined('ENVIRONMENT')) {
+     }
+
+     // Load Config Cache
+    -// $factoriesCache = new \CodeIgniter\Cache\FactoriesCache();
+    -// $factoriesCache->load('config');
+    +$factoriesCache = new \CodeIgniter\Cache\FactoriesCache();
+    +$factoriesCache->load('config');
+     // ^^^ Uncomment these lines if you want to use Config Caching.
+
+     /*
+    @@ -79,7 +79,7 @@ $app->setContext($context);
+     $app->run();
+
+     // Save Config Cache
+    -// $factoriesCache->save('config');
+    +$factoriesCache->save('config');
+     // ^^^ Uncomment this line if you want to use Config Caching.
+
+     // Exits the application, setting the exit code for CLI-based applications

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -270,7 +270,7 @@ Config Caching
 
 .. versionadded:: 4.4.0
 
-To improve performance, the Config Caching has been implemented.
+To improve performance, Config Caching has been implemented.
 
 Prerequisite
 ============
@@ -298,7 +298,7 @@ to shutdown, and the cached instances are used permanently.
 How to Update Config Values
 ===========================
 
-Once cached, the cache is never expired. Changing a existing Config file
+Once stored, the cached versions never expire. Changing a existing Config file
 (or changing Environment Variables for it) will not update the cache nor the Config
 values.
 

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -117,15 +117,16 @@ match the new array structure.
 Mandatory File Changes
 **********************
 
-index.php
-=========
+index.php and spark
+===================
 
-The following file received significant changes and
+The following files received significant changes and
 **you must merge the updated versions** with your application:
 
 - ``public/index.php`` (see also :ref:`v440-codeigniter-and-exit`)
+- ``spark``
 
-.. important:: If you don't update the above file, CodeIgniter will not work
+.. important:: If you don't update the above files, CodeIgniter will not work
     properly after running ``composer update``.
 
     The upgrade procedure, for example, is as follows:
@@ -134,6 +135,7 @@ The following file received significant changes and
 
         composer update
         cp vendor/codeigniter4/framework/public/index.php public/index.php
+        cp vendor/codeigniter4/framework/spark spark
 
 Config Files
 ============


### PR DESCRIPTION
**Description**
To improve performance.

How It Works:

- Save the all Config instances in Factories into a cache file before shutdown, if the state of the Config instances in Factories changes.
- Restore cached Config instances before CodeIgniter initialization if a cache is available.

Precautions:

- Once cached, the cache is never expired, and not updated unless the state of the Config instances in Factories changes.
- A change in the state of Config instances in Factories means that a new Config class is instantiated and shared in Factories.
- Therefore, simply changing a existing Config file (or changing Environment Variables for it) will continue to use the Config instance with the old cached values. In that case, you must manually delete the cache file.
- By default, every Config class that is cached must implement `__set_state()` method. 

Benchmark:

```
Requests/sec:    328.50 (Caching off)
Requests/sec:    449.71 (Caching on)
```

<details>

```
$ php -v
PHP 8.2.8 (cli) (built: Jul  6 2023 11:16:24) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.8, Copyright (c) Zend Technologies
    with Zend OPcache v8.2.8, Copyright (c), by Zend Technologies
```
```
$ composer update --no-dev
```
```
$ php spark env

CodeIgniter v4.3.6 Command Line Tool - Server Time: 2023-07-12 03:00:54 UTC+00:00

Your environment is currently set as production.
```
```
$ symfony server:start
```
```
$ wrk -t10 -d5s http://127.0.0.1:8000/
```
</details>

Caching off:
```
Running 5s test @ http://127.0.0.1:8000/
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    31.46ms   14.84ms 159.95ms   91.07%
    Req/Sec    32.96      8.29    50.00     85.34%
  1652 requests in 5.03s, 28.38MB read
Requests/sec:    328.50
Transfer/sec:      5.64MB
```
Caching on:
```diff
--- a/public/index.php
+++ b/public/index.php
@@ -49,8 +49,8 @@ if (! defined('ENVIRONMENT')) {
 }
 
 // Load Config Cache
-// $factoriesCache = new \CodeIgniter\Cache\FactoriesCache();
-// $factoriesCache->load('config');
+$factoriesCache = new \CodeIgniter\Cache\FactoriesCache();
+$factoriesCache->load('config');
 // ^^^ Uncomment these lines if you want to use Config Caching.
 
 /*
@@ -79,7 +79,7 @@ $app->setContext($context);
 $app->run();
 
 // Save Config Cache
-// $factoriesCache->save('config');
+$factoriesCache->save('config');
 // ^^^ Uncomment this line if you want to use Config Caching.
 
 // Exits the application, setting the exit code for CLI-based applications
```
```
Running 5s test @ http://127.0.0.1:8000/
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    23.67ms   14.49ms 171.32ms   92.59%
    Req/Sec    45.21     11.09    70.00     70.82%
  2258 requests in 5.02s, 38.80MB read
Requests/sec:    449.71
Transfer/sec:      7.73MB
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
