### PR TITLE
Prep for 4.3.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [v4.3.7](https://github.com/codeigniter4/CodeIgniter4/tree/v4.3.7) (2023-07-30)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.3.6...v4.3.7)
+
+### Breaking Changes
+
+* fix: FeatureTestTrait may change $params values passed to call(), and a few bug fixes by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7602
+* fix: auto routing legacy and $route->add() by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7690
+* fix: [Model] setValidationRule() cannot use with ruleGroup by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7691
+
+### Fixed Bugs
+
+* docs: fix incorrect description on RedirectException (1) by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7629
+* docs: fix incorrect description on RedirectException (2) by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7633
+* fix: skip http proxy added header by @jozefrebjak in https://github.com/codeigniter4/CodeIgniter4/pull/7622
+* fix: number_to_roman() param type by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7640
+* fix: [Auto Routing Improved] feature testing may use incorrect param count by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7597
+* fix: `url_to()` error message by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7652
+* fix: [ViewCells] caching by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7663
+* fix: [ViewCells] when there are cells with the same short name, only the first cell is loaded by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7686
+* Fix number comparison in number_to_amount() in number_helper.php by @sba in https://github.com/codeigniter4/CodeIgniter4/pull/7701
+* fix: wrong Config classname to config() in Toolbar by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7735
+* fix: $sensitiveDataInTrace does not work by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7725
+
+### Enhancements
+
+* Remove PHPStan from pre-commit hook by @lonnieezell in https://github.com/codeigniter4/CodeIgniter4/pull/7618
+
+### Refactoring
+
+* refactor: remove unused property in Encryption\Handlers\BaseHandler by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7579
+* refactor: use ::class to config() param by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7611
+* refactor: remove unused non-empty array in RequestTrait by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7620
+* refactor: [Cache] simplify code of `FileHandler::getItem()` by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/7667
+* refactor:  replace `config(Paths::class)` by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7702
+
 ## [v4.3.6](https://github.com/codeigniter4/CodeIgniter4/tree/v4.3.6) (2023-06-18)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.3.5...v4.3.6)
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -48,7 +48,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.3.6';
+    public const CI_VERSION = '4.3.7';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/v4.3.7.rst
+++ b/user_guide_src/source/changelogs/v4.3.7.rst
@@ -1,7 +1,7 @@
 Version 4.3.7
 #############
 
-Release Date: Unreleased
+Release Date: July 30, 2023
 
 **4.3.7 release of CodeIgniter4**
 
@@ -23,18 +23,12 @@ BREAKING
   changed from "**rules array**" to "**array** of **rules array** and **customErrors array**"
   (``[rules, customErrors]``).
 
-Message Changes
-***************
-
 Changes
 *******
 
 - The number helper function :php:func:`number_to_amount()`, which previously
   returned "1000", has been corrected to return "1 thousand" when the number
   is exactly 1000, for example.
-
-Deprecations
-************
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2019-' + str(year_now) + ' CodeIgniter Foundation'
 version = '4.3'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.3.6'
+release = '4.3.7'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_437.rst
+++ b/user_guide_src/source/installation/upgrade_437.rst
@@ -12,9 +12,6 @@ Please refer to the upgrade instructions corresponding to your installation meth
     :local:
     :depth: 2
 
-Mandatory File Changes
-**********************
-
 Breaking Changes
 ****************
 
@@ -52,9 +49,6 @@ If you use the method, update the code like the following::
         ↓
     [$rules, $customErrors] = $this->validation->loadRuleGroup($rules);
 
-Breaking Enhancements
-*********************
-
 Project Files
 *************
 
@@ -73,7 +67,7 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
-- @TODO
+- app/Config/Kint.php
 
 All Changes
 ===========
@@ -81,4 +75,16 @@ All Changes
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
+- app/Config/App.php
+- app/Config/Autoload.php
+- app/Config/Cache.php
+- app/Config/ContentSecurityPolicy.php
+- app/Config/Filters.php
+- app/Config/Kint.php
+- app/Config/Logger.php
+- app/Config/Migrations.php
+- app/Config/Modules.php
+- app/Config/Paths.php
+- app/Controllers/BaseController.php
+- app/Controllers/Home.php
+- composer.json


### PR DESCRIPTION
**Description**
Updates changelog and version references for 4.3.7.

Previous version: #7587
Release Code: TODO
New Changelog: TODO 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
