### PR TITLE
Add `normalize_path` helper function

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -94,7 +94,7 @@ class FileLocator
         // Check each path in the namespace
         foreach ($paths as $path) {
             // Ensure trailing slash
-            $path = rtrim($path, '/') . '/';
+            $path = rtrim($path, '\\/') . '/';
 
             // If we have a folder name, then the calling function
             // expects this file to be within that folder, like 'Views',
@@ -104,8 +104,11 @@ class FileLocator
             }
 
             $path .= $filename;
+
             if (is_file($path)) {
-                return $path;
+                helper('filesystem');
+
+                return normalize_path($path);
             }
         }
 

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -448,3 +448,20 @@ if (! function_exists('set_realpath')) {
         return is_dir($path) ? rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR : $path;
     }
 }
+
+if (! function_exists('normalize_path')) {
+    /**
+     * Normalizes the given path.
+     *
+     * @param bool $native If true, this will normalize all slashes to `DIRECTORY_SEPARATOR`. Otherwise,
+     *                     this will change all slashes to forward slashes ("/").
+     */
+    function normalize_path(string $path, bool $native = true): string
+    {
+        if ($native) {
+            return str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
+        }
+
+        return str_replace('\\', '/', $path);
+    }
+}

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -253,15 +253,17 @@ if (! function_exists('get_dir_file_info')) {
     function get_dir_file_info(string $sourceDir, bool $topLevelOnly = true, bool $recursion = false): array
     {
         static $fileData = [];
-        $relativePath    = $sourceDir;
+
+        $sourceDir    = realpath($sourceDir) ?: $sourceDir;
+        $relativePath = $sourceDir;
 
         try {
             $fp = opendir($sourceDir);
 
-            // reset the array and make sure $source_dir has a trailing slash on the initial call
+            // reset the array and make sure $sourceDir has a trailing slash on the initial call
             if ($recursion === false) {
                 $fileData  = [];
-                $sourceDir = rtrim(realpath($sourceDir), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+                $sourceDir = rtrim($sourceDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
             }
 
             // Used to be foreach (scandir($source_dir, 1) as $file), but scandir() is simply not as fast

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -85,13 +85,13 @@ final class AutoloaderTest extends CIUnitTestCase
 
         $ns = $loader->getNamespace();
         $this->assertCount(1, $ns['App']);
-        $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
+        $this->assertSame('ROOTPATH/app', normalize_path(clean_path($ns['App'][0]), false));
 
         $loader->initialize(new Autoload(), new Modules());
 
         $ns = $loader->getNamespace();
         $this->assertCount(1, $ns['App']);
-        $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
+        $this->assertSame('ROOTPATH/app', normalize_path(clean_path($ns['App'][0]), false));
     }
 
     public function testServiceAutoLoaderFromShareInstances()
@@ -284,9 +284,15 @@ final class AutoloaderTest extends CIUnitTestCase
         $loader = new Autoloader();
         $loader->initialize($config, $modules);
 
-        $namespaces = $loader->getNamespace();
+        $namespaces = array_map(
+            static fn (array $paths): array => array_map(
+                static fn (string $path): string => normalize_path($path, false),
+                $paths
+            ),
+            $loader->getNamespace()
+        );
         $this->assertSame('/Config/Autoload/Psr/Log/', $namespaces['Psr\Log'][0]);
-        $this->assertStringContainsString(VENDORPATH, $namespaces['Psr\Log'][1]);
+        $this->assertStringContainsString(normalize_path(VENDORPATH, false), $namespaces['Psr\Log'][1]);
     }
 
     public function testComposerPackagesOnly()

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -55,7 +55,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Controllers/Home'; // not namespaced
 
-        $expected = APPPATH . 'Controllers/Home.php';
+        $expected = normalize_path(APPPATH . 'Controllers/Home.php');
 
         $this->assertSame($expected, $this->locator->locateFile($file));
     }
@@ -71,7 +71,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'welcome_message'; // not namespaced
 
-        $expected = APPPATH . 'Views/welcome_message.php';
+        $expected = normalize_path(APPPATH . 'Views/welcome_message.php');
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
@@ -89,7 +89,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Controllers/Home'; // not namespaced
 
-        $expected = APPPATH . 'Controllers/Home.php';
+        $expected = normalize_path(APPPATH . 'Controllers/Home.php');
 
         // This works because $file contains `Controllers`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Controllers'));
@@ -99,7 +99,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\App\Views/errors/html/error_404.php';
 
-        $expected = APPPATH . 'Views/errors/html/error_404.php';
+        $expected = normalize_path(APPPATH . 'Views/errors/html/error_404.php');
 
         // This works because $file contains `Views`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
@@ -109,7 +109,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Views/welcome_message.php'; // not namespaced
 
-        $expected = APPPATH . 'Views/welcome_message.php';
+        $expected = normalize_path(APPPATH . 'Views/welcome_message.php');
 
         // This works because $file contains `Views`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
@@ -119,7 +119,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\Errors\error_404';
 
-        $expected = APPPATH . 'Views/errors/html/error_404.php';
+        $expected = normalize_path(APPPATH . 'Views/errors/html/error_404.php');
 
         // The namespace `Errors` (APPPATH . 'Views/errors') + the folder (`html`) + `error_404`
         $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
@@ -129,7 +129,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\Errors\html/error_404';
 
-        $expected = APPPATH . 'Views/errors/html/error_404.php';
+        $expected = normalize_path(APPPATH . 'Views/errors/html/error_404.php');
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
     }
@@ -138,7 +138,7 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\CodeIgniter\Devkit\View\Views/simple';
 
-        $expected = ROOTPATH . 'tests/_support/View/Views/simple.php';
+        $expected = normalize_path(ROOTPATH . 'tests/_support/View/Views/simple.php');
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
@@ -161,14 +161,14 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Acme\SampleProject\View\Views\simple';
 
-        $expected = ROOTPATH . 'tests/_support/View/Views/simple.php';
+        $expected = normalize_path(ROOTPATH . 'tests/_support/View/Views/simple.php');
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
     public function testSearchSimple()
     {
-        $expected = APPPATH . 'Config/App.php';
+        $expected = normalize_path(APPPATH . 'Config/App.php');
 
         $foundFiles = $this->locator->search('Config/App.php');
 
@@ -177,7 +177,7 @@ final class FileLocatorTest extends CIUnitTestCase
 
     public function testSearchWithFileExtension()
     {
-        $expected = APPPATH . 'Config/App.php';
+        $expected = normalize_path(APPPATH . 'Config/App.php');
 
         $foundFiles = $this->locator->search('Config/App', 'php');
 
@@ -208,8 +208,8 @@ final class FileLocatorTest extends CIUnitTestCase
 
         $this->assertSame(
             [
-                SYSTEMPATH . 'Language/en/Validation.php',
-                APPPATH . 'Language/en/Validation.php',
+                normalize_path(SYSTEMPATH . 'Language/en/Validation.php'),
+                normalize_path(APPPATH . 'Language/en/Validation.php'),
             ],
             $foundFiles
         );
@@ -224,9 +224,8 @@ final class FileLocatorTest extends CIUnitTestCase
     {
         $files = $this->locator->listFiles('Config/');
 
-        $expectedWin = APPPATH . 'Config\App.php';
-        $expectedLin = APPPATH . 'Config/App.php';
-        $this->assertTrue(in_array($expectedWin, $files, true) || in_array($expectedLin, $files, true));
+        $expected = normalize_path(APPPATH . 'Config/App.php');
+        $this->assertTrue(in_array($expected, $files, true));
     }
 
     public function testListFilesDoesNotContainDirectories()

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -49,49 +49,49 @@ final class FileWithVfsTest extends CIUnitTestCase
     public function testDestinationUnknown()
     {
         $destination = $this->start . 'charlie/cherry.php';
-        $this->assertSame($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testDestinationSameFileSameFolder()
     {
         $destination = $this->start . 'able/apple.php';
-        $this->assertSame($this->start . 'able/apple_1.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'able/apple_1.php', normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testDestinationSameFileDifferentFolder()
     {
         $destination = $this->start . 'baker/apple.php';
-        $this->assertSame($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testDestinationDifferentFileSameFolder()
     {
         $destination = $this->start . 'able/date.php';
-        $this->assertSame($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testDestinationDifferentFileDifferentFolder()
     {
         $destination = $this->start . 'baker/date.php';
-        $this->assertSame($destination, $this->file->getDestination($destination));
+        $this->assertSame($destination, normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testDestinationExistingFileDifferentFolder()
     {
         $destination = $this->start . 'baker/banana.php';
-        $this->assertSame($this->start . 'baker/banana_1.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'baker/banana_1.php', normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testDestinationDelimited()
     {
         $destination = $this->start . 'able/fig_3.php';
-        $this->assertSame($this->start . 'able/fig_4.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'able/fig_4.php', normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testDestinationDelimitedAlpha()
     {
         $destination = $this->start . 'able/prune_ripe.php';
-        $this->assertSame($this->start . 'able/prune_ripe_1.php', $this->file->getDestination($destination));
+        $this->assertSame($this->start . 'able/prune_ripe_1.php', normalize_path($this->file->getDestination($destination), false));
     }
 
     public function testMoveNormal()

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -561,4 +561,35 @@ final class FilesystemHelperTest extends CIUnitTestCase
     {
         $this->assertSame(SUPPORTPATH . 'Models/', set_realpath(SUPPORTPATH . 'Files/../Models', true));
     }
+
+    /**
+     * @dataProvider provideNormalizePath
+     */
+    public function testNormalizePath(string $expected, string $input, bool $native): void
+    {
+        $this->assertSame($expected, normalize_path($input, $native));
+    }
+
+    public static function provideNormalizePath(): iterable
+    {
+        yield ['/etc/hosts', '/etc\hosts', false];
+
+        yield ['C:/App/Users/User/Desktop/bar.php', 'C:\App/Users\User\Desktop/bar.php', false];
+
+        yield ['var/socket/tmp', 'var\socket/tmp', false];
+
+        if (! is_windows()) {
+            yield ['/etc/hosts', '/etc\hosts', true];
+
+            yield ['C:/App/Users/User/Desktop/bar.php', 'C:\App/Users\User\Desktop/bar.php', true];
+
+            yield ['var/socket/tmp', 'var\socket/tmp', true];
+        } else {
+            yield ['\etc\hosts', '/etc\hosts', true];
+
+            yield ['C:\App\Users\User\Desktop\bar.php', 'C:\App/Users\User\Desktop/bar.php', true];
+
+            yield ['var\socket\tmp', 'var\socket/tmp', true];
+        }
+    }
 }

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -316,8 +316,6 @@ final class FilesystemHelperTest extends CIUnitTestCase
     {
         $vfs = vfsStream::setup('root', null, $this->structure);
 
-        $filenames = get_filenames($vfs->url(), true, false, false);
-
         $expected = [
             'vfs://root/boo/far',
             'vfs://root/boo/faz',
@@ -325,7 +323,10 @@ final class FilesystemHelperTest extends CIUnitTestCase
             'vfs://root/foo/baz',
             'vfs://root/simpleFile',
         ];
-        $this->assertSame($expected, $filenames);
+        $this->assertSame(
+            $expected,
+            array_map(static fn (string $file): string => normalize_path($file, false), get_filenames($vfs->url(), true, false, false))
+        );
     }
 
     public function testGetFilenamesWithHidden()
@@ -348,7 +349,10 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
         $vfs = vfsStream::setup('root', null, $this->structure);
 
-        $this->assertSame($expected, get_filenames($vfs->url(), false, true));
+        $this->assertSame(
+            $expected,
+            array_map(static fn (string $file): string => normalize_path($file, false), get_filenames($vfs->url(), false, true))
+        );
     }
 
     public function testGetFilenamesWithRelativeSource()
@@ -368,7 +372,10 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
         $vfs = vfsStream::setup('root', null, $this->structure);
 
-        $this->assertSame($expected, get_filenames($vfs->url(), null));
+        $this->assertSame(
+            $expected,
+            array_map(static fn (string $file): string => normalize_path($file, false), get_filenames($vfs->url(), null))
+        );
     }
 
     public function testGetFilenamesWithFullSource()
@@ -378,17 +385,20 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $vfs = vfsStream::setup('root', null, $this->structure);
 
         $expected = [
-            $vfs->url() . DIRECTORY_SEPARATOR . 'AnEmptyFolder',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'boo',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'boo/far',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'boo/faz',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'foo',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'foo/bar',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'foo/baz',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'simpleFile',
+            $vfs->url() . '/AnEmptyFolder',
+            $vfs->url() . '/boo',
+            $vfs->url() . '/boo/far',
+            $vfs->url() . '/boo/faz',
+            $vfs->url() . '/foo',
+            $vfs->url() . '/foo/bar',
+            $vfs->url() . '/foo/baz',
+            $vfs->url() . '/simpleFile',
         ];
 
-        $this->assertSame($expected, get_filenames($vfs->url(), true));
+        $this->assertSame(
+            $expected,
+            array_map(static fn (string $file): string => normalize_path($file, false), get_filenames($vfs->url(), true)),
+        );
     }
 
     public function testGetFilenamesFailure()
@@ -398,7 +408,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
     public function testGetDirFileInfo()
     {
-        $file = SUPPORTPATH . 'Files/baker/banana.php';
+        $file = normalize_path(SUPPORTPATH . 'Files/baker/banana.php');
         $info = get_file_info($file);
 
         $expected = [
@@ -460,6 +470,11 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $this->assertSame($expected, get_file_info(SUPPORTPATH . 'Files/baker/banana.php', 'readable,writable,executable'));
     }
 
+    /**
+     * chmod does not work well on Windows
+     *
+     * @requires OS Linux|Darwin
+     */
     public function testGetFileInfoPerms()
     {
         $file     = SUPPORTPATH . 'Files/baker/banana.php';
@@ -559,7 +574,10 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
     public function testRealPathResolved()
     {
-        $this->assertSame(SUPPORTPATH . 'Models/', set_realpath(SUPPORTPATH . 'Files/../Models', true));
+        $this->assertSame(
+            normalize_path(SUPPORTPATH . 'Models/'),
+            normalize_path(set_realpath(SUPPORTPATH . 'Files/../Models', true))
+        );
     }
 
     /**

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -42,6 +42,15 @@ final class PublisherInputTest extends CIUnitTestCase
         helper(['filesystem']);
     }
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->file = normalize_path($this->file);
+
+        $this->directory = normalize_path($this->directory);
+    }
+
     public function testAddPathFile()
     {
         $publisher = new Publisher(SUPPORTPATH . 'Files');
@@ -83,7 +92,7 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
+            $this->file,
         ];
 
         $publisher->addPath('Files');
@@ -99,7 +108,7 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
+            $this->file,
         ];
 
         $publisher->addPaths([
@@ -118,8 +127,8 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Log/Handlers/TestHandler.php',
+            normalize_path(SUPPORTPATH . 'Files/baker/banana.php'),
+            normalize_path(SUPPORTPATH . 'Log/Handlers/TestHandler.php'),
         ];
 
         $publisher->addPaths([

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -44,6 +44,15 @@ final class PublisherSupportTest extends CIUnitTestCase
         helper(['filesystem']);
     }
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->file = normalize_path($this->file);
+
+        $this->directory = normalize_path($this->directory);
+    }
+
     public function testDiscoverDefault()
     {
         $result = Publisher::discover();

--- a/user_guide_src/source/changelogs/v4.3.7.rst
+++ b/user_guide_src/source/changelogs/v4.3.7.rst
@@ -43,6 +43,11 @@ Bugs Fixed
   ``$routes->add()``, the controller's other methods were inaccessible from the
   web browser.
 
+Enhancements
+************
+
+- Added a new filesystem helper function :php:func:`normalize_path()` that normalizes any given file path to use uniform slashes.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -245,3 +245,18 @@ The following functions are available:
     Examples:
 
     .. literalinclude:: filesystem_helper/015.php
+
+.. versionadded:: 4.3.7
+
+.. php:function:: normalize_path($path[, $native = true])
+
+    :param  string $path: File path
+    :param  bool $native: If true, this will normalize all slashes to `DIRECTORY_SEPARATOR`. Otherwise, this will change all slashes to forward slashes ("/").
+    :returns:   Normalized file path
+    :rtype:     string
+
+    Normalizes a given path.
+
+    Examples:
+
+    .. literalinclude:: filesystem_helper/016.php

--- a/user_guide_src/source/helpers/filesystem_helper/016.php
+++ b/user_guide_src/source/helpers/filesystem_helper/016.php
@@ -1,0 +1,11 @@
+<?php
+
+// on Windows environment
+$fileOnWindows = 'C:\App/Users\User\Desktop/bar.php';
+echo normalize_path($fileOnWindows); // 'C:\App\Users\User\Desktop\bar.php'
+echo normalize_path($fileOnWindows, false); // 'C:/App/Users/User/Desktop/bar.php'
+
+// on Linux environment
+$fileOnLinux = 'var\socket/tmp';
+echo normalize_path($fileOnLinux); // 'var/socket/tmp'
+echo normalize_path($fileOnLinux, false); // 'var/socket/tmp'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
This PR adds the `normalize_path` to enable uniform testing of path-sensitive tests. I put this against `develop` as this function is meant for testing, but can be used for non-testing as well. (Also I need this against develop as this will fix the errors identified in #7491 ).

In the context of tests, when to use `$native` mode is based on:
- The return format of the tested method.
- Which will give the lesser diffs

So, it's basically a matter of taste/choice.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
