### PR TITLE
[Rector] Enable skipped GetMockBuilderGetMockToCreateMockRector on EmailTest.php

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -39,7 +39,6 @@ use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\PHPUnit\Rector\MethodCall\AssertPropertyExistsRector;
-use Rector\PHPUnit\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Rector\Set\ValueObject\LevelSetList;
@@ -107,11 +106,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // use mt_rand instead of random_int on purpose on non-cryptographically random
         RandomFunctionRector::class,
-
-        // @TODO remove if https://github.com/rectorphp/rector-phpunit/issues/86 is fixed
-        GetMockBuilderGetMockToCreateMockRector::class => [
-            __DIR__ . '/tests/system/Email/EmailTest.php',
-        ],
 
         SimplifyRegexPatternRector::class,
     ]);


### PR DESCRIPTION

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

The `GetMockBuilderGetMockToCreateMockRector` bug was fixed at PR:

- https://github.com/rectorphp/rector-phpunit/pull/205

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
