### PR TITLE
style: use `yield_from_array_to_yields` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -62,6 +62,7 @@ $overrides = [
             'use',
         ],
     ],
+    'yield_from_array_to_yields' => true,
 ];
 
 $options = [

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -48,6 +48,7 @@ $overrides = [
             'use',
         ],
     ],
+    'yield_from_array_to_yields' => true,
 ];
 
 $options = [

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -53,6 +53,7 @@ $overrides = [
             'use',
         ],
     ],
+    'yield_from_array_to_yields' => true,
 ];
 
 $options = [

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -35,13 +35,15 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
 
     public function routeKeyProvider(): iterable
     {
-        yield from [
-            'root'                => ['/', '/'],
-            'placeholder num'     => ['shop/product/([0-9]+)', 'shop/product/123'],
-            'placeholder segment' => ['shop/product/([^/]+)', 'shop/product/abc_123'],
-            'placeholder any'     => ['shop/product/(.*)', 'shop/product/123/abc'],
-            'auto route'          => ['home/index[/...]', 'home/index/1/2/3/4/5'],
-        ];
+        yield 'root' => ['/', '/'];
+
+        yield 'placeholder num' => ['shop/product/([0-9]+)', 'shop/product/123'];
+
+        yield 'placeholder segment' => ['shop/product/([^/]+)', 'shop/product/abc_123'];
+
+        yield 'placeholder any' => ['shop/product/(.*)', 'shop/product/123/abc'];
+
+        yield 'auto route' => ['home/index[/...]', 'home/index/1/2/3/4/5'];
     }
 
     public function testGetFromPlaceholderCustomPlaceholder()

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -68,17 +68,23 @@ final class DotEnvTest extends CIUnitTestCase
 
     public function provideLoadVars(): iterable
     {
-        yield from [
-            ['bar', 'FOO'],
-            ['baz', 'BAR'],
-            ['with spaces', 'SPACED'],
-            ['', 'NULL'],
-            ['exported foo', 'char.expo.foo'],
-            ['variable', 'character.export.var'],
-            ['character', 'char.var'],
-            ['imports', 'char.exports'],
-            ['banana', 'fruit.export'],
-        ];
+        yield ['bar', 'FOO'];
+
+        yield ['baz', 'BAR'];
+
+        yield ['with spaces', 'SPACED'];
+
+        yield ['', 'NULL'];
+
+        yield ['exported foo', 'char.expo.foo'];
+
+        yield ['variable', 'character.export.var'];
+
+        yield ['character', 'char.var'];
+
+        yield ['imports', 'char.exports'];
+
+        yield ['banana', 'fruit.export'];
     }
 
     /**

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -100,14 +100,17 @@ final class CookieTest extends CIUnitTestCase
 
     public function prefixProvider(): iterable
     {
-        yield from [
-            ['prefix_', '', 'prefix_test'],
-            ['prefix_', '0', '0test'],
-            ['prefix_', 'new_', 'new_test'],
-            ['', '', 'test'],
-            ['', '0', '0test'],
-            ['', 'new_', 'new_test'],
-        ];
+        yield ['prefix_', '', 'prefix_test'];
+
+        yield ['prefix_', '0', '0test'];
+
+        yield ['prefix_', 'new_', 'new_test'];
+
+        yield ['', '', 'test'];
+
+        yield ['', '0', '0test'];
+
+        yield ['', 'new_', 'new_test'];
     }
 
     public function testValidationOfRawCookieName(): void

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -185,88 +185,103 @@ final class BaseConnectionTest extends CIUnitTestCase
 
     public function identifiersProvider(): iterable
     {
-        yield from [
-            // $prefixSingle, $protectIdentifiers, $fieldExists, $item, $expected
-            'empty string'        => [false, true, true, '', ''],
-            'empty string prefix' => [true, true, true, '', '"test_"'], // Incorrect usage? or should be ''?
+        // $prefixSingle, $protectIdentifiers, $fieldExists, $item, $expected
+        yield 'empty string' => [false, true, true, '', ''];
 
-            'single table'        => [false, true, false, 'jobs', '"jobs"'],
-            'single table prefix' => [true, true, false, 'jobs', '"test_jobs"'],
+        yield 'empty string prefix' => [true, true, true, '', '"test_"']; // Incorrect usage? or should be ''?
 
-            'string'        => [false, true, true, "'Accountant'", "'Accountant'"],
-            'single prefix' => [true, true, true, "'Accountant'", "'Accountant'"],
+        yield 'single table' => [false, true, false, 'jobs', '"jobs"'];
 
-            'numbers only'        => [false, true, false, '12345', '12345'], // Should be quoted?
-            'numbers only prefix' => [true, true, false, '12345', '"test_12345"'],
+        yield 'single table prefix' => [true, true, false, 'jobs', '"test_jobs"'];
 
-            'table AS alias'        => [false, true, false, 'role AS myRole', '"role" AS "myRole"'],
-            'table AS alias prefix' => [true, true, false, 'role AS myRole', '"test_role" AS "myRole"'],
+        yield 'string' => [false, true, true, "'Accountant'", "'Accountant'"];
 
-            'quoted table'        => [false, true, false, '"jobs"', '"jobs"'],
-            'quoted table prefix' => [true, true, false, '"jobs"', '"test_jobs"'],
+        yield 'single prefix' => [true, true, true, "'Accountant'", "'Accountant'"];
 
-            'quoted table alias'        => [false, true, false, '"jobs" "j"', '"jobs" "j"'],
-            'quoted table alias prefix' => [true, true, false, '"jobs" "j"', '"test_jobs" "j"'],
+        yield 'numbers only' => [false, true, false, '12345', '12345']; // Should be quoted?
 
-            'table.*'             => [false, true, true, 'jobs.*', '"test_jobs".*'], // Prefixed because it has segments
-            'table.* prefix'      => [true, true, true, 'jobs.*', '"test_jobs".*'],
-            'table.column'        => [false, true, true, 'users.id', '"test_users"."id"'], // Prefixed because it has segments
-            'table.column prefix' => [true, true, true, 'users.id', '"test_users"."id"'],
-            'table.column AS'     => [
-                false, true, true,
-                'users.id AS user_id',
-                '"test_users"."id" AS "user_id"', // Prefixed because it has segments
-            ],
-            'table.column AS prefix' => [
-                true, true, true,
-                'users.id AS user_id',
-                '"test_users"."id" AS "user_id"',
-            ],
+        yield 'numbers only prefix' => [true, true, false, '12345', '"test_12345"'];
 
-            'function table.column'        => [false, true, true, 'LOWER(jobs.name)', 'LOWER(jobs.name)'],
-            'function table.column prefix' => [true, true, true, 'LOWER(jobs.name)', 'LOWER(jobs.name)'],
+        yield 'table AS alias' => [false, true, false, 'role AS myRole', '"role" AS "myRole"'];
 
-            'function only'   => [false, true, true, 'RAND()', 'RAND()'],
-            'function column' => [false, true, true, 'SUM(id)', 'SUM(id)'],
+        yield 'table AS alias prefix' => [true, true, false, 'role AS myRole', '"test_role" AS "myRole"'];
 
-            'function column AS' => [
-                false, true, true,
-                'COUNT(payments) AS myAlias',
-                'COUNT(payments) AS myAlias',
-            ],
-            'function column AS prefix' => [
-                true, true, true,
-                'COUNT(payments) AS myAlias',
-                'COUNT(payments) AS myAlias',
-            ],
+        yield 'quoted table' => [false, true, false, '"jobs"', '"jobs"'];
 
-            'function quoted table column AS' => [
-                false, true, true,
-                'MAX("db"."payments") AS "payments"',
-                'MAX("db"."payments") AS "payments"',
-            ],
+        yield 'quoted table prefix' => [true, true, false, '"jobs"', '"test_jobs"'];
 
-            'quoted column operator AS' => [
-                false, true, true,
-                '"numericValue1" + "numericValue2" AS "numericResult"',
-                '"numericValue1"" + ""numericValue2" AS "numericResult"', // Cannot process correctly
-            ],
-            'quoted column operator AS no-protect' => [
-                false, false, true,
-                '"numericValue1" + "numericValue2" AS "numericResult"',
-                '"numericValue1" + "numericValue2" AS "numericResult"',
-            ],
+        yield 'quoted table alias' => [false, true, false, '"jobs" "j"', '"jobs" "j"'];
 
-            'sub query' => [
-                false, true, true,
-                '(SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid)',
-                '(SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid)',
-            ],
-            'sub query with missing `)` at the end' => [
-                false, true, true,
-                '(SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2',
-                '(SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2',
-            ],
+        yield 'quoted table alias prefix' => [true, true, false, '"jobs" "j"', '"test_jobs" "j"'];
+
+        yield 'table.*' => [false, true, true, 'jobs.*', '"test_jobs".*']; // Prefixed because it has segments
+
+        yield 'table.* prefix' => [true, true, true, 'jobs.*', '"test_jobs".*'];
+
+        yield 'table.column' => [false, true, true, 'users.id', '"test_users"."id"']; // Prefixed because it has segments
+
+        yield 'table.column prefix' => [true, true, true, 'users.id', '"test_users"."id"'];
+
+        yield 'table.column AS' => [
+            false, true, true,
+            'users.id AS user_id',
+            '"test_users"."id" AS "user_id"', // Prefixed because it has segments
+        ];
+
+        yield 'table.column AS prefix' => [
+            true, true, true,
+            'users.id AS user_id',
+            '"test_users"."id" AS "user_id"',
+        ];
+
+        yield 'function table.column' => [false, true, true, 'LOWER(jobs.name)', 'LOWER(jobs.name)'];
+
+        yield 'function table.column prefix' => [true, true, true, 'LOWER(jobs.name)', 'LOWER(jobs.name)'];
+
+        yield 'function only' => [false, true, true, 'RAND()', 'RAND()'];
+
+        yield 'function column' => [false, true, true, 'SUM(id)', 'SUM(id)'];
+
+        yield 'function column AS' => [
+            false, true, true,
+            'COUNT(payments) AS myAlias',
+            'COUNT(payments) AS myAlias',
+        ];
+
+        yield 'function column AS prefix' => [
+            true, true, true,
+            'COUNT(payments) AS myAlias',
+            'COUNT(payments) AS myAlias',
+        ];
+
+        yield 'function quoted table column AS' => [
+            false, true, true,
+            'MAX("db"."payments") AS "payments"',
+            'MAX("db"."payments") AS "payments"',
+        ];
+
+        yield 'quoted column operator AS' => [
+            false, true, true,
+            '"numericValue1" + "numericValue2" AS "numericResult"',
+            '"numericValue1"" + ""numericValue2" AS "numericResult"', // Cannot process correctly
+        ];
+
+        yield 'quoted column operator AS no-protect' => [
+            false, false, true,
+            '"numericValue1" + "numericValue2" AS "numericResult"',
+            '"numericValue1" + "numericValue2" AS "numericResult"',
+        ];
+
+        yield 'sub query' => [
+            false, true, true,
+            '(SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid)',
+            '(SELECT SUM(payments.amount) FROM payments WHERE payments.invoice_id=4) AS amount_paid)',
+        ];
+
+        yield 'sub query with missing `)` at the end' => [
+            false, true, true,
+            '(SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2',
+            '(SELECT MAX(advance_amount) FROM "orders" WHERE "id" > 2',
         ];
     }
 }

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -210,27 +210,29 @@ final class ConfigTest extends CIUnitTestCase
 
     public function convertDSNProvider(): iterable
     {
-        yield from [
-            [
-                'pgsql:host=localhost;port=5432;dbname=database_name;user=username;password=password',
-                'host=localhost port=5432 dbname=database_name user=username password=password',
-            ],
-            [
-                'pgsql:host=localhost;port=5432;dbname=database_name;user=username;password=we;port=we',
-                'host=localhost port=5432 dbname=database_name user=username password=we;port=we',
-            ],
-            [
-                'pgsql:host=localhost;port=5432;dbname=database_name',
-                'host=localhost port=5432 dbname=database_name',
-            ],
-            [
-                "pgsql:host=localhost;port=5432;dbname=database_name;options='--client_encoding=UTF8'",
-                "host=localhost port=5432 dbname=database_name options='--client_encoding=UTF8'",
-            ],
-            [
-                'pgsql:host=localhost;port=5432;dbname=database_name;something=stupid',
-                'host=localhost port=5432 dbname=database_name;something=stupid',
-            ],
+        yield [
+            'pgsql:host=localhost;port=5432;dbname=database_name;user=username;password=password',
+            'host=localhost port=5432 dbname=database_name user=username password=password',
+        ];
+
+        yield [
+            'pgsql:host=localhost;port=5432;dbname=database_name;user=username;password=we;port=we',
+            'host=localhost port=5432 dbname=database_name user=username password=we;port=we',
+        ];
+
+        yield [
+            'pgsql:host=localhost;port=5432;dbname=database_name',
+            'host=localhost port=5432 dbname=database_name',
+        ];
+
+        yield [
+            "pgsql:host=localhost;port=5432;dbname=database_name;options='--client_encoding=UTF8'",
+            "host=localhost port=5432 dbname=database_name options='--client_encoding=UTF8'",
+        ];
+
+        yield [
+            'pgsql:host=localhost;port=5432;dbname=database_name;something=stupid',
+            'host=localhost port=5432 dbname=database_name;something=stupid',
         ];
     }
 }

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -126,13 +126,15 @@ final class InvalidCharsTest extends CIUnitTestCase
 
     public function stringWithLineBreakAndTabProvider(): iterable
     {
-        yield from [
-            ["String contains \n line break."],
-            ["String contains \r line break."],
-            ["String contains \r\n line break."],
-            ["String contains \t tab."],
-            ["String contains \t and \r line \n break."],
-        ];
+        yield ["String contains \n line break."];
+
+        yield ["String contains \r line break."];
+
+        yield ["String contains \r\n line break."];
+
+        yield ["String contains \t tab."];
+
+        yield ["String contains \t and \r line \n break."];
     }
 
     /**
@@ -150,9 +152,8 @@ final class InvalidCharsTest extends CIUnitTestCase
 
     public function stringWithControlCharsProvider(): iterable
     {
-        yield from [
-            ["String contains null char.\0"],
-            ["String contains null char and line break.\0\n"],
-        ];
+        yield ["String contains null char.\0"];
+
+        yield ["String contains null char and line break.\0\n"];
     }
 }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -628,15 +628,19 @@ final class IncomingRequestTest extends CIUnitTestCase
 
     public function provideIsHTTPMethods(): iterable
     {
-        yield from [
-            ['GET'],
-            ['POST'],
-            ['PUT'],
-            ['DELETE'],
-            ['HEAD'],
-            ['PATCH'],
-            ['OPTIONS'],
-        ];
+        yield ['GET'];
+
+        yield ['POST'];
+
+        yield ['PUT'];
+
+        yield ['DELETE'];
+
+        yield ['HEAD'];
+
+        yield ['PATCH'];
+
+        yield ['OPTIONS'];
     }
 
     /**

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -293,26 +293,41 @@ final class ResponseTest extends CIUnitTestCase
 
     public function provideForRedirect(): iterable
     {
-        yield from [
-            ['Apache/2.4.17', 'HTTP/1.1', 'GET', null, 302],
-            ['Apache/2.4.17', 'HTTP/1.1', 'GET', 307, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'GET', 302, 302],
-            ['Apache/2.4.17', 'HTTP/1.1', 'POST', null, 303],
-            ['Apache/2.4.17', 'HTTP/1.1', 'POST', 307, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'POST', 302, 302],
-            ['Apache/2.4.17', 'HTTP/1.1', 'HEAD', null, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'HEAD', 307, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'HEAD', 302, 302],
-            ['Apache/2.4.17', 'HTTP/1.1', 'OPTIONS', null, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'OPTIONS', 307, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'OPTIONS', 302, 302],
-            ['Apache/2.4.17', 'HTTP/1.1', 'PUT', null, 303],
-            ['Apache/2.4.17', 'HTTP/1.1', 'PUT', 307, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'PUT', 302, 302],
-            ['Apache/2.4.17', 'HTTP/1.1', 'DELETE', null, 303],
-            ['Apache/2.4.17', 'HTTP/1.1', 'DELETE', 307, 307],
-            ['Apache/2.4.17', 'HTTP/1.1', 'DELETE', 302, 302],
-        ];
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'GET', null, 302];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'GET', 307, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'GET', 302, 302];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'POST', null, 303];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'POST', 307, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'POST', 302, 302];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'HEAD', null, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'HEAD', 307, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'HEAD', 302, 302];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'OPTIONS', null, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'OPTIONS', 307, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'OPTIONS', 302, 302];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'PUT', null, 303];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'PUT', 307, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'PUT', 302, 302];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'DELETE', null, 303];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'DELETE', 307, 307];
+
+        yield ['Apache/2.4.17', 'HTTP/1.1', 'DELETE', 302, 302];
     }
 
     /**
@@ -339,14 +354,17 @@ final class ResponseTest extends CIUnitTestCase
 
     public function provideForRedirectWithIIS(): iterable
     {
-        yield from [
-            ['HTTP/1.1', 'GET', null, 302],
-            ['HTTP/1.1', 'GET', 307, 307],
-            ['HTTP/1.1', 'GET', 302, 302],
-            ['HTTP/1.1', 'POST', null, 302],
-            ['HTTP/1.1', 'POST', 307, 307],
-            ['HTTP/1.1', 'POST', 302, 302],
-        ];
+        yield ['HTTP/1.1', 'GET', null, 302];
+
+        yield ['HTTP/1.1', 'GET', 307, 307];
+
+        yield ['HTTP/1.1', 'GET', 302, 302];
+
+        yield ['HTTP/1.1', 'POST', null, 302];
+
+        yield ['HTTP/1.1', 'POST', 307, 307];
+
+        yield ['HTTP/1.1', 'POST', 302, 302];
     }
 
     public function testSetCookieFails()

--- a/tests/system/I18n/TimeLegacyTest.php
+++ b/tests/system/I18n/TimeLegacyTest.php
@@ -1160,12 +1160,13 @@ final class TimeLegacyTest extends CIUnitTestCase
 
     public function provideLocales(): iterable
     {
-        yield from [
-            ['en'],
-            ['de'],
-            ['ar'],
-            ['fa'],
-        ];
+        yield ['en'];
+
+        yield ['de'];
+
+        yield ['ar'];
+
+        yield ['fa'];
     }
 
     public function testModify()

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1172,12 +1172,13 @@ final class TimeTest extends CIUnitTestCase
 
     public function provideLocales(): iterable
     {
-        yield from [
-            ['en'],
-            ['de'],
-            ['ar'],
-            ['fa'],
-        ];
+        yield ['en'];
+
+        yield ['de'];
+
+        yield ['ar'];
+
+        yield ['fa'];
     }
 
     public function testModify()

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -399,17 +399,16 @@ final class UpdateModelTest extends LiveModelTestCase
 
     public function provideInvalidIds(): iterable
     {
-        yield from [
-            [
-                null,
-                DatabaseException::class,
-                'Updates are not allowed unless they contain a "where" or "like" clause.',
-            ],
-            [
-                false,
-                InvalidArgumentException::class,
-                'update(): argument #1 ($id) should not be boolean.',
-            ],
+        yield [
+            null,
+            DatabaseException::class,
+            'Updates are not allowed unless they contain a "where" or "like" clause.',
+        ];
+
+        yield [
+            false,
+            InvalidArgumentException::class,
+            'update(): argument #1 ($id) should not be boolean.',
         ];
     }
 }

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -71,11 +71,11 @@ final class PublisherRestrictionsTest extends CIUnitTestCase
 
     public function fileProvider(): iterable
     {
-        yield from [
-            'php'  => ['index.php'],
-            'exe'  => ['cat.exe'],
-            'flat' => ['banana'],
-        ];
+        yield 'php' => ['index.php'];
+
+        yield 'exe' => ['cat.exe'];
+
+        yield 'flat' => ['banana'];
     }
 
     /**

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -407,24 +407,25 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function groupProvider(): iterable
     {
-        yield from [
-            ['admin', '/', [
-                'admin/users/list'   => '\Users::list',
-                'admin/delegate/foo' => '\Users::foo',
-            ]],
-            ['/', '', [
-                'users/list'   => '\Users::list',
-                'delegate/foo' => '\Users::foo',
-            ]],
-            ['', '', [
-                'users/list'   => '\Users::list',
-                'delegate/foo' => '\Users::foo',
-            ]],
-            ['', '/', [
-                'users/list'   => '\Users::list',
-                'delegate/foo' => '\Users::foo',
-            ]],
-        ];
+        yield ['admin', '/', [
+            'admin/users/list'   => '\Users::list',
+            'admin/delegate/foo' => '\Users::foo',
+        ]];
+
+        yield ['/', '', [
+            'users/list'   => '\Users::list',
+            'delegate/foo' => '\Users::foo',
+        ]];
+
+        yield ['', '', [
+            'users/list'   => '\Users::list',
+            'delegate/foo' => '\Users::foo',
+        ]];
+
+        yield ['', '/', [
+            'users/list'   => '\Users::list',
+            'delegate/foo' => '\Users::foo',
+        ]];
     }
 
     public function testHostnameOption()
@@ -1244,42 +1245,43 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function optionsProvider(): iterable
     {
-        yield from [
+        yield [
             [
-                [
-                    'foo' => 'options1',
-                ],
-                [
-                    'foo' => 'options2',
-                ],
+                'foo' => 'options1',
             ],
             [
-                [
-                    'as'  => 'admin',
-                    'foo' => 'options1',
-                ],
-                [
-                    'foo' => 'options2',
-                ],
+                'foo' => 'options2',
+            ],
+        ];
+
+        yield [
+            [
+                'as'  => 'admin',
+                'foo' => 'options1',
             ],
             [
-                [
-                    'foo' => 'options1',
-                ],
-                [
-                    'as'  => 'admin',
-                    'foo' => 'options2',
-                ],
+                'foo' => 'options2',
+            ],
+        ];
+
+        yield [
+            [
+                'foo' => 'options1',
             ],
             [
-                [
-                    'as'  => 'admin',
-                    'foo' => 'options1',
-                ],
-                [
-                    'as'  => 'admin',
-                    'foo' => 'options2',
-                ],
+                'as'  => 'admin',
+                'foo' => 'options2',
+            ],
+        ];
+
+        yield [
+            [
+                'as'  => 'admin',
+                'foo' => 'options1',
+            ],
+            [
+                'as'  => 'admin',
+                'foo' => 'options2',
             ],
         ];
     }

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -65,1137 +65,1360 @@ final class CreditCardRulesTest extends CIUnitTestCase
      */
     public function creditCardProvider(): iterable
     {
-        yield from [
-            'null_test' => [
-                'amex',
-                null,
-                false,
-            ],
-            'random_test' => [
-                'amex',
-                $this->generateCardNumber('37', 16),
-                false,
-            ],
-            'invalid_type' => [
-                'shorty',
-                '1111 1111 1111 1111',
-                false,
-            ],
-            'invalid_length' => [
-                'amex',
-                '',
-                false,
-            ],
-            'not_numeric' => [
-                'amex',
-                'abcd efgh ijkl mnop',
-                false,
-            ],
-            'bad_length' => [
-                'amex',
-                '3782 8224 6310 0051',
-                false,
-            ],
-            'bad_prefix' => [
-                'amex',
-                '3582 8224 6310 0051',
-                false,
-            ],
-            'amex1' => [
-                'amex',
-                '3782 8224 6310 005',
-                true,
-            ],
-            'amex2' => [
-                'amex',
-                '3714 4963 5398 431',
-                true,
-            ],
-            'dinersclub1' => [
-                'dinersclub',
-                '3056 9309 0259 04',
-                true,
-            ],
-            'dinersculb2' => [
-                'dinersclub',
-                '3852 0000 0232 37',
-                true,
-            ],
-            'discover1' => [
-                'discover',
-                '6011 1111 1111 1117',
-                true,
-            ],
-            'discover2' => [
-                'discover',
-                '6011 0009 9013 9424',
-                true,
-            ],
-            'jcb8' => [
-                'jcb',
-                '3530 1113 3330 0000',
-                true,
-            ],
-            'jcb9' => [
-                'jcb',
-                '3566 0020 2036 0505',
-                true,
-            ],
-            'mastercard12' => [
-                'mastercard',
-                '5555 5555 5555 4444',
-                true,
-            ],
-            'mastercard13' => [
-                'mastercard',
-                '5105 1051 0510 5100',
-                true,
-            ],
-            'visa4' => [
-                'visa',
-                '4111 1111 1111 1111',
-                true,
-            ],
-            'visa5' => [
-                'visa',
-                '4012 8888 8888 1881',
-                true,
-            ],
-            'visa6' => [
-                'visa',
-                '4222 2222 2222 2',
-                true,
-            ],
-            'dankort5' => [
-                'dankort',
-                '5019 7170 1010 3742',
-                true,
-            ],
-            'unionpay1' => [
-                'unionpay',
-                $this->generateCardNumber(62, 16),
-                true,
-            ],
-            'unionpay2' => [
-                'unionpay',
-                $this->generateCardNumber(62, 17),
-                true,
-            ],
-            'unionpay3' => [
-                'unionpay',
-                $this->generateCardNumber(62, 18),
-                true,
-            ],
-            'unionpay4' => [
-                'unionpay',
-                $this->generateCardNumber(62, 19),
-                true,
-            ],
-            'unionpay5' => [
-                'unionpay',
-                $this->generateCardNumber(63, 19),
-                false,
-            ],
-            'carteblanche1' => [
-                'carteblanche',
-                $this->generateCardNumber(300, 14),
-                true,
-            ],
-            'carteblanche2' => [
-                'carteblanche',
-                $this->generateCardNumber(301, 14),
-                true,
-            ],
-            'carteblanche3' => [
-                'carteblanche',
-                $this->generateCardNumber(302, 14),
-                true,
-            ],
-            'carteblanche4' => [
-                'carteblanche',
-                $this->generateCardNumber(303, 14),
-                true,
-            ],
-            'carteblanche5' => [
-                'carteblanche',
-                $this->generateCardNumber(304, 14),
-                true,
-            ],
-            'carteblanche6' => [
-                'carteblanche',
-                $this->generateCardNumber(305, 14),
-                true,
-            ],
-            'carteblanche7' => [
-                'carteblanche',
-                $this->generateCardNumber(306, 14),
-                false,
-            ],
-            'dinersclub3' => [
-                'dinersclub',
-                $this->generateCardNumber(300, 14),
-                true,
-            ],
-            'dinersclub4' => [
-                'dinersclub',
-                $this->generateCardNumber(301, 14),
-                true,
-            ],
-            'dinersclub5' => [
-                'dinersclub',
-                $this->generateCardNumber(302, 14),
-                true,
-            ],
-            'dinersclub6' => [
-                'dinersclub',
-                $this->generateCardNumber(303, 14),
-                true,
-            ],
-            'dinersclub7' => [
-                'dinersclub',
-                $this->generateCardNumber(304, 14),
-                true,
-            ],
-            'dinersclub8' => [
-                'dinersclub',
-                $this->generateCardNumber(305, 14),
-                true,
-            ],
-            'dinersclub9' => [
-                'dinersclub',
-                $this->generateCardNumber(309, 14),
-                true,
-            ],
-            'dinersclub10' => [
-                'dinersclub',
-                $this->generateCardNumber(36, 14),
-                true,
-            ],
-            'dinersclub11' => [
-                'dinersclub',
-                $this->generateCardNumber(38, 14),
-                true,
-            ],
-            'dinersclub12' => [
-                'dinersclub',
-                $this->generateCardNumber(39, 14),
-                true,
-            ],
-            'dinersclub13' => [
-                'dinersclub',
-                $this->generateCardNumber(54, 14),
-                true,
-            ],
-            'dinersclub14' => [
-                'dinersclub',
-                $this->generateCardNumber(55, 14),
-                true,
-            ],
-            'dinersclub15' => [
-                'dinersclub',
-                $this->generateCardNumber(300, 16),
-                true,
-            ],
-            'dinersclub16' => [
-                'dinersclub',
-                $this->generateCardNumber(301, 16),
-                true,
-            ],
-            'dinersclub17' => [
-                'dinersclub',
-                $this->generateCardNumber(302, 16),
-                true,
-            ],
-            'dinersclub18' => [
-                'dinersclub',
-                $this->generateCardNumber(303, 16),
-                true,
-            ],
-            'dinersclub19' => [
-                'dinersclub',
-                $this->generateCardNumber(304, 16),
-                true,
-            ],
-            'dinersclub20' => [
-                'dinersclub',
-                $this->generateCardNumber(305, 16),
-                true,
-            ],
-            'dinersclub21' => [
-                'dinersclub',
-                $this->generateCardNumber(309, 16),
-                true,
-            ],
-            'dinersclub22' => [
-                'dinersclub',
-                $this->generateCardNumber(36, 16),
-                true,
-            ],
-            'dinersclub23' => [
-                'dinersclub',
-                $this->generateCardNumber(38, 16),
-                true,
-            ],
-            'dinersclub24' => [
-                'dinersclub',
-                $this->generateCardNumber(39, 16),
-                true,
-            ],
-            'dinersclub25' => [
-                'dinersclub',
-                $this->generateCardNumber(54, 16),
-                true,
-            ],
-            'dinersclub26' => [
-                'dinersclub',
-                $this->generateCardNumber(55, 16),
-                true,
-            ],
-            'discover3' => [
-                'discover',
-                $this->generateCardNumber(6011, 16),
-                true,
-            ],
-            'discover4' => [
-                'discover',
-                $this->generateCardNumber(622, 16),
-                true,
-            ],
-            'discover5' => [
-                'discover',
-                $this->generateCardNumber(644, 16),
-                true,
-            ],
-            'discover6' => [
-                'discover',
-                $this->generateCardNumber(645, 16),
-                true,
-            ],
-            'discover7' => [
-                'discover',
-                $this->generateCardNumber(656, 16),
-                true,
-            ],
-            'discover8' => [
-                'discover',
-                $this->generateCardNumber(647, 16),
-                true,
-            ],
-            'discover9' => [
-                'discover',
-                $this->generateCardNumber(648, 16),
-                true,
-            ],
-            'discover10' => [
-                'discover',
-                $this->generateCardNumber(649, 16),
-                true,
-            ],
-            'discover11' => [
-                'discover',
-                $this->generateCardNumber(65, 16),
-                true,
-            ],
-            'discover12' => [
-                'discover',
-                $this->generateCardNumber(6011, 19),
-                true,
-            ],
-            'discover13' => [
-                'discover',
-                $this->generateCardNumber(622, 19),
-                true,
-            ],
-            'discover14' => [
-                'discover',
-                $this->generateCardNumber(644, 19),
-                true,
-            ],
-            'discover15' => [
-                'discover',
-                $this->generateCardNumber(645, 19),
-                true,
-            ],
-            'discover16' => [
-                'discover',
-                $this->generateCardNumber(656, 19),
-                true,
-            ],
-            'discover17' => [
-                'discover',
-                $this->generateCardNumber(647, 19),
-                true,
-            ],
-            'discover18' => [
-                'discover',
-                $this->generateCardNumber(648, 19),
-                true,
-            ],
-            'discover19' => [
-                'discover',
-                $this->generateCardNumber(649, 19),
-                true,
-            ],
-            'discover20' => [
-                'discover',
-                $this->generateCardNumber(65, 19),
-                true,
-            ],
-            'interpayment1' => [
-                'interpayment',
-                $this->generateCardNumber(4, 16),
-                true,
-            ],
-            'interpayment2' => [
-                'interpayment',
-                $this->generateCardNumber(4, 17),
-                true,
-            ],
-            'interpayment3' => [
-                'interpayment',
-                $this->generateCardNumber(4, 18),
-                true,
-            ],
-            'interpayment4' => [
-                'interpayment',
-                $this->generateCardNumber(4, 19),
-                true,
-            ],
-            'jcb1' => [
-                'jcb',
-                $this->generateCardNumber(352, 16),
-                true,
-            ],
-            'jcb2' => [
-                'jcb',
-                $this->generateCardNumber(353, 16),
-                true,
-            ],
-            'jcb3' => [
-                'jcb',
-                $this->generateCardNumber(354, 16),
-                true,
-            ],
-            'jcb4' => [
-                'jcb',
-                $this->generateCardNumber(355, 16),
-                true,
-            ],
-            'jcb5' => [
-                'jcb',
-                $this->generateCardNumber(356, 16),
-                true,
-            ],
-            'jcb6' => [
-                'jcb',
-                $this->generateCardNumber(357, 16),
-                true,
-            ],
-            'jcb7' => [
-                'jcb',
-                $this->generateCardNumber(358, 16),
-                true,
-            ],
-            'maestro1' => [
-                'maestro',
-                $this->generateCardNumber(50, 12),
-                true,
-            ],
-            'maestro2' => [
-                'maestro',
-                $this->generateCardNumber(56, 12),
-                true,
-            ],
-            'maestro3' => [
-                'maestro',
-                $this->generateCardNumber(57, 12),
-                true,
-            ],
-            'maestro4' => [
-                'maestro',
-                $this->generateCardNumber(58, 12),
-                true,
-            ],
-            'maestro5' => [
-                'maestro',
-                $this->generateCardNumber(59, 12),
-                true,
-            ],
-            'maestro6' => [
-                'maestro',
-                $this->generateCardNumber(60, 12),
-                true,
-            ],
-            'maestro7' => [
-                'maestro',
-                $this->generateCardNumber(61, 12),
-                true,
-            ],
-            'maestro8' => [
-                'maestro',
-                $this->generateCardNumber(62, 12),
-                true,
-            ],
-            'maestro9' => [
-                'maestro',
-                $this->generateCardNumber(63, 12),
-                true,
-            ],
-            'maestro10' => [
-                'maestro',
-                $this->generateCardNumber(64, 12),
-                true,
-            ],
-            'maestro11' => [
-                'maestro',
-                $this->generateCardNumber(65, 12),
-                true,
-            ],
-            'maestro12' => [
-                'maestro',
-                $this->generateCardNumber(66, 12),
-                true,
-            ],
-            'maestro13' => [
-                'maestro',
-                $this->generateCardNumber(67, 12),
-                true,
-            ],
-            'maestro14' => [
-                'maestro',
-                $this->generateCardNumber(68, 12),
-                true,
-            ],
-            'maestro15' => [
-                'maestro',
-                $this->generateCardNumber(69, 12),
-                true,
-            ],
-            'maestro16' => [
-                'maestro',
-                $this->generateCardNumber(50, 13),
-                true,
-            ],
-            'maestro17' => [
-                'maestro',
-                $this->generateCardNumber(56, 13),
-                true,
-            ],
-            'maestro18' => [
-                'maestro',
-                $this->generateCardNumber(57, 13),
-                true,
-            ],
-            'maestro19' => [
-                'maestro',
-                $this->generateCardNumber(58, 13),
-                true,
-            ],
-            'maestro20' => [
-                'maestro',
-                $this->generateCardNumber(59, 13),
-                true,
-            ],
-            'maestro21' => [
-                'maestro',
-                $this->generateCardNumber(60, 13),
-                true,
-            ],
-            'maestro22' => [
-                'maestro',
-                $this->generateCardNumber(61, 13),
-                true,
-            ],
-            'maestro23' => [
-                'maestro',
-                $this->generateCardNumber(62, 13),
-                true,
-            ],
-            'maestro24' => [
-                'maestro',
-                $this->generateCardNumber(63, 13),
-                true,
-            ],
-            'maestro25' => [
-                'maestro',
-                $this->generateCardNumber(64, 13),
-                true,
-            ],
-            'maestro26' => [
-                'maestro',
-                $this->generateCardNumber(65, 13),
-                true,
-            ],
-            'maestro27' => [
-                'maestro',
-                $this->generateCardNumber(66, 13),
-                true,
-            ],
-            'maestro28' => [
-                'maestro',
-                $this->generateCardNumber(67, 13),
-                true,
-            ],
-            'maestro29' => [
-                'maestro',
-                $this->generateCardNumber(68, 13),
-                true,
-            ],
-            'maestro30' => [
-                'maestro',
-                $this->generateCardNumber(69, 13),
-                true,
-            ],
-            'maestro31' => [
-                'maestro',
-                $this->generateCardNumber(50, 14),
-                true,
-            ],
-            'maestro32' => [
-                'maestro',
-                $this->generateCardNumber(56, 14),
-                true,
-            ],
-            'maestro33' => [
-                'maestro',
-                $this->generateCardNumber(57, 14),
-                true,
-            ],
-            'maestro34' => [
-                'maestro',
-                $this->generateCardNumber(58, 14),
-                true,
-            ],
-            'maestro35' => [
-                'maestro',
-                $this->generateCardNumber(59, 14),
-                true,
-            ],
-            'maestro36' => [
-                'maestro',
-                $this->generateCardNumber(60, 14),
-                true,
-            ],
-            'maestro37' => [
-                'maestro',
-                $this->generateCardNumber(61, 14),
-                true,
-            ],
-            'maestro38' => [
-                'maestro',
-                $this->generateCardNumber(62, 14),
-                true,
-            ],
-            'maestro39' => [
-                'maestro',
-                $this->generateCardNumber(63, 14),
-                true,
-            ],
-            'maestro40' => [
-                'maestro',
-                $this->generateCardNumber(64, 14),
-                true,
-            ],
-            'maestro41' => [
-                'maestro',
-                $this->generateCardNumber(65, 14),
-                true,
-            ],
-            'maestro42' => [
-                'maestro',
-                $this->generateCardNumber(66, 14),
-                true,
-            ],
-            'maestro43' => [
-                'maestro',
-                $this->generateCardNumber(67, 14),
-                true,
-            ],
-            'maestro44' => [
-                'maestro',
-                $this->generateCardNumber(68, 14),
-                true,
-            ],
-            'maestro45' => [
-                'maestro',
-                $this->generateCardNumber(69, 14),
-                true,
-            ],
-            'maestro46' => [
-                'maestro',
-                $this->generateCardNumber(50, 15),
-                true,
-            ],
-            'maestro47' => [
-                'maestro',
-                $this->generateCardNumber(56, 15),
-                true,
-            ],
-            'maestro48' => [
-                'maestro',
-                $this->generateCardNumber(57, 15),
-                true,
-            ],
-            'maestro49' => [
-                'maestro',
-                $this->generateCardNumber(58, 15),
-                true,
-            ],
-            'maestro50' => [
-                'maestro',
-                $this->generateCardNumber(59, 15),
-                true,
-            ],
-            'maestro51' => [
-                'maestro',
-                $this->generateCardNumber(60, 15),
-                true,
-            ],
-            'maestro52' => [
-                'maestro',
-                $this->generateCardNumber(61, 15),
-                true,
-            ],
-            'maestro53' => [
-                'maestro',
-                $this->generateCardNumber(62, 15),
-                true,
-            ],
-            'maestro54' => [
-                'maestro',
-                $this->generateCardNumber(63, 15),
-                true,
-            ],
-            'maestro55' => [
-                'maestro',
-                $this->generateCardNumber(64, 15),
-                true,
-            ],
-            'maestro56' => [
-                'maestro',
-                $this->generateCardNumber(65, 15),
-                true,
-            ],
-            'maestro57' => [
-                'maestro',
-                $this->generateCardNumber(66, 15),
-                true,
-            ],
-            'maestro58' => [
-                'maestro',
-                $this->generateCardNumber(67, 15),
-                true,
-            ],
-            'maestro59' => [
-                'maestro',
-                $this->generateCardNumber(68, 15),
-                true,
-            ],
-            'maestro60' => [
-                'maestro',
-                $this->generateCardNumber(69, 15),
-                true,
-            ],
-            'maestro61' => [
-                'maestro',
-                $this->generateCardNumber(50, 16),
-                true,
-            ],
-            'maestro62' => [
-                'maestro',
-                $this->generateCardNumber(56, 16),
-                true,
-            ],
-            'maestro63' => [
-                'maestro',
-                $this->generateCardNumber(57, 16),
-                true,
-            ],
-            'maestro64' => [
-                'maestro',
-                $this->generateCardNumber(58, 16),
-                true,
-            ],
-            'maestro65' => [
-                'maestro',
-                $this->generateCardNumber(59, 16),
-                true,
-            ],
-            'maestro66' => [
-                'maestro',
-                $this->generateCardNumber(60, 16),
-                true,
-            ],
-            'maestro67' => [
-                'maestro',
-                $this->generateCardNumber(61, 16),
-                true,
-            ],
-            'maestro68' => [
-                'maestro',
-                $this->generateCardNumber(62, 16),
-                true,
-            ],
-            'maestro69' => [
-                'maestro',
-                $this->generateCardNumber(63, 16),
-                true,
-            ],
-            'maestro70' => [
-                'maestro',
-                $this->generateCardNumber(64, 16),
-                true,
-            ],
-            'maestro71' => [
-                'maestro',
-                $this->generateCardNumber(65, 16),
-                true,
-            ],
-            'maestro72' => [
-                'maestro',
-                $this->generateCardNumber(66, 16),
-                true,
-            ],
-            'maestro73' => [
-                'maestro',
-                $this->generateCardNumber(67, 16),
-                true,
-            ],
-            'maestro74' => [
-                'maestro',
-                $this->generateCardNumber(68, 16),
-                true,
-            ],
-            'maestro75' => [
-                'maestro',
-                $this->generateCardNumber(69, 16),
-                true,
-            ],
-            'maestro91' => [
-                'maestro',
-                $this->generateCardNumber(50, 18),
-                true,
-            ],
-            'maestro92' => [
-                'maestro',
-                $this->generateCardNumber(56, 18),
-                true,
-            ],
-            'maestro93' => [
-                'maestro',
-                $this->generateCardNumber(57, 18),
-                true,
-            ],
-            'maestro94' => [
-                'maestro',
-                $this->generateCardNumber(58, 18),
-                true,
-            ],
-            'maestro95' => [
-                'maestro',
-                $this->generateCardNumber(59, 18),
-                true,
-            ],
-            'maestro96' => [
-                'maestro',
-                $this->generateCardNumber(60, 18),
-                true,
-            ],
-            'maestro97' => [
-                'maestro',
-                $this->generateCardNumber(61, 18),
-                true,
-            ],
-            'maestro98' => [
-                'maestro',
-                $this->generateCardNumber(62, 18),
-                true,
-            ],
-            'maestro99' => [
-                'maestro',
-                $this->generateCardNumber(63, 18),
-                true,
-            ],
-            'maestro100' => [
-                'maestro',
-                $this->generateCardNumber(64, 18),
-                true,
-            ],
-            'maestro101' => [
-                'maestro',
-                $this->generateCardNumber(65, 18),
-                true,
-            ],
-            'maestro102' => [
-                'maestro',
-                $this->generateCardNumber(66, 18),
-                true,
-            ],
-            'maestro103' => [
-                'maestro',
-                $this->generateCardNumber(67, 18),
-                true,
-            ],
-            'maestro104' => [
-                'maestro',
-                $this->generateCardNumber(68, 18),
-                true,
-            ],
-            'maestro105' => [
-                'maestro',
-                $this->generateCardNumber(69, 18),
-                true,
-            ],
-            'maestro106' => [
-                'maestro',
-                $this->generateCardNumber(50, 19),
-                true,
-            ],
-            'maestro107' => [
-                'maestro',
-                $this->generateCardNumber(56, 19),
-                true,
-            ],
-            'maestro108' => [
-                'maestro',
-                $this->generateCardNumber(57, 19),
-                true,
-            ],
-            'maestro109' => [
-                'maestro',
-                $this->generateCardNumber(58, 19),
-                true,
-            ],
-            'maestro110' => [
-                'maestro',
-                $this->generateCardNumber(59, 19),
-                true,
-            ],
-            'maestro111' => [
-                'maestro',
-                $this->generateCardNumber(60, 19),
-                true,
-            ],
-            'maestro112' => [
-                'maestro',
-                $this->generateCardNumber(61, 19),
-                true,
-            ],
-            'maestro113' => [
-                'maestro',
-                $this->generateCardNumber(62, 19),
-                true,
-            ],
-            'maestro114' => [
-                'maestro',
-                $this->generateCardNumber(63, 19),
-                true,
-            ],
-            'maestro115' => [
-                'maestro',
-                $this->generateCardNumber(64, 19),
-                true,
-            ],
-            'maestro116' => [
-                'maestro',
-                $this->generateCardNumber(65, 19),
-                true,
-            ],
-            'maestro117' => [
-                'maestro',
-                $this->generateCardNumber(66, 19),
-                true,
-            ],
-            'maestro118' => [
-                'maestro',
-                $this->generateCardNumber(67, 19),
-                true,
-            ],
-            'maestro119' => [
-                'maestro',
-                $this->generateCardNumber(68, 19),
-                true,
-            ],
-            'maestro120' => [
-                'maestro',
-                $this->generateCardNumber(69, 19),
-                true,
-            ],
-            'dankort1' => [
-                'dankort',
-                $this->generateCardNumber(5019, 16),
-                true,
-            ],
-            'dankort2' => [
-                'dankort',
-                $this->generateCardNumber(4175, 16),
-                true,
-            ],
-            'dankort3' => [
-                'dankort',
-                $this->generateCardNumber(4571, 16),
-                true,
-            ],
-            'dankort4' => [
-                'dankort',
-                $this->generateCardNumber(4, 16),
-                true,
-            ],
-            'mir1' => [
-                'mir',
-                $this->generateCardNumber(2200, 16),
-                true,
-            ],
-            'mir2' => [
-                'mir',
-                $this->generateCardNumber(2201, 16),
-                true,
-            ],
-            'mir3' => [
-                'mir',
-                $this->generateCardNumber(2202, 16),
-                true,
-            ],
-            'mir4' => [
-                'mir',
-                $this->generateCardNumber(2203, 16),
-                true,
-            ],
-            'mir5' => [
-                'mir',
-                $this->generateCardNumber(2204, 16),
-                true,
-            ],
-            'mastercard1' => [
-                'mastercard',
-                $this->generateCardNumber(51, 16),
-                true,
-            ],
-            'mastercard2' => [
-                'mastercard',
-                $this->generateCardNumber(52, 16),
-                true,
-            ],
-            'mastercard3' => [
-                'mastercard',
-                $this->generateCardNumber(53, 16),
-                true,
-            ],
-            'mastercard4' => [
-                'mastercard',
-                $this->generateCardNumber(54, 16),
-                true,
-            ],
-            'mastercard5' => [
-                'mastercard',
-                $this->generateCardNumber(55, 16),
-                true,
-            ],
-            'mastercard6' => [
-                'mastercard',
-                $this->generateCardNumber(22, 16),
-                true,
-            ],
-            'mastercard7' => [
-                'mastercard',
-                $this->generateCardNumber(23, 16),
-                true,
-            ],
-            'mastercard8' => [
-                'mastercard',
-                $this->generateCardNumber(24, 16),
-                true,
-            ],
-            'mastercard9' => [
-                'mastercard',
-                $this->generateCardNumber(25, 16),
-                true,
-            ],
-            'mastercard10' => [
-                'mastercard',
-                $this->generateCardNumber(26, 16),
-                true,
-            ],
-            'mastercard11' => [
-                'mastercard',
-                $this->generateCardNumber(27, 16),
-                true,
-            ],
-            'visa1' => [
-                'visa',
-                $this->generateCardNumber(4, 13),
-                true,
-            ],
-            'visa2' => [
-                'visa',
-                $this->generateCardNumber(4, 16),
-                true,
-            ],
-            'visa3' => [
-                'visa',
-                $this->generateCardNumber(4, 19),
-                true,
-            ],
-            'uatp' => [
-                'uatp',
-                $this->generateCardNumber(1, 15),
-                true,
-            ],
-            'verve1' => [
-                'verve',
-                $this->generateCardNumber(506, 16),
-                true,
-            ],
-            'verve2' => [
-                'verve',
-                $this->generateCardNumber(650, 16),
-                true,
-            ],
-            'verve3' => [
-                'verve',
-                $this->generateCardNumber(506, 19),
-                true,
-            ],
-            'verve4' => [
-                'verve',
-                $this->generateCardNumber(650, 19),
-                true,
-            ],
-            'cibc1' => [
-                'cibc',
-                $this->generateCardNumber(4506, 16),
-                true,
-            ],
-            'rbc1' => [
-                'rbc',
-                $this->generateCardNumber(45, 16),
-                true,
-            ],
-            'tdtrust' => [
-                'tdtrust',
-                $this->generateCardNumber(589297, 16),
-                true,
-            ],
-            'scotia1' => [
-                'scotia',
-                $this->generateCardNumber(4536, 16),
-                true,
-            ],
-            'bmoabm1' => [
-                'bmoabm',
-                $this->generateCardNumber(500, 16),
-                true,
-            ],
-            'hsbc1' => [
-                'hsbc',
-                $this->generateCardNumber(56, 16),
-                true,
-            ],
-            'hsbc2' => [
-                'hsbc',
-                $this->generateCardNumber(57, 16),
-                false,
-            ],
+        yield 'null_test' => [
+            'amex',
+            null,
+            false,
+        ];
+
+        yield 'random_test' => [
+            'amex',
+            $this->generateCardNumber('37', 16),
+            false,
+        ];
+
+        yield 'invalid_type' => [
+            'shorty',
+            '1111 1111 1111 1111',
+            false,
+        ];
+
+        yield 'invalid_length' => [
+            'amex',
+            '',
+            false,
+        ];
+
+        yield 'not_numeric' => [
+            'amex',
+            'abcd efgh ijkl mnop',
+            false,
+        ];
+
+        yield 'bad_length' => [
+            'amex',
+            '3782 8224 6310 0051',
+            false,
+        ];
+
+        yield 'bad_prefix' => [
+            'amex',
+            '3582 8224 6310 0051',
+            false,
+        ];
+
+        yield 'amex1' => [
+            'amex',
+            '3782 8224 6310 005',
+            true,
+        ];
+
+        yield 'amex2' => [
+            'amex',
+            '3714 4963 5398 431',
+            true,
+        ];
+
+        yield 'dinersclub1' => [
+            'dinersclub',
+            '3056 9309 0259 04',
+            true,
+        ];
+
+        yield 'dinersculb2' => [
+            'dinersclub',
+            '3852 0000 0232 37',
+            true,
+        ];
+
+        yield 'discover1' => [
+            'discover',
+            '6011 1111 1111 1117',
+            true,
+        ];
+
+        yield 'discover2' => [
+            'discover',
+            '6011 0009 9013 9424',
+            true,
+        ];
+
+        yield 'jcb8' => [
+            'jcb',
+            '3530 1113 3330 0000',
+            true,
+        ];
+
+        yield 'jcb9' => [
+            'jcb',
+            '3566 0020 2036 0505',
+            true,
+        ];
+
+        yield 'mastercard12' => [
+            'mastercard',
+            '5555 5555 5555 4444',
+            true,
+        ];
+
+        yield 'mastercard13' => [
+            'mastercard',
+            '5105 1051 0510 5100',
+            true,
+        ];
+
+        yield 'visa4' => [
+            'visa',
+            '4111 1111 1111 1111',
+            true,
+        ];
+
+        yield 'visa5' => [
+            'visa',
+            '4012 8888 8888 1881',
+            true,
+        ];
+
+        yield 'visa6' => [
+            'visa',
+            '4222 2222 2222 2',
+            true,
+        ];
+
+        yield 'dankort5' => [
+            'dankort',
+            '5019 7170 1010 3742',
+            true,
+        ];
+
+        yield 'unionpay1' => [
+            'unionpay',
+            $this->generateCardNumber(62, 16),
+            true,
+        ];
+
+        yield 'unionpay2' => [
+            'unionpay',
+            $this->generateCardNumber(62, 17),
+            true,
+        ];
+
+        yield 'unionpay3' => [
+            'unionpay',
+            $this->generateCardNumber(62, 18),
+            true,
+        ];
+
+        yield 'unionpay4' => [
+            'unionpay',
+            $this->generateCardNumber(62, 19),
+            true,
+        ];
+
+        yield 'unionpay5' => [
+            'unionpay',
+            $this->generateCardNumber(63, 19),
+            false,
+        ];
+
+        yield 'carteblanche1' => [
+            'carteblanche',
+            $this->generateCardNumber(300, 14),
+            true,
+        ];
+
+        yield 'carteblanche2' => [
+            'carteblanche',
+            $this->generateCardNumber(301, 14),
+            true,
+        ];
+
+        yield 'carteblanche3' => [
+            'carteblanche',
+            $this->generateCardNumber(302, 14),
+            true,
+        ];
+
+        yield 'carteblanche4' => [
+            'carteblanche',
+            $this->generateCardNumber(303, 14),
+            true,
+        ];
+
+        yield 'carteblanche5' => [
+            'carteblanche',
+            $this->generateCardNumber(304, 14),
+            true,
+        ];
+
+        yield 'carteblanche6' => [
+            'carteblanche',
+            $this->generateCardNumber(305, 14),
+            true,
+        ];
+
+        yield 'carteblanche7' => [
+            'carteblanche',
+            $this->generateCardNumber(306, 14),
+            false,
+        ];
+
+        yield 'dinersclub3' => [
+            'dinersclub',
+            $this->generateCardNumber(300, 14),
+            true,
+        ];
+
+        yield 'dinersclub4' => [
+            'dinersclub',
+            $this->generateCardNumber(301, 14),
+            true,
+        ];
+
+        yield 'dinersclub5' => [
+            'dinersclub',
+            $this->generateCardNumber(302, 14),
+            true,
+        ];
+
+        yield 'dinersclub6' => [
+            'dinersclub',
+            $this->generateCardNumber(303, 14),
+            true,
+        ];
+
+        yield 'dinersclub7' => [
+            'dinersclub',
+            $this->generateCardNumber(304, 14),
+            true,
+        ];
+
+        yield 'dinersclub8' => [
+            'dinersclub',
+            $this->generateCardNumber(305, 14),
+            true,
+        ];
+
+        yield 'dinersclub9' => [
+            'dinersclub',
+            $this->generateCardNumber(309, 14),
+            true,
+        ];
+
+        yield 'dinersclub10' => [
+            'dinersclub',
+            $this->generateCardNumber(36, 14),
+            true,
+        ];
+
+        yield 'dinersclub11' => [
+            'dinersclub',
+            $this->generateCardNumber(38, 14),
+            true,
+        ];
+
+        yield 'dinersclub12' => [
+            'dinersclub',
+            $this->generateCardNumber(39, 14),
+            true,
+        ];
+
+        yield 'dinersclub13' => [
+            'dinersclub',
+            $this->generateCardNumber(54, 14),
+            true,
+        ];
+
+        yield 'dinersclub14' => [
+            'dinersclub',
+            $this->generateCardNumber(55, 14),
+            true,
+        ];
+
+        yield 'dinersclub15' => [
+            'dinersclub',
+            $this->generateCardNumber(300, 16),
+            true,
+        ];
+
+        yield 'dinersclub16' => [
+            'dinersclub',
+            $this->generateCardNumber(301, 16),
+            true,
+        ];
+
+        yield 'dinersclub17' => [
+            'dinersclub',
+            $this->generateCardNumber(302, 16),
+            true,
+        ];
+
+        yield 'dinersclub18' => [
+            'dinersclub',
+            $this->generateCardNumber(303, 16),
+            true,
+        ];
+
+        yield 'dinersclub19' => [
+            'dinersclub',
+            $this->generateCardNumber(304, 16),
+            true,
+        ];
+
+        yield 'dinersclub20' => [
+            'dinersclub',
+            $this->generateCardNumber(305, 16),
+            true,
+        ];
+
+        yield 'dinersclub21' => [
+            'dinersclub',
+            $this->generateCardNumber(309, 16),
+            true,
+        ];
+
+        yield 'dinersclub22' => [
+            'dinersclub',
+            $this->generateCardNumber(36, 16),
+            true,
+        ];
+
+        yield 'dinersclub23' => [
+            'dinersclub',
+            $this->generateCardNumber(38, 16),
+            true,
+        ];
+
+        yield 'dinersclub24' => [
+            'dinersclub',
+            $this->generateCardNumber(39, 16),
+            true,
+        ];
+
+        yield 'dinersclub25' => [
+            'dinersclub',
+            $this->generateCardNumber(54, 16),
+            true,
+        ];
+
+        yield 'dinersclub26' => [
+            'dinersclub',
+            $this->generateCardNumber(55, 16),
+            true,
+        ];
+
+        yield 'discover3' => [
+            'discover',
+            $this->generateCardNumber(6011, 16),
+            true,
+        ];
+
+        yield 'discover4' => [
+            'discover',
+            $this->generateCardNumber(622, 16),
+            true,
+        ];
+
+        yield 'discover5' => [
+            'discover',
+            $this->generateCardNumber(644, 16),
+            true,
+        ];
+
+        yield 'discover6' => [
+            'discover',
+            $this->generateCardNumber(645, 16),
+            true,
+        ];
+
+        yield 'discover7' => [
+            'discover',
+            $this->generateCardNumber(656, 16),
+            true,
+        ];
+
+        yield 'discover8' => [
+            'discover',
+            $this->generateCardNumber(647, 16),
+            true,
+        ];
+
+        yield 'discover9' => [
+            'discover',
+            $this->generateCardNumber(648, 16),
+            true,
+        ];
+
+        yield 'discover10' => [
+            'discover',
+            $this->generateCardNumber(649, 16),
+            true,
+        ];
+
+        yield 'discover11' => [
+            'discover',
+            $this->generateCardNumber(65, 16),
+            true,
+        ];
+
+        yield 'discover12' => [
+            'discover',
+            $this->generateCardNumber(6011, 19),
+            true,
+        ];
+
+        yield 'discover13' => [
+            'discover',
+            $this->generateCardNumber(622, 19),
+            true,
+        ];
+
+        yield 'discover14' => [
+            'discover',
+            $this->generateCardNumber(644, 19),
+            true,
+        ];
+
+        yield 'discover15' => [
+            'discover',
+            $this->generateCardNumber(645, 19),
+            true,
+        ];
+
+        yield 'discover16' => [
+            'discover',
+            $this->generateCardNumber(656, 19),
+            true,
+        ];
+
+        yield 'discover17' => [
+            'discover',
+            $this->generateCardNumber(647, 19),
+            true,
+        ];
+
+        yield 'discover18' => [
+            'discover',
+            $this->generateCardNumber(648, 19),
+            true,
+        ];
+
+        yield 'discover19' => [
+            'discover',
+            $this->generateCardNumber(649, 19),
+            true,
+        ];
+
+        yield 'discover20' => [
+            'discover',
+            $this->generateCardNumber(65, 19),
+            true,
+        ];
+
+        yield 'interpayment1' => [
+            'interpayment',
+            $this->generateCardNumber(4, 16),
+            true,
+        ];
+
+        yield 'interpayment2' => [
+            'interpayment',
+            $this->generateCardNumber(4, 17),
+            true,
+        ];
+
+        yield 'interpayment3' => [
+            'interpayment',
+            $this->generateCardNumber(4, 18),
+            true,
+        ];
+
+        yield 'interpayment4' => [
+            'interpayment',
+            $this->generateCardNumber(4, 19),
+            true,
+        ];
+
+        yield 'jcb1' => [
+            'jcb',
+            $this->generateCardNumber(352, 16),
+            true,
+        ];
+
+        yield 'jcb2' => [
+            'jcb',
+            $this->generateCardNumber(353, 16),
+            true,
+        ];
+
+        yield 'jcb3' => [
+            'jcb',
+            $this->generateCardNumber(354, 16),
+            true,
+        ];
+
+        yield 'jcb4' => [
+            'jcb',
+            $this->generateCardNumber(355, 16),
+            true,
+        ];
+
+        yield 'jcb5' => [
+            'jcb',
+            $this->generateCardNumber(356, 16),
+            true,
+        ];
+
+        yield 'jcb6' => [
+            'jcb',
+            $this->generateCardNumber(357, 16),
+            true,
+        ];
+
+        yield 'jcb7' => [
+            'jcb',
+            $this->generateCardNumber(358, 16),
+            true,
+        ];
+
+        yield 'maestro1' => [
+            'maestro',
+            $this->generateCardNumber(50, 12),
+            true,
+        ];
+
+        yield 'maestro2' => [
+            'maestro',
+            $this->generateCardNumber(56, 12),
+            true,
+        ];
+
+        yield 'maestro3' => [
+            'maestro',
+            $this->generateCardNumber(57, 12),
+            true,
+        ];
+
+        yield 'maestro4' => [
+            'maestro',
+            $this->generateCardNumber(58, 12),
+            true,
+        ];
+
+        yield 'maestro5' => [
+            'maestro',
+            $this->generateCardNumber(59, 12),
+            true,
+        ];
+
+        yield 'maestro6' => [
+            'maestro',
+            $this->generateCardNumber(60, 12),
+            true,
+        ];
+
+        yield 'maestro7' => [
+            'maestro',
+            $this->generateCardNumber(61, 12),
+            true,
+        ];
+
+        yield 'maestro8' => [
+            'maestro',
+            $this->generateCardNumber(62, 12),
+            true,
+        ];
+
+        yield 'maestro9' => [
+            'maestro',
+            $this->generateCardNumber(63, 12),
+            true,
+        ];
+
+        yield 'maestro10' => [
+            'maestro',
+            $this->generateCardNumber(64, 12),
+            true,
+        ];
+
+        yield 'maestro11' => [
+            'maestro',
+            $this->generateCardNumber(65, 12),
+            true,
+        ];
+
+        yield 'maestro12' => [
+            'maestro',
+            $this->generateCardNumber(66, 12),
+            true,
+        ];
+
+        yield 'maestro13' => [
+            'maestro',
+            $this->generateCardNumber(67, 12),
+            true,
+        ];
+
+        yield 'maestro14' => [
+            'maestro',
+            $this->generateCardNumber(68, 12),
+            true,
+        ];
+
+        yield 'maestro15' => [
+            'maestro',
+            $this->generateCardNumber(69, 12),
+            true,
+        ];
+
+        yield 'maestro16' => [
+            'maestro',
+            $this->generateCardNumber(50, 13),
+            true,
+        ];
+
+        yield 'maestro17' => [
+            'maestro',
+            $this->generateCardNumber(56, 13),
+            true,
+        ];
+
+        yield 'maestro18' => [
+            'maestro',
+            $this->generateCardNumber(57, 13),
+            true,
+        ];
+
+        yield 'maestro19' => [
+            'maestro',
+            $this->generateCardNumber(58, 13),
+            true,
+        ];
+
+        yield 'maestro20' => [
+            'maestro',
+            $this->generateCardNumber(59, 13),
+            true,
+        ];
+
+        yield 'maestro21' => [
+            'maestro',
+            $this->generateCardNumber(60, 13),
+            true,
+        ];
+
+        yield 'maestro22' => [
+            'maestro',
+            $this->generateCardNumber(61, 13),
+            true,
+        ];
+
+        yield 'maestro23' => [
+            'maestro',
+            $this->generateCardNumber(62, 13),
+            true,
+        ];
+
+        yield 'maestro24' => [
+            'maestro',
+            $this->generateCardNumber(63, 13),
+            true,
+        ];
+
+        yield 'maestro25' => [
+            'maestro',
+            $this->generateCardNumber(64, 13),
+            true,
+        ];
+
+        yield 'maestro26' => [
+            'maestro',
+            $this->generateCardNumber(65, 13),
+            true,
+        ];
+
+        yield 'maestro27' => [
+            'maestro',
+            $this->generateCardNumber(66, 13),
+            true,
+        ];
+
+        yield 'maestro28' => [
+            'maestro',
+            $this->generateCardNumber(67, 13),
+            true,
+        ];
+
+        yield 'maestro29' => [
+            'maestro',
+            $this->generateCardNumber(68, 13),
+            true,
+        ];
+
+        yield 'maestro30' => [
+            'maestro',
+            $this->generateCardNumber(69, 13),
+            true,
+        ];
+
+        yield 'maestro31' => [
+            'maestro',
+            $this->generateCardNumber(50, 14),
+            true,
+        ];
+
+        yield 'maestro32' => [
+            'maestro',
+            $this->generateCardNumber(56, 14),
+            true,
+        ];
+
+        yield 'maestro33' => [
+            'maestro',
+            $this->generateCardNumber(57, 14),
+            true,
+        ];
+
+        yield 'maestro34' => [
+            'maestro',
+            $this->generateCardNumber(58, 14),
+            true,
+        ];
+
+        yield 'maestro35' => [
+            'maestro',
+            $this->generateCardNumber(59, 14),
+            true,
+        ];
+
+        yield 'maestro36' => [
+            'maestro',
+            $this->generateCardNumber(60, 14),
+            true,
+        ];
+
+        yield 'maestro37' => [
+            'maestro',
+            $this->generateCardNumber(61, 14),
+            true,
+        ];
+
+        yield 'maestro38' => [
+            'maestro',
+            $this->generateCardNumber(62, 14),
+            true,
+        ];
+
+        yield 'maestro39' => [
+            'maestro',
+            $this->generateCardNumber(63, 14),
+            true,
+        ];
+
+        yield 'maestro40' => [
+            'maestro',
+            $this->generateCardNumber(64, 14),
+            true,
+        ];
+
+        yield 'maestro41' => [
+            'maestro',
+            $this->generateCardNumber(65, 14),
+            true,
+        ];
+
+        yield 'maestro42' => [
+            'maestro',
+            $this->generateCardNumber(66, 14),
+            true,
+        ];
+
+        yield 'maestro43' => [
+            'maestro',
+            $this->generateCardNumber(67, 14),
+            true,
+        ];
+
+        yield 'maestro44' => [
+            'maestro',
+            $this->generateCardNumber(68, 14),
+            true,
+        ];
+
+        yield 'maestro45' => [
+            'maestro',
+            $this->generateCardNumber(69, 14),
+            true,
+        ];
+
+        yield 'maestro46' => [
+            'maestro',
+            $this->generateCardNumber(50, 15),
+            true,
+        ];
+
+        yield 'maestro47' => [
+            'maestro',
+            $this->generateCardNumber(56, 15),
+            true,
+        ];
+
+        yield 'maestro48' => [
+            'maestro',
+            $this->generateCardNumber(57, 15),
+            true,
+        ];
+
+        yield 'maestro49' => [
+            'maestro',
+            $this->generateCardNumber(58, 15),
+            true,
+        ];
+
+        yield 'maestro50' => [
+            'maestro',
+            $this->generateCardNumber(59, 15),
+            true,
+        ];
+
+        yield 'maestro51' => [
+            'maestro',
+            $this->generateCardNumber(60, 15),
+            true,
+        ];
+
+        yield 'maestro52' => [
+            'maestro',
+            $this->generateCardNumber(61, 15),
+            true,
+        ];
+
+        yield 'maestro53' => [
+            'maestro',
+            $this->generateCardNumber(62, 15),
+            true,
+        ];
+
+        yield 'maestro54' => [
+            'maestro',
+            $this->generateCardNumber(63, 15),
+            true,
+        ];
+
+        yield 'maestro55' => [
+            'maestro',
+            $this->generateCardNumber(64, 15),
+            true,
+        ];
+
+        yield 'maestro56' => [
+            'maestro',
+            $this->generateCardNumber(65, 15),
+            true,
+        ];
+
+        yield 'maestro57' => [
+            'maestro',
+            $this->generateCardNumber(66, 15),
+            true,
+        ];
+
+        yield 'maestro58' => [
+            'maestro',
+            $this->generateCardNumber(67, 15),
+            true,
+        ];
+
+        yield 'maestro59' => [
+            'maestro',
+            $this->generateCardNumber(68, 15),
+            true,
+        ];
+
+        yield 'maestro60' => [
+            'maestro',
+            $this->generateCardNumber(69, 15),
+            true,
+        ];
+
+        yield 'maestro61' => [
+            'maestro',
+            $this->generateCardNumber(50, 16),
+            true,
+        ];
+
+        yield 'maestro62' => [
+            'maestro',
+            $this->generateCardNumber(56, 16),
+            true,
+        ];
+
+        yield 'maestro63' => [
+            'maestro',
+            $this->generateCardNumber(57, 16),
+            true,
+        ];
+
+        yield 'maestro64' => [
+            'maestro',
+            $this->generateCardNumber(58, 16),
+            true,
+        ];
+
+        yield 'maestro65' => [
+            'maestro',
+            $this->generateCardNumber(59, 16),
+            true,
+        ];
+
+        yield 'maestro66' => [
+            'maestro',
+            $this->generateCardNumber(60, 16),
+            true,
+        ];
+
+        yield 'maestro67' => [
+            'maestro',
+            $this->generateCardNumber(61, 16),
+            true,
+        ];
+
+        yield 'maestro68' => [
+            'maestro',
+            $this->generateCardNumber(62, 16),
+            true,
+        ];
+
+        yield 'maestro69' => [
+            'maestro',
+            $this->generateCardNumber(63, 16),
+            true,
+        ];
+
+        yield 'maestro70' => [
+            'maestro',
+            $this->generateCardNumber(64, 16),
+            true,
+        ];
+
+        yield 'maestro71' => [
+            'maestro',
+            $this->generateCardNumber(65, 16),
+            true,
+        ];
+
+        yield 'maestro72' => [
+            'maestro',
+            $this->generateCardNumber(66, 16),
+            true,
+        ];
+
+        yield 'maestro73' => [
+            'maestro',
+            $this->generateCardNumber(67, 16),
+            true,
+        ];
+
+        yield 'maestro74' => [
+            'maestro',
+            $this->generateCardNumber(68, 16),
+            true,
+        ];
+
+        yield 'maestro75' => [
+            'maestro',
+            $this->generateCardNumber(69, 16),
+            true,
+        ];
+
+        yield 'maestro91' => [
+            'maestro',
+            $this->generateCardNumber(50, 18),
+            true,
+        ];
+
+        yield 'maestro92' => [
+            'maestro',
+            $this->generateCardNumber(56, 18),
+            true,
+        ];
+
+        yield 'maestro93' => [
+            'maestro',
+            $this->generateCardNumber(57, 18),
+            true,
+        ];
+
+        yield 'maestro94' => [
+            'maestro',
+            $this->generateCardNumber(58, 18),
+            true,
+        ];
+
+        yield 'maestro95' => [
+            'maestro',
+            $this->generateCardNumber(59, 18),
+            true,
+        ];
+
+        yield 'maestro96' => [
+            'maestro',
+            $this->generateCardNumber(60, 18),
+            true,
+        ];
+
+        yield 'maestro97' => [
+            'maestro',
+            $this->generateCardNumber(61, 18),
+            true,
+        ];
+
+        yield 'maestro98' => [
+            'maestro',
+            $this->generateCardNumber(62, 18),
+            true,
+        ];
+
+        yield 'maestro99' => [
+            'maestro',
+            $this->generateCardNumber(63, 18),
+            true,
+        ];
+
+        yield 'maestro100' => [
+            'maestro',
+            $this->generateCardNumber(64, 18),
+            true,
+        ];
+
+        yield 'maestro101' => [
+            'maestro',
+            $this->generateCardNumber(65, 18),
+            true,
+        ];
+
+        yield 'maestro102' => [
+            'maestro',
+            $this->generateCardNumber(66, 18),
+            true,
+        ];
+
+        yield 'maestro103' => [
+            'maestro',
+            $this->generateCardNumber(67, 18),
+            true,
+        ];
+
+        yield 'maestro104' => [
+            'maestro',
+            $this->generateCardNumber(68, 18),
+            true,
+        ];
+
+        yield 'maestro105' => [
+            'maestro',
+            $this->generateCardNumber(69, 18),
+            true,
+        ];
+
+        yield 'maestro106' => [
+            'maestro',
+            $this->generateCardNumber(50, 19),
+            true,
+        ];
+
+        yield 'maestro107' => [
+            'maestro',
+            $this->generateCardNumber(56, 19),
+            true,
+        ];
+
+        yield 'maestro108' => [
+            'maestro',
+            $this->generateCardNumber(57, 19),
+            true,
+        ];
+
+        yield 'maestro109' => [
+            'maestro',
+            $this->generateCardNumber(58, 19),
+            true,
+        ];
+
+        yield 'maestro110' => [
+            'maestro',
+            $this->generateCardNumber(59, 19),
+            true,
+        ];
+
+        yield 'maestro111' => [
+            'maestro',
+            $this->generateCardNumber(60, 19),
+            true,
+        ];
+
+        yield 'maestro112' => [
+            'maestro',
+            $this->generateCardNumber(61, 19),
+            true,
+        ];
+
+        yield 'maestro113' => [
+            'maestro',
+            $this->generateCardNumber(62, 19),
+            true,
+        ];
+
+        yield 'maestro114' => [
+            'maestro',
+            $this->generateCardNumber(63, 19),
+            true,
+        ];
+
+        yield 'maestro115' => [
+            'maestro',
+            $this->generateCardNumber(64, 19),
+            true,
+        ];
+
+        yield 'maestro116' => [
+            'maestro',
+            $this->generateCardNumber(65, 19),
+            true,
+        ];
+
+        yield 'maestro117' => [
+            'maestro',
+            $this->generateCardNumber(66, 19),
+            true,
+        ];
+
+        yield 'maestro118' => [
+            'maestro',
+            $this->generateCardNumber(67, 19),
+            true,
+        ];
+
+        yield 'maestro119' => [
+            'maestro',
+            $this->generateCardNumber(68, 19),
+            true,
+        ];
+
+        yield 'maestro120' => [
+            'maestro',
+            $this->generateCardNumber(69, 19),
+            true,
+        ];
+
+        yield 'dankort1' => [
+            'dankort',
+            $this->generateCardNumber(5019, 16),
+            true,
+        ];
+
+        yield 'dankort2' => [
+            'dankort',
+            $this->generateCardNumber(4175, 16),
+            true,
+        ];
+
+        yield 'dankort3' => [
+            'dankort',
+            $this->generateCardNumber(4571, 16),
+            true,
+        ];
+
+        yield 'dankort4' => [
+            'dankort',
+            $this->generateCardNumber(4, 16),
+            true,
+        ];
+
+        yield 'mir1' => [
+            'mir',
+            $this->generateCardNumber(2200, 16),
+            true,
+        ];
+
+        yield 'mir2' => [
+            'mir',
+            $this->generateCardNumber(2201, 16),
+            true,
+        ];
+
+        yield 'mir3' => [
+            'mir',
+            $this->generateCardNumber(2202, 16),
+            true,
+        ];
+
+        yield 'mir4' => [
+            'mir',
+            $this->generateCardNumber(2203, 16),
+            true,
+        ];
+
+        yield 'mir5' => [
+            'mir',
+            $this->generateCardNumber(2204, 16),
+            true,
+        ];
+
+        yield 'mastercard1' => [
+            'mastercard',
+            $this->generateCardNumber(51, 16),
+            true,
+        ];
+
+        yield 'mastercard2' => [
+            'mastercard',
+            $this->generateCardNumber(52, 16),
+            true,
+        ];
+
+        yield 'mastercard3' => [
+            'mastercard',
+            $this->generateCardNumber(53, 16),
+            true,
+        ];
+
+        yield 'mastercard4' => [
+            'mastercard',
+            $this->generateCardNumber(54, 16),
+            true,
+        ];
+
+        yield 'mastercard5' => [
+            'mastercard',
+            $this->generateCardNumber(55, 16),
+            true,
+        ];
+
+        yield 'mastercard6' => [
+            'mastercard',
+            $this->generateCardNumber(22, 16),
+            true,
+        ];
+
+        yield 'mastercard7' => [
+            'mastercard',
+            $this->generateCardNumber(23, 16),
+            true,
+        ];
+
+        yield 'mastercard8' => [
+            'mastercard',
+            $this->generateCardNumber(24, 16),
+            true,
+        ];
+
+        yield 'mastercard9' => [
+            'mastercard',
+            $this->generateCardNumber(25, 16),
+            true,
+        ];
+
+        yield 'mastercard10' => [
+            'mastercard',
+            $this->generateCardNumber(26, 16),
+            true,
+        ];
+
+        yield 'mastercard11' => [
+            'mastercard',
+            $this->generateCardNumber(27, 16),
+            true,
+        ];
+
+        yield 'visa1' => [
+            'visa',
+            $this->generateCardNumber(4, 13),
+            true,
+        ];
+
+        yield 'visa2' => [
+            'visa',
+            $this->generateCardNumber(4, 16),
+            true,
+        ];
+
+        yield 'visa3' => [
+            'visa',
+            $this->generateCardNumber(4, 19),
+            true,
+        ];
+
+        yield 'uatp' => [
+            'uatp',
+            $this->generateCardNumber(1, 15),
+            true,
+        ];
+
+        yield 'verve1' => [
+            'verve',
+            $this->generateCardNumber(506, 16),
+            true,
+        ];
+
+        yield 'verve2' => [
+            'verve',
+            $this->generateCardNumber(650, 16),
+            true,
+        ];
+
+        yield 'verve3' => [
+            'verve',
+            $this->generateCardNumber(506, 19),
+            true,
+        ];
+
+        yield 'verve4' => [
+            'verve',
+            $this->generateCardNumber(650, 19),
+            true,
+        ];
+
+        yield 'cibc1' => [
+            'cibc',
+            $this->generateCardNumber(4506, 16),
+            true,
+        ];
+
+        yield 'rbc1' => [
+            'rbc',
+            $this->generateCardNumber(45, 16),
+            true,
+        ];
+
+        yield 'tdtrust' => [
+            'tdtrust',
+            $this->generateCardNumber(589297, 16),
+            true,
+        ];
+
+        yield 'scotia1' => [
+            'scotia',
+            $this->generateCardNumber(4536, 16),
+            true,
+        ];
+
+        yield 'bmoabm1' => [
+            'bmoabm',
+            $this->generateCardNumber(500, 16),
+            true,
+        ];
+
+        yield 'hsbc1' => [
+            'hsbc',
+            $this->generateCardNumber(56, 16),
+            true,
+        ];
+
+        yield 'hsbc2' => [
+            'hsbc',
+            $this->generateCardNumber(57, 16),
+            false,
         ];
     }
 

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -131,100 +131,115 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function urlProvider(): iterable
     {
-        yield from [
-            [
-                'www.codeigniter.com',
-                true,
-                false,
-            ],
-            [
-                'http://codeigniter.com',
-                true,
-                true,
-            ],
-            // https://bugs.php.net/bug.php?id=51192
-            [
-                'http://accept-dashes.tld',
-                true,
-                true,
-            ],
-            [
-                'http://reject_underscores',
-                false,
-                false,
-            ],
-            // https://github.com/bcit-ci/CodeIgniter/issues/4415
-            [
-                'http://[::1]/ipv6',
-                true,
-                true,
-            ],
-            [
-                'htt://www.codeigniter.com',
-                false,
-                false,
-            ],
-            [
-                '',
-                false,
-                false,
-            ],
-            // https://github.com/codeigniter4/CodeIgniter4/issues/3156
-            [
-                'codeigniter',
-                true,   // What?
-                false,
-            ],
-            [
-                'code igniter',
-                false,
-                false,
-            ],
-            [
-                null,
-                false,
-                false,
-            ],
-            [
-                'http://',
-                true,   // Why?
-                false,
-            ],
-            [
-                'http:///oops.com',
-                false,
-                false,
-            ],
-            [
-                '123.com',
-                true,
-                false,
-            ],
-            [
-                'abc.123',
-                true,
-                false,
-            ],
-            [
-                'http:8080//abc.com',
-                true,   // Insane?
-                false,
-            ],
-            [
-                'mailto:support@codeigniter.com',
-                true,
-                false,
-            ],
-            [
-                '//example.com',
-                false,
-                false,
-            ],
-            [
-                "http://www.codeigniter.com\n",
-                false,
-                false,
-            ],
+        yield [
+            'www.codeigniter.com',
+            true,
+            false,
+        ];
+
+        yield [
+            'http://codeigniter.com',
+            true,
+            true,
+        ];
+
+        // https://bugs.php.net/bug.php?id=51192
+        yield [
+            'http://accept-dashes.tld',
+            true,
+            true,
+        ];
+
+        yield [
+            'http://reject_underscores',
+            false,
+            false,
+        ];
+
+        // https://github.com/bcit-ci/CodeIgniter/issues/4415
+        yield [
+            'http://[::1]/ipv6',
+            true,
+            true,
+        ];
+
+        yield [
+            'htt://www.codeigniter.com',
+            false,
+            false,
+        ];
+
+        yield [
+            '',
+            false,
+            false,
+        ];
+
+        // https://github.com/codeigniter4/CodeIgniter4/issues/3156
+        yield [
+            'codeigniter',
+            true,   // What?
+            false,
+        ];
+
+        yield [
+            'code igniter',
+            false,
+            false,
+        ];
+
+        yield [
+            null,
+            false,
+            false,
+        ];
+
+        yield [
+            'http://',
+            true,   // Why?
+            false,
+        ];
+
+        yield [
+            'http:///oops.com',
+            false,
+            false,
+        ];
+
+        yield [
+            '123.com',
+            true,
+            false,
+        ];
+
+        yield [
+            'abc.123',
+            true,
+            false,
+        ];
+
+        yield [
+            'http:8080//abc.com',
+            true,   // Insane?
+            false,
+        ];
+
+        yield [
+            'mailto:support@codeigniter.com',
+            true,
+            false,
+        ];
+
+        yield [
+            '//example.com',
+            false,
+            false,
+        ];
+
+        yield [
+            "http://www.codeigniter.com\n",
+            false,
+            false,
         ];
     }
 
@@ -262,49 +277,52 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function emailProviderSingle(): iterable
     {
-        yield from [
-            [
-                'email@sample.com',
-                true,
-            ],
-            [
-                'valid_email',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            'email@sample.com',
+            true,
+        ];
+
+        yield [
+            'valid_email',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
     public function emailsProvider(): iterable
     {
-        yield from [
-            [
-                '1@sample.com,2@sample.com',
-                true,
-            ],
-            [
-                '1@sample.com, 2@sample.com',
-                true,
-            ],
-            [
-                'email@sample.com',
-                true,
-            ],
-            [
-                '@sample.com,2@sample.com,validemail@email.ca',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
-            [
-                ',',
-                false,
-            ],
+        yield [
+            '1@sample.com,2@sample.com',
+            true,
+        ];
+
+        yield [
+            '1@sample.com, 2@sample.com',
+            true,
+        ];
+
+        yield [
+            'email@sample.com',
+            true,
+        ];
+
+        yield [
+            '@sample.com,2@sample.com,validemail@email.ca',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
+        ];
+
+        yield [
+            ',',
+            false,
         ];
     }
 
@@ -326,52 +344,58 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function ipProvider(): iterable
     {
-        yield from [
-            [
-                '127.0.0.1',
-                null,
-                true,
-            ],
-            [
-                '127.0.0.1',
-                'ipv4',
-                true,
-            ],
-            [
-                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-                null,
-                true,
-            ],
-            [
-                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-                'ipv6',
-                true,
-            ],
-            [
-                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-                'ipv4',
-                false,
-            ],
-            [
-                '127.0.0.1',
-                'ipv6',
-                false,
-            ],
-            [
-                'H001:0db8:85a3:0000:0000:8a2e:0370:7334',
-                null,
-                false,
-            ],
-            [
-                '127.0.0.259',
-                null,
-                false,
-            ],
-            [
-                null,
-                null,
-                false,
-            ],
+        yield [
+            '127.0.0.1',
+            null,
+            true,
+        ];
+
+        yield [
+            '127.0.0.1',
+            'ipv4',
+            true,
+        ];
+
+        yield [
+            '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            null,
+            true,
+        ];
+
+        yield [
+            '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            'ipv6',
+            true,
+        ];
+
+        yield [
+            '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            'ipv4',
+            false,
+        ];
+
+        yield [
+            '127.0.0.1',
+            'ipv6',
+            false,
+        ];
+
+        yield [
+            'H001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            null,
+            false,
+        ];
+
+        yield [
+            '127.0.0.259',
+            null,
+            false,
+        ];
+
+        yield [
+            null,
+            null,
+            false,
         ];
     }
 
@@ -395,19 +419,19 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function stringProvider(): iterable
     {
-        yield from [
-            [
-                '123',
-                true,
-            ],
-            [
-                123,
-                false,
-            ],
-            [
-                'hello',
-                true,
-            ],
+        yield [
+            '123',
+            true,
+        ];
+
+        yield [
+            123,
+            false,
+        ];
+
+        yield [
+            'hello',
+            true,
         ];
     }
 
@@ -429,27 +453,29 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function alphaProvider(): iterable
     {
-        yield from [
-            [
-                self::ALPHABET,
-                true,
-            ],
-            [
-                self::ALPHABET . ' ',
-                false,
-            ],
-            [
-                self::ALPHABET . '1',
-                false,
-            ],
-            [
-                self::ALPHABET . '*',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            self::ALPHABET,
+            true,
+        ];
+
+        yield [
+            self::ALPHABET . ' ',
+            false,
+        ];
+
+        yield [
+            self::ALPHABET . '1',
+            false,
+        ];
+
+        yield [
+            self::ALPHABET . '*',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -471,31 +497,34 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function alphaSpaceProvider(): iterable
     {
-        yield from [
-            [
-                null,
-                true,
-            ],
-            [
-                self::ALPHABET,
-                true,
-            ],
-            [
-                self::ALPHABET . ' ',
-                true,
-            ],
-            [
-                self::ALPHABET . "\n",
-                false,
-            ],
-            [
-                self::ALPHABET . '1',
-                false,
-            ],
-            [
-                self::ALPHABET . '*',
-                false,
-            ],
+        yield [
+            null,
+            true,
+        ];
+
+        yield [
+            self::ALPHABET,
+            true,
+        ];
+
+        yield [
+            self::ALPHABET . ' ',
+            true,
+        ];
+
+        yield [
+            self::ALPHABET . "\n",
+            false,
+        ];
+
+        yield [
+            self::ALPHABET . '1',
+            false,
+        ];
+
+        yield [
+            self::ALPHABET . '*',
+            false,
         ];
     }
 
@@ -517,23 +546,24 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function alphaNumericProvider(): iterable
     {
-        yield from [
-            [
-                self::ALPHANUMERIC,
-                true,
-            ],
-            [
-                self::ALPHANUMERIC . '\ ',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '_',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            self::ALPHANUMERIC,
+            true,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '\ ',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '_',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -555,79 +585,94 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function alphaNumericPunctProvider(): iterable
     {
-        yield from [
-            [
-                self::ALPHANUMERIC . ' ~!#$%&*-_+=|:.',
-                true,
-            ],
-            [
-                self::ALPHANUMERIC . '`',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . "\n",
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '@',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '^',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '(',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . ')',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '\\',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '{',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '}',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '[',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . ']',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '"',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . "'",
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '<',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '>',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . '/',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            self::ALPHANUMERIC . ' ~!#$%&*-_+=|:.',
+            true,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '`',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . "\n",
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '@',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '^',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '(',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . ')',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '\\',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '{',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '}',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '[',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . ']',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '"',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . "'",
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '<',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '>',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '/',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -649,23 +694,24 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function alphaNumericSpaceProvider(): Generator
     {
-        yield from [
-            [
-                ' ' . self::ALPHANUMERIC,
-                true,
-            ],
-            [
-                ' ' . self::ALPHANUMERIC . '-',
-                false,
-            ],
-            [
-                ' ' . self::ALPHANUMERIC . "\n",
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            ' ' . self::ALPHANUMERIC,
+            true,
+        ];
+
+        yield [
+            ' ' . self::ALPHANUMERIC . '-',
+            false,
+        ];
+
+        yield [
+            ' ' . self::ALPHANUMERIC . "\n",
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -687,23 +733,24 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function alphaDashProvider(): iterable
     {
-        yield from [
-            [
-                self::ALPHANUMERIC . '-',
-                true,
-            ],
-            [
-                self::ALPHANUMERIC . '-\ ',
-                false,
-            ],
-            [
-                self::ALPHANUMERIC . "-\n",
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            self::ALPHANUMERIC . '-',
+            true,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . '-\ ',
+            false,
+        ];
+
+        yield [
+            self::ALPHANUMERIC . "-\n",
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -725,23 +772,24 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function hexProvider(): iterable
     {
-        yield from [
-            [
-                'abcdefABCDEF0123456789',
-                true,
-            ],
-            [
-                self::ALPHANUMERIC,
-                false,
-            ],
-            [
-                'asdfjkl;',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            'abcdefABCDEF0123456789',
+            true,
+        ];
+
+        yield [
+            self::ALPHANUMERIC,
+            false,
+        ];
+
+        yield [
+            'asdfjkl;',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -763,39 +811,44 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function numericProvider(): iterable
     {
-        yield from [
-            [
-                '0',
-                true,
-            ],
-            [
-                '12314',
-                true,
-            ],
-            [
-                '-42',
-                true,
-            ],
-            [
-                '+42',
-                true,
-            ],
-            [
-                "+42\n",
-                false,
-            ],
-            [
-                '123a',
-                false,
-            ],
-            [
-                '--1',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            '0',
+            true,
+        ];
+
+        yield [
+            '12314',
+            true,
+        ];
+
+        yield [
+            '-42',
+            true,
+        ];
+
+        yield [
+            '+42',
+            true,
+        ];
+
+        yield [
+            "+42\n",
+            false,
+        ];
+
+        yield [
+            '123a',
+            false,
+        ];
+
+        yield [
+            '--1',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -885,39 +938,44 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function integerProvider(): iterable
     {
-        yield from [
-            [
-                '0',
-                true,
-            ],
-            [
-                '42',
-                true,
-            ],
-            [
-                '-1',
-                true,
-            ],
-            [
-                "+42\n",
-                false,
-            ],
-            [
-                '123a',
-                false,
-            ],
-            [
-                '1.9',
-                false,
-            ],
-            [
-                '--1',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            '0',
+            true,
+        ];
+
+        yield [
+            '42',
+            true,
+        ];
+
+        yield [
+            '-1',
+            true,
+        ];
+
+        yield [
+            "+42\n",
+            false,
+        ];
+
+        yield [
+            '123a',
+            false,
+        ];
+
+        yield [
+            '1.9',
+            false,
+        ];
+
+        yield [
+            '--1',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -939,43 +997,49 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function decimalProvider(): iterable
     {
-        yield from [
-            [
-                '1.0',
-                true,
-            ],
-            [
-                '-0.98',
-                true,
-            ],
-            [
-                '0',
-                true,
-            ],
-            [
-                "0\n",
-                false,
-            ],
-            [
-                '1.0a',
-                false,
-            ],
-            [
-                '-i',
-                false,
-            ],
-            [
-                '--1',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
-            [
-                '.25',
-                true,
-            ],
+        yield [
+            '1.0',
+            true,
+        ];
+
+        yield [
+            '-0.98',
+            true,
+        ];
+
+        yield [
+            '0',
+            true,
+        ];
+
+        yield [
+            "0\n",
+            false,
+        ];
+
+        yield [
+            '1.0a',
+            false,
+        ];
+
+        yield [
+            '-i',
+            false,
+        ];
+
+        yield [
+            '--1',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
+        ];
+
+        yield [
+            '.25',
+            true,
         ];
     }
 
@@ -997,27 +1061,29 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function naturalProvider(): iterable
     {
-        yield from [
-            [
-                '0',
-                true,
-            ],
-            [
-                '12',
-                true,
-            ],
-            [
-                '42a',
-                false,
-            ],
-            [
-                '-1',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            '0',
+            true,
+        ];
+
+        yield [
+            '12',
+            true,
+        ];
+
+        yield [
+            '42a',
+            false,
+        ];
+
+        yield [
+            '-1',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -1039,27 +1105,29 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function naturalZeroProvider(): iterable
     {
-        yield from [
-            [
-                '0',
-                false,
-            ],
-            [
-                '12',
-                true,
-            ],
-            [
-                '42a',
-                false,
-            ],
-            [
-                '-1',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            '0',
+            false,
+        ];
+
+        yield [
+            '12',
+            true,
+        ];
+
+        yield [
+            '42a',
+            false,
+        ];
+
+        yield [
+            '-1',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -1081,19 +1149,19 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function base64Provider(): iterable
     {
-        yield from [
-            [
-                base64_encode('string'),
-                true,
-            ],
-            [
-                'FA08GG',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            base64_encode('string'),
+            true,
+        ];
+
+        yield [
+            'FA08GG',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -1115,43 +1183,49 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function jsonProvider(): iterable
     {
-        yield from [
-            [
-                'null',
-                true,
-            ],
-            [
-                '"null"',
-                true,
-            ],
-            [
-                '600100825',
-                true,
-            ],
-            [
-                '{"A":"Yay.", "B":[0,5]}',
-                true,
-            ],
-            [
-                '[0,"2",2.2,"3.3"]',
-                true,
-            ],
-            [
-                null,
-                false,
-            ],
-            [
-                '600-Nope. Should not pass.',
-                false,
-            ],
-            [
-                '{"A":SHOULD_NOT_PASS}',
-                false,
-            ],
-            [
-                '[0,"2",2.2 "3.3"]',
-                false,
-            ],
+        yield [
+            'null',
+            true,
+        ];
+
+        yield [
+            '"null"',
+            true,
+        ];
+
+        yield [
+            '600100825',
+            true,
+        ];
+
+        yield [
+            '{"A":"Yay.", "B":[0,5]}',
+            true,
+        ];
+
+        yield [
+            '[0,"2",2.2,"3.3"]',
+            true,
+        ];
+
+        yield [
+            null,
+            false,
+        ];
+
+        yield [
+            '600-Nope. Should not pass.',
+            false,
+        ];
+
+        yield [
+            '{"A":SHOULD_NOT_PASS}',
+            false,
+        ];
+
+        yield [
+            '[0,"2",2.2 "3.3"]',
+            false,
         ];
     }
 
@@ -1173,23 +1247,24 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function timezoneProvider(): iterable
     {
-        yield from [
-            [
-                'America/Chicago',
-                true,
-            ],
-            [
-                'america/chicago',
-                false,
-            ],
-            [
-                'foo/bar',
-                false,
-            ],
-            [
-                null,
-                false,
-            ],
+        yield [
+            'America/Chicago',
+            true,
+        ];
+
+        yield [
+            'america/chicago',
+            false,
+        ];
+
+        yield [
+            'foo/bar',
+            false,
+        ];
+
+        yield [
+            null,
+            false,
         ];
     }
 
@@ -1211,172 +1286,202 @@ class FormatRulesTest extends CIUnitTestCase
 
     public function validDateProvider(): iterable
     {
-        yield from [
-            [
-                null,
-                'Y-m-d',
-                false,
-            ],
-            [
-                'Sun',
-                'D',
-                true,
-            ],
-            [
-                'Sun',
-                'd',
-                false,
-            ],
-            [
-                'Sun',
-                null,
-                true,
-            ],
-            [
-                '1500',
-                'Y',
-                true,
-            ],
-            [
-                '1500',
-                'y',
-                false,
-            ],
-            [
-                '1500',
-                null,
-                true,
-            ],
-            [
-                '09:26:05',
-                'H:i:s',
-                true,
-            ],
-            [
-                '09:26:5',
-                'H:i:s',
-                false,
-            ],
-            [
-                '1992-02-29',
-                'Y-m-d',
-                true,
-            ],
-            [
-                '1991-02-29',
-                'Y-m-d',
-                false,
-            ],
-            [
-                '1718-05-10 15:25:59',
-                'Y-m-d H:i:s',
-                true,
-            ],
-            [
-                '1718-05-10 15:5:59',
-                'Y-m-d H:i:s',
-                false,
-            ],
-            [
-                'Thu, 31 Oct 2013 13:31:00',
-                'D, d M Y H:i:s',
-                true,
-            ],
-            [
-                'Thu, 31 Jun 2013 13:31:00',
-                'D, d M Y H:i:s',
-                false,
-            ],
-            [
-                'Thu, 31 Jun 2013 13:31:00',
-                null,
-                true,
-            ],
-            [
-                '07.05.03',
-                'm.d.y',
-                true,
-            ],
-            [
-                '07.05.1803',
-                'm.d.y',
-                false,
-            ],
-            [
-                '19890109',
-                'Ymd',
-                true,
-            ],
-            [
-                '198919',
-                'Ymd',
-                false,
-            ],
-            [
-                '2, 7, 2001',
-                'j, n, Y',
-                true,
-            ],
-            [
-                '2, 17, 2001',
-                'j, n, Y',
-                false,
-            ],
-            [
-                '09-42-25, 12-11-17',
-                'h-i-s, j-m-y',
-                true,
-            ],
-            [
-                '09-42-25, 12-00-17',
-                'h-i-s, j-m-y',
-                false,
-            ],
-            [
-                '09-42-25, 12-00-17',
-                null,
-                false,
-            ],
-            [
-                'November 12, 2017, 9:42 am',
-                'F j, Y, g:i a',
-                true,
-            ],
-            [
-                'November 12, 2017, 19:42 am',
-                'F j, Y, g:i a',
-                false,
-            ],
-            [
-                'November 12, 2017, 9:42 am',
-                null,
-                true,
-            ],
-            [
-                'Monday 8th of August 2005 03:12:46 PM',
-                'l jS \of F Y h:i:s A',
-                true,
-            ],
-            [
-                'Monday 8th of August 2005 13:12:46 PM',
-                'l jS \of F Y h:i:s A',
-                false,
-            ],
-            [
-                '23:01:59 is now',
-                'H:m:s \i\s \n\o\w',
-                true,
-            ],
-            [
-                '23:01:59 is now',
-                'H:m:s is now',
-                false,
-            ],
-            [
-                '12/11/2017',
-                'd/m/Y',
-                true,
-            ],
+        yield [
+            null,
+            'Y-m-d',
+            false,
+        ];
+
+        yield [
+            'Sun',
+            'D',
+            true,
+        ];
+
+        yield [
+            'Sun',
+            'd',
+            false,
+        ];
+
+        yield [
+            'Sun',
+            null,
+            true,
+        ];
+
+        yield [
+            '1500',
+            'Y',
+            true,
+        ];
+
+        yield [
+            '1500',
+            'y',
+            false,
+        ];
+
+        yield [
+            '1500',
+            null,
+            true,
+        ];
+
+        yield [
+            '09:26:05',
+            'H:i:s',
+            true,
+        ];
+
+        yield [
+            '09:26:5',
+            'H:i:s',
+            false,
+        ];
+
+        yield [
+            '1992-02-29',
+            'Y-m-d',
+            true,
+        ];
+
+        yield [
+            '1991-02-29',
+            'Y-m-d',
+            false,
+        ];
+
+        yield [
+            '1718-05-10 15:25:59',
+            'Y-m-d H:i:s',
+            true,
+        ];
+
+        yield [
+            '1718-05-10 15:5:59',
+            'Y-m-d H:i:s',
+            false,
+        ];
+
+        yield [
+            'Thu, 31 Oct 2013 13:31:00',
+            'D, d M Y H:i:s',
+            true,
+        ];
+
+        yield [
+            'Thu, 31 Jun 2013 13:31:00',
+            'D, d M Y H:i:s',
+            false,
+        ];
+
+        yield [
+            'Thu, 31 Jun 2013 13:31:00',
+            null,
+            true,
+        ];
+
+        yield [
+            '07.05.03',
+            'm.d.y',
+            true,
+        ];
+
+        yield [
+            '07.05.1803',
+            'm.d.y',
+            false,
+        ];
+
+        yield [
+            '19890109',
+            'Ymd',
+            true,
+        ];
+
+        yield [
+            '198919',
+            'Ymd',
+            false,
+        ];
+
+        yield [
+            '2, 7, 2001',
+            'j, n, Y',
+            true,
+        ];
+
+        yield [
+            '2, 17, 2001',
+            'j, n, Y',
+            false,
+        ];
+
+        yield [
+            '09-42-25, 12-11-17',
+            'h-i-s, j-m-y',
+            true,
+        ];
+
+        yield [
+            '09-42-25, 12-00-17',
+            'h-i-s, j-m-y',
+            false,
+        ];
+
+        yield [
+            '09-42-25, 12-00-17',
+            null,
+            false,
+        ];
+
+        yield [
+            'November 12, 2017, 9:42 am',
+            'F j, Y, g:i a',
+            true,
+        ];
+
+        yield [
+            'November 12, 2017, 19:42 am',
+            'F j, Y, g:i a',
+            false,
+        ];
+
+        yield [
+            'November 12, 2017, 9:42 am',
+            null,
+            true,
+        ];
+
+        yield [
+            'Monday 8th of August 2005 03:12:46 PM',
+            'l jS \of F Y h:i:s A',
+            true,
+        ];
+
+        yield [
+            'Monday 8th of August 2005 13:12:46 PM',
+            'l jS \of F Y h:i:s A',
+            false,
+        ];
+
+        yield [
+            '23:01:59 is now',
+            'H:m:s \i\s \n\o\w',
+            true,
+        ];
+
+        yield [
+            '23:01:59 is now',
+            'H:m:s is now',
+            false,
+        ];
+
+        yield [
+            '12/11/2017',
+            'd/m/Y',
+            true,
         ];
     }
 }

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -62,14 +62,17 @@ class RulesTest extends CIUnitTestCase
 
     public function provideRequiredCases(): iterable
     {
-        yield from [
-            [['foo' => null], false],
-            [['foo' => 123], true],
-            [['foo' => null, 'bar' => 123], false],
-            [['foo' => [123]], true],
-            [['foo' => []], false],
-            [['foo' => new stdClass()], true],
-        ];
+        yield [['foo' => null], false];
+
+        yield [['foo' => 123], true];
+
+        yield [['foo' => null, 'bar' => 123], false];
+
+        yield [['foo' => [123]], true];
+
+        yield [['foo' => []], false];
+
+        yield [['foo' => new stdClass()], true];
     }
 
     /**
@@ -83,45 +86,49 @@ class RulesTest extends CIUnitTestCase
 
     public function ifExistProvider(): iterable
     {
-        yield from [
-            [
-                ['foo' => 'required'],
-                ['foo' => ''],
-                false,
-            ],
-            [
-                ['foo' => 'required'],
-                ['foo' => null],
-                false,
-            ],
-            [
-                ['foo' => 'if_exist|required'],
-                ['foo' => ''],
-                false,
-            ],
-            // Input data does not exist then the other rules will be ignored
-            [
-                ['foo' => 'if_exist|required'],
-                [],
-                true,
-            ],
-            // Testing for multi-dimensional data
-            [
-                ['foo.bar' => 'if_exist|required'],
-                ['foo' => ['bar' => '']],
-                false,
-            ],
-            [
-                ['foo.bar' => 'if_exist|required'],
-                ['foo' => []],
-                true,
-            ],
-            // Testing with closure
-            [
-                ['foo' => ['if_exist', static fn ($value) => true]],
-                ['foo' => []],
-                true,
-            ],
+        yield [
+            ['foo' => 'required'],
+            ['foo' => ''],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'required'],
+            ['foo' => null],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'if_exist|required'],
+            ['foo' => ''],
+            false,
+        ];
+
+        // Input data does not exist then the other rules will be ignored
+        yield [
+            ['foo' => 'if_exist|required'],
+            [],
+            true,
+        ];
+
+        // Testing for multi-dimensional data
+        yield [
+            ['foo.bar' => 'if_exist|required'],
+            ['foo' => ['bar' => '']],
+            false,
+        ];
+
+        yield [
+            ['foo.bar' => 'if_exist|required'],
+            ['foo' => []],
+            true,
+        ];
+
+        // Testing with closure
+        yield [
+            ['foo' => ['if_exist', static fn ($value) => true]],
+            ['foo' => []],
+            true,
         ];
     }
 
@@ -136,156 +143,182 @@ class RulesTest extends CIUnitTestCase
 
     public function providePermitEmptyCases(): iterable
     {
-        yield from [
-            // If the rule is only `permit_empty`, any value will pass.
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => ''],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => '0'],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => '-0'],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_emails'],
-                ['foo' => 0],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => -0],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => 0.0],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_emails'],
-                ['foo' => '0.0'],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => -0.0],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => '-0.0'],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => null],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => false],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => 'user@domain.tld'],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|valid_email'],
-                ['foo' => 'invalid'],
-                false,
-            ],
-            // Required has more priority
-            [
-                ['foo' => 'permit_empty|required|valid_email'],
-                ['foo' => ''],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|required'],
-                ['foo' => ''],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|required'],
-                ['foo' => null],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|required'],
-                ['foo' => false],
-                false,
-            ],
-            // This tests will return true because the input data is trimmed
-            [
-                ['foo' => 'permit_empty|required'],
-                ['foo' => '0'],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required'],
-                ['foo' => 0],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required'],
-                ['foo' => 0.0],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required_with[bar]'],
-                ['foo' => ''],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required_with[bar]'],
-                ['foo' => 0],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required_with[bar]'],
-                ['foo' => 0.0, 'bar' => 1],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required_with[bar]'],
-                ['foo' => '', 'bar' => 1],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|required_without[bar]'],
-                ['foo' => ''],
-                false,
-            ],
-            [
-                ['foo' => 'permit_empty|required_without[bar]'],
-                ['foo' => 0],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required_without[bar]'],
-                ['foo' => 0.0, 'bar' => 1],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty|required_without[bar]'],
-                ['foo' => '', 'bar' => 1],
-                true,
-            ],
-            // Testing with closure
-            [
-                ['foo' => ['permit_empty', static fn ($value) => true]],
-                ['foo' => ''],
-                true,
-            ],
+        yield // If the rule is only `permit_empty`, any value will pass.
+        [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => ''],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => '0'],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => '-0'],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_emails'],
+            ['foo' => 0],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => -0],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => 0.0],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_emails'],
+            ['foo' => '0.0'],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => -0.0],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => '-0.0'],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => null],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => false],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => 'user@domain.tld'],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|valid_email'],
+            ['foo' => 'invalid'],
+            false,
+        ];
+
+        // Required has more priority
+        yield [
+            ['foo' => 'permit_empty|required|valid_email'],
+            ['foo' => ''],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required'],
+            ['foo' => ''],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required'],
+            ['foo' => null],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required'],
+            ['foo' => false],
+            false,
+        ];
+
+        // This tests will return true because the input data is trimmed
+        yield [
+            ['foo' => 'permit_empty|required'],
+            ['foo' => '0'],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required'],
+            ['foo' => 0],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required'],
+            ['foo' => 0.0],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_with[bar]'],
+            ['foo' => ''],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_with[bar]'],
+            ['foo' => 0],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_with[bar]'],
+            ['foo' => 0.0, 'bar' => 1],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_with[bar]'],
+            ['foo' => '', 'bar' => 1],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_without[bar]'],
+            ['foo' => ''],
+            false,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_without[bar]'],
+            ['foo' => 0],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_without[bar]'],
+            ['foo' => 0.0, 'bar' => 1],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty|required_without[bar]'],
+            ['foo' => '', 'bar' => 1],
+            true,
+        ];
+
+        // Testing with closure
+        yield [
+            ['foo' => ['permit_empty', static fn ($value) => true]],
+            ['foo' => ''],
+            true,
         ];
     }
 
@@ -300,11 +333,11 @@ class RulesTest extends CIUnitTestCase
 
     public function provideMatchesCases(): iterable
     {
-        yield from [
-            [['foo' => null, 'bar' => null], true],
-            [['foo' => 'match', 'bar' => 'match'], true],
-            [['foo' => 'match', 'bar' => 'nope'], false],
-        ];
+        yield [['foo' => null, 'bar' => null], true];
+
+        yield [['foo' => 'match', 'bar' => 'match'], true];
+
+        yield [['foo' => 'match', 'bar' => 'nope'], false];
     }
 
     /**
@@ -318,10 +351,9 @@ class RulesTest extends CIUnitTestCase
 
     public function provideMatchesNestedCases(): iterable
     {
-        yield from [
-            [['nested' => ['foo' => 'match', 'bar' => 'match']], true],
-            [['nested' => ['foo' => 'match', 'bar' => 'nope']], false],
-        ];
+        yield [['nested' => ['foo' => 'match', 'bar' => 'match']], true];
+
+        yield [['nested' => ['foo' => 'match', 'bar' => 'nope']], false];
     }
 
     /**
@@ -353,13 +385,15 @@ class RulesTest extends CIUnitTestCase
 
     public function provideEqualsCases(): iterable
     {
-        yield from [
-            'null'   => [['foo' => null], '', false],
-            'empty'  => [['foo' => ''], '', true],
-            'fail'   => [['foo' => 'bar'], 'notbar', false],
-            'pass'   => [['foo' => 'bar'], 'bar', true],
-            'casing' => [['foo' => 'bar'], 'Bar', false],
-        ];
+        yield 'null' => [['foo' => null], '', false];
+
+        yield 'empty' => [['foo' => ''], '', true];
+
+        yield 'fail' => [['foo' => 'bar'], 'notbar', false];
+
+        yield 'pass' => [['foo' => 'bar'], 'bar', true];
+
+        yield 'casing' => [['foo' => 'bar'], 'Bar', false];
     }
 
     /**
@@ -373,12 +407,13 @@ class RulesTest extends CIUnitTestCase
 
     public function provideMinLengthCases(): iterable
     {
-        yield from [
-            'null'    => [null, '2', false],
-            'less'    => ['bar', '2', true],
-            'equal'   => ['bar', '3', true],
-            'greater' => ['bar', '4', false],
-        ];
+        yield 'null' => [null, '2', false];
+
+        yield 'less' => ['bar', '2', true];
+
+        yield 'equal' => ['bar', '3', true];
+
+        yield 'greater' => ['bar', '4', false];
     }
 
     /**
@@ -407,12 +442,13 @@ class RulesTest extends CIUnitTestCase
 
     public function provideExactLengthCases(): iterable
     {
-        yield from [
-            'null'    => [null, false],
-            'exact'   => ['bar', true],
-            'less'    => ['ba', false],
-            'greater' => ['bars', false],
-        ];
+        yield 'null' => [null, false];
+
+        yield 'exact' => ['bar', true];
+
+        yield 'less' => ['ba', false];
+
+        yield 'greater' => ['bars', false];
     }
 
     public function testExactLengthDetectsBadLength(): void
@@ -434,17 +470,23 @@ class RulesTest extends CIUnitTestCase
 
     public function greaterThanProvider(): iterable
     {
-        yield from [
-            ['-10', '-11', true],
-            ['10', '9', true],
-            ['10', '10', false],
-            ['10.1', '10', true],
-            ['10.0', '10', false],
-            ['9.9', '10', false],
-            ['10', 'a', false],
-            ['10a', '10', false],
-            [null, null, false],
-        ];
+        yield ['-10', '-11', true];
+
+        yield ['10', '9', true];
+
+        yield ['10', '10', false];
+
+        yield ['10.1', '10', true];
+
+        yield ['10.0', '10', false];
+
+        yield ['9.9', '10', false];
+
+        yield ['10', 'a', false];
+
+        yield ['10a', '10', false];
+
+        yield [null, null, false];
     }
 
     /**
@@ -459,18 +501,25 @@ class RulesTest extends CIUnitTestCase
 
     public function greaterThanEqualProvider(): iterable
     {
-        yield from [
-            ['0', '0', true],
-            ['1', '0', true],
-            ['-1', '0', false],
-            ['1.0', '1', true],
-            ['1.1', '1', true],
-            ['0.9', '1', false],
-            ['10a', '0', false],
-            [null, null, false],
-            ['1', null, true],
-            [null, '1', false],
-        ];
+        yield ['0', '0', true];
+
+        yield ['1', '0', true];
+
+        yield ['-1', '0', false];
+
+        yield ['1.0', '1', true];
+
+        yield ['1.1', '1', true];
+
+        yield ['0.9', '1', false];
+
+        yield ['10a', '0', false];
+
+        yield [null, null, false];
+
+        yield ['1', null, true];
+
+        yield [null, '1', false];
     }
 
     /**
@@ -485,18 +534,25 @@ class RulesTest extends CIUnitTestCase
 
     public function lessThanProvider(): iterable
     {
-        yield from [
-            ['-10', '-11', false],
-            ['9', '10', true],
-            ['10', '9', false],
-            ['10', '10', false],
-            ['9.9', '10', true],
-            ['10.1', '10', false],
-            ['10.0', '10', false],
-            ['10', 'a', true],
-            ['10a', '10', false],
-            [null, null, false],
-        ];
+        yield ['-10', '-11', false];
+
+        yield ['9', '10', true];
+
+        yield ['10', '9', false];
+
+        yield ['10', '10', false];
+
+        yield ['9.9', '10', true];
+
+        yield ['10.1', '10', false];
+
+        yield ['10.0', '10', false];
+
+        yield ['10', 'a', true];
+
+        yield ['10a', '10', false];
+
+        yield [null, null, false];
     }
 
     /**
@@ -511,18 +567,25 @@ class RulesTest extends CIUnitTestCase
 
     public function lessThanEqualProvider(): iterable
     {
-        yield from [
-            ['0', '0', true],
-            ['1', '0', false],
-            ['-1', '0', true],
-            ['1.0', '1', true],
-            ['0.9', '1', true],
-            ['1.1', '1', false],
-            ['10a', '0', false],
-            [null, null, false],
-            ['1', null, false],
-            [null, '1', false],
-        ];
+        yield ['0', '0', true];
+
+        yield ['1', '0', false];
+
+        yield ['-1', '0', true];
+
+        yield ['1.0', '1', true];
+
+        yield ['0.9', '1', true];
+
+        yield ['1.1', '1', false];
+
+        yield ['10a', '0', false];
+
+        yield [null, null, false];
+
+        yield ['1', null, false];
+
+        yield [null, '1', false];
     }
 
     /**
@@ -547,17 +610,23 @@ class RulesTest extends CIUnitTestCase
 
     public function inListProvider(): iterable
     {
-        yield from [
-            ['red', 'red,Blue,123', true],
-            ['Blue', 'red, Blue,123', true],
-            ['Blue', 'red,Blue,123', true],
-            ['123', 'red,Blue,123', true],
-            ['Red', 'red,Blue,123', false],
-            [' red', 'red,Blue,123', false],
-            ['1234', 'red,Blue,123', false],
-            [null, 'red,Blue,123', false],
-            ['red', null, false],
-        ];
+        yield ['red', 'red,Blue,123', true];
+
+        yield ['Blue', 'red, Blue,123', true];
+
+        yield ['Blue', 'red,Blue,123', true];
+
+        yield ['123', 'red,Blue,123', true];
+
+        yield ['Red', 'red,Blue,123', false];
+
+        yield [' red', 'red,Blue,123', false];
+
+        yield ['1234', 'red,Blue,123', false];
+
+        yield [null, 'red,Blue,123', false];
+
+        yield ['red', null, false];
     }
 
     /**
@@ -583,33 +652,40 @@ class RulesTest extends CIUnitTestCase
 
     public function requiredWithProvider(): iterable
     {
-        yield from [
-            ['nope', 'bar', false],
-            ['foo', 'bar', true],
-            ['nope', 'baz', true],
-            [null, null, true],
-            [null, 'foo', false],
-            ['foo', null, true],
-            [
-                'array.emptyField1',
-                'array.emptyField2',
-                true,
-            ],
-            [
-                'array.nonEmptyField1',
-                'array.emptyField2',
-                true,
-            ],
-            [
-                'array.emptyField1',
-                'array.nonEmptyField2',
-                false,
-            ],
-            [
-                'array.nonEmptyField1',
-                'array.nonEmptyField2',
-                true,
-            ],
+        yield ['nope', 'bar', false];
+
+        yield ['foo', 'bar', true];
+
+        yield ['nope', 'baz', true];
+
+        yield [null, null, true];
+
+        yield [null, 'foo', false];
+
+        yield ['foo', null, true];
+
+        yield [
+            'array.emptyField1',
+            'array.emptyField2',
+            true,
+        ];
+
+        yield [
+            'array.nonEmptyField1',
+            'array.emptyField2',
+            true,
+        ];
+
+        yield [
+            'array.emptyField1',
+            'array.nonEmptyField2',
+            false,
+        ];
+
+        yield [
+            'array.nonEmptyField1',
+            'array.nonEmptyField2',
+            true,
         ];
     }
 
@@ -631,24 +707,33 @@ class RulesTest extends CIUnitTestCase
 
     public function RequiredWithAndOtherRulesProvider(): iterable
     {
-        yield from [
-            // `otherField` and `mustBeADate` do not exist
-            [true, []],
-            // `mustBeADate` does not exist
-            [false, ['otherField' => 'exists']],
-            // ``otherField` does not exist
-            [true, ['mustBeADate' => '2023-06-12']],
-            [true, ['mustBeADate' => '']],
-            [true, ['mustBeADate' => null]],
-            [true, ['mustBeADate' => []]],
-            // `otherField` and `mustBeADate` exist
-            [true, ['mustBeADate' => '', 'otherField' => '']],
-            [true, ['mustBeADate' => '2023-06-12', 'otherField' => 'exists']],
-            [true, ['mustBeADate' => '2023-06-12', 'otherField' => '']],
-            [false, ['mustBeADate' => '', 'otherField' => 'exists']],
-            [false, ['mustBeADate' => [], 'otherField' => 'exists']],
-            [false, ['mustBeADate' => null, 'otherField' => 'exists']],
-        ];
+        // `otherField` and `mustBeADate` do not exist
+        yield [true, []];
+
+        // `mustBeADate` does not exist
+        yield [false, ['otherField' => 'exists']];
+
+        // ``otherField` does not exist
+        yield [true, ['mustBeADate' => '2023-06-12']];
+
+        yield [true, ['mustBeADate' => '']];
+
+        yield [true, ['mustBeADate' => null]];
+
+        yield [true, ['mustBeADate' => []]];
+
+        // `otherField` and `mustBeADate` exist
+        yield [true, ['mustBeADate' => '', 'otherField' => '']];
+
+        yield [true, ['mustBeADate' => '2023-06-12', 'otherField' => 'exists']];
+
+        yield [true, ['mustBeADate' => '2023-06-12', 'otherField' => '']];
+
+        yield [false, ['mustBeADate' => '', 'otherField' => 'exists']];
+
+        yield [false, ['mustBeADate' => [], 'otherField' => 'exists']];
+
+        yield [false, ['mustBeADate' => null, 'otherField' => 'exists']];
     }
 
     /**
@@ -668,11 +753,11 @@ class RulesTest extends CIUnitTestCase
 
     public function RequiredWithAndOtherRuleWithValueZeroProvider(): iterable
     {
-        yield from [
-            [true, ['married' => '0', 'partner_name' => '']],
-            [true, ['married' => '1', 'partner_name' => 'Foo']],
-            [false, ['married' => '1', 'partner_name' => '']],
-        ];
+        yield [true, ['married' => '0', 'partner_name' => '']];
+
+        yield [true, ['married' => '1', 'partner_name' => 'Foo']];
+
+        yield [false, ['married' => '1', 'partner_name' => '']];
     }
 
     /**
@@ -698,32 +783,38 @@ class RulesTest extends CIUnitTestCase
 
     public function requiredWithoutProvider(): iterable
     {
-        yield from [
-            ['nope', 'bars', false],
-            ['foo', 'nope', true],
-            [null, null, false],
-            [null, 'foo', true],
-            ['foo', null, true],
-            [
-                'array.emptyField1',
-                'array.emptyField2',
-                false,
-            ],
-            [
-                'array.nonEmptyField1',
-                'array.emptyField2',
-                true,
-            ],
-            [
-                'array.emptyField1',
-                'array.nonEmptyField2',
-                true,
-            ],
-            [
-                'array.nonEmptyField1',
-                'array.nonEmptyField2',
-                true,
-            ],
+        yield ['nope', 'bars', false];
+
+        yield ['foo', 'nope', true];
+
+        yield [null, null, false];
+
+        yield [null, 'foo', true];
+
+        yield ['foo', null, true];
+
+        yield [
+            'array.emptyField1',
+            'array.emptyField2',
+            false,
+        ];
+
+        yield [
+            'array.nonEmptyField1',
+            'array.emptyField2',
+            true,
+        ];
+
+        yield [
+            'array.emptyField1',
+            'array.nonEmptyField2',
+            true,
+        ];
+
+        yield [
+            'array.nonEmptyField1',
+            'array.nonEmptyField2',
+            true,
         ];
     }
 
@@ -744,37 +835,39 @@ class RulesTest extends CIUnitTestCase
 
     public function requiredWithoutMultipleProvider(): iterable
     {
-        yield from [
-            'all empty' => [
-                '',
-                '',
-                '',
-                false,
-            ],
-            'foo is not empty' => [
-                'a',
-                '',
-                '',
-                true,
-            ],
-            'bar is not empty' => [
-                '',
-                'b',
-                '',
-                false,
-            ],
-            'baz is not empty' => [
-                '',
-                '',
-                'c',
-                false,
-            ],
-            'bar,baz are not empty' => [
-                '',
-                'b',
-                'c',
-                true,
-            ],
+        yield 'all empty' => [
+            '',
+            '',
+            '',
+            false,
+        ];
+
+        yield 'foo is not empty' => [
+            'a',
+            '',
+            '',
+            true,
+        ];
+
+        yield 'bar is not empty' => [
+            '',
+            'b',
+            '',
+            false,
+        ];
+
+        yield 'baz is not empty' => [
+            '',
+            '',
+            'c',
+            false,
+        ];
+
+        yield 'bar,baz are not empty' => [
+            '',
+            'b',
+            'c',
+            true,
         ];
     }
 
@@ -790,33 +883,34 @@ class RulesTest extends CIUnitTestCase
 
     public function requiredWithoutMultipleWithoutFieldsProvider(): iterable
     {
-        yield from [
-            'baz is missing' => [
-                [
-                    'foo' => '',
-                    'bar' => '',
-                ],
-                false,
+        yield 'baz is missing' => [
+            [
+                'foo' => '',
+                'bar' => '',
             ],
-            'bar,baz are missing' => [
-                [
-                    'foo' => '',
-                ],
-                false,
+            false,
+        ];
+
+        yield 'bar,baz are missing' => [
+            [
+                'foo' => '',
             ],
-            'bar is not empty' => [
-                [
-                    'foo' => '',
-                    'bar' => 'b',
-                ],
-                false,
+            false,
+        ];
+
+        yield 'bar is not empty' => [
+            [
+                'foo' => '',
+                'bar' => 'b',
             ],
-            'foo is not empty' => [
-                [
-                    'foo' => 'a',
-                ],
-                true,
+            false,
+        ];
+
+        yield 'foo is not empty' => [
+            [
+                'foo' => 'a',
             ],
+            true,
         ];
     }
 }

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -66,1137 +66,1360 @@ final class CreditCardRulesTest extends CIUnitTestCase
      */
     public function creditCardProvider(): iterable
     {
-        yield from [
-            'null_test' => [
-                'amex',
-                null,
-                false,
-            ],
-            'random_test' => [
-                'amex',
-                $this->generateCardNumber('37', 16),
-                false,
-            ],
-            'invalid_type' => [
-                'shorty',
-                '1111 1111 1111 1111',
-                false,
-            ],
-            'invalid_length' => [
-                'amex',
-                '',
-                false,
-            ],
-            'not_numeric' => [
-                'amex',
-                'abcd efgh ijkl mnop',
-                false,
-            ],
-            'bad_length' => [
-                'amex',
-                '3782 8224 6310 0051',
-                false,
-            ],
-            'bad_prefix' => [
-                'amex',
-                '3582 8224 6310 0051',
-                false,
-            ],
-            'amex1' => [
-                'amex',
-                '3782 8224 6310 005',
-                true,
-            ],
-            'amex2' => [
-                'amex',
-                '3714 4963 5398 431',
-                true,
-            ],
-            'dinersclub1' => [
-                'dinersclub',
-                '3056 9309 0259 04',
-                true,
-            ],
-            'dinersculb2' => [
-                'dinersclub',
-                '3852 0000 0232 37',
-                true,
-            ],
-            'discover1' => [
-                'discover',
-                '6011 1111 1111 1117',
-                true,
-            ],
-            'discover2' => [
-                'discover',
-                '6011 0009 9013 9424',
-                true,
-            ],
-            'jcb8' => [
-                'jcb',
-                '3530 1113 3330 0000',
-                true,
-            ],
-            'jcb9' => [
-                'jcb',
-                '3566 0020 2036 0505',
-                true,
-            ],
-            'mastercard12' => [
-                'mastercard',
-                '5555 5555 5555 4444',
-                true,
-            ],
-            'mastercard13' => [
-                'mastercard',
-                '5105 1051 0510 5100',
-                true,
-            ],
-            'visa4' => [
-                'visa',
-                '4111 1111 1111 1111',
-                true,
-            ],
-            'visa5' => [
-                'visa',
-                '4012 8888 8888 1881',
-                true,
-            ],
-            'visa6' => [
-                'visa',
-                '4222 2222 2222 2',
-                true,
-            ],
-            'dankort5' => [
-                'dankort',
-                '5019 7170 1010 3742',
-                true,
-            ],
-            'unionpay1' => [
-                'unionpay',
-                $this->generateCardNumber(62, 16),
-                true,
-            ],
-            'unionpay2' => [
-                'unionpay',
-                $this->generateCardNumber(62, 17),
-                true,
-            ],
-            'unionpay3' => [
-                'unionpay',
-                $this->generateCardNumber(62, 18),
-                true,
-            ],
-            'unionpay4' => [
-                'unionpay',
-                $this->generateCardNumber(62, 19),
-                true,
-            ],
-            'unionpay5' => [
-                'unionpay',
-                $this->generateCardNumber(63, 19),
-                false,
-            ],
-            'carteblanche1' => [
-                'carteblanche',
-                $this->generateCardNumber(300, 14),
-                true,
-            ],
-            'carteblanche2' => [
-                'carteblanche',
-                $this->generateCardNumber(301, 14),
-                true,
-            ],
-            'carteblanche3' => [
-                'carteblanche',
-                $this->generateCardNumber(302, 14),
-                true,
-            ],
-            'carteblanche4' => [
-                'carteblanche',
-                $this->generateCardNumber(303, 14),
-                true,
-            ],
-            'carteblanche5' => [
-                'carteblanche',
-                $this->generateCardNumber(304, 14),
-                true,
-            ],
-            'carteblanche6' => [
-                'carteblanche',
-                $this->generateCardNumber(305, 14),
-                true,
-            ],
-            'carteblanche7' => [
-                'carteblanche',
-                $this->generateCardNumber(306, 14),
-                false,
-            ],
-            'dinersclub3' => [
-                'dinersclub',
-                $this->generateCardNumber(300, 14),
-                true,
-            ],
-            'dinersclub4' => [
-                'dinersclub',
-                $this->generateCardNumber(301, 14),
-                true,
-            ],
-            'dinersclub5' => [
-                'dinersclub',
-                $this->generateCardNumber(302, 14),
-                true,
-            ],
-            'dinersclub6' => [
-                'dinersclub',
-                $this->generateCardNumber(303, 14),
-                true,
-            ],
-            'dinersclub7' => [
-                'dinersclub',
-                $this->generateCardNumber(304, 14),
-                true,
-            ],
-            'dinersclub8' => [
-                'dinersclub',
-                $this->generateCardNumber(305, 14),
-                true,
-            ],
-            'dinersclub9' => [
-                'dinersclub',
-                $this->generateCardNumber(309, 14),
-                true,
-            ],
-            'dinersclub10' => [
-                'dinersclub',
-                $this->generateCardNumber(36, 14),
-                true,
-            ],
-            'dinersclub11' => [
-                'dinersclub',
-                $this->generateCardNumber(38, 14),
-                true,
-            ],
-            'dinersclub12' => [
-                'dinersclub',
-                $this->generateCardNumber(39, 14),
-                true,
-            ],
-            'dinersclub13' => [
-                'dinersclub',
-                $this->generateCardNumber(54, 14),
-                true,
-            ],
-            'dinersclub14' => [
-                'dinersclub',
-                $this->generateCardNumber(55, 14),
-                true,
-            ],
-            'dinersclub15' => [
-                'dinersclub',
-                $this->generateCardNumber(300, 16),
-                true,
-            ],
-            'dinersclub16' => [
-                'dinersclub',
-                $this->generateCardNumber(301, 16),
-                true,
-            ],
-            'dinersclub17' => [
-                'dinersclub',
-                $this->generateCardNumber(302, 16),
-                true,
-            ],
-            'dinersclub18' => [
-                'dinersclub',
-                $this->generateCardNumber(303, 16),
-                true,
-            ],
-            'dinersclub19' => [
-                'dinersclub',
-                $this->generateCardNumber(304, 16),
-                true,
-            ],
-            'dinersclub20' => [
-                'dinersclub',
-                $this->generateCardNumber(305, 16),
-                true,
-            ],
-            'dinersclub21' => [
-                'dinersclub',
-                $this->generateCardNumber(309, 16),
-                true,
-            ],
-            'dinersclub22' => [
-                'dinersclub',
-                $this->generateCardNumber(36, 16),
-                true,
-            ],
-            'dinersclub23' => [
-                'dinersclub',
-                $this->generateCardNumber(38, 16),
-                true,
-            ],
-            'dinersclub24' => [
-                'dinersclub',
-                $this->generateCardNumber(39, 16),
-                true,
-            ],
-            'dinersclub25' => [
-                'dinersclub',
-                $this->generateCardNumber(54, 16),
-                true,
-            ],
-            'dinersclub26' => [
-                'dinersclub',
-                $this->generateCardNumber(55, 16),
-                true,
-            ],
-            'discover3' => [
-                'discover',
-                $this->generateCardNumber(6011, 16),
-                true,
-            ],
-            'discover4' => [
-                'discover',
-                $this->generateCardNumber(622, 16),
-                true,
-            ],
-            'discover5' => [
-                'discover',
-                $this->generateCardNumber(644, 16),
-                true,
-            ],
-            'discover6' => [
-                'discover',
-                $this->generateCardNumber(645, 16),
-                true,
-            ],
-            'discover7' => [
-                'discover',
-                $this->generateCardNumber(656, 16),
-                true,
-            ],
-            'discover8' => [
-                'discover',
-                $this->generateCardNumber(647, 16),
-                true,
-            ],
-            'discover9' => [
-                'discover',
-                $this->generateCardNumber(648, 16),
-                true,
-            ],
-            'discover10' => [
-                'discover',
-                $this->generateCardNumber(649, 16),
-                true,
-            ],
-            'discover11' => [
-                'discover',
-                $this->generateCardNumber(65, 16),
-                true,
-            ],
-            'discover12' => [
-                'discover',
-                $this->generateCardNumber(6011, 19),
-                true,
-            ],
-            'discover13' => [
-                'discover',
-                $this->generateCardNumber(622, 19),
-                true,
-            ],
-            'discover14' => [
-                'discover',
-                $this->generateCardNumber(644, 19),
-                true,
-            ],
-            'discover15' => [
-                'discover',
-                $this->generateCardNumber(645, 19),
-                true,
-            ],
-            'discover16' => [
-                'discover',
-                $this->generateCardNumber(656, 19),
-                true,
-            ],
-            'discover17' => [
-                'discover',
-                $this->generateCardNumber(647, 19),
-                true,
-            ],
-            'discover18' => [
-                'discover',
-                $this->generateCardNumber(648, 19),
-                true,
-            ],
-            'discover19' => [
-                'discover',
-                $this->generateCardNumber(649, 19),
-                true,
-            ],
-            'discover20' => [
-                'discover',
-                $this->generateCardNumber(65, 19),
-                true,
-            ],
-            'interpayment1' => [
-                'interpayment',
-                $this->generateCardNumber(4, 16),
-                true,
-            ],
-            'interpayment2' => [
-                'interpayment',
-                $this->generateCardNumber(4, 17),
-                true,
-            ],
-            'interpayment3' => [
-                'interpayment',
-                $this->generateCardNumber(4, 18),
-                true,
-            ],
-            'interpayment4' => [
-                'interpayment',
-                $this->generateCardNumber(4, 19),
-                true,
-            ],
-            'jcb1' => [
-                'jcb',
-                $this->generateCardNumber(352, 16),
-                true,
-            ],
-            'jcb2' => [
-                'jcb',
-                $this->generateCardNumber(353, 16),
-                true,
-            ],
-            'jcb3' => [
-                'jcb',
-                $this->generateCardNumber(354, 16),
-                true,
-            ],
-            'jcb4' => [
-                'jcb',
-                $this->generateCardNumber(355, 16),
-                true,
-            ],
-            'jcb5' => [
-                'jcb',
-                $this->generateCardNumber(356, 16),
-                true,
-            ],
-            'jcb6' => [
-                'jcb',
-                $this->generateCardNumber(357, 16),
-                true,
-            ],
-            'jcb7' => [
-                'jcb',
-                $this->generateCardNumber(358, 16),
-                true,
-            ],
-            'maestro1' => [
-                'maestro',
-                $this->generateCardNumber(50, 12),
-                true,
-            ],
-            'maestro2' => [
-                'maestro',
-                $this->generateCardNumber(56, 12),
-                true,
-            ],
-            'maestro3' => [
-                'maestro',
-                $this->generateCardNumber(57, 12),
-                true,
-            ],
-            'maestro4' => [
-                'maestro',
-                $this->generateCardNumber(58, 12),
-                true,
-            ],
-            'maestro5' => [
-                'maestro',
-                $this->generateCardNumber(59, 12),
-                true,
-            ],
-            'maestro6' => [
-                'maestro',
-                $this->generateCardNumber(60, 12),
-                true,
-            ],
-            'maestro7' => [
-                'maestro',
-                $this->generateCardNumber(61, 12),
-                true,
-            ],
-            'maestro8' => [
-                'maestro',
-                $this->generateCardNumber(62, 12),
-                true,
-            ],
-            'maestro9' => [
-                'maestro',
-                $this->generateCardNumber(63, 12),
-                true,
-            ],
-            'maestro10' => [
-                'maestro',
-                $this->generateCardNumber(64, 12),
-                true,
-            ],
-            'maestro11' => [
-                'maestro',
-                $this->generateCardNumber(65, 12),
-                true,
-            ],
-            'maestro12' => [
-                'maestro',
-                $this->generateCardNumber(66, 12),
-                true,
-            ],
-            'maestro13' => [
-                'maestro',
-                $this->generateCardNumber(67, 12),
-                true,
-            ],
-            'maestro14' => [
-                'maestro',
-                $this->generateCardNumber(68, 12),
-                true,
-            ],
-            'maestro15' => [
-                'maestro',
-                $this->generateCardNumber(69, 12),
-                true,
-            ],
-            'maestro16' => [
-                'maestro',
-                $this->generateCardNumber(50, 13),
-                true,
-            ],
-            'maestro17' => [
-                'maestro',
-                $this->generateCardNumber(56, 13),
-                true,
-            ],
-            'maestro18' => [
-                'maestro',
-                $this->generateCardNumber(57, 13),
-                true,
-            ],
-            'maestro19' => [
-                'maestro',
-                $this->generateCardNumber(58, 13),
-                true,
-            ],
-            'maestro20' => [
-                'maestro',
-                $this->generateCardNumber(59, 13),
-                true,
-            ],
-            'maestro21' => [
-                'maestro',
-                $this->generateCardNumber(60, 13),
-                true,
-            ],
-            'maestro22' => [
-                'maestro',
-                $this->generateCardNumber(61, 13),
-                true,
-            ],
-            'maestro23' => [
-                'maestro',
-                $this->generateCardNumber(62, 13),
-                true,
-            ],
-            'maestro24' => [
-                'maestro',
-                $this->generateCardNumber(63, 13),
-                true,
-            ],
-            'maestro25' => [
-                'maestro',
-                $this->generateCardNumber(64, 13),
-                true,
-            ],
-            'maestro26' => [
-                'maestro',
-                $this->generateCardNumber(65, 13),
-                true,
-            ],
-            'maestro27' => [
-                'maestro',
-                $this->generateCardNumber(66, 13),
-                true,
-            ],
-            'maestro28' => [
-                'maestro',
-                $this->generateCardNumber(67, 13),
-                true,
-            ],
-            'maestro29' => [
-                'maestro',
-                $this->generateCardNumber(68, 13),
-                true,
-            ],
-            'maestro30' => [
-                'maestro',
-                $this->generateCardNumber(69, 13),
-                true,
-            ],
-            'maestro31' => [
-                'maestro',
-                $this->generateCardNumber(50, 14),
-                true,
-            ],
-            'maestro32' => [
-                'maestro',
-                $this->generateCardNumber(56, 14),
-                true,
-            ],
-            'maestro33' => [
-                'maestro',
-                $this->generateCardNumber(57, 14),
-                true,
-            ],
-            'maestro34' => [
-                'maestro',
-                $this->generateCardNumber(58, 14),
-                true,
-            ],
-            'maestro35' => [
-                'maestro',
-                $this->generateCardNumber(59, 14),
-                true,
-            ],
-            'maestro36' => [
-                'maestro',
-                $this->generateCardNumber(60, 14),
-                true,
-            ],
-            'maestro37' => [
-                'maestro',
-                $this->generateCardNumber(61, 14),
-                true,
-            ],
-            'maestro38' => [
-                'maestro',
-                $this->generateCardNumber(62, 14),
-                true,
-            ],
-            'maestro39' => [
-                'maestro',
-                $this->generateCardNumber(63, 14),
-                true,
-            ],
-            'maestro40' => [
-                'maestro',
-                $this->generateCardNumber(64, 14),
-                true,
-            ],
-            'maestro41' => [
-                'maestro',
-                $this->generateCardNumber(65, 14),
-                true,
-            ],
-            'maestro42' => [
-                'maestro',
-                $this->generateCardNumber(66, 14),
-                true,
-            ],
-            'maestro43' => [
-                'maestro',
-                $this->generateCardNumber(67, 14),
-                true,
-            ],
-            'maestro44' => [
-                'maestro',
-                $this->generateCardNumber(68, 14),
-                true,
-            ],
-            'maestro45' => [
-                'maestro',
-                $this->generateCardNumber(69, 14),
-                true,
-            ],
-            'maestro46' => [
-                'maestro',
-                $this->generateCardNumber(50, 15),
-                true,
-            ],
-            'maestro47' => [
-                'maestro',
-                $this->generateCardNumber(56, 15),
-                true,
-            ],
-            'maestro48' => [
-                'maestro',
-                $this->generateCardNumber(57, 15),
-                true,
-            ],
-            'maestro49' => [
-                'maestro',
-                $this->generateCardNumber(58, 15),
-                true,
-            ],
-            'maestro50' => [
-                'maestro',
-                $this->generateCardNumber(59, 15),
-                true,
-            ],
-            'maestro51' => [
-                'maestro',
-                $this->generateCardNumber(60, 15),
-                true,
-            ],
-            'maestro52' => [
-                'maestro',
-                $this->generateCardNumber(61, 15),
-                true,
-            ],
-            'maestro53' => [
-                'maestro',
-                $this->generateCardNumber(62, 15),
-                true,
-            ],
-            'maestro54' => [
-                'maestro',
-                $this->generateCardNumber(63, 15),
-                true,
-            ],
-            'maestro55' => [
-                'maestro',
-                $this->generateCardNumber(64, 15),
-                true,
-            ],
-            'maestro56' => [
-                'maestro',
-                $this->generateCardNumber(65, 15),
-                true,
-            ],
-            'maestro57' => [
-                'maestro',
-                $this->generateCardNumber(66, 15),
-                true,
-            ],
-            'maestro58' => [
-                'maestro',
-                $this->generateCardNumber(67, 15),
-                true,
-            ],
-            'maestro59' => [
-                'maestro',
-                $this->generateCardNumber(68, 15),
-                true,
-            ],
-            'maestro60' => [
-                'maestro',
-                $this->generateCardNumber(69, 15),
-                true,
-            ],
-            'maestro61' => [
-                'maestro',
-                $this->generateCardNumber(50, 16),
-                true,
-            ],
-            'maestro62' => [
-                'maestro',
-                $this->generateCardNumber(56, 16),
-                true,
-            ],
-            'maestro63' => [
-                'maestro',
-                $this->generateCardNumber(57, 16),
-                true,
-            ],
-            'maestro64' => [
-                'maestro',
-                $this->generateCardNumber(58, 16),
-                true,
-            ],
-            'maestro65' => [
-                'maestro',
-                $this->generateCardNumber(59, 16),
-                true,
-            ],
-            'maestro66' => [
-                'maestro',
-                $this->generateCardNumber(60, 16),
-                true,
-            ],
-            'maestro67' => [
-                'maestro',
-                $this->generateCardNumber(61, 16),
-                true,
-            ],
-            'maestro68' => [
-                'maestro',
-                $this->generateCardNumber(62, 16),
-                true,
-            ],
-            'maestro69' => [
-                'maestro',
-                $this->generateCardNumber(63, 16),
-                true,
-            ],
-            'maestro70' => [
-                'maestro',
-                $this->generateCardNumber(64, 16),
-                true,
-            ],
-            'maestro71' => [
-                'maestro',
-                $this->generateCardNumber(65, 16),
-                true,
-            ],
-            'maestro72' => [
-                'maestro',
-                $this->generateCardNumber(66, 16),
-                true,
-            ],
-            'maestro73' => [
-                'maestro',
-                $this->generateCardNumber(67, 16),
-                true,
-            ],
-            'maestro74' => [
-                'maestro',
-                $this->generateCardNumber(68, 16),
-                true,
-            ],
-            'maestro75' => [
-                'maestro',
-                $this->generateCardNumber(69, 16),
-                true,
-            ],
-            'maestro91' => [
-                'maestro',
-                $this->generateCardNumber(50, 18),
-                true,
-            ],
-            'maestro92' => [
-                'maestro',
-                $this->generateCardNumber(56, 18),
-                true,
-            ],
-            'maestro93' => [
-                'maestro',
-                $this->generateCardNumber(57, 18),
-                true,
-            ],
-            'maestro94' => [
-                'maestro',
-                $this->generateCardNumber(58, 18),
-                true,
-            ],
-            'maestro95' => [
-                'maestro',
-                $this->generateCardNumber(59, 18),
-                true,
-            ],
-            'maestro96' => [
-                'maestro',
-                $this->generateCardNumber(60, 18),
-                true,
-            ],
-            'maestro97' => [
-                'maestro',
-                $this->generateCardNumber(61, 18),
-                true,
-            ],
-            'maestro98' => [
-                'maestro',
-                $this->generateCardNumber(62, 18),
-                true,
-            ],
-            'maestro99' => [
-                'maestro',
-                $this->generateCardNumber(63, 18),
-                true,
-            ],
-            'maestro100' => [
-                'maestro',
-                $this->generateCardNumber(64, 18),
-                true,
-            ],
-            'maestro101' => [
-                'maestro',
-                $this->generateCardNumber(65, 18),
-                true,
-            ],
-            'maestro102' => [
-                'maestro',
-                $this->generateCardNumber(66, 18),
-                true,
-            ],
-            'maestro103' => [
-                'maestro',
-                $this->generateCardNumber(67, 18),
-                true,
-            ],
-            'maestro104' => [
-                'maestro',
-                $this->generateCardNumber(68, 18),
-                true,
-            ],
-            'maestro105' => [
-                'maestro',
-                $this->generateCardNumber(69, 18),
-                true,
-            ],
-            'maestro106' => [
-                'maestro',
-                $this->generateCardNumber(50, 19),
-                true,
-            ],
-            'maestro107' => [
-                'maestro',
-                $this->generateCardNumber(56, 19),
-                true,
-            ],
-            'maestro108' => [
-                'maestro',
-                $this->generateCardNumber(57, 19),
-                true,
-            ],
-            'maestro109' => [
-                'maestro',
-                $this->generateCardNumber(58, 19),
-                true,
-            ],
-            'maestro110' => [
-                'maestro',
-                $this->generateCardNumber(59, 19),
-                true,
-            ],
-            'maestro111' => [
-                'maestro',
-                $this->generateCardNumber(60, 19),
-                true,
-            ],
-            'maestro112' => [
-                'maestro',
-                $this->generateCardNumber(61, 19),
-                true,
-            ],
-            'maestro113' => [
-                'maestro',
-                $this->generateCardNumber(62, 19),
-                true,
-            ],
-            'maestro114' => [
-                'maestro',
-                $this->generateCardNumber(63, 19),
-                true,
-            ],
-            'maestro115' => [
-                'maestro',
-                $this->generateCardNumber(64, 19),
-                true,
-            ],
-            'maestro116' => [
-                'maestro',
-                $this->generateCardNumber(65, 19),
-                true,
-            ],
-            'maestro117' => [
-                'maestro',
-                $this->generateCardNumber(66, 19),
-                true,
-            ],
-            'maestro118' => [
-                'maestro',
-                $this->generateCardNumber(67, 19),
-                true,
-            ],
-            'maestro119' => [
-                'maestro',
-                $this->generateCardNumber(68, 19),
-                true,
-            ],
-            'maestro120' => [
-                'maestro',
-                $this->generateCardNumber(69, 19),
-                true,
-            ],
-            'dankort1' => [
-                'dankort',
-                $this->generateCardNumber(5019, 16),
-                true,
-            ],
-            'dankort2' => [
-                'dankort',
-                $this->generateCardNumber(4175, 16),
-                true,
-            ],
-            'dankort3' => [
-                'dankort',
-                $this->generateCardNumber(4571, 16),
-                true,
-            ],
-            'dankort4' => [
-                'dankort',
-                $this->generateCardNumber(4, 16),
-                true,
-            ],
-            'mir1' => [
-                'mir',
-                $this->generateCardNumber(2200, 16),
-                true,
-            ],
-            'mir2' => [
-                'mir',
-                $this->generateCardNumber(2201, 16),
-                true,
-            ],
-            'mir3' => [
-                'mir',
-                $this->generateCardNumber(2202, 16),
-                true,
-            ],
-            'mir4' => [
-                'mir',
-                $this->generateCardNumber(2203, 16),
-                true,
-            ],
-            'mir5' => [
-                'mir',
-                $this->generateCardNumber(2204, 16),
-                true,
-            ],
-            'mastercard1' => [
-                'mastercard',
-                $this->generateCardNumber(51, 16),
-                true,
-            ],
-            'mastercard2' => [
-                'mastercard',
-                $this->generateCardNumber(52, 16),
-                true,
-            ],
-            'mastercard3' => [
-                'mastercard',
-                $this->generateCardNumber(53, 16),
-                true,
-            ],
-            'mastercard4' => [
-                'mastercard',
-                $this->generateCardNumber(54, 16),
-                true,
-            ],
-            'mastercard5' => [
-                'mastercard',
-                $this->generateCardNumber(55, 16),
-                true,
-            ],
-            'mastercard6' => [
-                'mastercard',
-                $this->generateCardNumber(22, 16),
-                true,
-            ],
-            'mastercard7' => [
-                'mastercard',
-                $this->generateCardNumber(23, 16),
-                true,
-            ],
-            'mastercard8' => [
-                'mastercard',
-                $this->generateCardNumber(24, 16),
-                true,
-            ],
-            'mastercard9' => [
-                'mastercard',
-                $this->generateCardNumber(25, 16),
-                true,
-            ],
-            'mastercard10' => [
-                'mastercard',
-                $this->generateCardNumber(26, 16),
-                true,
-            ],
-            'mastercard11' => [
-                'mastercard',
-                $this->generateCardNumber(27, 16),
-                true,
-            ],
-            'visa1' => [
-                'visa',
-                $this->generateCardNumber(4, 13),
-                true,
-            ],
-            'visa2' => [
-                'visa',
-                $this->generateCardNumber(4, 16),
-                true,
-            ],
-            'visa3' => [
-                'visa',
-                $this->generateCardNumber(4, 19),
-                true,
-            ],
-            'uatp' => [
-                'uatp',
-                $this->generateCardNumber(1, 15),
-                true,
-            ],
-            'verve1' => [
-                'verve',
-                $this->generateCardNumber(506, 16),
-                true,
-            ],
-            'verve2' => [
-                'verve',
-                $this->generateCardNumber(650, 16),
-                true,
-            ],
-            'verve3' => [
-                'verve',
-                $this->generateCardNumber(506, 19),
-                true,
-            ],
-            'verve4' => [
-                'verve',
-                $this->generateCardNumber(650, 19),
-                true,
-            ],
-            'cibc1' => [
-                'cibc',
-                $this->generateCardNumber(4506, 16),
-                true,
-            ],
-            'rbc1' => [
-                'rbc',
-                $this->generateCardNumber(45, 16),
-                true,
-            ],
-            'tdtrust' => [
-                'tdtrust',
-                $this->generateCardNumber(589297, 16),
-                true,
-            ],
-            'scotia1' => [
-                'scotia',
-                $this->generateCardNumber(4536, 16),
-                true,
-            ],
-            'bmoabm1' => [
-                'bmoabm',
-                $this->generateCardNumber(500, 16),
-                true,
-            ],
-            'hsbc1' => [
-                'hsbc',
-                $this->generateCardNumber(56, 16),
-                true,
-            ],
-            'hsbc2' => [
-                'hsbc',
-                $this->generateCardNumber(57, 16),
-                false,
-            ],
+        yield 'null_test' => [
+            'amex',
+            null,
+            false,
+        ];
+
+        yield 'random_test' => [
+            'amex',
+            $this->generateCardNumber('37', 16),
+            false,
+        ];
+
+        yield 'invalid_type' => [
+            'shorty',
+            '1111 1111 1111 1111',
+            false,
+        ];
+
+        yield 'invalid_length' => [
+            'amex',
+            '',
+            false,
+        ];
+
+        yield 'not_numeric' => [
+            'amex',
+            'abcd efgh ijkl mnop',
+            false,
+        ];
+
+        yield 'bad_length' => [
+            'amex',
+            '3782 8224 6310 0051',
+            false,
+        ];
+
+        yield 'bad_prefix' => [
+            'amex',
+            '3582 8224 6310 0051',
+            false,
+        ];
+
+        yield 'amex1' => [
+            'amex',
+            '3782 8224 6310 005',
+            true,
+        ];
+
+        yield 'amex2' => [
+            'amex',
+            '3714 4963 5398 431',
+            true,
+        ];
+
+        yield 'dinersclub1' => [
+            'dinersclub',
+            '3056 9309 0259 04',
+            true,
+        ];
+
+        yield 'dinersculb2' => [
+            'dinersclub',
+            '3852 0000 0232 37',
+            true,
+        ];
+
+        yield 'discover1' => [
+            'discover',
+            '6011 1111 1111 1117',
+            true,
+        ];
+
+        yield 'discover2' => [
+            'discover',
+            '6011 0009 9013 9424',
+            true,
+        ];
+
+        yield 'jcb8' => [
+            'jcb',
+            '3530 1113 3330 0000',
+            true,
+        ];
+
+        yield 'jcb9' => [
+            'jcb',
+            '3566 0020 2036 0505',
+            true,
+        ];
+
+        yield 'mastercard12' => [
+            'mastercard',
+            '5555 5555 5555 4444',
+            true,
+        ];
+
+        yield 'mastercard13' => [
+            'mastercard',
+            '5105 1051 0510 5100',
+            true,
+        ];
+
+        yield 'visa4' => [
+            'visa',
+            '4111 1111 1111 1111',
+            true,
+        ];
+
+        yield 'visa5' => [
+            'visa',
+            '4012 8888 8888 1881',
+            true,
+        ];
+
+        yield 'visa6' => [
+            'visa',
+            '4222 2222 2222 2',
+            true,
+        ];
+
+        yield 'dankort5' => [
+            'dankort',
+            '5019 7170 1010 3742',
+            true,
+        ];
+
+        yield 'unionpay1' => [
+            'unionpay',
+            $this->generateCardNumber(62, 16),
+            true,
+        ];
+
+        yield 'unionpay2' => [
+            'unionpay',
+            $this->generateCardNumber(62, 17),
+            true,
+        ];
+
+        yield 'unionpay3' => [
+            'unionpay',
+            $this->generateCardNumber(62, 18),
+            true,
+        ];
+
+        yield 'unionpay4' => [
+            'unionpay',
+            $this->generateCardNumber(62, 19),
+            true,
+        ];
+
+        yield 'unionpay5' => [
+            'unionpay',
+            $this->generateCardNumber(63, 19),
+            false,
+        ];
+
+        yield 'carteblanche1' => [
+            'carteblanche',
+            $this->generateCardNumber(300, 14),
+            true,
+        ];
+
+        yield 'carteblanche2' => [
+            'carteblanche',
+            $this->generateCardNumber(301, 14),
+            true,
+        ];
+
+        yield 'carteblanche3' => [
+            'carteblanche',
+            $this->generateCardNumber(302, 14),
+            true,
+        ];
+
+        yield 'carteblanche4' => [
+            'carteblanche',
+            $this->generateCardNumber(303, 14),
+            true,
+        ];
+
+        yield 'carteblanche5' => [
+            'carteblanche',
+            $this->generateCardNumber(304, 14),
+            true,
+        ];
+
+        yield 'carteblanche6' => [
+            'carteblanche',
+            $this->generateCardNumber(305, 14),
+            true,
+        ];
+
+        yield 'carteblanche7' => [
+            'carteblanche',
+            $this->generateCardNumber(306, 14),
+            false,
+        ];
+
+        yield 'dinersclub3' => [
+            'dinersclub',
+            $this->generateCardNumber(300, 14),
+            true,
+        ];
+
+        yield 'dinersclub4' => [
+            'dinersclub',
+            $this->generateCardNumber(301, 14),
+            true,
+        ];
+
+        yield 'dinersclub5' => [
+            'dinersclub',
+            $this->generateCardNumber(302, 14),
+            true,
+        ];
+
+        yield 'dinersclub6' => [
+            'dinersclub',
+            $this->generateCardNumber(303, 14),
+            true,
+        ];
+
+        yield 'dinersclub7' => [
+            'dinersclub',
+            $this->generateCardNumber(304, 14),
+            true,
+        ];
+
+        yield 'dinersclub8' => [
+            'dinersclub',
+            $this->generateCardNumber(305, 14),
+            true,
+        ];
+
+        yield 'dinersclub9' => [
+            'dinersclub',
+            $this->generateCardNumber(309, 14),
+            true,
+        ];
+
+        yield 'dinersclub10' => [
+            'dinersclub',
+            $this->generateCardNumber(36, 14),
+            true,
+        ];
+
+        yield 'dinersclub11' => [
+            'dinersclub',
+            $this->generateCardNumber(38, 14),
+            true,
+        ];
+
+        yield 'dinersclub12' => [
+            'dinersclub',
+            $this->generateCardNumber(39, 14),
+            true,
+        ];
+
+        yield 'dinersclub13' => [
+            'dinersclub',
+            $this->generateCardNumber(54, 14),
+            true,
+        ];
+
+        yield 'dinersclub14' => [
+            'dinersclub',
+            $this->generateCardNumber(55, 14),
+            true,
+        ];
+
+        yield 'dinersclub15' => [
+            'dinersclub',
+            $this->generateCardNumber(300, 16),
+            true,
+        ];
+
+        yield 'dinersclub16' => [
+            'dinersclub',
+            $this->generateCardNumber(301, 16),
+            true,
+        ];
+
+        yield 'dinersclub17' => [
+            'dinersclub',
+            $this->generateCardNumber(302, 16),
+            true,
+        ];
+
+        yield 'dinersclub18' => [
+            'dinersclub',
+            $this->generateCardNumber(303, 16),
+            true,
+        ];
+
+        yield 'dinersclub19' => [
+            'dinersclub',
+            $this->generateCardNumber(304, 16),
+            true,
+        ];
+
+        yield 'dinersclub20' => [
+            'dinersclub',
+            $this->generateCardNumber(305, 16),
+            true,
+        ];
+
+        yield 'dinersclub21' => [
+            'dinersclub',
+            $this->generateCardNumber(309, 16),
+            true,
+        ];
+
+        yield 'dinersclub22' => [
+            'dinersclub',
+            $this->generateCardNumber(36, 16),
+            true,
+        ];
+
+        yield 'dinersclub23' => [
+            'dinersclub',
+            $this->generateCardNumber(38, 16),
+            true,
+        ];
+
+        yield 'dinersclub24' => [
+            'dinersclub',
+            $this->generateCardNumber(39, 16),
+            true,
+        ];
+
+        yield 'dinersclub25' => [
+            'dinersclub',
+            $this->generateCardNumber(54, 16),
+            true,
+        ];
+
+        yield 'dinersclub26' => [
+            'dinersclub',
+            $this->generateCardNumber(55, 16),
+            true,
+        ];
+
+        yield 'discover3' => [
+            'discover',
+            $this->generateCardNumber(6011, 16),
+            true,
+        ];
+
+        yield 'discover4' => [
+            'discover',
+            $this->generateCardNumber(622, 16),
+            true,
+        ];
+
+        yield 'discover5' => [
+            'discover',
+            $this->generateCardNumber(644, 16),
+            true,
+        ];
+
+        yield 'discover6' => [
+            'discover',
+            $this->generateCardNumber(645, 16),
+            true,
+        ];
+
+        yield 'discover7' => [
+            'discover',
+            $this->generateCardNumber(656, 16),
+            true,
+        ];
+
+        yield 'discover8' => [
+            'discover',
+            $this->generateCardNumber(647, 16),
+            true,
+        ];
+
+        yield 'discover9' => [
+            'discover',
+            $this->generateCardNumber(648, 16),
+            true,
+        ];
+
+        yield 'discover10' => [
+            'discover',
+            $this->generateCardNumber(649, 16),
+            true,
+        ];
+
+        yield 'discover11' => [
+            'discover',
+            $this->generateCardNumber(65, 16),
+            true,
+        ];
+
+        yield 'discover12' => [
+            'discover',
+            $this->generateCardNumber(6011, 19),
+            true,
+        ];
+
+        yield 'discover13' => [
+            'discover',
+            $this->generateCardNumber(622, 19),
+            true,
+        ];
+
+        yield 'discover14' => [
+            'discover',
+            $this->generateCardNumber(644, 19),
+            true,
+        ];
+
+        yield 'discover15' => [
+            'discover',
+            $this->generateCardNumber(645, 19),
+            true,
+        ];
+
+        yield 'discover16' => [
+            'discover',
+            $this->generateCardNumber(656, 19),
+            true,
+        ];
+
+        yield 'discover17' => [
+            'discover',
+            $this->generateCardNumber(647, 19),
+            true,
+        ];
+
+        yield 'discover18' => [
+            'discover',
+            $this->generateCardNumber(648, 19),
+            true,
+        ];
+
+        yield 'discover19' => [
+            'discover',
+            $this->generateCardNumber(649, 19),
+            true,
+        ];
+
+        yield 'discover20' => [
+            'discover',
+            $this->generateCardNumber(65, 19),
+            true,
+        ];
+
+        yield 'interpayment1' => [
+            'interpayment',
+            $this->generateCardNumber(4, 16),
+            true,
+        ];
+
+        yield 'interpayment2' => [
+            'interpayment',
+            $this->generateCardNumber(4, 17),
+            true,
+        ];
+
+        yield 'interpayment3' => [
+            'interpayment',
+            $this->generateCardNumber(4, 18),
+            true,
+        ];
+
+        yield 'interpayment4' => [
+            'interpayment',
+            $this->generateCardNumber(4, 19),
+            true,
+        ];
+
+        yield 'jcb1' => [
+            'jcb',
+            $this->generateCardNumber(352, 16),
+            true,
+        ];
+
+        yield 'jcb2' => [
+            'jcb',
+            $this->generateCardNumber(353, 16),
+            true,
+        ];
+
+        yield 'jcb3' => [
+            'jcb',
+            $this->generateCardNumber(354, 16),
+            true,
+        ];
+
+        yield 'jcb4' => [
+            'jcb',
+            $this->generateCardNumber(355, 16),
+            true,
+        ];
+
+        yield 'jcb5' => [
+            'jcb',
+            $this->generateCardNumber(356, 16),
+            true,
+        ];
+
+        yield 'jcb6' => [
+            'jcb',
+            $this->generateCardNumber(357, 16),
+            true,
+        ];
+
+        yield 'jcb7' => [
+            'jcb',
+            $this->generateCardNumber(358, 16),
+            true,
+        ];
+
+        yield 'maestro1' => [
+            'maestro',
+            $this->generateCardNumber(50, 12),
+            true,
+        ];
+
+        yield 'maestro2' => [
+            'maestro',
+            $this->generateCardNumber(56, 12),
+            true,
+        ];
+
+        yield 'maestro3' => [
+            'maestro',
+            $this->generateCardNumber(57, 12),
+            true,
+        ];
+
+        yield 'maestro4' => [
+            'maestro',
+            $this->generateCardNumber(58, 12),
+            true,
+        ];
+
+        yield 'maestro5' => [
+            'maestro',
+            $this->generateCardNumber(59, 12),
+            true,
+        ];
+
+        yield 'maestro6' => [
+            'maestro',
+            $this->generateCardNumber(60, 12),
+            true,
+        ];
+
+        yield 'maestro7' => [
+            'maestro',
+            $this->generateCardNumber(61, 12),
+            true,
+        ];
+
+        yield 'maestro8' => [
+            'maestro',
+            $this->generateCardNumber(62, 12),
+            true,
+        ];
+
+        yield 'maestro9' => [
+            'maestro',
+            $this->generateCardNumber(63, 12),
+            true,
+        ];
+
+        yield 'maestro10' => [
+            'maestro',
+            $this->generateCardNumber(64, 12),
+            true,
+        ];
+
+        yield 'maestro11' => [
+            'maestro',
+            $this->generateCardNumber(65, 12),
+            true,
+        ];
+
+        yield 'maestro12' => [
+            'maestro',
+            $this->generateCardNumber(66, 12),
+            true,
+        ];
+
+        yield 'maestro13' => [
+            'maestro',
+            $this->generateCardNumber(67, 12),
+            true,
+        ];
+
+        yield 'maestro14' => [
+            'maestro',
+            $this->generateCardNumber(68, 12),
+            true,
+        ];
+
+        yield 'maestro15' => [
+            'maestro',
+            $this->generateCardNumber(69, 12),
+            true,
+        ];
+
+        yield 'maestro16' => [
+            'maestro',
+            $this->generateCardNumber(50, 13),
+            true,
+        ];
+
+        yield 'maestro17' => [
+            'maestro',
+            $this->generateCardNumber(56, 13),
+            true,
+        ];
+
+        yield 'maestro18' => [
+            'maestro',
+            $this->generateCardNumber(57, 13),
+            true,
+        ];
+
+        yield 'maestro19' => [
+            'maestro',
+            $this->generateCardNumber(58, 13),
+            true,
+        ];
+
+        yield 'maestro20' => [
+            'maestro',
+            $this->generateCardNumber(59, 13),
+            true,
+        ];
+
+        yield 'maestro21' => [
+            'maestro',
+            $this->generateCardNumber(60, 13),
+            true,
+        ];
+
+        yield 'maestro22' => [
+            'maestro',
+            $this->generateCardNumber(61, 13),
+            true,
+        ];
+
+        yield 'maestro23' => [
+            'maestro',
+            $this->generateCardNumber(62, 13),
+            true,
+        ];
+
+        yield 'maestro24' => [
+            'maestro',
+            $this->generateCardNumber(63, 13),
+            true,
+        ];
+
+        yield 'maestro25' => [
+            'maestro',
+            $this->generateCardNumber(64, 13),
+            true,
+        ];
+
+        yield 'maestro26' => [
+            'maestro',
+            $this->generateCardNumber(65, 13),
+            true,
+        ];
+
+        yield 'maestro27' => [
+            'maestro',
+            $this->generateCardNumber(66, 13),
+            true,
+        ];
+
+        yield 'maestro28' => [
+            'maestro',
+            $this->generateCardNumber(67, 13),
+            true,
+        ];
+
+        yield 'maestro29' => [
+            'maestro',
+            $this->generateCardNumber(68, 13),
+            true,
+        ];
+
+        yield 'maestro30' => [
+            'maestro',
+            $this->generateCardNumber(69, 13),
+            true,
+        ];
+
+        yield 'maestro31' => [
+            'maestro',
+            $this->generateCardNumber(50, 14),
+            true,
+        ];
+
+        yield 'maestro32' => [
+            'maestro',
+            $this->generateCardNumber(56, 14),
+            true,
+        ];
+
+        yield 'maestro33' => [
+            'maestro',
+            $this->generateCardNumber(57, 14),
+            true,
+        ];
+
+        yield 'maestro34' => [
+            'maestro',
+            $this->generateCardNumber(58, 14),
+            true,
+        ];
+
+        yield 'maestro35' => [
+            'maestro',
+            $this->generateCardNumber(59, 14),
+            true,
+        ];
+
+        yield 'maestro36' => [
+            'maestro',
+            $this->generateCardNumber(60, 14),
+            true,
+        ];
+
+        yield 'maestro37' => [
+            'maestro',
+            $this->generateCardNumber(61, 14),
+            true,
+        ];
+
+        yield 'maestro38' => [
+            'maestro',
+            $this->generateCardNumber(62, 14),
+            true,
+        ];
+
+        yield 'maestro39' => [
+            'maestro',
+            $this->generateCardNumber(63, 14),
+            true,
+        ];
+
+        yield 'maestro40' => [
+            'maestro',
+            $this->generateCardNumber(64, 14),
+            true,
+        ];
+
+        yield 'maestro41' => [
+            'maestro',
+            $this->generateCardNumber(65, 14),
+            true,
+        ];
+
+        yield 'maestro42' => [
+            'maestro',
+            $this->generateCardNumber(66, 14),
+            true,
+        ];
+
+        yield 'maestro43' => [
+            'maestro',
+            $this->generateCardNumber(67, 14),
+            true,
+        ];
+
+        yield 'maestro44' => [
+            'maestro',
+            $this->generateCardNumber(68, 14),
+            true,
+        ];
+
+        yield 'maestro45' => [
+            'maestro',
+            $this->generateCardNumber(69, 14),
+            true,
+        ];
+
+        yield 'maestro46' => [
+            'maestro',
+            $this->generateCardNumber(50, 15),
+            true,
+        ];
+
+        yield 'maestro47' => [
+            'maestro',
+            $this->generateCardNumber(56, 15),
+            true,
+        ];
+
+        yield 'maestro48' => [
+            'maestro',
+            $this->generateCardNumber(57, 15),
+            true,
+        ];
+
+        yield 'maestro49' => [
+            'maestro',
+            $this->generateCardNumber(58, 15),
+            true,
+        ];
+
+        yield 'maestro50' => [
+            'maestro',
+            $this->generateCardNumber(59, 15),
+            true,
+        ];
+
+        yield 'maestro51' => [
+            'maestro',
+            $this->generateCardNumber(60, 15),
+            true,
+        ];
+
+        yield 'maestro52' => [
+            'maestro',
+            $this->generateCardNumber(61, 15),
+            true,
+        ];
+
+        yield 'maestro53' => [
+            'maestro',
+            $this->generateCardNumber(62, 15),
+            true,
+        ];
+
+        yield 'maestro54' => [
+            'maestro',
+            $this->generateCardNumber(63, 15),
+            true,
+        ];
+
+        yield 'maestro55' => [
+            'maestro',
+            $this->generateCardNumber(64, 15),
+            true,
+        ];
+
+        yield 'maestro56' => [
+            'maestro',
+            $this->generateCardNumber(65, 15),
+            true,
+        ];
+
+        yield 'maestro57' => [
+            'maestro',
+            $this->generateCardNumber(66, 15),
+            true,
+        ];
+
+        yield 'maestro58' => [
+            'maestro',
+            $this->generateCardNumber(67, 15),
+            true,
+        ];
+
+        yield 'maestro59' => [
+            'maestro',
+            $this->generateCardNumber(68, 15),
+            true,
+        ];
+
+        yield 'maestro60' => [
+            'maestro',
+            $this->generateCardNumber(69, 15),
+            true,
+        ];
+
+        yield 'maestro61' => [
+            'maestro',
+            $this->generateCardNumber(50, 16),
+            true,
+        ];
+
+        yield 'maestro62' => [
+            'maestro',
+            $this->generateCardNumber(56, 16),
+            true,
+        ];
+
+        yield 'maestro63' => [
+            'maestro',
+            $this->generateCardNumber(57, 16),
+            true,
+        ];
+
+        yield 'maestro64' => [
+            'maestro',
+            $this->generateCardNumber(58, 16),
+            true,
+        ];
+
+        yield 'maestro65' => [
+            'maestro',
+            $this->generateCardNumber(59, 16),
+            true,
+        ];
+
+        yield 'maestro66' => [
+            'maestro',
+            $this->generateCardNumber(60, 16),
+            true,
+        ];
+
+        yield 'maestro67' => [
+            'maestro',
+            $this->generateCardNumber(61, 16),
+            true,
+        ];
+
+        yield 'maestro68' => [
+            'maestro',
+            $this->generateCardNumber(62, 16),
+            true,
+        ];
+
+        yield 'maestro69' => [
+            'maestro',
+            $this->generateCardNumber(63, 16),
+            true,
+        ];
+
+        yield 'maestro70' => [
+            'maestro',
+            $this->generateCardNumber(64, 16),
+            true,
+        ];
+
+        yield 'maestro71' => [
+            'maestro',
+            $this->generateCardNumber(65, 16),
+            true,
+        ];
+
+        yield 'maestro72' => [
+            'maestro',
+            $this->generateCardNumber(66, 16),
+            true,
+        ];
+
+        yield 'maestro73' => [
+            'maestro',
+            $this->generateCardNumber(67, 16),
+            true,
+        ];
+
+        yield 'maestro74' => [
+            'maestro',
+            $this->generateCardNumber(68, 16),
+            true,
+        ];
+
+        yield 'maestro75' => [
+            'maestro',
+            $this->generateCardNumber(69, 16),
+            true,
+        ];
+
+        yield 'maestro91' => [
+            'maestro',
+            $this->generateCardNumber(50, 18),
+            true,
+        ];
+
+        yield 'maestro92' => [
+            'maestro',
+            $this->generateCardNumber(56, 18),
+            true,
+        ];
+
+        yield 'maestro93' => [
+            'maestro',
+            $this->generateCardNumber(57, 18),
+            true,
+        ];
+
+        yield 'maestro94' => [
+            'maestro',
+            $this->generateCardNumber(58, 18),
+            true,
+        ];
+
+        yield 'maestro95' => [
+            'maestro',
+            $this->generateCardNumber(59, 18),
+            true,
+        ];
+
+        yield 'maestro96' => [
+            'maestro',
+            $this->generateCardNumber(60, 18),
+            true,
+        ];
+
+        yield 'maestro97' => [
+            'maestro',
+            $this->generateCardNumber(61, 18),
+            true,
+        ];
+
+        yield 'maestro98' => [
+            'maestro',
+            $this->generateCardNumber(62, 18),
+            true,
+        ];
+
+        yield 'maestro99' => [
+            'maestro',
+            $this->generateCardNumber(63, 18),
+            true,
+        ];
+
+        yield 'maestro100' => [
+            'maestro',
+            $this->generateCardNumber(64, 18),
+            true,
+        ];
+
+        yield 'maestro101' => [
+            'maestro',
+            $this->generateCardNumber(65, 18),
+            true,
+        ];
+
+        yield 'maestro102' => [
+            'maestro',
+            $this->generateCardNumber(66, 18),
+            true,
+        ];
+
+        yield 'maestro103' => [
+            'maestro',
+            $this->generateCardNumber(67, 18),
+            true,
+        ];
+
+        yield 'maestro104' => [
+            'maestro',
+            $this->generateCardNumber(68, 18),
+            true,
+        ];
+
+        yield 'maestro105' => [
+            'maestro',
+            $this->generateCardNumber(69, 18),
+            true,
+        ];
+
+        yield 'maestro106' => [
+            'maestro',
+            $this->generateCardNumber(50, 19),
+            true,
+        ];
+
+        yield 'maestro107' => [
+            'maestro',
+            $this->generateCardNumber(56, 19),
+            true,
+        ];
+
+        yield 'maestro108' => [
+            'maestro',
+            $this->generateCardNumber(57, 19),
+            true,
+        ];
+
+        yield 'maestro109' => [
+            'maestro',
+            $this->generateCardNumber(58, 19),
+            true,
+        ];
+
+        yield 'maestro110' => [
+            'maestro',
+            $this->generateCardNumber(59, 19),
+            true,
+        ];
+
+        yield 'maestro111' => [
+            'maestro',
+            $this->generateCardNumber(60, 19),
+            true,
+        ];
+
+        yield 'maestro112' => [
+            'maestro',
+            $this->generateCardNumber(61, 19),
+            true,
+        ];
+
+        yield 'maestro113' => [
+            'maestro',
+            $this->generateCardNumber(62, 19),
+            true,
+        ];
+
+        yield 'maestro114' => [
+            'maestro',
+            $this->generateCardNumber(63, 19),
+            true,
+        ];
+
+        yield 'maestro115' => [
+            'maestro',
+            $this->generateCardNumber(64, 19),
+            true,
+        ];
+
+        yield 'maestro116' => [
+            'maestro',
+            $this->generateCardNumber(65, 19),
+            true,
+        ];
+
+        yield 'maestro117' => [
+            'maestro',
+            $this->generateCardNumber(66, 19),
+            true,
+        ];
+
+        yield 'maestro118' => [
+            'maestro',
+            $this->generateCardNumber(67, 19),
+            true,
+        ];
+
+        yield 'maestro119' => [
+            'maestro',
+            $this->generateCardNumber(68, 19),
+            true,
+        ];
+
+        yield 'maestro120' => [
+            'maestro',
+            $this->generateCardNumber(69, 19),
+            true,
+        ];
+
+        yield 'dankort1' => [
+            'dankort',
+            $this->generateCardNumber(5019, 16),
+            true,
+        ];
+
+        yield 'dankort2' => [
+            'dankort',
+            $this->generateCardNumber(4175, 16),
+            true,
+        ];
+
+        yield 'dankort3' => [
+            'dankort',
+            $this->generateCardNumber(4571, 16),
+            true,
+        ];
+
+        yield 'dankort4' => [
+            'dankort',
+            $this->generateCardNumber(4, 16),
+            true,
+        ];
+
+        yield 'mir1' => [
+            'mir',
+            $this->generateCardNumber(2200, 16),
+            true,
+        ];
+
+        yield 'mir2' => [
+            'mir',
+            $this->generateCardNumber(2201, 16),
+            true,
+        ];
+
+        yield 'mir3' => [
+            'mir',
+            $this->generateCardNumber(2202, 16),
+            true,
+        ];
+
+        yield 'mir4' => [
+            'mir',
+            $this->generateCardNumber(2203, 16),
+            true,
+        ];
+
+        yield 'mir5' => [
+            'mir',
+            $this->generateCardNumber(2204, 16),
+            true,
+        ];
+
+        yield 'mastercard1' => [
+            'mastercard',
+            $this->generateCardNumber(51, 16),
+            true,
+        ];
+
+        yield 'mastercard2' => [
+            'mastercard',
+            $this->generateCardNumber(52, 16),
+            true,
+        ];
+
+        yield 'mastercard3' => [
+            'mastercard',
+            $this->generateCardNumber(53, 16),
+            true,
+        ];
+
+        yield 'mastercard4' => [
+            'mastercard',
+            $this->generateCardNumber(54, 16),
+            true,
+        ];
+
+        yield 'mastercard5' => [
+            'mastercard',
+            $this->generateCardNumber(55, 16),
+            true,
+        ];
+
+        yield 'mastercard6' => [
+            'mastercard',
+            $this->generateCardNumber(22, 16),
+            true,
+        ];
+
+        yield 'mastercard7' => [
+            'mastercard',
+            $this->generateCardNumber(23, 16),
+            true,
+        ];
+
+        yield 'mastercard8' => [
+            'mastercard',
+            $this->generateCardNumber(24, 16),
+            true,
+        ];
+
+        yield 'mastercard9' => [
+            'mastercard',
+            $this->generateCardNumber(25, 16),
+            true,
+        ];
+
+        yield 'mastercard10' => [
+            'mastercard',
+            $this->generateCardNumber(26, 16),
+            true,
+        ];
+
+        yield 'mastercard11' => [
+            'mastercard',
+            $this->generateCardNumber(27, 16),
+            true,
+        ];
+
+        yield 'visa1' => [
+            'visa',
+            $this->generateCardNumber(4, 13),
+            true,
+        ];
+
+        yield 'visa2' => [
+            'visa',
+            $this->generateCardNumber(4, 16),
+            true,
+        ];
+
+        yield 'visa3' => [
+            'visa',
+            $this->generateCardNumber(4, 19),
+            true,
+        ];
+
+        yield 'uatp' => [
+            'uatp',
+            $this->generateCardNumber(1, 15),
+            true,
+        ];
+
+        yield 'verve1' => [
+            'verve',
+            $this->generateCardNumber(506, 16),
+            true,
+        ];
+
+        yield 'verve2' => [
+            'verve',
+            $this->generateCardNumber(650, 16),
+            true,
+        ];
+
+        yield 'verve3' => [
+            'verve',
+            $this->generateCardNumber(506, 19),
+            true,
+        ];
+
+        yield 'verve4' => [
+            'verve',
+            $this->generateCardNumber(650, 19),
+            true,
+        ];
+
+        yield 'cibc1' => [
+            'cibc',
+            $this->generateCardNumber(4506, 16),
+            true,
+        ];
+
+        yield 'rbc1' => [
+            'rbc',
+            $this->generateCardNumber(45, 16),
+            true,
+        ];
+
+        yield 'tdtrust' => [
+            'tdtrust',
+            $this->generateCardNumber(589297, 16),
+            true,
+        ];
+
+        yield 'scotia1' => [
+            'scotia',
+            $this->generateCardNumber(4536, 16),
+            true,
+        ];
+
+        yield 'bmoabm1' => [
+            'bmoabm',
+            $this->generateCardNumber(500, 16),
+            true,
+        ];
+
+        yield 'hsbc1' => [
+            'hsbc',
+            $this->generateCardNumber(56, 16),
+            true,
+        ];
+
+        yield 'hsbc2' => [
+            'hsbc',
+            $this->generateCardNumber(57, 16),
+            false,
         ];
     }
 

--- a/tests/system/Validation/StrictRules/FormatRulesTest.php
+++ b/tests/system/Validation/StrictRules/FormatRulesTest.php
@@ -42,31 +42,34 @@ final class FormatRulesTest extends TraditionalFormatRulesTest
 
     public function alphaSpaceProvider(): Generator
     {
-        yield from [
-            [
-                null,
-                false,  // true in Traditional Rule
-            ],
-            [
-                self::ALPHABET,
-                true,
-            ],
-            [
-                self::ALPHABET . ' ',
-                true,
-            ],
-            [
-                self::ALPHABET . "\n",
-                false,
-            ],
-            [
-                self::ALPHABET . '1',
-                false,
-            ],
-            [
-                self::ALPHABET . '*',
-                false,
-            ],
+        yield [
+            null,
+            false,  // true in Traditional Rule
+        ];
+
+        yield [
+            self::ALPHABET,
+            true,
+        ];
+
+        yield [
+            self::ALPHABET . ' ',
+            true,
+        ];
+
+        yield [
+            self::ALPHABET . "\n",
+            false,
+        ];
+
+        yield [
+            self::ALPHABET . '1',
+            false,
+        ];
+
+        yield [
+            self::ALPHABET . '*',
+            false,
         ];
     }
 

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -52,43 +52,46 @@ final class RulesTest extends TraditionalRulesTest
 
     public function providePermitEmptyCasesStrict(): iterable
     {
-        yield from [
-            [
-                ['foo' => 'permit_empty'],
-                ['foo' => ''],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty'],
-                ['foo' => '0'],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty'],
-                ['foo' => 0],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty'],
-                ['foo' => 0.0],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty'],
-                ['foo' => null],
-                true,
-            ],
-            [
-                ['foo' => 'permit_empty'],
-                ['foo' => false],
-                true,
-            ],
-            // Testing with closure
-            [
-                ['foo' => ['permit_empty', static fn ($value) => true]],
-                ['foo' => ''],
-                true,
-            ],
+        yield [
+            ['foo' => 'permit_empty'],
+            ['foo' => ''],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty'],
+            ['foo' => '0'],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty'],
+            ['foo' => 0],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty'],
+            ['foo' => 0.0],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty'],
+            ['foo' => null],
+            true,
+        ];
+
+        yield [
+            ['foo' => 'permit_empty'],
+            ['foo' => false],
+            true,
+        ];
+        // Testing with closure
+        yield [
+            ['foo' => ['permit_empty', static fn ($value) => true]],
+            ['foo' => ''],
+            true,
         ];
     }
 
@@ -107,15 +110,19 @@ final class RulesTest extends TraditionalRulesTest
 
     public function provideGreaterThanEqualStrict(): iterable
     {
-        yield from [
-            [0, '0', true],
-            [1, '0', true],
-            [-1, '0', false],
-            [1.0, '1', true],
-            [1.1, '1', true],
-            [0.9, '1', false],
-            [true, '0', false],
-        ];
+        yield [0, '0', true];
+
+        yield [1, '0', true];
+
+        yield [-1, '0', false];
+
+        yield [1.0, '1', true];
+
+        yield [1.1, '1', true];
+
+        yield [0.9, '1', false];
+
+        yield [true, '0', false];
     }
 
     /**
@@ -133,16 +140,21 @@ final class RulesTest extends TraditionalRulesTest
 
     public function provideGreaterThanStrict(): iterable
     {
-        yield from [
-            [-10, '-11', true],
-            [10, '9', true],
-            [10, '10', false],
-            [10.1, '10', true],
-            [10.0, '10', false],
-            [9.9, '10', false],
-            [10, 'a', false],
-            [true, '0', false],
-        ];
+        yield [-10, '-11', true];
+
+        yield [10, '9', true];
+
+        yield [10, '10', false];
+
+        yield [10.1, '10', true];
+
+        yield [10.0, '10', false];
+
+        yield [9.9, '10', false];
+
+        yield [10, 'a', false];
+
+        yield [true, '0', false];
     }
 
     /**
@@ -160,17 +172,23 @@ final class RulesTest extends TraditionalRulesTest
 
     public function provideLessThanStrict(): iterable
     {
-        yield from [
-            [-10, '-11', false],
-            [9, '10', true],
-            [10, '9', false],
-            [10, '10', false],
-            [9.9, '10', true],
-            [10.1, '10', false],
-            [10.0, '10', false],
-            [10, 'a', true],
-            [true, '0', false],
-        ];
+        yield [-10, '-11', false];
+
+        yield [9, '10', true];
+
+        yield [10, '9', false];
+
+        yield [10, '10', false];
+
+        yield [9.9, '10', true];
+
+        yield [10.1, '10', false];
+
+        yield [10.0, '10', false];
+
+        yield [10, 'a', true];
+
+        yield [true, '0', false];
     }
 
     /**
@@ -188,14 +206,18 @@ final class RulesTest extends TraditionalRulesTest
 
     public function provideLessThanEqualStrict(): iterable
     {
-        yield from [
-            [0, '0', true],
-            [1, '0', false],
-            [-1, '0', true],
-            [1.0, '1', true],
-            [0.9, '1', true],
-            [1.1, '1', false],
-            [true, '0', false],
-        ];
+        yield [0, '0', true];
+
+        yield [1, '0', false];
+
+        yield [-1, '0', true];
+
+        yield [1.0, '1', true];
+
+        yield [0.9, '1', true];
+
+        yield [1.1, '1', false];
+
+        yield [true, '0', false];
     }
 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -624,63 +624,70 @@ class ValidationTest extends CIUnitTestCase
 
     public function rulesSetupProvider(): iterable
     {
-        yield from [
+        yield [
+            'min_length[10]',
+            'The foo field must be at least 10 characters in length.',
+        ];
+
+        yield [
+            'min_length[10]',
+            'The foo field is very short.',
+            ['foo' => ['min_length' => 'The {field} field is very short.']],
+        ];
+
+        yield [
+            ['min_length[10]'],
+            'The foo field must be at least 10 characters in length.',
+        ];
+
+        yield [
+            ['min_length[10]'],
+            'The foo field is very short.',
+            ['foo' => ['min_length' => 'The {field} field is very short.']],
+        ];
+
+        yield [
+            ['rules' => 'min_length[10]'],
+            'The foo field must be at least 10 characters in length.',
+        ];
+
+        yield [
+            ['rules' => ['min_length[10]']],
+            'The foo field must be at least 10 characters in length.',
+        ];
+
+        yield [
             [
-                'min_length[10]',
-                'The foo field must be at least 10 characters in length.',
+                'label' => 'Foo Bar',
+                'rules' => 'min_length[10]',
             ],
+            'The Foo Bar field must be at least 10 characters in length.',
+        ];
+
+        yield [
             [
-                'min_length[10]',
-                'The foo field is very short.',
-                ['foo' => ['min_length' => 'The {field} field is very short.']],
+                'label' => 'Foo Bar',
+                'rules' => ['min_length[10]'],
             ],
+            'The Foo Bar field must be at least 10 characters in length.',
+        ];
+
+        yield [
             [
-                ['min_length[10]'],
-                'The foo field must be at least 10 characters in length.',
+                'label' => 'Foo Bar',
+                'rules' => 'min_length[10]',
             ],
+            'The Foo Bar field is very short.',
+            ['foo' => ['min_length' => 'The {field} field is very short.']],
+        ];
+
+        yield [
             [
-                ['min_length[10]'],
-                'The foo field is very short.',
-                ['foo' => ['min_length' => 'The {field} field is very short.']],
+                'label'  => 'Foo Bar',
+                'rules'  => 'min_length[10]',
+                'errors' => ['min_length' => 'The {field} field is very short.'],
             ],
-            [
-                ['rules' => 'min_length[10]'],
-                'The foo field must be at least 10 characters in length.',
-            ],
-            [
-                ['rules' => ['min_length[10]']],
-                'The foo field must be at least 10 characters in length.',
-            ],
-            [
-                [
-                    'label' => 'Foo Bar',
-                    'rules' => 'min_length[10]',
-                ],
-                'The Foo Bar field must be at least 10 characters in length.',
-            ],
-            [
-                [
-                    'label' => 'Foo Bar',
-                    'rules' => ['min_length[10]'],
-                ],
-                'The Foo Bar field must be at least 10 characters in length.',
-            ],
-            [
-                [
-                    'label' => 'Foo Bar',
-                    'rules' => 'min_length[10]',
-                ],
-                'The Foo Bar field is very short.',
-                ['foo' => ['min_length' => 'The {field} field is very short.']],
-            ],
-            [
-                [
-                    'label'  => 'Foo Bar',
-                    'rules'  => 'min_length[10]',
-                    'errors' => ['min_length' => 'The {field} field is very short.'],
-                ],
-                'The Foo Bar field is very short.',
-            ],
+            'The Foo Bar field is very short.',
         ];
     }
 
@@ -972,56 +979,56 @@ class ValidationTest extends CIUnitTestCase
 
     public function arrayFieldDataProvider(): iterable
     {
-        yield from [
-            'all_rules_should_pass' => [
-                'body' => [
-                    'foo' => [
-                        'a',
-                        'b',
-                        'c',
-                    ],
-                ],
-                'rules' => [
-                    'foo.0' => 'required|alpha|max_length[2]',
-                    'foo.1' => 'required|alpha|max_length[2]',
-                    'foo.2' => 'required|alpha|max_length[2]',
-                ],
-                'results' => [],
-            ],
-            'first_field_will_return_required_error' => [
-                'body' => [
-                    'foo' => [
-                        '',
-                        'b',
-                        'c',
-                    ],
-                ],
-                'rules' => [
-                    'foo.0' => 'required|alpha|max_length[2]',
-                    'foo.1' => 'required|alpha|max_length[2]',
-                    'foo.2' => 'required|alpha|max_length[2]',
-                ],
-                'results' => [
-                    'foo.0' => 'The foo.0 field is required.',
+        yield 'all_rules_should_pass' => [
+            'body' => [
+                'foo' => [
+                    'a',
+                    'b',
+                    'c',
                 ],
             ],
-            'first_and second_field_will_return_required_and_min_length_error' => [
-                'body' => [
-                    'foo' => [
-                        '',
-                        'b',
-                        'c',
-                    ],
+            'rules' => [
+                'foo.0' => 'required|alpha|max_length[2]',
+                'foo.1' => 'required|alpha|max_length[2]',
+                'foo.2' => 'required|alpha|max_length[2]',
+            ],
+            'results' => [],
+        ];
+
+        yield 'first_field_will_return_required_error' => [
+            'body' => [
+                'foo' => [
+                    '',
+                    'b',
+                    'c',
                 ],
-                'rules' => [
-                    'foo.0' => 'required|alpha|max_length[2]',
-                    'foo.1' => 'required|alpha|min_length[2]|max_length[4]',
-                    'foo.2' => 'required|alpha|max_length[2]',
+            ],
+            'rules' => [
+                'foo.0' => 'required|alpha|max_length[2]',
+                'foo.1' => 'required|alpha|max_length[2]',
+                'foo.2' => 'required|alpha|max_length[2]',
+            ],
+            'results' => [
+                'foo.0' => 'The foo.0 field is required.',
+            ],
+        ];
+
+        yield 'first_and second_field_will_return_required_and_min_length_error' => [
+            'body' => [
+                'foo' => [
+                    '',
+                    'b',
+                    'c',
                 ],
-                'results' => [
-                    'foo.0' => 'The foo.0 field is required.',
-                    'foo.1' => 'The foo.1 field must be at least 2 characters in length.',
-                ],
+            ],
+            'rules' => [
+                'foo.0' => 'required|alpha|max_length[2]',
+                'foo.1' => 'required|alpha|min_length[2]|max_length[4]',
+                'foo.2' => 'required|alpha|max_length[2]',
+            ],
+            'results' => [
+                'foo.0' => 'The foo.0 field is required.',
+                'foo.1' => 'The foo.1 field must be at least 2 characters in length.',
             ],
         ];
     }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
```console
$ vendor/bin/php-cs-fixer describe yield_from_array_to_yields
Description of yield_from_array_to_yields rule.
Yield from array must be unpacked to series of yields.
The conversion will make the array in `yield from` changed in arrays of 1 less dimension.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,7 +1,7 @@
    <?php function generate() {
   -    yield from [
   -        1,
   -        2,
   -        3,
   -    ];
   +
   +        yield 1;
   +        yield 2;
   +        yield 3;
   +
    }

   ----------- end diff -----------
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
