### PR TITLE
fix: [4.4] merge Exception::maskSensitiveData() fix into BaseExceptionHandler

### DIFF
--- a/system/Debug/BaseExceptionHandler.php
+++ b/system/Debug/BaseExceptionHandler.php
@@ -70,7 +70,7 @@ abstract class BaseExceptionHandler
         $trace = $exception->getTrace();
 
         if ($this->config->sensitiveDataInTrace !== []) {
-            $this->maskSensitiveData($trace, $this->config->sensitiveDataInTrace);
+            $trace = $this->maskSensitiveData($trace, $this->config->sensitiveDataInTrace);
         }
 
         return [
@@ -89,30 +89,49 @@ abstract class BaseExceptionHandler
      *
      * @param array|object $trace
      */
-    protected function maskSensitiveData(&$trace, array $keysToMask, string $path = ''): void
+    protected function maskSensitiveData($trace, array $keysToMask, string $path = '')
+    {
+        foreach ($trace as $i => $line) {
+            $trace[$i]['args'] = $this->maskData($line['args'], $keysToMask);
+        }
+
+        return $trace;
+    }
+
+    /**
+     * @param array|object $args
+     *
+     * @return array|object
+     */
+    private function maskData($args, array $keysToMask, string $path = '')
     {
         foreach ($keysToMask as $keyToMask) {
             $explode = explode('/', $keyToMask);
             $index   = end($explode);
 
             if (strpos(strrev($path . '/' . $index), strrev($keyToMask)) === 0) {
-                if (is_array($trace) && array_key_exists($index, $trace)) {
-                    $trace[$index] = '******************';
-                } elseif (is_object($trace) && property_exists($trace, $index) && isset($trace->{$index})) {
-                    $trace->{$index} = '******************';
+                if (is_array($args) && array_key_exists($index, $args)) {
+                    $args[$index] = '******************';
+                } elseif (
+                    is_object($args) && property_exists($args, $index)
+                    && isset($args->{$index}) && is_scalar($args->{$index})
+                ) {
+                    $args->{$index} = '******************';
                 }
             }
         }
 
-        if (is_object($trace)) {
-            $trace = get_object_vars($trace);
-        }
-
-        if (is_array($trace)) {
-            foreach ($trace as $pathKey => $subarray) {
-                $this->maskSensitiveData($subarray, $keysToMask, $path . '/' . $pathKey);
+        if (is_array($args)) {
+            foreach ($args as $pathKey => $subarray) {
+                $args[$pathKey] = $this->maskData($subarray, $keysToMask, $path . '/' . $pathKey);
+            }
+        } elseif (is_object($args)) {
+            foreach ($args as $pathKey => $subarray) {
+                $args->{$pathKey} = $this->maskData($subarray, $keysToMask, $path . '/' . $pathKey);
             }
         }
+
+        return $args;
     }
 
     /**

--- a/system/Debug/BaseExceptionHandler.php
+++ b/system/Debug/BaseExceptionHandler.php
@@ -86,10 +86,8 @@ abstract class BaseExceptionHandler
 
     /**
      * Mask sensitive data in the trace.
-     *
-     * @param array|object $trace
      */
-    protected function maskSensitiveData($trace, array $keysToMask, string $path = '')
+    protected function maskSensitiveData(array $trace, array $keysToMask, string $path = ''): array
     {
         foreach ($trace as $i => $line) {
             $trace[$i]['args'] = $this->maskData($line['args'], $keysToMask);

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -338,7 +338,7 @@ class Exceptions
      *
      * @return array|object
      *
-     * @deprecated No longer used. Moved to BaseExceptionHandler.
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     protected function maskSensitiveData($trace, array $keysToMask, string $path = '')
     {
@@ -353,6 +353,8 @@ class Exceptions
      * @param array|object $args
      *
      * @return array|object
+     *
+     * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */
     private function maskData($args, array $keysToMask, string $path = '')
     {

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -334,9 +334,9 @@ class Exceptions
     /**
      * Mask sensitive data in the trace.
      *
-     * @param array|object $trace
+     * @param array $trace
      *
-     * @return array|object
+     * @return array
      *
      * @deprecated 4.4.0 No longer used. Moved to BaseExceptionHandler.
      */


### PR DESCRIPTION
**Description**
Follow-up #7725

`Exception::maskSensitiveData()` has been moved to `BaseExceptionHandler` in 4.4.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
