### PR TITLE
fix: Time serialization

### DIFF
--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -1126,17 +1126,16 @@ final class TimeTest extends CIUnitTestCase
         $this->assertNull($time->weekOfWeek);
     }
 
-    // @TODO Uncomment when PHP 8.2.4 Segmentation fault fixed.
-    //    public function testUnserializeTimeObject()
-    //    {
-    //        $time1     = new Time('August 28, 2020 10:04:00pm', 'Asia/Manila', 'en');
-    //        $timeCache = serialize($time1);
-    //        $time2     = unserialize($timeCache);
-    //
-    //        $this->assertInstanceOf(Time::class, $time2);
-    //        $this->assertTrue($time2->equals($time1));
-    //        $this->assertNotSame($time1, $time2);
-    //    }
+    public function testUnserializeTimeObject()
+    {
+        $time1     = new Time('August 28, 2020 10:04:00pm', 'Asia/Manila', 'en');
+        $timeCache = serialize($time1);
+        $time2     = unserialize($timeCache);
+
+        $this->assertInstanceOf(Time::class, $time2);
+        $this->assertTrue($time2->equals($time1));
+        $this->assertNotSame($time1, $time2);
+    }
 
     public function testSetTestNowWithTimeZone(): void
     {


### PR DESCRIPTION
**Description**
Fix crash #7780 #7362 

```
$ php vendor/bin/phpunit --filter TimeTest tests/system/I18n/TimeTest.php
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.7
Configuration: /home/aleksandr/www/ci-app/phpunit.xml.dist
Warning:       No code coverage driver available

.....................................................................................................................................      133 / 133 (100%)

Time: 00:00.174, Memory: 16.00 MB

OK (133 tests, 196 assertions)
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
