### PR TITLE
Prep for 4.3.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v4.3.8](https://github.com/codeigniter4/CodeIgniter4/tree/v4.3.8) (2023-08-25)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.3.7...v4.3.8)
+
+### Fixed Bugs
+
+* fix: [Pager] knocks down variables for View by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7758
+* fix: Model::insertBatch() causes error to non auto increment table by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7759
+* fix: [Model] updateBatch() may generate invalid SQL statement by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7787
+* fix: Model inserts cast $primaryKey value when using Entity by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7806
+* fix: instances of Validation rules are incremented each time `run()` is executed by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7815
+* fix: filter except empty by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7823
+* fix: `set_checkbox()` checks unchecked checkbox by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7818
+
+### Refactoring
+
+* Normalize data provider names by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/7656
+* refactor: remove Model::$tempPrimaryKeyValue by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7760
+* Remove unused cast on RedisHandler by @samsonasik in https://github.com/codeigniter4/CodeIgniter4/pull/7786
+
 ## [v4.3.7](https://github.com/codeigniter4/CodeIgniter4/tree/v4.3.7) (2023-07-30)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.3.6...v4.3.7)
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -48,7 +48,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.3.7';
+    public const CI_VERSION = '4.3.8';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/v4.3.8.rst
+++ b/user_guide_src/source/changelogs/v4.3.8.rst
@@ -1,7 +1,7 @@
 Version 4.3.8
 #############
 
-Release Date: August 25th, 2023
+Release Date: August 25, 2023
 
 **4.3.8 release of CodeIgniter4**
 

--- a/user_guide_src/source/changelogs/v4.3.8.rst
+++ b/user_guide_src/source/changelogs/v4.3.8.rst
@@ -1,25 +1,13 @@
 Version 4.3.8
 #############
 
-Release Date: Unreleased
+Release Date: August 25th, 2023
 
 **4.3.8 release of CodeIgniter4**
 
 .. contents::
     :local:
     :depth: 3
-
-BREAKING
-********
-
-Message Changes
-***************
-
-Changes
-*******
-
-Deprecations
-************
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2019-' + str(year_now) + ' CodeIgniter Foundation'
 version = '4.3'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.3.7'
+release = '4.3.8'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_438.rst
+++ b/user_guide_src/source/installation/upgrade_438.rst
@@ -12,15 +12,6 @@ Please refer to the upgrade instructions corresponding to your installation meth
     :local:
     :depth: 2
 
-Mandatory File Changes
-**********************
-
-Breaking Changes
-****************
-
-Breaking Enhancements
-*********************
-
 Project Files
 *************
 

--- a/user_guide_src/source/installation/upgrade_438.rst
+++ b/user_guide_src/source/installation/upgrade_438.rst
@@ -39,7 +39,7 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
-- @TODO
+- composer.json
 
 All Changes
 ===========
@@ -47,4 +47,4 @@ All Changes
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
+- composer.json


### PR DESCRIPTION
**Description**
Updates changelog and version references for 4.3.8.

Previous version: #7749
Release Code: TODO
New Changelog: TODO

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
