### PR TITLE
refactor: move callExit() to index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -67,3 +67,7 @@ $app->setContext($context);
  */
 
 $app->run();
+
+// Exits the application, setting the exit code for CLI-based applications
+// that might be watching.
+exit(EXIT_SUCCESS);

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -372,7 +372,6 @@ class CodeIgniter
         }
 
         $this->sendResponse();
-        $this->callExit(EXIT_SUCCESS);
     }
 
     /**
@@ -1088,6 +1087,8 @@ class CodeIgniter
      * without actually stopping script execution.
      *
      * @param int $code
+     *
+     * @deprecated 4.4.0 No longer Used. Moved to index.php.
      */
     protected function callExit($code)
     {

--- a/system/Test/Mock/MockCodeIgniter.php
+++ b/system/Test/Mock/MockCodeIgniter.php
@@ -17,6 +17,11 @@ class MockCodeIgniter extends CodeIgniter
 {
     protected ?string $context = 'web';
 
+    /**
+     * @param int $code
+     *
+     * @deprecated 4.4.0 No longer Used. Moved to index.php.
+     */
     protected function callExit($code)
     {
         // Do not call exit() in testing.

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -263,6 +263,7 @@ Deprecations
     - ``CodeIgniter::cache()`` method is deprecated. No longer used. Use ``ResponseCache`` instead.
     - ``CodeIgniter::cachePage()`` method is deprecated. No longer used. Use ``ResponseCache`` instead.
     - ``CodeIgniter::generateCacheName()`` method is deprecated. No longer used. Use ``ResponseCache`` instead.
+    - ``CodeIgniter::callExit()`` method is deprecated. No longer used.
 - **RedirectException:** ``\CodeIgniter\Router\Exceptions\RedirectException`` is deprecated. Use ``\CodeIgniter\HTTP\Exceptions\RedirectException`` instead.
 - **Session:** The property ``$sessionDriverName``, ``$sessionCookieName``,
   ``$sessionExpiration``, ``$sessionSavePath``, ``$sessionMatchIP``,

--- a/user_guide_src/source/changelogs/v4.4.0.rst
+++ b/user_guide_src/source/changelogs/v4.4.0.rst
@@ -64,6 +64,14 @@ Autoloader
 Previously, CodeIgniter's autoloader allowed loading class names ending with the `.php` extension. This means instantiating objects like `new Foo.php()` was possible
 and would instantiate as `new Foo()`. Since `Foo.php` is an invalid class name, this behavior of the autoloader is changed. Now, instantiating such classes would fail.
 
+.. _v440-codeigniter-and-exit:
+
+CodeIgniter and exit()
+----------------------
+
+The ``CodeIgniter::run()`` method no longer calls ``exit(EXIT_SUCCESS)``. The
+exit call is moved to **public/index.php**.
+
 .. _v440-interface-changes:
 
 Interface Changes

--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -117,6 +117,24 @@ match the new array structure.
 Mandatory File Changes
 **********************
 
+index.php
+=========
+
+The following file received significant changes and
+**you must merge the updated versions** with your application:
+
+- ``public/index.php`` (see also :ref:`v440-codeigniter-and-exit`)
+
+.. important:: If you don't update the above file, CodeIgniter will not work
+    properly after running ``composer update``.
+
+    The upgrade procedure, for example, is as follows:
+
+    .. code-block:: console
+
+        composer update
+        cp vendor/codeigniter4/framework/public/index.php public/index.php
+
 Config Files
 ============
 


### PR DESCRIPTION
**Description**
The method is not needed.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
