### PR TITLE
feat: add Factories::define() to explicitly override a class

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="system/Cache/Handlers/MemcachedHandler.php">
     <UndefinedClass>
       <code>Memcache</code>
@@ -104,7 +104,9 @@
   </file>
   <file src="tests/system/Config/FactoriesTest.php">
     <UndefinedClass>
-      <code><![CDATA['SomeWidget']]></code>
+      <code><![CDATA['App\Models\UserModel']]></code>
+      <code><![CDATA['App\Models\UserModel']]></code>
+      <code><![CDATA['Config\TestRegistrar']]></code>
     </UndefinedClass>
   </file>
   <file src="tests/system/Database/BaseConnectionTest.php">

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -221,8 +221,8 @@ class Factories
 
         // If an App version was requested then see if it verifies
         if (
-            // preferApp is used only for no namespace class or Config class.
-            (strpos($name, '\\') === false || self::isConfig($options['component']))
+            // preferApp is used only for no namespace class.
+            strpos($name, '\\') === false
             && $options['preferApp'] && class_exists($appname)
             && self::verifyInstanceOf($options, $name)
         ) {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -146,16 +146,6 @@ class Factories
             return $instance;
         }
 
-        // Check for an existing Config definition with basename.
-        if (self::isConfig($options['component'])) {
-            $basename = self::getBasename($alias);
-
-            $instance = self::getDefinedInstance($options, $basename, $arguments);
-            if ($instance !== null) {
-                return $instance;
-            }
-        }
-
         // Try to locate the class
         if (! $class = self::locateClass($options, $alias)) {
             return null;

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -322,6 +322,7 @@ class Factories
      * @return array<string, bool|string|null>
      *
      * @internal For testing only
+     * @testTag
      */
     public static function getOptions(string $component): array
     {
@@ -401,6 +402,7 @@ class Factories
      * @param string $alias     Class alias. See the $aliases property.
      *
      * @internal For testing only
+     * @testTag
      */
     public static function injectMock(string $component, string $alias, object $instance)
     {
@@ -427,6 +429,7 @@ class Factories
      * Gets a basename from a class alias, namespaced or not.
      *
      * @internal For testing only
+     * @testTag
      */
     public static function getBasename(string $alias): string
     {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -226,8 +226,8 @@ class Factories
 
         // If an App version was requested then see if it verifies
         if (
-            // preferApp is used only for no namespace class.
-            strpos($alias, '\\') === false
+            // preferApp is used only for no namespaced class.
+            ! self::isNamespaced($alias)
             && $options['preferApp'] && class_exists($appname)
             && self::verifyInstanceOf($options, $alias)
         ) {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -85,8 +85,8 @@ class Factories
      *
      * @param string $component Lowercase, plural component name
      * @param string $alias     Class alias. See the $aliases property.
-     * @param string $classname FQCN to load
-     * @phpstan-param class-string $classname FQCN to load
+     * @param string $classname FQCN to be loaded
+     * @phpstan-param class-string $classname FQCN to be loaded
      */
     public static function define(string $component, string $alias, string $classname): void
     {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -117,6 +117,14 @@ class Factories
     }
 
     /**
+     * Is the component Config?
+     */
+    private static function isConfig(string $component): bool
+    {
+        return $component === 'config';
+    }
+
+    /**
      * Finds a component class
      *
      * @param array  $options The array of component-specific directives
@@ -135,7 +143,7 @@ class Factories
 
         // Determine the relative class names we need
         $basename = self::getBasename($name);
-        $appname  = $options['component'] === 'config'
+        $appname  = self::isConfig($options['component'])
             ? 'Config\\' . $basename
             : rtrim(APP_NAMESPACE, '\\') . '\\' . $options['path'] . '\\' . $basename;
 
@@ -194,7 +202,7 @@ class Factories
         }
 
         // Special case for Config since its App namespace is actually \Config
-        if ($options['component'] === 'config') {
+        if (self::isConfig($options['component'])) {
             return strpos($name, 'Config') === 0;
         }
 
@@ -233,7 +241,7 @@ class Factories
             return self::$options[$component];
         }
 
-        $values = $component === 'config'
+        $values = self::isConfig($component)
             // Handle Config as a special case to prevent logic loops
             ? self::$configOptions
             // Load values from the best Factory configuration (will include Registrars)

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -166,7 +166,6 @@ class Factories
                     self::$instances[$options['component']][$class] = new $class(...$arguments);
 
                     return self::$instances[$options['component']][$class];
-
                 }
             }
         }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -125,7 +125,11 @@ class Factories
     protected static function locateClass(array $options, string $name): ?string
     {
         // Check for low-hanging fruit
-        if (class_exists($name, false) && self::verifyPreferApp($options, $name) && self::verifyInstanceOf($options, $name)) {
+        if (
+            class_exists($name, false)
+            && self::verifyPreferApp($options, $name)
+            && self::verifyInstanceOf($options, $name)
+        ) {
             return $name;
         }
 
@@ -136,7 +140,10 @@ class Factories
             : rtrim(APP_NAMESPACE, '\\') . '\\' . $options['path'] . '\\' . $basename;
 
         // If an App version was requested then see if it verifies
-        if ($options['preferApp'] && class_exists($appname) && self::verifyInstanceOf($options, $name)) {
+        if (
+            $options['preferApp'] && class_exists($appname)
+            && self::verifyInstanceOf($options, $name)
+        ) {
             return $appname;
         }
 

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -410,17 +410,16 @@ class Factories
         $component = strtolower($component);
         self::getOptions($component);
 
-        $class    = get_class($instance);
-        $basename = self::getBasename($alias);
+        $class = get_class($instance);
 
         self::$instances[$component][$class] = $instance;
         self::$aliases[$component][$alias]   = $class;
 
         if (self::isConfig($component)) {
-            if ($alias !== $basename) {
-                self::$aliases[$component][$basename] = $class;
+            if (self::isNamespaced($alias)) {
+                self::$aliases[$component][self::getBasename($alias)] = $class;
             } else {
-                self::$aliases[$component]['Config\\' . $basename] = $class;
+                self::$aliases[$component]['Config\\' . $alias] = $class;
             }
         }
     }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -401,7 +401,11 @@ class Factories
         self::$basenames[$component][$name]  = $class;
 
         if (self::isConfig($component)) {
-            self::$basenames[$component][$basename] = $class;
+            if ($name !== $basename) {
+                self::$basenames[$component][$basename] = $class;
+            } else {
+                self::$basenames[$component]['Config\\' . $basename] = $class;
+            }
         }
     }
 

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -65,6 +65,8 @@ class Factories
      * A multi-dimensional array with components as
      * keys to the array of name-indexed instances.
      *
+     * [component => [FQCN => instance]]
+     *
      * @var array<string, array<string, object>>
      * @phpstan-var  array<string, array<class-string, object>>
      */
@@ -118,6 +120,8 @@ class Factories
 
     /**
      * Is the component Config?
+     *
+     * @param string $component Lowercase, plural component name
      */
     private static function isConfig(string $component): bool
     {
@@ -231,6 +235,8 @@ class Factories
      * @param string $component Lowercase, plural component name
      *
      * @return array<string, bool|string|null>
+     *
+     * @internal For testing only
      */
     public static function getOptions(string $component): array
     {
@@ -247,6 +253,8 @@ class Factories
             // Load values from the best Factory configuration (will include Registrars)
             : config(Factory::class)->{$component} ?? [];
 
+        // The setOptions() reset the component. So getOptions() may reset
+        // the component.
         return self::setOptions($component, $values);
     }
 
@@ -254,6 +262,7 @@ class Factories
      * Normalizes, stores, and returns the configuration for a specific component
      *
      * @param string $component Lowercase, plural component name
+     * @param array  $values    option values
      *
      * @return array<string, bool|string|null> The result after applying defaults and normalization
      */
@@ -305,6 +314,8 @@ class Factories
      *
      * @param string $component Lowercase, plural component name
      * @param string $name      The name of the instance
+     *
+     * @internal For testing only
      */
     public static function injectMock(string $component, string $name, object $instance)
     {
@@ -321,6 +332,8 @@ class Factories
 
     /**
      * Gets a basename from a class name, namespaced or not.
+     *
+     * @internal For testing only
      */
     public static function getBasename(string $name): string
     {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -52,10 +52,14 @@ class Factories
     ];
 
     /**
-     * Mapping of classnames (with or without namespace) to
-     * their instances.
+     * Mapping of class aliases to their true Full Qualified Class Name (FQCN).
      *
-     * [component => [name => FQCN]]
+     * Class aliases can be:
+     *     - FQCN. E.g., 'App\Lib\SomeLib'
+     *     - short classname. E.g., 'SomeLib'
+     *     - short classname with sub-directories. E.g., 'Sub/SomeLib'
+     *
+     * [component => [alias => FQCN]]
      *
      * @var array<string, array<string, string>>
      * @phpstan-var array<string, array<string, class-string>>
@@ -65,6 +69,7 @@ class Factories
     /**
      * Store for instances of any component that
      * has been requested as "shared".
+     *
      * A multi-dimensional array with components as
      * keys to the array of name-indexed instances.
      *
@@ -79,7 +84,7 @@ class Factories
      * Define the class to load. You can *override* the concrete class.
      *
      * @param string $component Lowercase, plural component name
-     * @param string $name      Classname. The first parameter of Factories magic method
+     * @param string $name      Class alias. See the $basenames property.
      * @param string $classname FQCN to load
      * @phpstan-param class-string $classname FQCN to load
      */
@@ -114,7 +119,7 @@ class Factories
      */
     public static function __callStatic(string $component, array $arguments)
     {
-        // First argument is the name, second is options
+        // First argument is the class alias, second is options
         $name    = trim(array_shift($arguments), '\\ ');
         $options = array_shift($arguments) ?? [];
 
@@ -200,7 +205,7 @@ class Factories
      * Finds a component class
      *
      * @param array  $options The array of component-specific directives
-     * @param string $name    Class name, namespace optional
+     * @param string $name    Class alias. See the $basenames property.
      */
     protected static function locateClass(array $options, string $name): ?string
     {
@@ -266,7 +271,7 @@ class Factories
      * Verifies that a class & config satisfy the "preferApp" option
      *
      * @param array  $options The array of component-specific directives
-     * @param string $name    Class name, namespace optional
+     * @param string $name    Class alias. See the $basenames property.
      */
     protected static function verifyPreferApp(array $options, string $name): bool
     {
@@ -287,7 +292,7 @@ class Factories
      * Verifies that a class & config satisfy the "instanceOf" option
      *
      * @param array  $options The array of component-specific directives
-     * @param string $name    Class name, namespace optional
+     * @param string $name    Class alias. See the $basenames property.
      */
     protected static function verifyInstanceOf(array $options, string $name): bool
     {
@@ -383,7 +388,7 @@ class Factories
      * Helper method for injecting mock instances
      *
      * @param string $component Lowercase, plural component name
-     * @param string $name      The name of the instance
+     * @param string $name      Class alias. See the $basenames property.
      *
      * @internal For testing only
      */

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -242,8 +242,8 @@ class Factories
         // Have to do this the hard way...
         $locator = Services::locator();
 
-        // Check if the class was namespaced
-        if (strpos($alias, '\\') !== false) {
+        // Check if the class alias was namespaced
+        if (self::isNamespaced($alias)) {
             if (! $file = $locator->locateFile($alias, $options['path'])) {
                 return null;
             }
@@ -265,6 +265,16 @@ class Factories
         }
 
         return null;
+    }
+
+    /**
+     * Is the class alias namespaced or not?
+     *
+     * @param string $alias Class alias. See the $aliases property.
+     */
+    private static function isNamespaced(string $alias): bool
+    {
+        return strpos($alias, '\\') !== false;
     }
 
     /**
@@ -414,7 +424,7 @@ class Factories
     }
 
     /**
-     * Gets a basename from a class name, namespaced or not.
+     * Gets a basename from a class alias, namespaced or not.
      *
      * @internal For testing only
      */

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -140,15 +140,17 @@ class Factories
             return null;
         }
 
-        // Check for an existing instance
+        // Check for an existing definition
         if (isset(self::$aliases[$options['component']][$alias])) {
             $class = self::$aliases[$options['component']][$alias];
 
             // Need to verify if the shared instance matches the request
             if (self::verifyInstanceOf($options, $class)) {
+                // Check for an existing instance
                 if (isset(self::$instances[$options['component']][$class])) {
                     return self::$instances[$options['component']][$class];
                 }
+
                 self::$instances[$options['component']][$class] = new $class(...$arguments);
 
                 return self::$instances[$options['component']][$class];
@@ -156,7 +158,7 @@ class Factories
             }
         }
 
-        // Check for an existing Config instance with basename.
+        // Check for an existing Config definition with basename.
         if (self::isConfig($options['component'])) {
             $basename = self::getBasename($alias);
 
@@ -165,9 +167,11 @@ class Factories
 
                 // Need to verify if the shared instance matches the request
                 if (self::verifyInstanceOf($options, $class)) {
+                    // Check for an existing instance
                     if (isset(self::$instances[$options['component']][$class])) {
                         return self::$instances[$options['component']][$class];
                     }
+
                     self::$instances[$options['component']][$class] = new $class(...$arguments);
 
                     return self::$instances[$options['component']][$class];

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -141,41 +141,18 @@ class Factories
         }
 
         // Check for an existing definition
-        if (isset(self::$aliases[$options['component']][$alias])) {
-            $class = self::$aliases[$options['component']][$alias];
-
-            // Need to verify if the shared instance matches the request
-            if (self::verifyInstanceOf($options, $class)) {
-                // Check for an existing instance
-                if (isset(self::$instances[$options['component']][$class])) {
-                    return self::$instances[$options['component']][$class];
-                }
-
-                self::$instances[$options['component']][$class] = new $class(...$arguments);
-
-                return self::$instances[$options['component']][$class];
-
-            }
+        $instance = self::getDefinedInstance($options, $alias, $arguments);
+        if ($instance !== null) {
+            return $instance;
         }
 
         // Check for an existing Config definition with basename.
         if (self::isConfig($options['component'])) {
             $basename = self::getBasename($alias);
 
-            if (isset(self::$aliases[$options['component']][$basename])) {
-                $class = self::$aliases[$options['component']][$basename];
-
-                // Need to verify if the shared instance matches the request
-                if (self::verifyInstanceOf($options, $class)) {
-                    // Check for an existing instance
-                    if (isset(self::$instances[$options['component']][$class])) {
-                        return self::$instances[$options['component']][$class];
-                    }
-
-                    self::$instances[$options['component']][$class] = new $class(...$arguments);
-
-                    return self::$instances[$options['component']][$class];
-                }
+            $instance = self::getDefinedInstance($options, $basename, $arguments);
+            if ($instance !== null) {
+                return $instance;
             }
         }
 
@@ -193,6 +170,32 @@ class Factories
         }
 
         return self::$instances[$options['component']][$class];
+    }
+
+    /**
+     * Gets the defined instance. If not exists, creates new one.
+     *
+     * @return object|null
+     */
+    private static function getDefinedInstance(array $options, string $alias, array $arguments)
+    {
+        if (isset(self::$aliases[$options['component']][$alias])) {
+            $class = self::$aliases[$options['component']][$alias];
+
+            // Need to verify if the shared instance matches the request
+            if (self::verifyInstanceOf($options, $class)) {
+                // Check for an existing instance
+                if (isset(self::$instances[$options['component']][$class])) {
+                    return self::$instances[$options['component']][$class];
+                }
+
+                self::$instances[$options['component']][$class] = new $class(...$arguments);
+
+                return self::$instances[$options['component']][$class];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -52,7 +52,7 @@ class Factories
     ];
 
     /**
-     * Mapping of class aliases to their true Full Qualified Class Name (FQCN).
+     * Mapping of class aliases to their true Fully Qualified Class Name (FQCN).
      *
      * Class aliases can be:
      *     - FQCN. E.g., 'App\Lib\SomeLib'

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -321,7 +321,7 @@ final class FactoriesTest extends CIUnitTestCase
         $this->assertNotSame($cell1, $cell2);
     }
 
-    public function testDefineTwice()
+    public function testDefineSameAliasTwiceWithDifferentClasses()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -338,6 +338,24 @@ final class FactoriesTest extends CIUnitTestCase
             'CodeIgniter\Shield\Models\UserModel',
             EntityModel::class
         );
+    }
+
+    public function testDefineSameAliasAndSameClassTwice()
+    {
+        Factories::define(
+            'models',
+            'CodeIgniter\Shield\Models\UserModel',
+            UserModel::class
+        );
+        Factories::define(
+            'models',
+            'CodeIgniter\Shield\Models\UserModel',
+            UserModel::class
+        );
+
+        $model = model('CodeIgniter\Shield\Models\UserModel');
+
+        $this->assertInstanceOf(UserModel::class, $model);
     }
 
     public function testDefineNonExistentClass()

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -255,7 +255,27 @@ final class FactoriesTest extends CIUnitTestCase
         $this->assertInstanceOf(SomeWidget::class, $result);
     }
 
-    public function testPreferAppOverridesConfigClassname()
+    public function testShortnameReturnsConfigInApp()
+    {
+        // Create a config class in App
+        $file   = APPPATH . 'Config/TestRegistrar.php';
+        $source = <<<'EOL'
+            <?php
+            namespace Config;
+            class TestRegistrar
+            {}
+            EOL;
+        file_put_contents($file, $source);
+
+        $result = Factories::config('TestRegistrar');
+
+        $this->assertInstanceOf('Config\TestRegistrar', $result);
+
+        // Delete the config class in App
+        unlink($file);
+    }
+
+    public function testFullClassnameIgnoresPreferApp()
     {
         // Create a config class in App
         $file   = APPPATH . 'Config/TestRegistrar.php';
@@ -269,7 +289,7 @@ final class FactoriesTest extends CIUnitTestCase
 
         $result = Factories::config(TestRegistrar::class);
 
-        $this->assertInstanceOf('Config\TestRegistrar', $result);
+        $this->assertInstanceOf(TestRegistrar::class, $result);
 
         Factories::setOptions('config', ['preferApp' => false]);
 

--- a/tests/system/Database/ModelFactoryTest.php
+++ b/tests/system/Database/ModelFactoryTest.php
@@ -66,12 +66,12 @@ final class ModelFactoryTest extends CIUnitTestCase
         $this->assertNull(ModelFactory::get('Banana'));
     }
 
-    public function testBasenameReturnsExistingNamespaceInstance()
+    public function testBasenameDoesNotReturnExistingNamespaceInstance()
     {
         ModelFactory::injectMock(UserModel::class, new JobModel());
 
         $basenameModel = ModelFactory::get('UserModel');
 
-        $this->assertInstanceOf(JobModel::class, $basenameModel);
+        $this->assertInstanceOf(UserModel::class, $basenameModel);
     }
 }

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -11,7 +11,7 @@
 
 namespace CodeIgniter\Test;
 
-use CodeIgniter\Database\ModelFactory;
+use CodeIgniter\Config\Factories;
 use Tests\Support\Models\EntityModel;
 use Tests\Support\Models\EventModel;
 use Tests\Support\Models\FabricatorModel;
@@ -98,12 +98,16 @@ final class FabricatorTest extends CIUnitTestCase
 
     public function testModelUsesNewInstance()
     {
-        // Inject the wrong model for UserModel to show it is ignored by Fabricator
+        // Inject the wrong model for UserModel
         $mock = new FabricatorModel();
-        ModelFactory::injectMock(UserModel::class, $mock);
+        Factories::injectMock('models', UserModel::class, $mock);
 
         $fabricator = new Fabricator(UserModel::class);
-        $this->assertInstanceOf(UserModel::class, $fabricator->getModel());
+
+        // Fabricator gets the instance from Factories, so it is FabricatorModel.
+        $this->assertInstanceOf(FabricatorModel::class, $fabricator->getModel());
+        // But Fabricator creates a new instance.
+        $this->assertNotSame($mock, $fabricator->getModel());
     }
 
     public function testGetModelReturnsModel()

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -29,6 +29,35 @@ or more was specified. See :ref:`upgrade-440-uri-setsegment`.
 
 The next segment (``+1``) of the current last segment can be set as before.
 
+.. _v440-factories:
+
+Factories
+---------
+
+Passing Fully Qualified Classname
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now ``preferApp`` works only when you request
+:ref:`a classname without a namespace <factories-passing-classname-without-namespace>`.
+
+For example, when you call ``model(\Myth\Auth\Models\UserModel::class)`` or
+``model('Myth\Auth\Models\UserModel')``:
+
+   - before:
+
+      - returns ``App\Models\UserModel`` if exists and ``preferApp`` is true (default)
+      - returns ``Myth\Auth\Models\UserModel`` if exists and ``preferApp`` is false
+
+   - after:
+
+      - returns ``Myth\Auth\Models\UserModel`` even if ``preferApp`` is true (default)
+      - returns ``App\Models\UserModel`` if you define ``Factories::define('models', 'Myth\Auth\Models\UserModel', 'App\Models\UserModel')`` before calling the ``model()``
+
+Property Name
+^^^^^^^^^^^^^
+
+The property ``Factories::$basenames`` has been renamed to ``$aliases``.
+
 .. _v440-interface-changes:
 
 Interface Changes
@@ -164,6 +193,8 @@ Others
 - **RedirectException:** can also take an object that implements ResponseInterface as its first argument.
 - **RedirectException:** implements ResponsableInterface.
 - **DebugBar:** Now :ref:`view-routes` are displayed in *DEFINED ROUTES* on the *Routes* tab.
+- **Factories:** You can now define the classname that will actually be loaded.
+  See :ref:`factories-defining-classname-to-be-loaded`.
 
 Message Changes
 ***************

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -54,8 +54,17 @@ by using the magic static method of the Factories class, ``Factories::models()``
 
 The static method name is called *component*.
 
-By default, Factories first searches in the ``App`` namespace for the path corresponding to the magic static method name.
+.. _factories-passing-classname-without-namespace:
+
+Passing Classname without Namespace
+-----------------------------------
+
+If you pass a classname without a namespace, Factories first searches in the
+``App`` namespace for the path corresponding to the magic static method name.
 ``Factories::models()`` searches the **app/Models** directory.
+
+Passing Short Classname
+^^^^^^^^^^^^^^^^^^^^^^^
 
 In the following code, if you have ``App\Models\UserModel``, the instance will be returned:
 
@@ -68,31 +77,35 @@ you get back the instance as before:
 
 .. literalinclude:: factories/003.php
 
-preferApp option
-----------------
+Passing Short Classname with Sub-directories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You could also request a specific class:
+If you want to load a class in sub directories, you use the ``/`` as a separator.
+The following code loads **app/Libraries/Sub/SubLib.php** if it exists:
+
+.. literalinclude:: factories/013.php
+   :lines: 2-
+
+Passing Full Qualified Classname
+--------------------------------
+
+You could also request a full qualified classname:
 
 .. literalinclude:: factories/002.php
    :lines: 2-
 
-If you have only ``Blog\Models\UserModel``, the instance will be returned.
-But if you have both ``App\Models\UserModel`` and ``Blog\Models\UserModel``,
-the instance of ``App\Models\UserModel`` will be returned.
+It returns the instance of ``Blog\Models\UserModel`` if it exists.
 
-If you want to get ``Blog\Models\UserModel``, you need to disable the option ``preferApp``:
+.. note:: Prior to v4.4.0, when you requested a full qualified classname,
+    if you had only ``Blog\Models\UserModel``, the instance would be returned.
+    But if you had both ``App\Models\UserModel`` and ``Blog\Models\UserModel``,
+    the instance of ``App\Models\UserModel`` would be returned.
 
-.. literalinclude:: factories/010.php
-   :lines: 2-
+    If you wanted to get ``Blog\Models\UserModel``, you needed to disable the
+    option ``preferApp``:
 
-Loading a Class in Sub-directories
-==================================
-
-If you want to load a class in sub directories, you use the ``/`` as a separator.
-The following code loads **app/Libraries/Sub/SubLib.php**:
-
-.. literalinclude:: factories/013.php
-   :lines: 2-
+    .. literalinclude:: factories/010.php
+       :lines: 2-
 
 Convenience Functions
 *********************
@@ -153,6 +166,9 @@ getShared  boolean        Whether to return a shared instance of the class or lo
 preferApp  boolean        Whether a class with the same basename in the App namespace  ``true``
                           overrides other explicit class requests.
 ========== ============== ============================================================ ===================================================
+
+.. note:: Since v4.4.0, ``preferApp`` works only when you request
+    :ref:`a classname without a namespace <factories-passing-classname-without-namespace>`.
 
 Factories Behavior
 ******************

--- a/user_guide_src/source/concepts/factories.rst
+++ b/user_guide_src/source/concepts/factories.rst
@@ -128,6 +128,29 @@ The second function, :php:func:`model()` returns a new instance of a Model class
 
 .. literalinclude:: factories/009.php
 
+.. _factories-defining-classname-to-be-loaded:
+
+Defining Classname to be Loaded
+*******************************
+
+.. versionadded:: 4.4.0
+
+You could define a classname to be loaded before loading the class with
+the ``Factories::define()`` method:
+
+.. literalinclude:: factories/014.php
+   :lines: 2-
+
+The first parameter is a component. The second parameter is a class alias
+(the first parameter to Factories magic static method), and the third parameter
+is the true full qualified classname to be loaded.
+
+After that, if you load ``Myth\Auth\Models\UserModel`` with Factories, the
+``App\Models\UserModel`` instance will be returned:
+
+.. literalinclude:: factories/015.php
+   :lines: 2-
+
 Factory Parameters
 ******************
 

--- a/user_guide_src/source/concepts/factories/014.php
+++ b/user_guide_src/source/concepts/factories/014.php
@@ -1,0 +1,3 @@
+<?php
+
+Factories::define('models', 'Myth\Auth\Models\UserModel', 'App\Models\UserModel');

--- a/user_guide_src/source/concepts/factories/015.php
+++ b/user_guide_src/source/concepts/factories/015.php
@@ -1,0 +1,3 @@
+<?php
+
+$users = model('Myth\Auth\Models\UserModel');

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -47,9 +47,10 @@ All of the configuration files that ship with CodeIgniter are namespaced with
 ``Config``. Using this namespace in your application will provide the best
 performance since it knows exactly where to find the files.
 
-.. note:: ``config()`` finds the file in **app/Config/** when there is a class with the same shortname,
+.. note:: Prior to v4.4.0, ``config()`` finds the file in **app/Config/** when there
+    is a class with the same shortname,
     even if you specify a fully qualified class name like ``config(\Acme\Blog\Config\Blog::class)``.
-    This is because ``config()`` is a wrapper for the ``Factories`` class which uses ``preferApp`` by default. See :ref:`factories-loading-class` for more information.
+    This behavior has been fixed in v4.4.0, and returns the specified instance.
 
 Getting a Config Property
 =========================

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -189,14 +189,15 @@ with the ``new`` command:
 
 .. literalinclude:: modules/008.php
 
-Config files are automatically discovered whenever using the :php:func:`config()` function that is always available.
+Config files are automatically discovered whenever using the :php:func:`config()` function that is always available, and you pass a short classname to it.
 
 .. note:: We don't recommend you use the same short classname in modules.
-    Modules that need to override or add to known configurations in **app/Config/** should use :ref:`registrars`.
+    Modules that need to override or add to known configurations in **app/Config/** should use :ref:`Implicit Registrars <registrars>`.
 
-.. note:: ``config()`` finds the file in **app/Config/** when there is a class with the same shortname,
+.. note:: Prior to v4.4.0, ``config()`` finds the file in **app/Config/** when there
+    is a class with the same shortname,
     even if you specify a fully qualified class name like ``config(\Acme\Blog\Config\Blog::class)``.
-    This is because ``config()`` is a wrapper for the ``Factories`` class which uses ``preferApp`` by default. See :ref:`factories-loading-class` for more information.
+    This behavior has been fixed in v4.4.0, and returns the specified instance.
 
 Migrations
 ==========

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -73,6 +73,21 @@ This bug was fixed and now URIs for underscores (**foo_bar**) is not accessible.
 If you have links to URIs for underscores (**foo_bar**), update them with URIs
 for dashes (**foo-bar**).
 
+When Passing Fully Qualified Classnames to Factories
+====================================================
+
+The behavior of passing fully qualified classnames to Factories has been changed.
+See :ref:`ChangeLog <v440-factories>` for details.
+
+If you have code like ``model('\Myth\Auth\Models\UserModel::class')`` or
+``model('Myth\Auth\Models\UserModel')`` (the code may be in the third-party packages),
+and you expect to load your ``App\Models\UserModel``, you need to define the
+classname to be loaded before the first loading of that class::
+
+    Factories::define('models', 'Myth\Auth\Models\UserModel', 'App\Models\UserModel');
+
+See :ref:`factories-defining-classname-to-be-loaded` for details.
+
 Interface Changes
 =================
 


### PR DESCRIPTION
**Description**
Fixes #7694

- add `Factories::define()` to explicitly *override* a class
- [BC] `preferApp` works only for no namespaced classname
- [BC] rename `Factories::$basenames` to `$aliases`

I would like to deprecate `preferApp` option.

**Changes**
Property structure:
```php
$basenames = [component => [basename => FQCN]];
↓
$aliases = [component => [alias => FQCN]];
```
*basename* is a short classname, or short classname with sub-directories.
*alias* is a FQCN, short classname, or short classname with sub-directories.
`Factories::define()` sets `$aliases`.

Behavior:
- `model(\Myth\Auth\Models\UserModel::class)` or `model('Myth\Auth\Models\UserModel')`
   - before: 
      - returns `App\Models\UserModel` if exists and `preferApp` is true
      - returns `Myth\Auth\Models\UserModel` if exists and `preferApp` is false
   - after: 
      - returns `Myth\Auth\Models\UserModel` even if `preferApp` is true
      -  returns `App\Models\UserModel` if you define `Factories::define('models', 'Myth\Auth\Models\UserModel', 'App\Models\UserModel')` before the first call of the `model()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
