### PR TITLE
refactor:  replace `config(Paths::class)`

### DIFF
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -13,7 +13,10 @@ use CodeIgniter\Config\AutoloadConfig;
  * can find the files as needed.
  *
  * NOTE: If you use an identical key in $psr4 or $classmap, then
- * the values in this file will overwrite the framework's values.
+ *       the values in this file will overwrite the framework's values.
+ *
+ * NOTE: This class is required prior to Autoloader instantiation,
+ *       and does not extend BaseConfig.
  */
 class Autoload extends AutoloadConfig
 {

--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -95,7 +95,8 @@ class Cache extends BaseConfig
      * A string of reserved characters that will not be allowed in keys or tags.
      * Strings that violate this restriction will cause handlers to throw.
      * Default: {}()/\@:
-     * Note: The default set is required for PSR-6 compliance.
+     *
+     * NOTE: The default set is required for PSR-6 compliance.
      */
     public string $reservedCharacters = '{}()/\@:';
 

--- a/app/Config/ContentSecurityPolicy.php
+++ b/app/Config/ContentSecurityPolicy.php
@@ -39,7 +39,7 @@ class ContentSecurityPolicy extends BaseConfig
 
     // -------------------------------------------------------------------------
     // Sources allowed
-    // Note: once you set a policy to 'none', it cannot be further restricted
+    // NOTE: once you set a policy to 'none', it cannot be further restricted
     // -------------------------------------------------------------------------
 
     /**

--- a/app/Config/Logger.php
+++ b/app/Config/Logger.php
@@ -99,7 +99,7 @@ class Logger extends BaseConfig
              * An extension of 'php' allows for protecting the log files via basic
              * scripting, when they are to be stored under a publicly accessible directory.
              *
-             * Note: Leaving it blank will default to 'log'.
+             * NOTE: Leaving it blank will default to 'log'.
              */
             'fileExtension' => '',
 

--- a/app/Config/Migrations.php
+++ b/app/Config/Migrations.php
@@ -40,7 +40,7 @@ class Migrations extends BaseConfig
      * using the CLI command:
      *   > php spark make:migration
      *
-     * Note: if you set an unsupported format, migration runner will not find
+     * NOTE: if you set an unsupported format, migration runner will not find
      *       your migration files.
      *
      * Supported formats:

--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -7,7 +7,8 @@ use CodeIgniter\Modules\Modules as BaseModules;
 /**
  * Modules Configuration.
  *
- * NOTE: This class is required prior to Autoloader instantiation.
+ * NOTE: This class is required prior to Autoloader instantiation,
+ *       and does not extend BaseConfig.
  */
 class Modules extends BaseModules
 {

--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -4,6 +4,11 @@ namespace Config;
 
 use CodeIgniter\Modules\Modules as BaseModules;
 
+/**
+ * Modules Configuration.
+ *
+ * NOTE: This class is required prior to Autoloader instantiation.
+ */
 class Modules extends BaseModules
 {
     /**

--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -12,6 +12,8 @@ namespace Config;
  * share a system folder between multiple applications, and more.
  *
  * All paths are relative to the project's root folder.
+ *
+ * @immutable
  */
 class Paths
 {

--- a/app/Config/Paths.php
+++ b/app/Config/Paths.php
@@ -13,6 +13,9 @@ namespace Config;
  *
  * All paths are relative to the project's root folder.
  *
+ * NOTE: This class is required prior to Autoloader instantiation,
+ *       and does not extend BaseConfig.
+ *
  * @immutable
  */
 class Paths

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -461,7 +461,7 @@ class Services extends BaseService
             return static::getSharedInstance('parser', $viewPath, $config);
         }
 
-        $viewPath = $viewPath ?: config(Paths::class)->viewDirectory;
+        $viewPath = $viewPath ?: (new Paths())->viewDirectory;
         $config ??= config(ViewConfig::class);
 
         return new Parser($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
@@ -480,7 +480,7 @@ class Services extends BaseService
             return static::getSharedInstance('renderer', $viewPath, $config);
         }
 
-        $viewPath = $viewPath ?: config(Paths::class)->viewDirectory;
+        $viewPath = $viewPath ?: (new Paths())->viewDirectory;
         $config ??= config(ViewConfig::class);
 
         return new View($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());


### PR DESCRIPTION
**Description**
`Paths` is immutable, so we do not need to share the instance.
And `config(Paths::class)` is slower than `new Paths()`.

Test | Time | Memory
-- | -- | --
new paths() | 0.0023 | 0 Bytes
config(paths::class) | 0.0182 | 0 Bytes

```php
<?php

namespace App\Controllers;

use Config\Paths;

class Home extends BaseController
{
    public function index()
    {
        $iterator = new \CodeIgniter\Debug\Iterator();

        $iterator->add('new Paths()', static function () {
            $config = new Paths();
        });

        $iterator->add('config(Paths::class)', static function () {
            $config = config(Paths::class);
        });

        return $iterator->run(10000);
    }
}
```

Related #7696

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
