### PR TITLE
[GitHub Actions] Use `--trust-gpg-keys` option and remove `--global` option for phpDocumentor installation

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Download latest phpDocumentor
         working-directory: source
-        run: phive install --force-accept-unsigned phpDocumentor
+        run: phive --no-progress install --trust-gpg-keys 8AC0BAA79732DD42 phpDocumentor
 
       - name: Prepare API repo
         working-directory: api


### PR DESCRIPTION
fixes #7821

**Description**
Use `--trust-gpg-keys` option and remove `--global` option for `phive install`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

ref. #7832, #7833