### PR TITLE
[GitHub Actions] Fix `deploy-apidocs.yml` for phpDocumentor usage

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Download latest phpDocumentor
         working-directory: source
-        run: sudo phive --no-progress install --global --trust-gpg-keys 8AC0BAA79732DD42 phpDocumentor
+        run: phive install --force-accept-unsigned phpDocumentor
 
       - name: Prepare API repo
         working-directory: api
@@ -61,7 +61,7 @@ jobs:
       - name: Build API in source repo
         working-directory: source
         run: |
-          phpDocumentor run --ansi --verbose
+          php tools/phpDocumentor run --ansi --verbose
           cp -R ${GITHUB_WORKSPACE}/source/api/build/* ${GITHUB_WORKSPACE}/api/docs
 
       - name: Deploy to API repo


### PR DESCRIPTION
**Description**
Follow-up #7832 

Fix GitHub Actions Error.

e.g. https://github.com/codeigniter4/CodeIgniter4/actions/runs/5887864586/job/15967978898
```
Run phpDocumentor run --ansi --verbose
PHP Warning:  require(phar:///usr/local/bin/phpDocumentor/bin/phpdoc): Failed to open stream: phar error: no directory in "phar:///usr/local/bin/phpDocumentor/bin/phpdoc", must have at least phar:///usr/local/bin/phpDocumentor/bin/phpdoc/ for root directory (always use full path to a new phar) in /usr/local/bin/phpDocumentor on line 10
PHP Fatal error:  Uncaught Error: Failed opening required 'phar:///usr/local/bin/phpDocumentor/bin/phpdoc' (include_path='.:/usr/share/php') in /usr/local/bin/phpDocumentor:10
Stack trace:
#0 {main}
  thrown in /usr/local/bin/phpDocumentor on line 10
Error: Process completed with exit code 255.
```

Fixed according to the official phpDocumentor documentation.

see also. https://github.com/phpDocumentor/phpDocumentor


This time, I checked the operation **completely** in the local development environment.

Sorry and Thanks.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
