### PR TITLE
[4.4] update cs and add missing `@return`

### DIFF
--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -47,6 +47,9 @@ class FrameworkException extends RuntimeException implements ExceptionInterface
         return new static(lang('Core.invalidDirectory', [$path]));
     }
 
+    /**
+     * @return static
+     */
     public static function forCopyError(string $path)
     {
         return new static(lang('Core.copyError', [$path]));

--- a/user_guide_src/source/outgoing/response/003.php
+++ b/user_guide_src/source/outgoing/response/003.php
@@ -6,5 +6,6 @@ $data = [
 ];
 
 return $this->response->setJSON($data);
+
 // or
 return $this->response->setXML($data);


### PR DESCRIPTION
**Description**
- update cs and add missing `@return`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
