### PR TITLE
fix: Factories may not return shared instance

### DIFF
--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -165,11 +165,6 @@ class Factories
         self::createInstance($options['component'], $class, $arguments);
         self::setAlias($options['component'], $alias, $class);
 
-        // If a short classname is specified, also register FQCN to share the instance.
-        if (! isset(self::$aliases[$options['component']][$class])) {
-            self::setAlias($options['component'], $class, $class);
-        }
-
         return self::$instances[$options['component']][$class];
     }
 
@@ -231,6 +226,11 @@ class Factories
     {
         self::$aliases[$component][$alias] = $class;
         self::$updated[$component]         = true;
+
+        // If a short classname is specified, also register FQCN to share the instance.
+        if (! isset(self::$aliases[$component][$class])) {
+            self::$aliases[$component][$class] = $class;
+        }
     }
 
     /**

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -162,9 +162,8 @@ class Factories
             return null;
         }
 
-        self::$instances[$options['component']][$class] = new $class(...$arguments);
-        self::$aliases[$options['component']][$alias]   = $class;
-        self::$updated[$options['component']]           = true;
+        self::createInstance($options['component'], $class, $arguments);
+        self::$aliases[$options['component']][$alias] = $class;
 
         // If a short classname is specified, also register FQCN to share the instance.
         if (! isset(self::$aliases[$options['component']][$class])) {
@@ -192,8 +191,7 @@ class Factories
                     return self::$instances[$options['component']][$class];
                 }
 
-                self::$instances[$options['component']][$class] = new $class(...$arguments);
-                self::$updated[$options['component']]           = true;
+                self::createInstance($options['component'], $class, $arguments);
 
                 return self::$instances[$options['component']][$class];
             }
@@ -216,6 +214,15 @@ class Factories
         }
 
         return null;
+    }
+
+    /**
+     * Creates the shared instance.
+     */
+    private static function createInstance(string $component, string $class, array $arguments): void
+    {
+        self::$instances[$component][$class] = new $class(...$arguments);
+        self::$updated[$component]           = true;
     }
 
     /**

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -163,11 +163,11 @@ class Factories
         }
 
         self::createInstance($options['component'], $class, $arguments);
-        self::$aliases[$options['component']][$alias] = $class;
+        self::setAlias($options['component'], $alias, $class);
 
         // If a short classname is specified, also register FQCN to share the instance.
         if (! isset(self::$aliases[$options['component']][$class])) {
-            self::$aliases[$options['component']][$class] = $class;
+            self::setAlias($options['component'], $class, $class);
         }
 
         return self::$instances[$options['component']][$class];
@@ -206,8 +206,7 @@ class Factories
         if (self::verifyInstanceOf($options, $class)) {
             // Check for an existing instance for the class
             if (isset(self::$instances[$options['component']][$class])) {
-                self::$aliases[$options['component']][$alias] = $class;
-                self::$updated[$options['component']]         = true;
+                self::setAlias($options['component'], $alias, $class);
 
                 return self::$instances[$options['component']][$class];
             }
@@ -223,6 +222,15 @@ class Factories
     {
         self::$instances[$component][$class] = new $class(...$arguments);
         self::$updated[$component]           = true;
+    }
+
+    /**
+     * Sets alias
+     */
+    private static function setAlias(string $component, string $alias, string $class): void
+    {
+        self::$aliases[$component][$alias] = $class;
+        self::$updated[$component]         = true;
     }
 
     /**

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -197,14 +197,11 @@ class Factories
             return null;
         }
 
-        // Need to verify if the shared instance matches the request
-        if (self::verifyInstanceOf($options, $class)) {
-            // Check for an existing instance for the class
-            if (isset(self::$instances[$options['component']][$class])) {
-                self::setAlias($options['component'], $alias, $class);
+        // Check for an existing instance for the class
+        if (isset(self::$instances[$options['component']][$class])) {
+            self::setAlias($options['component'], $alias, $class);
 
-                return self::$instances[$options['component']][$class];
-            }
+            return self::$instances[$options['component']][$class];
         }
 
         return null;

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -142,6 +142,7 @@ class Factories
                 return new $class(...$arguments);
             }
 
+            // Try to locate the class
             if ($class = self::locateClass($options, $alias)) {
                 return new $class(...$arguments);
             }
@@ -179,6 +180,7 @@ class Factories
      */
     private static function getDefinedInstance(array $options, string $alias, array $arguments)
     {
+        // The alias is already defined.
         if (isset(self::$aliases[$options['component']][$alias])) {
             $class = self::$aliases[$options['component']][$alias];
 
@@ -190,6 +192,21 @@ class Factories
                 }
 
                 self::$instances[$options['component']][$class] = new $class(...$arguments);
+
+                return self::$instances[$options['component']][$class];
+            }
+        }
+
+        // Try to locate the class
+        if (! $class = self::locateClass($options, $alias)) {
+            return null;
+        }
+
+        // Need to verify if the shared instance matches the request
+        if (self::verifyInstanceOf($options, $class)) {
+            // Check for an existing instance for the class
+            if (isset(self::$instances[$options['component']][$class])) {
+                self::$aliases[$options['component']][$alias] = $class;
 
                 return self::$instances[$options['component']][$class];
             }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -228,7 +228,7 @@ class Factories
         self::$updated[$component]         = true;
 
         // If a short classname is specified, also register FQCN to share the instance.
-        if (! isset(self::$aliases[$component][$class])) {
+        if (! isset(self::$aliases[$component][$class]) && ! self::isNamespaced($alias)) {
             self::$aliases[$component][$class] = $class;
         }
     }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -118,6 +118,7 @@ class Factories
         self::getOptions($component);
 
         self::$aliases[$component][$alias] = $classname;
+        self::$updated[$component]         = true;
     }
 
     /**
@@ -192,6 +193,7 @@ class Factories
                 }
 
                 self::$instances[$options['component']][$class] = new $class(...$arguments);
+                self::$updated[$options['component']]           = true;
 
                 return self::$instances[$options['component']][$class];
             }
@@ -207,6 +209,7 @@ class Factories
             // Check for an existing instance for the class
             if (isset(self::$instances[$options['component']][$class])) {
                 self::$aliases[$options['component']][$alias] = $class;
+                self::$updated[$options['component']]         = true;
 
                 return self::$instances[$options['component']][$class];
             }

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Config;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\App;
 use Config\Database;
 use InvalidArgumentException;
 use ReflectionClass;
@@ -320,6 +321,14 @@ final class FactoriesTest extends CIUnitTestCase
         $cell2 = Factories::cells('\\' . \Tests\Support\View\OtherCells\SampleClass::class);
 
         $this->assertNotSame($cell1, $cell2);
+    }
+
+    public function testCanLoadSharedConfigWithDifferentAlias()
+    {
+        $config1 = Factories::config(App::class);
+        $config2 = Factories::config('App');
+
+        $this->assertSame($config1, $config2);
     }
 
     public function testDefineSameAliasTwiceWithDifferentClasses()


### PR DESCRIPTION
**Description**
If you call `config(AuthJWT::class)` (FQCN) and after that, call `config('AuthJWT')` (shortname),
the new instance is returned even if both are exactly the same class.
And the first shared instance is replaced with the next one.

See https://github.com/codeigniter4/shield/issues/802

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
