### PR TITLE
docs: replace type mixed in DB Utils

### DIFF
--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -260,7 +260,7 @@ abstract class BaseUtils
      *
      * @param array|string $params
      *
-     * @return mixed
+     * @return false|never|string
      *
      * @throws DatabaseException
      */
@@ -316,7 +316,7 @@ abstract class BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @return mixed
+     * @return false|never|string
      */
     abstract public function _backup(?array $prefs = null);
 }

--- a/system/Database/MySQLi/Utils.php
+++ b/system/Database/MySQLi/Utils.php
@@ -36,7 +36,7 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @return mixed
+     * @return never
      */
     public function _backup(?array $prefs = null)
     {

--- a/system/Database/OCI8/Utils.php
+++ b/system/Database/OCI8/Utils.php
@@ -29,7 +29,7 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @return mixed
+     * @return never
      */
     public function _backup(?array $prefs = null)
     {

--- a/system/Database/Postgre/Utils.php
+++ b/system/Database/Postgre/Utils.php
@@ -36,7 +36,7 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @return mixed
+     * @return never
      */
     public function _backup(?array $prefs = null)
     {

--- a/system/Database/SQLSRV/Utils.php
+++ b/system/Database/SQLSRV/Utils.php
@@ -44,7 +44,7 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @return mixed
+     * @return never
      */
     public function _backup(?array $prefs = null)
     {

--- a/system/Database/SQLite3/Utils.php
+++ b/system/Database/SQLite3/Utils.php
@@ -29,7 +29,7 @@ class Utils extends BaseUtils
     /**
      * Platform dependent version of the backup function.
      *
-     * @return mixed
+     * @return never
      */
     public function _backup(?array $prefs = null)
     {


### PR DESCRIPTION
**Description**
See #6310

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
