### PR TITLE
Configure `php_unit_data_provider_return_type` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -43,7 +43,9 @@ $finder = Finder::create()
         __DIR__ . '/spark',
     ]);
 
-$overrides = [];
+$overrides = [
+    'php_unit_data_provider_return_type' => true,
+];
 
 $options = [
     'cacheFile' => 'build/.php-cs-fixer.cache',

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -29,7 +29,9 @@ $finder = Finder::create()
         __DIR__ . '/admin/starter/builds',
     ]);
 
-$overrides = [];
+$overrides = [
+    'php_unit_data_provider_return_type' => true,
+];
 
 $options = [
     'cacheFile' => 'build/.php-cs-fixer.no-header.cache',

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -29,10 +29,11 @@ $finder = Finder::create()
     ]);
 
 $overrides = [
-    'echo_tag_syntax'             => false,
-    'php_unit_internal_class'     => false,
-    'no_unused_imports'           => false,
-    'class_attributes_separation' => false,
+    'echo_tag_syntax'                    => false,
+    'php_unit_internal_class'            => false,
+    'no_unused_imports'                  => false,
+    'class_attributes_separation'        => false,
+    'php_unit_data_provider_return_type' => true,
 ];
 
 $options = [

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -463,7 +463,7 @@ final class CLITest extends CIUnitTestCase
         $this->assertSame($this->getStreamFilterBuffer(), $expected);
     }
 
-    public function tableProvider()
+    public function tableProvider(): iterable
     {
         $head = [
             'ID',

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -35,7 +35,7 @@ final class BaseHandlerTest extends CIUnitTestCase
         BaseHandler::validateKey($input);
     }
 
-    public function invalidTypeProvider(): array
+    public function invalidTypeProvider(): iterable
     {
         return [
             [true],

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -296,7 +296,7 @@ final class FileHandlerTest extends AbstractHandlerTest
         $this->assertSame($string, $mode);
     }
 
-    public function modeProvider()
+    public function modeProvider(): iterable
     {
         return [
             [

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -789,7 +789,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         CITestStreamFilter::removeErrorFilter();
     }
 
-    public function cacheQueryStringProvider(): array
+    public function cacheQueryStringProvider(): iterable
     {
         $testingUrls = [
             'test', // URL #1

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -138,7 +138,7 @@ final class CommandTest extends CIUnitTestCase
         $this->assertSame($expected, ParamsReveal::$args);
     }
 
-    public function commandArgsProvider(): array
+    public function commandArgsProvider(): iterable
     {
         return [
             [

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
-use Generator;
 
 /**
  * @internal
@@ -34,7 +33,7 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
         $this->assertSame($expected, $uri);
     }
 
-    public function routeKeyProvider(): Generator
+    public function routeKeyProvider(): iterable
     {
         yield from [
             'root'                => ['/', '/'],

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -604,7 +604,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->assertSame($expected, clean_path($input));
     }
 
-    public function dirtyPathsProvider()
+    public function dirtyPathsProvider(): iterable
     {
         $ds = DIRECTORY_SEPARATOR;
 

--- a/tests/system/Config/MimesTest.php
+++ b/tests/system/Config/MimesTest.php
@@ -21,7 +21,7 @@ use Config\Mimes;
  */
 final class MimesTest extends CIUnitTestCase
 {
-    public function extensionsList()
+    public function extensionsList(): iterable
     {
         return [
             'null' => [
@@ -55,7 +55,7 @@ final class MimesTest extends CIUnitTestCase
         $this->assertSame($expected, Mimes::guessExtensionFromType($mime));
     }
 
-    public function mimesList()
+    public function mimesList(): iterable
     {
         return [
             'null' => [

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -16,7 +16,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\Cookie as CookieConfig;
 use DateTimeImmutable;
 use DateTimeZone;
-use Generator;
 use LogicException;
 
 /**
@@ -99,7 +98,7 @@ final class CookieTest extends CIUnitTestCase
         $this->assertSame($expected, $cookie->getPrefixedName());
     }
 
-    public function prefixProvider(): Generator
+    public function prefixProvider(): iterable
     {
         yield from [
             ['prefix_', '', 'prefix_test'],

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -14,7 +14,6 @@ namespace CodeIgniter\Database;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
-use Generator;
 use Throwable;
 
 /**
@@ -184,7 +183,7 @@ final class BaseConnectionTest extends CIUnitTestCase
         $this->assertSame($expected, $return);
     }
 
-    public function identifiersProvider(): Generator
+    public function identifiersProvider(): iterable
     {
         yield from [
             // $prefixSingle, $protectIdentifiers, $fieldExists, $item, $expected

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -104,7 +104,7 @@ final class BaseQueryTest extends CIUnitTestCase
         $this->assertSame($newSQL, $query->getQuery());
     }
 
-    public function queryTypes()
+    public function queryTypes(): iterable
     {
         return [
             'select' => [
@@ -577,7 +577,7 @@ final class BaseQueryTest extends CIUnitTestCase
         $this->assertSame($expected, $query->getQuery());
     }
 
-    public function queryKeywords()
+    public function queryKeywords(): iterable
     {
         return [
             'highlightKeyWords' => [

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -392,7 +392,7 @@ final class WhereTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
-    public function provideInvalidKeys()
+    public function provideInvalidKeys(): iterable
     {
         return [
             'null'         => [null],
@@ -413,7 +413,7 @@ final class WhereTest extends CIUnitTestCase
         $builder->whereIn($key, ['Politician', 'Accountant']);
     }
 
-    public function provideInvalidValues()
+    public function provideInvalidValues(): iterable
     {
         return [
             'null'                    => [null],

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\Database;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
-use Generator;
 
 /**
  * @internal
@@ -209,7 +208,7 @@ final class ConfigTest extends CIUnitTestCase
         $this->assertSame($expected, $this->getPrivateProperty($conn, 'DSN'));
     }
 
-    public function convertDSNProvider(): Generator
+    public function convertDSNProvider(): iterable
     {
         yield from [
             [

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -32,7 +32,7 @@ final class EmailTest extends CIUnitTestCase
         $this->assertStringContainsString('Invalid email address: "invalid"', $email->printDebugger());
     }
 
-    public function autoClearProvider()
+    public function autoClearProvider(): iterable
     {
         return [
             'autoclear'     => [true],

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -208,7 +208,7 @@ final class FiltersTest extends CIUnitTestCase
         $this->assertSame($expected, $filters->initialize()->getFilters());
     }
 
-    public function provideExcept()
+    public function provideExcept(): iterable
     {
         return [
             [

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -124,7 +124,7 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
-    public function stringWithLineBreakAndTabProvider()
+    public function stringWithLineBreakAndTabProvider(): iterable
     {
         yield from [
             ["String contains \n line break."],
@@ -148,7 +148,7 @@ final class InvalidCharsTest extends CIUnitTestCase
         $this->invalidChars->before($this->request);
     }
 
-    public function stringWithControlCharsProvider()
+    public function stringWithControlCharsProvider(): iterable
     {
         yield from [
             ["String contains null char.\0"],

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -115,7 +115,7 @@ final class XMLFormatterTest extends CIUnitTestCase
         $this->assertSame($expectedXML, $this->xmlFormatter->format($input));
     }
 
-    public function invalidTagsProvider()
+    public function invalidTagsProvider(): iterable
     {
         return [
             [

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -517,7 +517,7 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->fetchGlobal('post', 'clients[]'));
     }
 
-    public function ipAddressChecks()
+    public function ipAddressChecks(): iterable
     {
         return [
             'empty' => [

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -16,7 +16,6 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\Files\UploadedFile;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
-use Generator;
 use InvalidArgumentException;
 use TypeError;
 
@@ -519,7 +518,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame($expected, $request->getRawInput());
     }
 
-    public function provideRawInputVarChecks()
+    public function provideRawInputVarChecks(): iterable
     {
         return [
             [
@@ -627,7 +626,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertTrue($request->is(strtolower($value)));
     }
 
-    public function provideIsHTTPMethods(): Generator
+    public function provideIsHTTPMethods(): iterable
     {
         yield from [
             ['GET'],
@@ -840,7 +839,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertNull($this->request->getGetPost('gc'));
     }
 
-    public function providePathChecks()
+    public function providePathChecks(): iterable
     {
         return [
             'not /index.php' => [

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -185,7 +185,7 @@ final class MessageTest extends CIUnitTestCase
         $this->assertSame('json, html, xml', $this->message->getHeaderLine('Accept'));
     }
 
-    public function provideArrayHeaderValue()
+    public function provideArrayHeaderValue(): iterable
     {
         return [
             'existing for next not append' => [

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -532,7 +532,7 @@ final class RequestTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->fetchGlobal('post', 'people[0]', FILTER_VALIDATE_INT));
     }
 
-    public function ipAddressChecks()
+    public function ipAddressChecks(): iterable
     {
         return [
             'empty' => [

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -291,7 +291,7 @@ final class ResponseTest extends CIUnitTestCase
         $this->assertSame($expectedCode, $response->getStatusCode());
     }
 
-    public function provideForRedirect()
+    public function provideForRedirect(): iterable
     {
         yield from [
             ['Apache/2.4.17', 'HTTP/1.1', 'GET', null, 302],
@@ -337,7 +337,7 @@ final class ResponseTest extends CIUnitTestCase
         unset($_SERVER['SERVER_SOFTWARE']);
     }
 
-    public function provideForRedirectWithIIS()
+    public function provideForRedirectWithIIS(): iterable
     {
         yield from [
             ['HTTP/1.1', 'GET', null, 302],

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -136,7 +136,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expectedPath, $uri->getPath());
     }
 
-    public function provideURLs(): array
+    public function provideURLs(): iterable
     {
         return [
             '' => [
@@ -375,7 +375,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expectedPath, $uri->getPath());
     }
 
-    public function providePaths(): array
+    public function providePaths(): iterable
     {
         return [
             '' => [
@@ -431,7 +431,7 @@ final class URITest extends CIUnitTestCase
         ];
     }
 
-    public function invalidPaths()
+    public function invalidPaths(): iterable
     {
         return [
             'dot-segment' => [
@@ -555,7 +555,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame('', $uri->getQuery());
     }
 
-    public function authorityInfo()
+    public function authorityInfo(): iterable
     {
         return [
             'host-only' => [
@@ -590,7 +590,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expected, $uri->getAuthority());
     }
 
-    public function defaultPorts()
+    public function defaultPorts(): iterable
     {
         return [
             'http' => [
@@ -629,7 +629,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($authority, $uri->getAuthority());
     }
 
-    public function defaultDots()
+    public function defaultDots(): iterable
     {
         return [
             [
@@ -738,7 +738,7 @@ final class URITest extends CIUnitTestCase
         $this->assertSame($expected, URI::removeDotSegments($path));
     }
 
-    public function defaultResolutions()
+    public function defaultResolutions(): iterable
     {
         return [
             [

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -320,7 +320,7 @@ final class ArrayHelperTest extends CIUnitTestCase
         array_sort_by_multiple_keys($data, $sortColumns);
     }
 
-    public static function deepSearchProvider()
+    public static function deepSearchProvider(): iterable
     {
         return [
             [
@@ -346,7 +346,7 @@ final class ArrayHelperTest extends CIUnitTestCase
         ];
     }
 
-    public static function sortByMultipleKeysProvider()
+    public static function sortByMultipleKeysProvider(): iterable
     {
         $seed = [
             0 => [

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -243,7 +243,7 @@ final class InflectorHelperTest extends CIUnitTestCase
         }
     }
 
-    public function provideOrdinal()
+    public function provideOrdinal(): iterable
     {
         return [
             ['st', 1],

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -235,7 +235,7 @@ final class CurrentUrlTest extends CIUnitTestCase
         $this->assertSame('assets/image.jpg', uri_string());
     }
 
-    public function urlIsProvider()
+    public function urlIsProvider(): iterable
     {
         return [
             [

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -112,7 +112,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test anchor
 
-    public function anchorNormalPatterns()
+    public function anchorNormalPatterns(): iterable
     {
         return [
             'normal01' => [
@@ -171,7 +171,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
-    public function anchorNoindexPatterns()
+    public function anchorNoindexPatterns(): iterable
     {
         return [
             'noindex01' => [
@@ -238,7 +238,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
-    public function anchorSubpagePatterns()
+    public function anchorSubpagePatterns(): iterable
     {
         return [
             'subpage01' => [
@@ -295,7 +295,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($expected, anchor($uri, $title, $attributes, $this->config));
     }
 
-    public function anchorExamplePatterns()
+    public function anchorExamplePatterns(): iterable
     {
         return [
             'egpage01' => [
@@ -341,7 +341,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test anchor_popup
 
-    public function anchorPopupPatterns()
+    public function anchorPopupPatterns(): iterable
     {
         return [
             'normal01' => [
@@ -399,7 +399,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test mailto
 
-    public function mailtoPatterns()
+    public function mailtoPatterns(): iterable
     {
         return [
             'page01' => [
@@ -438,7 +438,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test safe_mailto
 
-    public function safeMailtoPatterns()
+    public function safeMailtoPatterns(): iterable
     {
         return [
             'page01' => [
@@ -487,7 +487,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test auto_link
 
-    public function autolinkUrls()
+    public function autolinkUrls(): iterable
     {
         return [
             'test01' => [
@@ -536,7 +536,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($out, auto_link($in, 'url'));
     }
 
-    public function autolinkEmails()
+    public function autolinkEmails(): iterable
     {
         return [
             'test01' => [
@@ -585,7 +585,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($out, auto_link($in, 'email'));
     }
 
-    public function autolinkBoth()
+    public function autolinkBoth(): iterable
     {
         return [
             'test01' => [
@@ -634,7 +634,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->assertSame($out, auto_link($in));
     }
 
-    public function autolinkPopup()
+    public function autolinkPopup(): iterable
     {
         return [
             'test01' => [
@@ -685,7 +685,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
     // Test prep_url
 
-    public function prepUrlProvider()
+    public function prepUrlProvider(): iterable
     {
         // input, expected, secure
         return [
@@ -854,7 +854,7 @@ final class MiscUrlTest extends CIUnitTestCase
         url_to($route);
     }
 
-    public function urlToProvider()
+    public function urlToProvider(): iterable
     {
         $page = config('App')->indexPage !== '' ? config('App')->indexPage . '/' : '';
 
@@ -874,7 +874,7 @@ final class MiscUrlTest extends CIUnitTestCase
         ];
     }
 
-    public function urlToMissingRoutesProvider()
+    public function urlToMissingRoutesProvider(): iterable
     {
         return [
             [

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -81,7 +81,7 @@ final class SiteUrlTest extends CIUnitTestCase
         $this->assertSame($expectedBaseUrl, base_url($path, $scheme));
     }
 
-    public function configProvider()
+    public function configProvider(): iterable
     {
         // baseURL, indexPage, scheme, secure, path, expectedSiteUrl, expectedBaseUrl
         return [

--- a/tests/system/I18n/TimeLegacyTest.php
+++ b/tests/system/I18n/TimeLegacyTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use DateTime;
 use DateTimeZone;
-use Generator;
 use IntlDateFormatter;
 use Locale;
 
@@ -1159,7 +1158,7 @@ final class TimeLegacyTest extends CIUnitTestCase
         $this->assertSame('2017-03-10 12:00:00', (string) $time);
     }
 
-    public function provideLocales(): Generator
+    public function provideLocales(): iterable
     {
         yield from [
             ['en'],

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use DateTime;
 use DateTimeZone;
-use Generator;
 use IntlDateFormatter;
 use Locale;
 
@@ -1171,7 +1170,7 @@ final class TimeTest extends CIUnitTestCase
         $this->assertSame('2017-03-10 12:00:00', (string) $time);
     }
 
-    public function provideLocales(): Generator
+    public function provideLocales(): iterable
     {
         yield from [
             ['en'],

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -213,7 +213,7 @@ final class LanguageTest extends CIUnitTestCase
         $this->assertSame('billions and billions', lang('Core.bazillion', [], 'en'));
     }
 
-    public function MessageBundles()
+    public function MessageBundles(): iterable
     {
         return [
             ['CLI'],

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -14,7 +14,6 @@ namespace CodeIgniter\Models;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity\Entity;
-use Generator;
 use InvalidArgumentException;
 use stdClass;
 use Tests\Support\Models\EventModel;
@@ -398,7 +397,7 @@ final class UpdateModelTest extends LiveModelTestCase
         $this->model->update($id, ['name' => 'Foo Bar']);
     }
 
-    public function provideInvalidIds(): Generator
+    public function provideInvalidIds(): iterable
     {
         yield from [
             [

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -69,7 +69,7 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
         $this->assertSame($expected, $errors[$file]->getMessage());
     }
 
-    public function fileProvider()
+    public function fileProvider(): iterable
     {
         yield from [
             'php'  => ['index.php'],
@@ -99,7 +99,7 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
         $this->assertInstanceOf(Publisher::class, $publisher);
     }
 
-    public function destinationProvider()
+    public function destinationProvider(): iterable
     {
         return [
             'explicit' => [

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -15,7 +15,6 @@ use CodeIgniter\Config\Services;
 use CodeIgniter\Router\Exceptions\RouterException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
-use Generator;
 
 /**
  * @internal
@@ -121,7 +120,7 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
         $this->assertSame('/en/contact', $routes->reverseRoute('myController::goto'));
     }
 
-    public function reverseRoutingHandlerProvider(): Generator
+    public function reverseRoutingHandlerProvider(): iterable
     {
         return yield from [
             'Omit namespace'                  => ['Galleries::showUserGallery'],

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -405,7 +405,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutes());
     }
 
-    public function groupProvider()
+    public function groupProvider(): iterable
     {
         yield from [
             ['admin', '/', [
@@ -1242,7 +1242,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($options, $options1);
     }
 
-    public function optionsProvider()
+    public function optionsProvider(): iterable
     {
         yield from [
             [
@@ -1657,7 +1657,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expects, $router->handle('/0'));
     }
 
-    public function provideRouteDefaultNamespace()
+    public function provideRouteDefaultNamespace(): iterable
     {
         return [
             'with \\ prefix'    => ['\App\Controllers'],

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -870,7 +870,7 @@ final class RouterTest extends CIUnitTestCase
         $router->handle($url);
     }
 
-    public function provideRedirectCase(): array
+    public function provideRedirectCase(): iterable
     {
         // [$route, $redirectFrom, $redirectTo, $url, $expectedPath, $alias]
         return [

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -79,7 +79,7 @@ final class DOMParserTest extends CIUnitTestCase
         $this->assertSame(['href' => 'http://example.com'], $selector['attr']);
     }
 
-    public function provideText()
+    public function provideText(): iterable
     {
         return [
             'en' => ['Hello World'],

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -284,7 +284,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->get('0');
     }
 
-    public function provideRoutesData()
+    public function provideRoutesData(): iterable
     {
         return [
             'non parameterized cli' => [

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -46,7 +46,7 @@ final class TestResponseTest extends CIUnitTestCase
     /**
      * Provides status codes and their expected "OK"
      */
-    public function statusCodeProvider(): array
+    public function statusCodeProvider(): iterable
     {
         return [
             [

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -208,7 +208,7 @@ final class ThrottleTest extends CIUnitTestCase
         }
     }
 
-    public function tokenTimeUsecases(): array
+    public function tokenTimeUsecases(): iterable
     {
         return [
             '2 capacity / 200 seconds (100s refresh, 0.01 tokens/s) -> 5 checks, 1 cost each' => [

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
-use Generator;
 use Tests\Support\Validation\TestRules;
 
 /**
@@ -64,7 +63,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
      *
      * @see https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
      */
-    public function creditCardProvider(): Generator
+    public function creditCardProvider(): iterable
     {
         yield from [
             'null_test' => [

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -129,7 +129,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
     }
 
-    public function urlProvider(): Generator
+    public function urlProvider(): iterable
     {
         yield from [
             [
@@ -260,7 +260,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function emailProviderSingle(): Generator
+    public function emailProviderSingle(): iterable
     {
         yield from [
             [
@@ -278,7 +278,7 @@ class FormatRulesTest extends CIUnitTestCase
         ];
     }
 
-    public function emailsProvider(): Generator
+    public function emailsProvider(): iterable
     {
         yield from [
             [
@@ -324,7 +324,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function ipProvider(): Generator
+    public function ipProvider(): iterable
     {
         yield from [
             [
@@ -393,7 +393,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function stringProvider(): Generator
+    public function stringProvider(): iterable
     {
         yield from [
             [
@@ -427,7 +427,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaProvider(): Generator
+    public function alphaProvider(): iterable
     {
         yield from [
             [
@@ -469,7 +469,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaSpaceProvider(): Generator
+    public function alphaSpaceProvider(): iterable
     {
         yield from [
             [
@@ -515,7 +515,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaNumericProvider(): Generator
+    public function alphaNumericProvider(): iterable
     {
         yield from [
             [
@@ -553,7 +553,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaNumericPunctProvider(): Generator
+    public function alphaNumericPunctProvider(): iterable
     {
         yield from [
             [
@@ -685,7 +685,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function alphaDashProvider(): Generator
+    public function alphaDashProvider(): iterable
     {
         yield from [
             [
@@ -723,7 +723,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function hexProvider(): Generator
+    public function hexProvider(): iterable
     {
         yield from [
             [
@@ -761,7 +761,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function numericProvider(): Generator
+    public function numericProvider(): iterable
     {
         yield from [
             [
@@ -837,7 +837,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertsame($expected, $this->validation->run($data));
     }
 
-    public function integerInvalidTypeDataProvider(): Generator
+    public function integerInvalidTypeDataProvider(): iterable
     {
         // TypeError : CodeIgniter\Validation\FormatRules::integer(): Argument #1 ($str) must be of type ?string, array given
         // yield 'array with int' => [
@@ -883,7 +883,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function integerProvider(): Generator
+    public function integerProvider(): iterable
     {
         yield from [
             [
@@ -937,7 +937,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function decimalProvider(): Generator
+    public function decimalProvider(): iterable
     {
         yield from [
             [
@@ -995,7 +995,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function naturalProvider(): Generator
+    public function naturalProvider(): iterable
     {
         yield from [
             [
@@ -1037,7 +1037,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function naturalZeroProvider(): Generator
+    public function naturalZeroProvider(): iterable
     {
         yield from [
             [
@@ -1079,7 +1079,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function base64Provider(): Generator
+    public function base64Provider(): iterable
     {
         yield from [
             [
@@ -1113,7 +1113,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function jsonProvider(): Generator
+    public function jsonProvider(): iterable
     {
         yield from [
             [
@@ -1171,7 +1171,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function timezoneProvider(): Generator
+    public function timezoneProvider(): iterable
     {
         yield from [
             [
@@ -1209,7 +1209,7 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function validDateProvider(): Generator
+    public function validDateProvider(): iterable
     {
         yield from [
             [

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
-use Generator;
 use stdClass;
 use Tests\Support\Validation\TestRules;
 
@@ -61,7 +60,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideRequiredCases(): Generator
+    public function provideRequiredCases(): iterable
     {
         yield from [
             [['foo' => null], false],
@@ -82,7 +81,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function ifExistProvider(): Generator
+    public function ifExistProvider(): iterable
     {
         yield from [
             [
@@ -135,7 +134,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function providePermitEmptyCases(): Generator
+    public function providePermitEmptyCases(): iterable
     {
         yield from [
             // If the rule is only `permit_empty`, any value will pass.
@@ -299,7 +298,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideMatchesCases(): Generator
+    public function provideMatchesCases(): iterable
     {
         yield from [
             [['foo' => null, 'bar' => null], true],
@@ -317,7 +316,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideMatchesNestedCases(): Generator
+    public function provideMatchesNestedCases(): iterable
     {
         yield from [
             [['nested' => ['foo' => 'match', 'bar' => 'match']], true],
@@ -352,7 +351,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideEqualsCases(): Generator
+    public function provideEqualsCases(): iterable
     {
         yield from [
             'null'   => [['foo' => null], '', false],
@@ -372,7 +371,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run(['foo' => $data]));
     }
 
-    public function provideMinLengthCases(): Generator
+    public function provideMinLengthCases(): iterable
     {
         yield from [
             'null'    => [null, '2', false],
@@ -406,7 +405,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run(['foo' => $data]));
     }
 
-    public function provideExactLengthCases(): Generator
+    public function provideExactLengthCases(): iterable
     {
         yield from [
             'null'    => [null, false],
@@ -433,7 +432,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function greaterThanProvider(): Generator
+    public function greaterThanProvider(): iterable
     {
         yield from [
             ['-10', '-11', true],
@@ -458,7 +457,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function greaterThanEqualProvider(): Generator
+    public function greaterThanEqualProvider(): iterable
     {
         yield from [
             ['0', '0', true],
@@ -484,7 +483,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function lessThanProvider(): Generator
+    public function lessThanProvider(): iterable
     {
         yield from [
             ['-10', '-11', false],
@@ -510,7 +509,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function lessThanEqualProvider(): Generator
+    public function lessThanEqualProvider(): iterable
     {
         yield from [
             ['0', '0', true],
@@ -546,7 +545,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame(! $expected, $this->validation->run($data));
     }
 
-    public function inListProvider(): Generator
+    public function inListProvider(): iterable
     {
         yield from [
             ['red', 'red,Blue,123', true],
@@ -582,7 +581,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function requiredWithProvider(): Generator
+    public function requiredWithProvider(): iterable
     {
         yield from [
             ['nope', 'bar', false],
@@ -630,7 +629,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $result);
     }
 
-    public function RequiredWithAndOtherRulesProvider(): Generator
+    public function RequiredWithAndOtherRulesProvider(): iterable
     {
         yield from [
             // `otherField` and `mustBeADate` do not exist
@@ -667,7 +666,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $result);
     }
 
-    public function RequiredWithAndOtherRuleWithValueZeroProvider(): Generator
+    public function RequiredWithAndOtherRuleWithValueZeroProvider(): iterable
     {
         yield from [
             [true, ['married' => '0', 'partner_name' => '']],
@@ -697,7 +696,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function requiredWithoutProvider(): Generator
+    public function requiredWithoutProvider(): iterable
     {
         yield from [
             ['nope', 'bars', false],
@@ -743,7 +742,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($result, $this->validation->run($data));
     }
 
-    public function requiredWithoutMultipleProvider(): Generator
+    public function requiredWithoutMultipleProvider(): iterable
     {
         yield from [
             'all empty' => [
@@ -789,7 +788,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($result, $this->validation->run($data));
     }
 
-    public function requiredWithoutMultipleWithoutFieldsProvider(): Generator
+    public function requiredWithoutMultipleWithoutFieldsProvider(): iterable
     {
         yield from [
             'baz is missing' => [

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -14,7 +14,6 @@ namespace CodeIgniter\Validation\StrictRules;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Validation;
 use Config\Services;
-use Generator;
 use Tests\Support\Validation\TestRules;
 
 /**
@@ -65,7 +64,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
      *
      * @see https://www.paypalobjects.com/en_US/vhelp/paypalmanager_help/credit_card_numbers.htm
      */
-    public function creditCardProvider(): Generator
+    public function creditCardProvider(): iterable
     {
         yield from [
             'null_test' => [

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\Validation\StrictRules;
 
 use CodeIgniter\Validation\RulesTest as TraditionalRulesTest;
 use CodeIgniter\Validation\Validation;
-use Generator;
 use Tests\Support\Validation\TestRules;
 
 /**
@@ -51,7 +50,7 @@ final class RulesTest extends TraditionalRulesTest
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function providePermitEmptyCasesStrict(): Generator
+    public function providePermitEmptyCasesStrict(): iterable
     {
         yield from [
             [
@@ -106,7 +105,7 @@ final class RulesTest extends TraditionalRulesTest
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideGreaterThanEqualStrict(): Generator
+    public function provideGreaterThanEqualStrict(): iterable
     {
         yield from [
             [0, '0', true],
@@ -132,7 +131,7 @@ final class RulesTest extends TraditionalRulesTest
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideGreaterThanStrict(): Generator
+    public function provideGreaterThanStrict(): iterable
     {
         yield from [
             [-10, '-11', true],
@@ -159,7 +158,7 @@ final class RulesTest extends TraditionalRulesTest
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideLessThanStrict(): Generator
+    public function provideLessThanStrict(): iterable
     {
         yield from [
             [-10, '-11', false],
@@ -187,7 +186,7 @@ final class RulesTest extends TraditionalRulesTest
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function provideLessThanEqualStrict(): Generator
+    public function provideLessThanEqualStrict(): iterable
     {
         yield from [
             [0, '0', true],

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -18,7 +18,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use Config\App;
 use Config\Services;
-use Generator;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Support\Validation\TestRules;
 use TypeError;
@@ -339,7 +338,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function arrayDataProvider(): Generator
+    public function arrayDataProvider(): iterable
     {
         yield 'list array' => [
             [1, 2, 3, 4, 5],
@@ -391,7 +390,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public function isIntInvalidTypeDataProvider(): Generator
+    public function isIntInvalidTypeDataProvider(): iterable
     {
         yield 'array with int' => [
             [555],
@@ -623,7 +622,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->getError('foo'));
     }
 
-    public function rulesSetupProvider(): Generator
+    public function rulesSetupProvider(): iterable
     {
         yield from [
             [
@@ -971,7 +970,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($results, $this->validation->getErrors());
     }
 
-    public function arrayFieldDataProvider(): Generator
+    public function arrayFieldDataProvider(): iterable
     {
         yield from [
             'all_rules_should_pass' => [
@@ -1206,7 +1205,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function dotNotationForIfExistProvider(): Generator
+    public function dotNotationForIfExistProvider(): iterable
     {
         yield 'dot-on-end-fail' => [
             false,

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -418,7 +418,7 @@ final class ParserTest extends CIUnitTestCase
         $this->assertSame($result, $this->parser->renderString($template));
     }
 
-    public function escValueTypes()
+    public function escValueTypes(): iterable
     {
         return [
             'scalar'     => [42],


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
```console
$ vendor/bin/php-cs-fixer describe php_unit_data_provider_return_type
Description of php_unit_data_provider_return_type rule.
The return type of PHPUnit data provider must be `iterable`.
Data provider must return `iterable`, either an array of arrays or an object that implements the `Traversable` interface.

Fixer applying this rule is risky.
Risky when relying on signature of the data provider.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,8 @@
    <?php
    class FooTest extends TestCase {
        /**
         * @dataProvider provideSomethingCases
         */
        public function testSomething($expected, $actual) {}
   -    public function provideSomethingCases(): array {}
   +    public function provideSomethingCases(): iterable {}
    }

   ----------- end diff -----------

 * Example #2.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,8 @@
    <?php
    class FooTest extends TestCase {
        /**
         * @dataProvider provideSomethingCases
         */
        public function testSomething($expected, $actual) {}
   -    public function provideSomethingCases() {}
   +    public function provideSomethingCases(): iterable {}
    }

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
