### PR TITLE
fix: $sensitiveDataInTrace does not work

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -932,11 +932,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Debug/Exceptions.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Debug\\\\Exceptions\\:\\:maskSensitiveData\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Debug/Exceptions.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Debug\\\\Exceptions\\:\\:render\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Debug/Exceptions.php',

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -293,7 +293,7 @@ class Exceptions
         $trace = $exception->getTrace();
 
         if ($this->config->sensitiveDataInTrace !== []) {
-            $this->maskSensitiveData($trace, $this->config->sensitiveDataInTrace);
+            $trace = $this->maskSensitiveData($trace, $this->config->sensitiveDataInTrace);
         }
 
         return [
@@ -311,8 +311,10 @@ class Exceptions
      * Mask sensitive data in the trace.
      *
      * @param array|object $trace
+     *
+     * @return array|object
      */
-    protected function maskSensitiveData(&$trace, array $keysToMask, string $path = '')
+    protected function maskSensitiveData($trace, array $keysToMask, string $path = '')
     {
         foreach ($keysToMask as $keyToMask) {
             $explode = explode('/', $keyToMask);
@@ -327,15 +329,17 @@ class Exceptions
             }
         }
 
-        if (is_object($trace)) {
-            $trace = get_object_vars($trace);
-        }
-
         if (is_array($trace)) {
             foreach ($trace as $pathKey => $subarray) {
-                $this->maskSensitiveData($subarray, $keysToMask, $path . '/' . $pathKey);
+                $trace[$pathKey] = $this->maskSensitiveData($subarray, $keysToMask, $path . '/' . $pathKey);
+            }
+        } elseif (is_object($trace)) {
+            foreach ($trace as $pathKey => $subarray) {
+                $trace->{$pathKey} = $this->maskSensitiveData($subarray, $keysToMask, $path . '/' . $pathKey);
             }
         }
+
+        return $trace;
     }
 
     /**

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Debug;
 
+use App\Controllers\Home;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Entity\Exceptions\CastException;
 use CodeIgniter\Exceptions\ConfigException;
@@ -157,7 +158,7 @@ final class ExceptionsTest extends CIUnitTestCase
                 'file'     => '/var/www/CodeIgniter4/app/Controllers/Home.php',
                 'line'     => 15,
                 'function' => 'f',
-                'class'    => 'App\\Controllers\\Home',
+                'class'    => Home::class,
                 'type'     => '->',
                 'args'     => [
                     0 => (object) [
@@ -180,7 +181,7 @@ final class ExceptionsTest extends CIUnitTestCase
                 'file'     => '/var/www/CodeIgniter4/system/CodeIgniter.php',
                 'line'     => 932,
                 'function' => 'index',
-                'class'    => 'App\\Controllers\\Home',
+                'class'    => Home::class,
                 'type'     => '->',
                 'args'     => [
                 ],
@@ -206,7 +207,7 @@ final class ExceptionsTest extends CIUnitTestCase
                 'file'     => '/var/www/CodeIgniter4/app/Controllers/Home.php',
                 'line'     => 15,
                 'function' => 'f',
-                'class'    => 'App\\Controllers\\Home',
+                'class'    => Home::class,
                 'type'     => '->',
                 'args'     => [
                 ],
@@ -215,7 +216,7 @@ final class ExceptionsTest extends CIUnitTestCase
                 'file'     => '/var/www/CodeIgniter4/system/CodeIgniter.php',
                 'line'     => 932,
                 'function' => 'index',
-                'class'    => 'App\\Controllers\\Home',
+                'class'    => Home::class,
                 'type'     => '->',
                 'args'     => [
                 ],

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -196,4 +196,36 @@ final class ExceptionsTest extends CIUnitTestCase
         $this->assertSame(['password' => '******************'], $newTrace[0]['args'][2]);
         $this->assertSame(['password' => '******************'], $newTrace[0]['args'][3]['default']);
     }
+
+    public function testMaskSensitiveDataTraceDataKey(): void
+    {
+        $maskSensitiveData = $this->getPrivateMethodInvoker($this->exception, 'maskSensitiveData');
+
+        $trace = [
+            0 => [
+                'file'     => '/var/www/CodeIgniter4/app/Controllers/Home.php',
+                'line'     => 15,
+                'function' => 'f',
+                'class'    => 'App\\Controllers\\Home',
+                'type'     => '->',
+                'args'     => [
+                ],
+            ],
+            1 => [
+                'file'     => '/var/www/CodeIgniter4/system/CodeIgniter.php',
+                'line'     => 932,
+                'function' => 'index',
+                'class'    => 'App\\Controllers\\Home',
+                'type'     => '->',
+                'args'     => [
+                ],
+            ],
+        ];
+        $keysToMask = ['file'];
+        $path       = '';
+
+        $newTrace = $maskSensitiveData($trace, $keysToMask, $path);
+
+        $this->assertSame('/var/www/CodeIgniter4/app/Controllers/Home.php', $newTrace[0]['file']);
+    }
 }

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -147,4 +147,53 @@ final class ExceptionsTest extends CIUnitTestCase
             );
         }
     }
+
+    public function testMaskSensitiveData(): void
+    {
+        $maskSensitiveData = $this->getPrivateMethodInvoker($this->exception, 'maskSensitiveData');
+
+        $trace = [
+            0 => [
+                'file'     => '/var/www/CodeIgniter4/app/Controllers/Home.php',
+                'line'     => 15,
+                'function' => 'f',
+                'class'    => 'App\\Controllers\\Home',
+                'type'     => '->',
+                'args'     => [
+                    0 => (object) [
+                        'password' => 'secret1',
+                    ],
+                    1 => (object) [
+                        'default' => [
+                            'password' => 'secret2',
+                        ],
+                    ],
+                    2 => [
+                        'password' => 'secret3',
+                    ],
+                    3 => [
+                        'default' => ['password' => 'secret4'],
+                    ],
+                ],
+            ],
+            1 => [
+                'file'     => '/var/www/CodeIgniter4/system/CodeIgniter.php',
+                'line'     => 932,
+                'function' => 'index',
+                'class'    => 'App\\Controllers\\Home',
+                'type'     => '->',
+                'args'     => [
+                ],
+            ],
+        ];
+        $keysToMask = ['password'];
+        $path       = '';
+
+        $newTrace = $maskSensitiveData($trace, $keysToMask, $path);
+
+        $this->assertSame(['password' => '******************'], (array) $newTrace[0]['args'][0]);
+        $this->assertSame(['password' => '******************'], $newTrace[0]['args'][1]->default);
+        $this->assertSame(['password' => '******************'], $newTrace[0]['args'][2]);
+        $this->assertSame(['password' => '******************'], $newTrace[0]['args'][3]['default']);
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #7708

- fix: params defined in `$sensitiveDataInTrace` may not be masked
- fix: `maskSensitiveData()` may mask backtrace data like `file`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
