### PR TITLE
docs: remove `>` in console command

### DIFF
--- a/contributing/documentation.rst
+++ b/contributing/documentation.rst
@@ -171,3 +171,16 @@ As a general rule, we use ``**`` for in-line file paths, and `````` for source c
 E.g.::
 
     Open the **app/Config/Filters.php** file and update the ``$methods`` property like the following:
+
+**********
+Code Block
+**********
+
+CLI Command
+===========
+
+::
+
+    .. code-block:: console
+
+        php spark migrate

--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -241,6 +241,10 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 	margin-top: 2rem;
 }
 
+.highlight-console .highlight {
+    background-color: #fffff0;
+}
+
 /* Messages ----------------------------------------------------------------- */
 
 .rst-content .success {

--- a/user_guide_src/source/_static/css/citheme_dark.css
+++ b/user_guide_src/source/_static/css/citheme_dark.css
@@ -343,4 +343,8 @@
     .highlight .ni {
         color: #b780b7;
     }
+
+    .highlight-console .highlight pre {
+        background: #434343;
+    }
 }

--- a/user_guide_src/source/cli/cli_commands.rst
+++ b/user_guide_src/source/cli/cli_commands.rst
@@ -65,9 +65,11 @@ run()
 -----
 
 The ``run()`` method is the method that is called when the command is being run. The ``$params`` array is a list of
-any CLI arguments after the command name for your use. If the CLI string was::
+any CLI arguments after the command name for your use. If the CLI string was:
 
-    > php spark foo bar baz
+.. code-block:: console
+
+    php spark foo bar baz
 
 Then **foo** is the command name, and the ``$params`` array would be:
 

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -14,9 +14,11 @@ Introduction
 ************
 
 All built-in generators reside under the ``Generators`` group when listed using ``php spark list``.
-To view the full description and usage information on a particular generator, use the command::
+To view the full description and usage information on a particular generator, use the command:
 
-    > php spark help <generator_command>
+.. code-block:: console
+
+    php spark help <generator_command>
 
 where ``<generator_command>`` will be replaced with the command to check.
 
@@ -287,9 +289,11 @@ wrapper to the controller, model, entity, migration, and seeder generator comman
 name that will be used to name all the generated classes. Also, **individual options** supported by each
 generator command are recognized by the scaffold command.
 
-Running this in your terminal::
+Running this in your terminal:
 
-    > php spark make:scaffold user
+.. code-block:: console
+
+    php spark make:scaffold user
 
 will create the following files:
 

--- a/user_guide_src/source/cli/cli_overview.rst
+++ b/user_guide_src/source/cli/cli_overview.rst
@@ -36,9 +36,11 @@ The Spark Commands
 
 CodeIgniter ships with the official command **spark** and built-in commands.
 
-You can run the spark and see the help::
+You can run the spark and see the help:
 
-    > php spark
+.. code-block:: console
+
+    php spark
 
 See the :doc:`spark_commands` page for detailed information.
 

--- a/user_guide_src/source/cli/spark_commands.rst
+++ b/user_guide_src/source/cli/spark_commands.rst
@@ -23,48 +23,64 @@ Showing List of Commands
 
 When called **spark** without specifying a command, a simple help page is displayed
 that also provides a list of available commands and their descriptions, sorted by
-categories::
+categories:
 
-    > php spark
+.. code-block:: console
+
+    php spark
 
 spark list
 ^^^^^^^^^^
 
-``php spark`` is the exactly same as the ``list`` command::
+``php spark`` is the exactly same as the ``list`` command:
 
-    > php spark list
+.. code-block:: console
+
+    php spark list
 
 You may also use the ``--simple`` option to get a raw list of all available commands,
-sorted alphabetically::
+sorted alphabetically:
 
-    > php spark list --simple
+.. code-block:: console
+
+    php spark list --simple
 
 Showing Help
 ------------
 
-You can get help about any CLI command using the ``help`` command as follows::
+You can get help about any CLI command using the ``help`` command as follows:
 
-    > php spark help db:seed
+.. code-block:: console
 
-Since v4.3.0, you can also use the ``--help`` option instead of the ``help`` command::
+    php spark help db:seed
 
-    > php spark db:seed --help
+Since v4.3.0, you can also use the ``--help`` option instead of the ``help`` command:
+
+.. code-block:: console
+
+    php spark db:seed --help
 
 Running a Command
 -----------------
 
-You should pass the name of the command as the first argument to run that command::
+You should pass the name of the command as the first argument to run that command:
 
-    > php spark migrate
+.. code-block:: console
 
-Some commands take additional arguments, which should be provided directly after the command, separated by spaces::
+    php spark migrate
 
-    > php spark db:seed DevUserSeeder
+Some commands take additional arguments, which should be provided directly after the command, separated by spaces:
+
+.. code-block:: console
+
+    php spark db:seed DevUserSeeder
 
 For all of the commands CodeIgniter provides, if you do not provide the required arguments, you will be prompted
-for the information it needs to run correctly::
+for the information it needs to run correctly:
 
-    > php spark make:controller
+.. code-block:: console
+
+    php spark make:controller
 
     Controller class name :
 
@@ -72,17 +88,21 @@ Suppressing Header Output
 -------------------------
 
 When you run a command, the header with CodeIgniter version and the current time
-is output::
+is output:
 
-    > php spark env
+.. code-block:: console
+
+    php spark env
 
     CodeIgniter v4.3.5 Command Line Tool - Server Time: 2023-06-16 12:45:31 UTC+00:00
 
     Your environment is currently set as development.
 
-You may always pass ``--no-header`` to suppress the header output, helpful for parsing results::
+You may always pass ``--no-header`` to suppress the header output, helpful for parsing results:
 
-    > php spark env --no-header
+.. code-block:: console
+
+    php spark env --no-header
 
     Your environment is currently set as development.
 

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -55,9 +55,11 @@ those classes can be found in:
 The key of each row is the namespace itself. This does not need a trailing back slash.
 The value is the location to the directory the classes can be found in.
 
-.. note:: You can check the namespace configuration by ``spark namespaces`` command::
+.. note:: You can check the namespace configuration by ``spark namespaces`` command:
 
-    > php spark namespaces
+    .. code-block:: console
+
+        php spark namespaces
 
 By default, the application directory is namespace to the ``App`` namespace. You must namespace the controllers,
 libraries, or models in the application directory, and they will be found under the ``App`` namespace.

--- a/user_guide_src/source/dbmgmt/db_commands.rst
+++ b/user_guide_src/source/dbmgmt/db_commands.rst
@@ -19,9 +19,11 @@ db:table --show
 ---------------
 
 To list all the tables in your database straight from your favorite terminal,
-you can use the ``db:table --show`` command::
+you can use the ``db:table --show`` command:
 
-    > php spark db:table --show
+.. code-block:: console
+
+    php spark db:table --show
 
 When using this command it is assumed that a table exists.
 Otherwise, CodeIgniter will complain that the database has no tables.
@@ -32,21 +34,27 @@ Retrieve Some Records
 db:table
 --------
 
-When you have a table named ``my_table``, you can see the field names and the records of a table::
+When you have a table named ``my_table``, you can see the field names and the records of a table:
 
-    > php spark db:table my_table
+.. code-block:: console
+
+    .. code-block:: consolephp spark db:table my_table
 
 If the table ``my_table`` is not in the database, CodeIgniter displays a list of available tables to select.
 
-You can also use the following command without the table name::
+You can also use the following command without the table name:
 
-    > php spark db:table
+.. code-block:: console
+
+    php spark db:table
 
 In this case, the table name will be asked.
 
-You can also pass a few options::
+You can also pass a few options:
 
-    > php spark db:table my_table --limit-rows 50 --limit-field-value 20 --desc
+.. code-block:: console
+
+    php spark db:table my_table --limit-rows 50 --limit-field-value 20 --desc
 
 The option ``--limit-rows 50`` limits the number of rows to 50 rows.
 
@@ -60,9 +68,11 @@ Retrieve Field Metadata
 db:table --metadata
 -------------------
 
-When you have a table named ``my_table``, you can see metadata like the column type, max length of the table with the ``--metadata`` option::
+When you have a table named ``my_table``, you can see metadata like the column type, max length of the table with the ``--metadata`` option:
 
-    > php spark db:table my_table --metadata
+.. code-block:: console
+
+    php spark db:table my_table --metadata
 
 When using this command it is assumed that the table exists.
 Otherwise, CodeIgniter will show a table list to select.

--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -60,19 +60,24 @@ CodeIgniter supports creating databases straight from your favorite terminal usi
 command. By using this command it is assumed that the database is not yet existing. Otherwise, CodeIgniter
 will complain that the database creation has failed.
 
-To start, just type the command and the name of the database (e.g., ``foo``)::
+To start, just type the command and the name of the database (e.g., ``foo``):
 
-    > php spark db:create foo
+.. code-block:: console
+
+    php spark db:create foo
 
 If everything went fine, you should expect the ``Database "foo" successfully created.`` message displayed.
 
 If you are on a testing environment or you are using the SQLite3 driver, you may pass in the file extension
 for the file where the database will be created using the ``--ext`` option. Valid values are ``db`` and
 ``sqlite`` and defaults to ``db``. Remember that these should not be preceded by a period.
-::
+:
 
-    > php spark db:create foo --ext sqlite
-    // will create the db file in WRITEPATH/foo.sqlite
+.. code-block:: console
+
+    php spark db:create foo --ext sqlite
+
+The above command will create the db file in **WRITEPATH/foo.sqlite**.
 
 .. note:: When using the special SQLite3 database name ``:memory:``, expect that the command will still
     produce a success message but no database file is created. This is because SQLite3 will just use

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -107,9 +107,11 @@ that wish to use them. The tools primarily provide access to the same methods th
 migrate
 =======
 
-Migrates a database group with all available migrations::
+Migrates a database group with all available migrations:
 
-    > php spark migrate
+.. code-block:: console
+
+    php spark migrate
 
 You can use (migrate) with the following options:
 
@@ -117,13 +119,19 @@ You can use (migrate) with the following options:
 - ``-n`` - to choose namespace, otherwise (App) namespace will be used.
 - ``--all`` - to migrate all namespaces to the latest migration.
 
-This example will migrate ``Acme\Blog`` namespace with any new migrations on the test database group::
+This example will migrate ``Acme\Blog`` namespace with any new migrations on the test database group:
 
-    For Unix:
-    > php spark migrate -g test -n Acme\\Blog
+For Unix:
 
-    For Windows:
-    > php spark migrate -g test -n Acme\Blog
+.. code-block:: console
+
+    php spark migrate -g test -n Acme\\Blog
+
+For Windows:
+
+.. code-block:: console
+
+    php spark migrate -g test -n Acme\Blog
 
 When using the ``--all`` option, it will scan through all namespaces attempting to find any migrations that have
 not been run. These will all be collected and then sorted as a group by date created. This should help
@@ -132,9 +140,11 @@ to minimize any potential conflicts between the main application and any modules
 rollback
 ========
 
-Rolls back all migrations, taking the database group to a blank slate, effectively migration 0::
+Rolls back all migrations, taking the database group to a blank slate, effectively migration 0:
 
-  > php spark migrate:rollback
+.. code-block:: console
+
+  php spark migrate:rollback
 
 You can use (rollback) with the following options:
 
@@ -145,9 +155,11 @@ You can use (rollback) with the following options:
 refresh
 =======
 
-Refreshes the database state by first rolling back all migrations, and then migrating all::
+Refreshes the database state by first rolling back all migrations, and then migrating all:
 
-  > php spark migrate:refresh
+.. code-block:: console
+
+  php spark migrate:refresh
 
 You can use (refresh) with the following options:
 
@@ -159,9 +171,11 @@ You can use (refresh) with the following options:
 status
 ======
 
-Displays a list of all migrations and the date and time they ran, or '--' if they have not been run::
+Displays a list of all migrations and the date and time they ran, or '--' if they have not been run:
 
-  > php spark migrate:status
+.. code-block:: console
+
+  php spark migrate:status
 
   ...
 
@@ -184,9 +198,9 @@ Creates a skeleton migration file in **app/Database/Migrations**.
 It automatically prepends the current timestamp. The class name it
 creates is the Pascal case version of the filename.
 
-::
+.. code-block:: console
 
-  > php spark make:migration <class> [options]
+  php spark make:migration <class> [options]
 
 You can use (``make:migration``) with the following options:
 

--- a/user_guide_src/source/dbmgmt/seeds.rst
+++ b/user_guide_src/source/dbmgmt/seeds.rst
@@ -48,28 +48,37 @@ Command Line Seeding
 ====================
 
 You can also seed data from the command line, as part of the Migrations CLI tools, if you don't want to create
-a dedicated controller::
+a dedicated controller:
 
-    > php spark db:seed TestSeeder
+.. code-block:: console
+
+    php spark db:seed TestSeeder
 
 *********************
 Creating Seeder Files
 *********************
 
-Using the command line, you can easily generate seed files.
+Using the command line, you can easily generate seed files:
 
-::
+.. code-block:: console
 
-    > php spark make:seeder user --suffix
-    // Output: UserSeeder.php file located at app/Database/Seeds directory.
+    php spark make:seeder user --suffix
 
-You can supply the ``root`` namespace where the seed file will be stored by supplying the ``--namespace`` option::
+The above command outputs **UserSeeder.php** file located at **app/Database/Seeds** directory.
 
-    For Unix:
-    > php spark make:seeder MySeeder --namespace Acme\\Blog
+You can supply the ``root`` namespace where the seed file will be stored by supplying the ``--namespace`` option:
 
-    For Windows:
-    > php spark make:seeder MySeeder --namespace Acme\Blog
+For Unix:
+
+.. code-block:: console
+
+    php spark make:seeder MySeeder --namespace Acme\\Blog
+
+For Windows:
+
+.. code-block:: console
+
+    php spark make:seeder MySeeder --namespace Acme\Blog
 
 If ``Acme\Blog`` is mapped to **app/Blog** directory, then this command will generate **MySeeder.php** at **app/Blog/Database/Seeds** directory.
 

--- a/user_guide_src/source/extending/composer_packages.rst
+++ b/user_guide_src/source/extending/composer_packages.rst
@@ -143,9 +143,11 @@ Open **.php-cs-fixer.dist.php** in your editor, and fix the folder path::
          ])
          ->exclude([
 
-That't it. Now you can run Coding Standards Fixer::
+That't it. Now you can run Coding Standards Fixer:
 
-    > vendor/bin/php-cs-fixer fix --ansi --verbose --diff
+.. code-block:: console
+
+    vendor/bin/php-cs-fixer fix --ansi --verbose --diff
 
 If you add ``scripts.cs-fix`` in your **composer.json**, you can run it with
 ``composer cs-fix`` command::

--- a/user_guide_src/source/general/environments.rst
+++ b/user_guide_src/source/general/environments.rst
@@ -54,9 +54,11 @@ The simplest method to set the variable is in your :ref:`.env file <dotenv-file>
 
     CI_ENVIRONMENT = development
 
-.. note:: You can change the ``CI_ENVIRONMENT`` value in **.env** file by ``spark env`` command::
+.. note:: You can change the ``CI_ENVIRONMENT`` value in **.env** file by ``spark env`` command:
 
-    > php spark env production
+    .. code-block:: console
+
+        php spark env production
 
 .. _environment-apache:
 
@@ -135,9 +137,11 @@ Confirming the Current Environment
 
 To confirm the current environment, simply echo the constant ``ENVIRONMENT``.
 
-You can also check the current environment by ``spark env`` command::
+You can also check the current environment by ``spark env`` command:
 
-    > php spark env
+.. code-block:: console
+
+    php spark env
 
 *************************************
 Effects on Default Framework Behavior

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -212,13 +212,20 @@ Seeds
 =====
 
 Seed files can be used from both the CLI and called from within other seed files as long as the full namespace
-is provided. If calling on the CLI, you will need to provide double backslashes::
+is provided. If calling on the CLI, you will need to provide double backslashes:
 
-    For Unix:
-    > php spark db:seed Acme\\Blog\\Database\\Seeds\\TestPostSeeder
 
-    For Windows:
-    > php spark db:seed Acme\Blog\Database\Seeds\TestPostSeeder
+For Unix:
+
+.. code-block:: console
+
+    php spark db:seed Acme\\Blog\\Database\\Seeds\\TestPostSeeder
+
+For Windows:
+
+.. code-block:: console
+
+    php spark db:seed Acme\Blog\Database\Seeds\TestPostSeeder
 
 Helpers
 =======

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -179,9 +179,11 @@ filter:check
 
 .. versionadded:: 4.3.0
 
-Check the filters for the route ``/`` with **GET** method::
+Check the filters for the route ``/`` with **GET** method:
 
-    > php spark filter:check get /
+.. code-block:: console
+
+    php spark filter:check get /
 
 The output is like the following:
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -837,9 +837,11 @@ CodeIgniter has the following :doc:`command </cli/spark_commands>` to display al
 spark routes
 ============
 
-Displays all routes and filters::
+Displays all routes and filters:
 
-    > php spark routes
+.. code-block:: console
+
+    php spark routes
 
 The output is like the following:
 
@@ -924,6 +926,8 @@ Sort by Handler
 
 .. versionadded:: 4.3.0
 
-You can sort the routes by *Handler*::
+You can sort the routes by *Handler*:
 
-    > php spark routes -h
+.. code-block:: console
+
+    php spark routes -h

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -35,9 +35,11 @@ a new CodeIgniter4 based project.
 Installation
 ------------
 
-In the folder above your project root::
+In the folder above your project root:
 
-    > composer create-project codeigniter4/appstarter project-root
+.. code-block:: console
+
+    composer create-project codeigniter4/appstarter project-root
 
 The command above will create a **project-root** folder.
 
@@ -49,9 +51,11 @@ If you omit the "project-root" argument, the command will create an
     So if you install CodeIgniter under the folder that contains the special characters like ``(``, ``)``, etc., CodeIgniter won't work.
 
 .. important:: When you deploy to your production server, don't forget to run the
-    following command::
+    following command:
 
-    > composer install --no-dev
+    .. code-block:: console
+
+        composer install --no-dev
 
     The above command will remove the Composer packages only for development
     that are not needed in the production environment. This will greatly reduce
@@ -68,9 +72,11 @@ See :ref:`initial-configuration` for the details.
 Upgrading
 ---------
 
-Whenever there is a new release, then from the command line in your project root::
+Whenever there is a new release, then from the command line in your project root:
 
-    > composer update
+.. code-block:: console
+
+    composer update
 
 Read the :doc:`upgrade instructions <upgrading>`, and check Breaking Changes and Enhancements.
 
@@ -108,15 +114,19 @@ The `development user guide <https://codeigniter4.github.io/CodeIgniter4/>`_ is 
 Note that this differs from the released user guide, and will pertain to the
 develop branch explicitly.
 
-In your project root::
+In your project root:
 
-    > php builds development
+.. code-block:: console
+
+    php builds development
 
 The command above will update **composer.json** to point to the ``develop`` branch of the
 working repository, and update the corresponding paths in config and XML files. To revert
-these changes run::
+these changes run:
 
-    > php builds release
+.. code-block:: console
+
+    php builds release
 
 After using the ``builds`` command be sure to run ``composer update`` to sync your vendor
 folder with the latest target build.
@@ -134,14 +144,18 @@ Installation
 Develop your app inside the ``app`` folder, and the ``public`` folder
 will be your document root.
 
-In your project root::
+In your project root:
 
-    > composer require codeigniter4/framework
+.. code-block:: console
+
+    composer require codeigniter4/framework
 
 .. important:: When you deploy to your production server, don't forget to run the
-    following command::
+    following command:
 
-    > composer install --no-dev
+.. code-block:: console
+
+    composer install --no-dev
 
     The above command will remove the Composer packages only for development
     that are not needed in the production environment. This will greatly reduce
@@ -167,7 +181,9 @@ Upgrading
 
 Whenever there is a new release, then from the command line in your project root::
 
-    > composer update
+.. code-block:: console
+
+    composer update
 
 Read the :doc:`upgrade instructions <upgrading>`, and check Breaking Changes and Enhancements.
 
@@ -200,8 +216,10 @@ Translations Installation
 If you want to take advantage of the system message translations,
 they can be added to your project in a similar fashion.
 
-From the command line inside your project root::
+From the command line inside your project root:
 
-    > composer require codeigniter4/translations
+.. code-block:: console
+
+    composer require codeigniter4/translations
 
 These will be updated along with the framework whenever you do a ``composer update``.

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -57,9 +57,11 @@ Local Development Server
 
 CodeIgniter 4 comes with a local development server, leveraging PHP's built-in web server
 with CodeIgniter routing. You can launch it, with the following command line
-in the main directory::
+in the main directory:
 
-    > php spark serve
+.. code-block:: console
+
+    php spark serve
 
 This will launch the server and you can now view your application in your browser at http://localhost:8080.
 
@@ -72,19 +74,25 @@ all unix-type systems (including macOS) will typically keep the file at **/etc/h
 
 The local development server can be customized with three command line options:
 
-- You can use the ``--host`` CLI option to specify a different host to run the application at::
+- You can use the ``--host`` CLI option to specify a different host to run the application at:
 
-    > php spark serve --host example.dev
+    .. code-block:: console
+
+        php spark serve --host example.dev
 
 - By default, the server runs on port 8080 but you might have more than one site running, or already have
-  another application using that port. You can use the ``--port`` CLI option to specify a different one::
+  another application using that port. You can use the ``--port`` CLI option to specify a different one:
 
-    > php spark serve --port 8081
+    .. code-block:: console
+
+        php spark serve --port 8081
 
 - You can also specify a specific version of PHP to use, with the ``--php`` CLI option, with its value
-  set to the path of the PHP executable you want to use::
+  set to the path of the PHP executable you want to use:
 
-    > php spark serve --php /usr/bin/php7.6.5.4
+    .. code-block:: console
+
+        php spark serve --php /usr/bin/php7.6.5.4
 
 *******************
 Hosting with Apache
@@ -206,10 +214,12 @@ Place your project folder as follows, where **htdocs** is the Apache document ro
     │      └── public/
     └── htdocs/
 
-Navigate to the **htdocs** folder and create a symbolic link as follows::
+Navigate to the **htdocs** folder and create a symbolic link as follows:
 
-    > cd htdocs/
-    > ln -s ../myproject/public/ myproject
+.. code-block:: console
+
+    cd htdocs/
+    ln -s ../myproject/public/ myproject
 
 Using Alias
 -----------

--- a/user_guide_src/source/installation/troubleshooting.rst
+++ b/user_guide_src/source/installation/troubleshooting.rst
@@ -11,9 +11,11 @@ Here are some common installation problems, and suggested workarounds.
 How do I know if my install is working?
 ---------------------------------------
 
-From the command line, at your project root::
+From the command line, at your project root:
 
-    > php spark serve
+.. code-block:: console
+
+    php spark serve
 
 ``http://localhost:8080`` in your browser should then show the default
 welcome page:

--- a/user_guide_src/source/installation/upgrade_420.rst
+++ b/user_guide_src/source/installation/upgrade_420.rst
@@ -27,11 +27,13 @@ The following files received significant changes and
 .. important:: If you don't update the above two files, CodeIgniter will not work at all
     after running ``composer update``.
 
-    The upgrade procedure, for example, is as follows::
+    The upgrade procedure, for example, is as follows:
 
-        > composer update
-        > cp vendor/codeigniter4/framework/public/index.php public/index.php
-        > cp vendor/codeigniter4/framework/spark .
+    .. code-block:: console
+
+        composer update
+        cp vendor/codeigniter4/framework/public/index.php public/index.php
+        cp vendor/codeigniter4/framework/spark .
 
 Config/Constants.php
 ====================

--- a/user_guide_src/source/installation/upgrade_430.rst
+++ b/user_guide_src/source/installation/upgrade_430.rst
@@ -21,11 +21,13 @@ Composer Version
 If you are using older version of Composer, upgrade your ``composer`` tool,
 and delete the **vendor/** directory, and run ``composer update`` again.
 
-The procedure, for example, is as follows::
+The procedure, for example, is as follows:
 
-    > composer self-update
-    > rm -rf vendor/
-    > composer update
+.. code-block:: console
+
+    composer self-update
+    rm -rf vendor/
+    composer update
 
 Mandatory File Changes
 **********************
@@ -40,10 +42,12 @@ The following files received significant changes and
 
 .. important:: If you do not update this file, Spark commands will not work at all after running ``composer update``.
 
-    The upgrade procedure, for example, is as follows::
+    The upgrade procedure, for example, is as follows:
 
-        > composer update
-        > cp vendor/codeigniter4/framework/spark .
+    .. code-block:: console
+
+        composer update
+        cp vendor/codeigniter4/framework/spark .
 
 Config Files
 ============

--- a/user_guide_src/source/installation/upgrade_431.rst
+++ b/user_guide_src/source/installation/upgrade_431.rst
@@ -21,11 +21,13 @@ Composer Version
 If you are using older version of Composer, upgrade your ``composer`` tool,
 and delete the **vendor/** directory, and run ``composer update`` again.
 
-The procedure, for example, is as follows::
+The procedure, for example, is as follows:
 
-    > composer self-update
-    > rm -rf vendor/
-    > composer update
+.. code-block:: console
+
+    composer self-update
+    rm -rf vendor/
+    composer update
 
 Mandatory File Changes
 **********************

--- a/user_guide_src/source/installation/upgrade_migrations.rst
+++ b/user_guide_src/source/installation/upgrade_migrations.rst
@@ -17,9 +17,11 @@ What has been changed
 - First of all, the sequential naming (``001_create_users``, ``002_create_posts``) of migrations is not longer supported. Version 4 of CodeIgniter only supports the timestamp scheme (``20121031100537_create_users``, ``20121031500638_create_posts``) . If you have used sequential naming you have to rename each migration file.
 - The migration table definition was changed. If you upgrade from CI3 to CI4 and use the same database,
   You need to upgrade the migration table definition and its data.
-- The migration procedure has been also changed. You can now migrate the database with a simple CLI command::
+- The migration procedure has been also changed. You can now migrate the database with a simple CLI command:
 
-    > php spark migrate
+.. code-block:: console
+
+    php spark migrate
 
 Upgrade Guide
 =============

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -85,16 +85,20 @@ These tools are not required to use Cache driver but might help you.
 cache:clear
 ===========
 
-Clears the current system caches::
+Clears the current system caches:
 
-    > php spark cache:clear
+.. code-block:: console
+
+    php spark cache:clear
 
 cache:info
 ==========
 
-Shows file cache information in the current system::
+Shows file cache information in the current system:
 
-    > php spark cache:info
+.. code-block:: console
+
+    php spark cache:info
 
 .. note:: This command only supports the File cache handler.
 
@@ -317,9 +321,11 @@ Predis Caching
 ==============
 
 Predis is a flexible and feature-complete PHP client library for the Redis key-value store.
-To use it, from the command line inside your project root::
+To use it, from the command line inside your project root:
 
-    > composer require predis/predis
+.. code-block:: console
+
+    composer require predis/predis
 
 For more information on Redis, please see
 `https://github.com/nrk/predis <https://github.com/nrk/predis>`_.

--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -66,9 +66,11 @@ different directory and it will return any child classes found:
 
 .. literalinclude:: publisher/006.php
 
-Most of the time you will not need to handle your own discovery, just use the provided "publish" command::
+Most of the time you will not need to handle your own discovery, just use the provided "publish" command:
 
-    > php spark publish
+.. code-block:: console
+
+    php spark publish
 
 By default on your class extension ``publish()`` will add all files from your ``$source`` and merge them
 out to your destination, overwriting on collision.
@@ -118,10 +120,12 @@ to keep up with. You can create a publication definition in your project to sync
 
 .. literalinclude:: publisher/009.php
 
-Now add the dependency via Composer and call ``spark publish`` to run the publication::
+Now add the dependency via Composer and call ``spark publish`` to run the publication:
 
-    > composer require twbs/bootstrap
-    > php spark publish
+.. code-block:: console
+
+    composer require twbs/bootstrap
+    php spark publish
 
 ... and you'll end up with something like this::
 

--- a/user_guide_src/source/libraries/sessions.rst
+++ b/user_guide_src/source/libraries/sessions.rst
@@ -515,12 +515,13 @@ it. But be careful because the system user *running* the script is usually
 not your own, but something like 'www-data' instead, so only setting those
 permissions will probably break your application.
 
-Instead, you should do something like this, depending on your environment
-::
+Instead, you should do something like this, depending on your environment:
 
-    > mkdir /<path to your application directory>/writable/sessions/
-    > chmod 0700 /<path to your application directory>/writable/sessions/
-    > chown www-data /<path to your application directory>/writable/sessions/
+.. code-block:: console
+
+    mkdir /<path to your application directory>/writable/sessions/
+    chmod 0700 /<path to your application directory>/writable/sessions/
+    chown www-data /<path to your application directory>/writable/sessions/
 
 Bonus Tip
 ---------
@@ -637,10 +638,12 @@ Setting Up Database Table with Command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you'd rather not do all of this by hand, you can use the ``make:migration --session`` command
-from the cli to generate a migration file for you::
+from the cli to generate a migration file for you:
 
-  > php spark make:migration --session
-  > php spark migrate
+.. code-block:: console
+
+  php spark make:migration --session
+  php spark migrate
 
 This command will take the ``$savePath`` and ``$matchIP`` settings into account
 when it generates the code.

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -243,9 +243,11 @@ into your **app** folder. The incorporated translations will be automatically
 picked up because the ``App`` namespace is mapped to your **app** folder.
 
 Alternately, a better practice would be to run the following command inside your
-project::
+project:
 
-    > composer require codeigniter4/translations
+.. code-block:: console
+
+    composer require codeigniter4/translations
 
 The translated messages will be automatically picked
 up because the translations folders get mapped appropriately.

--- a/user_guide_src/source/outgoing/view_cells.rst
+++ b/user_guide_src/source/outgoing/view_cells.rst
@@ -94,9 +94,9 @@ Generating Cell via Command
 
 You can also create a controlled cell via a built in command from the CLI. The command is ``php spark make:cell``. It takes one argument, the name of the cell to create. The name should be in PascalCase, and the class will be created in the **app/Cells** directory. The view file will also be created in the **app/Cells** directory.
 
-::
+.. code-block:: console
 
-    > php spark make:cell AlertMessageCell
+    php spark make:cell AlertMessageCell
 
 Using a Different View
 ======================

--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -28,18 +28,24 @@ to install it globally we do not recommend it, since it can cause compatibility 
 system as time goes on.
 
 Ensure that you have Composer installed on your system. From the project root (the directory that contains the
-application and system directories) type the following from the command line::
+application and system directories) type the following from the command line:
 
-    > composer require --dev phpunit/phpunit
+.. code-block:: console
+
+    composer require --dev phpunit/phpunit
 
 This will install the correct version for your current PHP version. Once that is done, you can run all of the
-tests for this project by typing::
+tests for this project by typing:
 
-    > vendor/bin/phpunit
+.. code-block:: console
 
-If you are using Windows, use the following command::
+    vendor/bin/phpunit
 
-    > vendor\bin\phpunit
+If you are using Windows, use the following command:
+
+.. code-block:: console
+
+    vendor\bin\phpunit
 
 Phar
 ----

--- a/user_guide_src/source/tutorial/index.rst
+++ b/user_guide_src/source/tutorial/index.rst
@@ -62,9 +62,11 @@ Installing CodeIgniter
 
 You can download a release manually from the site, but for this tutorial we will
 use the recommended way and install the AppStarter package through Composer.
-From your command line type the following::
+From your command line type the following:
 
-    > composer create-project codeigniter4/appstarter ci-news
+.. code-block:: console
+
+    composer create-project codeigniter4/appstarter ci-news
 
 This creates a new folder, **ci-news**, which contains your application code, with
 CodeIgniter installed in the vendor folder.
@@ -93,9 +95,11 @@ With that out of the way it's time to view your application in a browser. You ca
 serve it through any server of your choice, Apache, Nginx, etc, but CodeIgniter
 comes with a simple command that takes advantage of PHP's built-in server to get
 you up and running fast on your development machines. Type the following on the
-command line from the root of your project::
+command line from the root of your project:
 
-    > php spark serve
+.. code-block:: console
+
+    php spark serve
 
 The Welcome Page
 ****************

--- a/user_guide_src/source/tutorial/static_pages.rst
+++ b/user_guide_src/source/tutorial/static_pages.rst
@@ -175,9 +175,11 @@ since it will not properly process the ``.htaccess`` rules that are provided in
 ``public``, and which eliminate the need to specify "**index.php/**"
 as part of a URL. CodeIgniter has its own command that you can use though.
 
-From the command line, at the root of your project::
+From the command line, at the root of your project:
 
-    > php spark serve
+.. code-block:: console
+
+    php spark serve
 
 will start a web server, accessible on port 8080. If you set the location field
 in your browser to ``localhost:8080``, you should see the CodeIgniter welcome page.


### PR DESCRIPTION
**Description**
- remove the command prompt `>` so that the commands can be copy pasted. 
   - See https://github.com/codeigniter4/CodeIgniter4/pull/7742#discussion_r1278292610

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
