### PR TITLE
Prevented .env variables from exposing on the exception screen

### DIFF
--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -146,6 +146,12 @@ $errorId = uniqid('error', true);
                         </thead>
                         <tbody>
                         <?php foreach ($GLOBALS[$var] as $key => $value) : ?>
+                            <?php
+                                <!-- Remove $_ENV variables from exposing to the $_SERVER -->
+                                if (in_array($key, array_keys($_ENV))) {
+                                    continue;
+                                }
+                            ?>
                             <tr>
                                 <td><?= esc($key) ?></td>
                                 <td>


### PR DESCRIPTION
**Description**
See #7704

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
