### PR TITLE
Fix `spark migrate` issue with -g option

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -165,12 +165,13 @@ class MigrationRunner
             throw ConfigException::forDisabledMigrations();
         }
 
-        $this->ensureTable();
 
         if ($group !== null) {
             $this->groupFilter = $group;
             $this->setGroup($group);
         }
+
+        $this->ensureTable();
 
         $migrations = $this->findMigrations();
 


### PR DESCRIPTION
**Description**
Supersedes #7845

When performing a spark migrate with the -g option to use a different DBgroup other than the default, and when there's no default database configured, the migration fails. This is because `$this->ensureTable()` is executed before `$this->setGroup($group)`. I've simply moved `$this->ensureTable()` to execute after setting the group.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
