### PR TITLE
fix: `set_checkbox()` checks unchecked checkbox

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -629,8 +629,11 @@ if (! function_exists('set_checkbox')) {
             return '';
         }
 
+        $session     = Services::session();
+        $hasOldInput = $session->has('_ci_old_input');
+
         // Unchecked checkbox and radio inputs are not even submitted by browsers ...
-        if ((string) $input === '0' || ! empty($request->getPost()) || ! empty(old($field))) {
+        if ((string) $input === '0' || ! empty($request->getPost()) || $hasOldInput) {
             return ($input === $value) ? ' checked="checked"' : '';
         }
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -868,6 +868,29 @@ final class FormHelperTest extends CIUnitTestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/7814
+     */
+    public function testSetCheckboxWithUnchecked(): void
+    {
+        $_SESSION = [
+            '_ci_old_input' => [
+                'post' => [
+                ],
+            ],
+        ];
+
+        $this->assertSame(
+            '',
+            set_checkbox('fruit', 'apple', true)
+        );
+
+        $this->assertSame(
+            '',
+            set_checkbox('fruit', 'apple')
+        );
+    }
+
+    /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */


### PR DESCRIPTION
**Description**
Fixes #7814

`set_checkbox()` with default `true` checks unchecked checkbox when redirected back with input.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
