### PR TITLE
docs: add @immutable to Config classes that do not extend BaseConfig

### DIFF
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -17,6 +17,8 @@ use CodeIgniter\Config\AutoloadConfig;
  *
  * NOTE: This class is required prior to Autoloader instantiation,
  *       and does not extend BaseConfig.
+ *
+ * @immutable
  */
 class Autoload extends AutoloadConfig
 {

--- a/app/Config/DocTypes.php
+++ b/app/Config/DocTypes.php
@@ -2,6 +2,9 @@
 
 namespace Config;
 
+/**
+ * @immutable
+ */
 class DocTypes
 {
     /**

--- a/app/Config/ForeignCharacters.php
+++ b/app/Config/ForeignCharacters.php
@@ -4,6 +4,9 @@ namespace Config;
 
 use CodeIgniter\Config\ForeignCharacters as BaseForeignCharacters;
 
+/**
+ * @immutable
+ */
 class ForeignCharacters extends BaseForeignCharacters
 {
 }

--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -15,6 +15,8 @@ namespace Config;
  *
  * When working with mime types, please make sure you have the ´fileinfo´
  * extension enabled to reliably detect the media types.
+ *
+ * @immutable
  */
 class Mimes
 {

--- a/app/Config/Modules.php
+++ b/app/Config/Modules.php
@@ -9,6 +9,8 @@ use CodeIgniter\Modules\Modules as BaseModules;
  *
  * NOTE: This class is required prior to Autoloader instantiation,
  *       and does not extend BaseConfig.
+ *
+ * @immutable
  */
 class Modules extends BaseModules
 {


### PR DESCRIPTION
**Description**
There is no reason to change the values after the instantiation.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
