### PR TITLE
Fix number comparison in number_to_amount() in number_helper.php

### DIFF
--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -69,9 +69,9 @@ if (! function_exists('number_to_amount')) {
      *
      * @see https://simple.wikipedia.org/wiki/Names_for_large_numbers
      *
-     * @param int|string $num       Will be cast as int
-     * @param int        $precision [optional] The optional number of decimal digits to round to.
-     * @param string     $locale    [optional]
+     * @param int|string  $num       Will be cast as int
+     * @param int         $precision [optional] The optional number of decimal digits to round to.
+     * @param string|null $locale    [optional]
      *
      * @return bool|string
      */

--- a/system/Helpers/number_helper.php
+++ b/system/Helpers/number_helper.php
@@ -69,7 +69,9 @@ if (! function_exists('number_to_amount')) {
      *
      * @see https://simple.wikipedia.org/wiki/Names_for_large_numbers
      *
-     * @param int|string $num
+     * @param int|string $num       Will be cast as int
+     * @param int        $precision [optional] The optional number of decimal digits to round to.
+     * @param string     $locale    [optional]
      *
      * @return bool|string
      */
@@ -91,19 +93,19 @@ if (! function_exists('number_to_amount')) {
             $generalLocale = substr($locale, 0, $underscorePos);
         }
 
-        if ($num > 1_000_000_000_000_000) {
+        if ($num >= 1_000_000_000_000_000) {
             $suffix = lang('Number.quadrillion', [], $generalLocale);
             $num    = round(($num / 1_000_000_000_000_000), $precision);
-        } elseif ($num > 1_000_000_000_000) {
+        } elseif ($num >= 1_000_000_000_000) {
             $suffix = lang('Number.trillion', [], $generalLocale);
             $num    = round(($num / 1_000_000_000_000), $precision);
-        } elseif ($num > 1_000_000_000) {
+        } elseif ($num >= 1_000_000_000) {
             $suffix = lang('Number.billion', [], $generalLocale);
             $num    = round(($num / 1_000_000_000), $precision);
-        } elseif ($num > 1_000_000) {
+        } elseif ($num >= 1_000_000) {
             $suffix = lang('Number.million', [], $generalLocale);
             $num    = round(($num / 1_000_000), $precision);
-        } elseif ($num > 1000) {
+        } elseif ($num >= 1000) {
             $suffix = lang('Number.thousand', [], $generalLocale);
             $num    = round(($num / 1000), $precision);
         }

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -101,26 +101,45 @@ final class NumberHelperTest extends CIUnitTestCase
     public function testThousands()
     {
         $this->assertSame('123 thousand', number_to_amount('123,000', 0, 'en_US'));
+        $this->assertSame('1 thousand', number_to_amount('1000', 0, 'en_US'));
+        $this->assertSame('999 thousand', number_to_amount('999499', 0, 'en_US'));
+        $this->assertSame('1,000 thousand', number_to_amount('999500', 0, 'en_US'));
+        $this->assertSame('1,000 thousand', number_to_amount('999999', 0, 'en_US'));
     }
 
     public function testMillions()
     {
         $this->assertSame('123.4 million', number_to_amount('123,400,000', 1, 'en_US'));
+        $this->assertSame('1 million', number_to_amount('1,000,000', 1, 'en_US'));
+        $this->assertSame('1.5 million', number_to_amount('1,499,999', 1, 'en_US'));
+        $this->assertSame('1.5 million', number_to_amount('1,500,000', 1, 'en_US'));
+        $this->assertSame('1.5 million', number_to_amount('1,549,999', 1, 'en_US'));
+        $this->assertSame('1.6 million', number_to_amount('1,550,000', 1, 'en_US'));
+        $this->assertSame('999.5 million', number_to_amount('999,500,000', 1, 'en_US'));
+        $this->assertSame('1,000 million', number_to_amount('999,500,000', 0, 'en_US'));
+        $this->assertSame('1,000 million', number_to_amount('999,999,999', 1, 'en_US'));
     }
 
     public function testBillions()
     {
         $this->assertSame('123.46 billion', number_to_amount('123,456,000,000', 2, 'en_US'));
+        $this->assertSame('1 billion', number_to_amount('1,000,000,000', 2, 'en_US'));
+        $this->assertSame('1,000 billion', number_to_amount('999,999,999,999', 2, 'en_US'));
     }
 
     public function testTrillions()
     {
         $this->assertSame('123.457 trillion', number_to_amount('123,456,700,000,000', 3, 'en_US'));
+        $this->assertSame('1 trillion', number_to_amount('1,000,000,000,000', 3, 'en_US'));
+        $this->assertSame('1,000 trillion', number_to_amount('999,999,999,999,999', 3, 'en_US'));
     }
 
     public function testQuadrillions()
     {
         $this->assertSame('123.5 quadrillion', number_to_amount('123,456,700,000,000,000', 1, 'en_US'));
+        $this->assertSame('1 quadrillion', number_to_amount('1,000,000,000,000,000', 0, 'en_US'));
+        $this->assertSame('1,000 quadrillion', number_to_amount('999,999,999,999,999,999', 0, 'en_US'));
+        $this->assertSame('1,000 quadrillion', number_to_amount('1,000,000,000,000,000,000', 0, 'en_US'));
     }
 
     public function testCurrencyCurrentLocale()

--- a/user_guide_src/source/changelogs/v4.3.7.rst
+++ b/user_guide_src/source/changelogs/v4.3.7.rst
@@ -22,6 +22,10 @@ Message Changes
 Changes
 *******
 
+- The number helper function :php:func:`number_to_amount()`, which previously
+  returned "1000", has been corrected to return "1 thousand" when the number
+  is exactly 1000, for example.
+
 Deprecations
 ************
 


### PR DESCRIPTION
**Description**
replaces https://github.com/codeigniter4/CodeIgniter4/pull/7648

1000 gives 1 thousand and not 1000
1000000 gives 1 million and not 1000 thousand
and so on...

And it compares now the same way like the function number_to_size above

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
