### PR TITLE
Adjust registering of custom fixers for PHP 8.0+ only

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,16 +46,23 @@ $finder = Finder::create()
 $overrides = [];
 
 $options = [
-    'cacheFile'    => 'build/.php-cs-fixer.cache',
-    'finder'       => $finder,
-    'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
-    'customRules'  => [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ],
+    'cacheFile' => 'build/.php-cs-fixer.cache',
+    'finder'    => $finder,
 ];
 
-return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
+$config = Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
     'CodeIgniter 4 framework',
     'CodeIgniter Foundation',
     'admin@codeigniter.com'
 );
+
+// @TODO: remove this check when support for PHP 7.4 is dropped
+if (PHP_VERSION_ID >= 80000) {
+    $config
+        ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
+        ->setRules(array_merge($config->getRules(), [
+            NoCodeSeparatorCommentFixer::name() => true,
+        ]));
+}
+
+return $config;

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -32,12 +32,19 @@ $finder = Finder::create()
 $overrides = [];
 
 $options = [
-    'cacheFile'    => 'build/.php-cs-fixer.no-header.cache',
-    'finder'       => $finder,
-    'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
-    'customRules'  => [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ],
+    'cacheFile' => 'build/.php-cs-fixer.no-header.cache',
+    'finder'    => $finder,
 ];
 
-return Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
+$config = Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
+
+// @TODO: remove this check when support for PHP 7.4 is dropped
+if (PHP_VERSION_ID >= 80000) {
+    $config
+        ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
+        ->setRules(array_merge($config->getRules(), [
+            NoCodeSeparatorCommentFixer::name() => true,
+        ]));
+}
+
+return $config;

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -36,12 +36,19 @@ $overrides = [
 ];
 
 $options = [
-    'cacheFile'    => 'build/.php-cs-fixer.user-guide.cache',
-    'finder'       => $finder,
-    'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
-    'customRules'  => [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ],
+    'cacheFile' => 'build/.php-cs-fixer.no-header.cache',
+    'finder'    => $finder,
 ];
 
-return Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
+$config = Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
+
+// @TODO: remove this check when support for PHP 7.4 is dropped
+if (PHP_VERSION_ID >= 80000) {
+    $config
+        ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
+        ->setRules(array_merge($config->getRules(), [
+            NoCodeSeparatorCommentFixer::name() => true,
+        ]));
+}
+
+return $config;


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
`php-cs-fixer` recently adjusted the return types of its `Preg` methods. Yes, that class is internal but `cs-config` depended on that. With the return type change, it used the native `preg_*` functions instead. Since `cs-config` needs `^8.0.1` the fix won't work with 7.4.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
