### PR TITLE
[GitHub Actions] Use PHP 8.1 for phpDocumentor

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           tools: phive
           coverage: none
 


### PR DESCRIPTION
**Description**
Fixes #7821

Use PHP 8.1 for phpDocumentor

fix this error: https://github.com/codeigniter4/CodeIgniter4/actions/runs/5889034105/job/15971401987


```
php tools/phpDocumentor run --ansi --verbose
  cp -R ${GITHUB_WORKSPACE}/source/api/build/* ${GITHUB_WORKSPACE}/api/docs
  shell: /usr/bin/bash -e {0}
  env:
    COMPOSER_PROCESS_TIMEOUT: 0
    COMPOSER_NO_INTERACTION: 1
    COMPOSER_NO_AUDIT: 1
Composer detected issues in your platform:

Your Composer dependencies require a PHP version ">= 8.1.0". You are running 8.0.29.

PHP Fatal error:  Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.1.0". You are running 8.0.29. in phar:///home/runner/.phive/phars/phpdocumentor-[3](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5889034105/job/15971401987#step:8:3).[4](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5889034105/job/15971401987#step:8:4).0.phar/vendor/composer/platform_check.php on line 24
Error: Process completed with exit code 2[5](https://github.com/codeigniter4/CodeIgniter4/actions/runs/5889034105/job/15971401987#step:8:5)5.
```
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
