### PR TITLE
chore: fix validate-version

### DIFF
--- a/.github/scripts/validate-version
+++ b/.github/scripts/validate-version
@@ -10,7 +10,7 @@ FILES=("system/CodeIgniter.php" "user_guide_src/source/conf.py")
 LENGTH="${#FILES[@]}"
 
 for FILE in "${FILES[@]}"; do
-    COUNT="$((COUNT + $(grep -c "$FILE" -e "$1")))"
+    COUNT="$((COUNT + $(grep -c "$FILE" -e "'$1'")))"
 done
 
 if [[ $COUNT -ne $LENGTH ]]; then


### PR DESCRIPTION
**Description**
Fixes #7854

```console
$ bash .github/scripts/validate-version 4.4.0
CodeIgniter version is updated to v4.4.0
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
