### PR TITLE
fix: instances of Validation rules are incremented each time `run()` is executed

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -107,6 +107,8 @@ class Validation implements ValidationInterface
         $this->config = $config;
 
         $this->view = $view;
+
+        $this->loadRuleSets();
     }
 
     /**
@@ -127,7 +129,6 @@ class Validation implements ValidationInterface
         // `DBGroup` is a reserved name. For is_unique and is_not_unique
         $data['DBGroup'] = $dbGroup;
 
-        $this->loadRuleSets();
         $this->loadRuleGroup($group);
 
         // If no rules exist, we return false to ensure

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -240,6 +240,22 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run([]));
     }
 
+    public function testRuleClassesInstantiatedOnce(): void
+    {
+        $this->validation->setRules([]);
+        $this->validation->run([]);
+        $count1 = count(
+            $this->getPrivateProperty($this->validation, 'ruleSetInstances')
+        );
+
+        $this->validation->run([]);
+        $count2 = count(
+            $this->getPrivateProperty($this->validation, 'ruleSetInstances')
+        );
+
+        $this->assertSame($count1, $count2);
+    }
+
     public function testRunDoesTheBasics(): void
     {
         $data = ['foo' => 'notanumber'];


### PR DESCRIPTION
**Description**
Instances of Validation rules are incremented each time `run()` is executed.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
