### PR TITLE
fix: FeatureTest may cause risky tests

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -468,6 +468,8 @@ class CodeIgniter
 
             // If a ResponseInterface instance is returned then send it back to the client and stop
             if ($possibleResponse instanceof ResponseInterface) {
+                $this->outputBufferingEnd();
+
                 return $possibleResponse;
             }
 

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -51,7 +51,11 @@ trait FeatureTestTrait
             $collection->resetRoutes();
 
             foreach ($routes as $route) {
-                $collection->{$route[0]}($route[1], $route[2]);
+                if (isset($route[3])) {
+                    $collection->{$route[0]}($route[1], $route[2], $route[3]);
+                } else {
+                    $collection->{$route[0]}($route[1], $route[2]);
+                }
             }
         }
 

--- a/tests/_support/Config/Filters.php
+++ b/tests/_support/Config/Filters.php
@@ -11,5 +11,8 @@
 
 namespace Tests\Support\Config\Filters;
 
+/**
+ * @psalm-suppress UndefinedGlobalVariable
+ */
 $filters->aliases['test-customfilter']   = \Tests\Support\Filters\Customfilter::class;
 $filters->aliases['test-redirectfilter'] = \Tests\Support\Filters\RedirectFilter::class;

--- a/tests/_support/Config/Filters.php
+++ b/tests/_support/Config/Filters.php
@@ -11,4 +11,5 @@
 
 namespace Tests\Support\Config\Filters;
 
-$filters->aliases['test-customfilter'] = \Tests\Support\Filters\Customfilter::class;
+$filters->aliases['test-customfilter']   = \Tests\Support\Filters\Customfilter::class;
+$filters->aliases['test-redirectfilter'] = \Tests\Support\Filters\RedirectFilter::class;

--- a/tests/_support/Filters/RedirectFilter.php
+++ b/tests/_support/Filters/RedirectFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Filters;
+
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+
+class RedirectFilter implements \CodeIgniter\Filters\FilterInterface
+{
+    public function before(RequestInterface $request, $arguments = null)
+    {
+        return redirect()->to('login');
+    }
+
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void
+    {
+    }
+}

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -77,6 +77,21 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertSame('http://example.com/index.php/foo/bar/1/2/3', current_url());
     }
 
+    public function testCallGetAndFilterReturnsResponse(): void
+    {
+        $this->withRoutes([
+            [
+                'get',
+                'admin',
+                static fn () => 'Admin Area',
+                ['filter' => 'test-redirectfilter'],
+            ],
+        ]);
+        $response = $this->get('admin');
+
+        $response->assertRedirectTo('login');
+    }
+
     public function testClosureWithEcho()
     {
         $this->withRoutes([


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/shield/issues/802

```
1) Tests\Authentication\Filters\PermissionFilterTest::testFilterNotAuthorized
Test code or tested code did not (only) close its own output buffers
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
