### PR TITLE
fix: filter except empty

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -546,7 +546,7 @@ class Filters
     /**
      * Check except paths
      *
-     * @param string       $uri   URI to check
+     * @param string       $uri   URI path relative to baseURL (all lowercase)
      * @param array|string $paths The except path patterns
      *
      * @return bool True if the URI matches except paths.
@@ -568,6 +568,9 @@ class Filters
 
     /**
      * Check the URI path as pseudo-regex
+     *
+     * @param string $uri   URI path relative to baseURL (all lowercase)
+     * @param array  $paths The except path patterns
      */
     private function checkPseudoRegex(string $uri, array $paths): bool
     {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -536,19 +536,7 @@ class Filters
             $paths = [$paths];
         }
 
-        // treat each paths as pseudo-regex
-        foreach ($paths as $path) {
-            // need to escape path separators
-            $path = str_replace('/', '\/', trim($path, '/ '));
-            // need to make pseudo wildcard real
-            $path = strtolower(str_replace('*', '.*', $path));
-            // Does this rule apply here?
-            if (preg_match('#^' . $path . '$#', $uri, $match) === 1) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->checkPseudoRegex($uri, $paths);
     }
 
     /**
@@ -571,12 +559,21 @@ class Filters
             $paths = [$paths];
         }
 
-        // treat each paths as pseudo-regex
+        return $this->checkPseudoRegex($uri, $paths);
+    }
+
+    /**
+     * Check the URI path as pseudo-regex
+     */
+    private function checkPseudoRegex(string $uri, array $paths): bool
+    {
+        // treat each path as pseudo-regex
         foreach ($paths as $path) {
             // need to escape path separators
             $path = str_replace('/', '\/', trim($path, '/ '));
             // need to make pseudo wildcard real
             $path = strtolower(str_replace('*', '.*', $path));
+
             // Does this rule apply here?
             if (preg_match('#^' . $path . '$#', $uri, $match) === 1) {
                 return true;

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -156,7 +156,9 @@ class Filters
      * Runs through all of the filters for the specified
      * uri and position.
      *
-     * @return mixed|RequestInterface|ResponseInterface
+     * @param string $uri URI path relative to baseURL
+     *
+     * @return RequestInterface|ResponseInterface|string|null
      *
      * @throws FilterException
      */
@@ -220,6 +222,8 @@ class Filters
      * We go ahead and process the entire tree because we'll need to
      * run through both a before and after and don't want to double
      * process the rows.
+     *
+     * @param string|null $uri URI path relative to baseURL (all lowercase)
      *
      * @return Filters
      */
@@ -391,7 +395,7 @@ class Filters
     /**
      * Add any applicable (not excluded) global filter settings to the mix.
      *
-     * @param string $uri
+     * @param string|null $uri URI path relative to baseURL (all lowercase)
      *
      * @return void
      */
@@ -454,7 +458,7 @@ class Filters
     /**
      * Add any applicable configured filters to the mix.
      *
-     * @param string $uri
+     * @param string|null $uri URI path relative to baseURL (all lowercase)
      *
      * @return void
      */

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -416,7 +416,7 @@ class Filters
                         if (isset($rules['except'])) {
                             // grab the exclusion rules
                             $check = $rules['except'];
-                            if ($this->pathApplies($uri, $check)) {
+                            if ($this->checkExcept($uri, $check)) {
                                 $keep = false;
                             }
                         }
@@ -529,6 +529,41 @@ class Filters
         // empty path matches all
         if (empty($paths)) {
             return true;
+        }
+
+        // make sure the paths are iterable
+        if (is_string($paths)) {
+            $paths = [$paths];
+        }
+
+        // treat each paths as pseudo-regex
+        foreach ($paths as $path) {
+            // need to escape path separators
+            $path = str_replace('/', '\/', trim($path, '/ '));
+            // need to make pseudo wildcard real
+            $path = strtolower(str_replace('*', '.*', $path));
+            // Does this rule apply here?
+            if (preg_match('#^' . $path . '$#', $uri, $match) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check except paths
+     *
+     * @param string       $uri   URI to check
+     * @param array|string $paths The except path patterns
+     *
+     * @return bool True if the URI matches except paths.
+     */
+    private function checkExcept(string $uri, $paths): bool
+    {
+        // empty path does not match anything
+        if (empty($paths)) {
+            return false;
         }
 
         // make sure the paths are iterable

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -553,8 +553,8 @@ class Filters
      */
     private function checkExcept(string $uri, $paths): bool
     {
-        // empty path does not match anything
-        if (empty($paths)) {
+        // empty array does not match anything
+        if ($paths === []) {
             return false;
         }
 

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -215,15 +215,23 @@ final class FiltersTest extends CIUnitTestCase
                 ['admin/*'],
             ],
             [
-                [],
+                ['admin/*', 'foo/*'],
+            ],
+            [
+                ['*'],
+            ],
+            [
+                'admin/*',
             ],
         ];
     }
 
     /**
      * @dataProvider provideProcessMethodProcessGlobalsWithExcept
+     *
+     * @param array|string $except
      */
-    public function testProcessMethodProcessGlobalsWithExcept(array $except): void
+    public function testProcessMethodProcessGlobalsWithExcept($except): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
 

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -639,6 +639,40 @@ final class FiltersTest extends CIUnitTestCase
         $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }
 
+    public function testBeforeExceptEmptyArray(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $config = [
+            'aliases' => [
+                'foo' => '',
+                'bar' => '',
+                'baz' => '',
+            ],
+            'globals' => [
+                'before' => [
+                    'foo' => ['except' => []],
+                    'bar',
+                ],
+                'after' => [
+                    'baz',
+                ],
+            ],
+        ];
+        $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
+        $filters       = $this->createFilters($filtersConfig);
+
+        $uri      = 'admin/foo/bar';
+        $expected = [
+            'before' => [
+                'foo',
+                'bar',
+            ],
+            'after' => ['baz'],
+        ];
+        $this->assertSame($expected, $filters->initialize($uri)->getFilters());
+    }
+
     public function testAfterExceptString(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -646,6 +646,52 @@ final class FiltersTest extends CIUnitTestCase
                     'after' => ['baz'],
                 ],
             ],
+            'empty string not exclude' => [
+                'admin/foo/bar',
+                // The URI path '' means the baseURL.
+                '',
+                [
+                    'before' => [
+                        'foo',
+                        'bar',
+                    ],
+                    'after' => ['baz'],
+                ],
+            ],
+            'empty string exclude' => [
+                // The URI path '' means the baseURL.
+                '',
+                // So this setting excludes `foo` filter only to the baseURL.
+                '',
+                [
+                    'before' => [
+                        'bar',
+                    ],
+                    'after' => ['baz'],
+                ],
+            ],
+            'slash not exclude' => [
+                'admin/foo/bar',
+                '/',
+                [
+                    'before' => [
+                        'foo',
+                        'bar',
+                    ],
+                    'after' => ['baz'],
+                ],
+            ],
+            'slash exclude' => [
+                // The URI path '' means the baseURL.
+                '',
+                '/',
+                [
+                    'before' => [
+                        'bar',
+                    ],
+                    'after' => ['baz'],
+                ],
+            ],
         ];
     }
 

--- a/user_guide_src/source/changelogs/v4.3.8.rst
+++ b/user_guide_src/source/changelogs/v4.3.8.rst
@@ -24,6 +24,12 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Controller Filters:** In previous versions, ``['except' => []]`` or ``['except' => '']``
+  meant "except all". The bug has been fixed, and now
+
+    - ``['except' => []]`` means to exclude nothing.
+    - ``['except' => '']`` means to exclude the baseURL only.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/7822#issuecomment-1678597588


This PR changes the behavior:
- `['except' => []]` means to exclude nothing.
- `['except' => '']` means to exclude baseURL only.
   - because the URI string `''` means the URI path for the baseURL.
   - when navigating to the baseURL, `uri_string()` returns `''`.

---

`['except' => []]` or `['except' => '']` means "except all" in the current code.
This behavior is unexpected, and not good for security.

If a dev comments out all items in `except` key accidentally, the filter will be disabled.
```php
['except' => [
    // 'foo/*',
    // 'bar/*',
]]
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
