### PR TITLE
fix: wrong Config classname to config() in Toolbar

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -365,7 +365,7 @@ class Toolbar
                 return;
             }
 
-            $toolbar = Services::toolbar(config(self::class));
+            $toolbar = Services::toolbar(config(ToolbarConfig::class));
             $stats   = $app->getPerformanceStats();
             $data    = $toolbar->run(
                 $stats['startTime'],


### PR DESCRIPTION
**Description**
From https://github.com/codeigniter4/CodeIgniter4/pull/7660/commits/6f8f3a21b3eccae7619ad8d6c1abf3c72dd9fc36

I don't know why, but this bug crashes `spark serve` with #7733

**Steps to Reproduce**

Check out #7733. Run `spark serve`.

```
CodeIgniter development server started on http://localhost:8080
Press Control-C to stop.
[Tue Jul 25 14:07:30 2023] PHP 8.1.21 Development Server (http://localhost:8080) started
```

Navigate to http://localhost:8080/, and I see:
>Unable to connect
>Firefox can’t establish a connection to the server at localhost:8080.

```
[Tue Jul 25 14:07:55 2023] [::1]:50620 Accepted
CodeIgniter development server started on http://localhost:8081
Press Control-C to stop.
[Tue Jul 25 14:07:55 2023] PHP 8.1.21 Development Server (http://localhost:8081) started
```
**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
