### PR TITLE
Fix GPG key to trust in deploy api docs action

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Download latest phpDocumentor
         working-directory: source
-        run: sudo phive --no-progress install --global --trust-gpg-keys 67F861C3D889C656 phpDocumentor
+        run: sudo phive --no-progress install --global --trust-gpg-keys 8AC0BAA79732DD42 phpDocumentor
 
       - name: Prepare API repo
         working-directory: api


### PR DESCRIPTION
Fix below error in GitHub Action.

e.g. https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748

```
sudo phive --no-progress install --global --trust-gpg-keys 67F861C3D889C656 phpDocumentor
  shell: /usr/bin/bash -e {0}
  env:
    COMPOSER_PROCESS_TIMEOUT: 0
    COMPOSER_NO_INTERACTION: 1
    COMPOSER_NO_AUDIT: 1
Phive 0.15.2 - Copyright (C) 2015-202[3](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748#step:6:3) by Arne Blankerts, Sebastian Heuer and Contributors
Fetching repository list
Downloading https://phar.io/data/repositories.xml
Downloading https://api.github.com/repos/phpdocumentor/phpdocumentor2/releases?per_page=100
Downloading https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.[4](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748#step:6:4).0/phpDocumentor.phar
Downloading https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.4.0/phpDocumentor.phar.asc
Downloading key 8AC0BAA79732DD42
Trying to connect to keys.openpgp.org (37.218.24[5](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748#step:6:5).50)
Downloading https://keys.openpgp.org/pks/lookup?op=get&options=mr&search=0x8AC0BAA79732DD42
Successfully downloaded key.
Error:    Needs tty to be able to confirm

	Fingerprint: F33A 0AF[6](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748#step:6:6) 9AF[7](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748#step:6:7) A[8](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748#step:6:9)B1 5017 DB52 6DA3 ACC4 [9](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5886110536/job/15963492748#step:6:10)91F FAE5

	phpDocumentor <info@phpdoc.org>

	Created: 2019-07-26

Import this key? [y|N] 
Error: Process completed with exit code 4.
```