### PR TITLE
refactor: remove Model::$tempPrimaryKeyValue

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -760,7 +760,7 @@ abstract class BaseModel
 
         // Must be called first, so we don't
         // strip out created_at values.
-        $data = $this->doProtectFields($data);
+        $data = $this->doProtectFieldsForInsert($data);
 
         // doProtectFields() can further remove elements from
         // $data so we need to check for empty dataset again

--- a/system/Model.php
+++ b/system/Model.php
@@ -130,13 +130,6 @@ class Model extends BaseModel
     protected $escape = [];
 
     /**
-     * Primary Key value when inserting and useAutoIncrement is false.
-     *
-     * @var int|string|null
-     */
-    private $tempPrimaryKeyValue;
-
-    /**
      * Builder method names that should not be used in the Model.
      *
      * @var string[] method name
@@ -280,13 +273,6 @@ class Model extends BaseModel
     {
         $escape       = $this->escape;
         $this->escape = [];
-
-        // If $useAutoIncrement is false, add the primary key data.
-        if ($this->useAutoIncrement === false && $this->tempPrimaryKeyValue !== null) {
-            $data[$this->primaryKey] = $this->tempPrimaryKeyValue;
-
-            $this->tempPrimaryKeyValue = null;
-        }
 
         // Require non-empty primaryKey when
         // not using auto-increment feature
@@ -717,14 +703,6 @@ class Model extends BaseModel
             } else {
                 $data = $this->transformDataToArray($data, 'insert');
                 $data = array_merge($this->tempData['data'], $data);
-            }
-        }
-
-        if ($this->useAutoIncrement === false) {
-            if (is_array($data) && isset($data[$this->primaryKey])) {
-                $this->tempPrimaryKeyValue = $data[$this->primaryKey];
-            } elseif (is_object($data) && isset($data->{$this->primaryKey})) {
-                $this->tempPrimaryKeyValue = $data->{$this->primaryKey};
             }
         }
 


### PR DESCRIPTION
~~Needs #7759~~

**Description**
Follow-up #6827

#7759 makes `$tempPrimaryKeyValue` unnecessary.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
