### PR TITLE
fix: replace `config(DocTypes::class)` with `new DocTypes()`

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -890,7 +890,8 @@ if (! function_exists('_solidus')) {
      */
     function _solidus(): string
     {
-        if (config(DocTypes::class)->html5 ?? false) {
+        $docTypes = new DocTypes();
+        if ($docTypes->html5 ?? false) {
             return '';
         }
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -886,11 +886,20 @@ if (! function_exists('_solidus')) {
     /**
      * Generates the solidus character (`/`) depending on the HTML5 compatibility flag in `Config\DocTypes`
      *
+     * @param DocTypes|null $docTypesConfig New config. For testing purpose only.
+     *
      * @internal
      */
-    function _solidus(): string
+    function _solidus(?DocTypes $docTypesConfig = null): string
     {
-        $docTypes = new DocTypes();
+        static $docTypes = null;
+
+        if ($docTypesConfig !== null) {
+            $docTypes = $docTypesConfig;
+        }
+
+        $docTypes ??= new DocTypes();
+
         if ($docTypes->html5 ?? false) {
             return '';
         }

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -323,10 +323,11 @@ class Typography
      */
     public function nl2brExceptPre(string $str): string
     {
-        $newstr = '';
+        $newstr   = '';
+        $docTypes = new DocTypes();
 
         for ($ex = explode('pre>', $str), $ct = count($ex), $i = 0; $i < $ct; $i++) {
-            $xhtml = ! (config(DocTypes::class)->html5 ?? false);
+            $xhtml = ! ($docTypes->html5 ?? false);
             $newstr .= (($i % 2) === 0) ? nl2br($ex[$i], $xhtml) : $ex[$i];
 
             if ($ct - 1 !== $i) {

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -31,6 +31,7 @@ use CodeIgniter\Test\Mock\MockSession;
 use CodeIgniter\Test\TestLogger;
 use Config\App;
 use Config\Cookie;
+use Config\DocTypes;
 use Config\Logger;
 use Config\Modules;
 use Config\Routing;
@@ -180,14 +181,24 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testSolidusElementXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $this->assertSame(' /', _solidus());
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
+    }
+
+    private function disableHtml5()
+    {
+        $doctypes        = new DocTypes();
+        $doctypes->html5 = false;
+        _solidus($doctypes);
+    }
+
+    private function enableHtml5()
+    {
+        $doctypes = new DocTypes();
+        _solidus($doctypes);
     }
 
     public function testView(): void

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Helpers;
 use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use Config\DocTypes;
 use Config\Filters;
 use Config\Services;
 
@@ -262,9 +263,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormInputXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<EOH
             <input type="text" name="username" value="johndoe" id="username" maxlength="100" size="50" style="width:50%" />\n
@@ -279,8 +278,20 @@ final class FormHelperTest extends CIUnitTestCase
         ];
         $this->assertSame($expected, form_input($data));
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
+    }
+
+    private function disableHtml5()
+    {
+        $doctypes        = new DocTypes();
+        $doctypes->html5 = false;
+        _solidus($doctypes);
+    }
+
+    private function enableHtml5()
+    {
+        $doctypes = new DocTypes();
+        _solidus($doctypes);
     }
 
     public function testFormInputWithExtra(): void
@@ -317,17 +328,14 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormUploadXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<EOH
             <input type="file" name="attachment" />\n
             EOH;
         $this->assertSame($expected, form_upload('attachment'));
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testFormTextarea(): void
@@ -656,17 +664,14 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testFormCheckboxXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<EOH
             <input type="checkbox" name="newsletter" value="accept" checked="checked" />\n
             EOH;
         $this->assertSame($expected, form_checkbox('newsletter', 'accept', true));
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testFormCheckboxArrayData(): void

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use Config\DocTypes;
 
 /**
  * @internal
@@ -206,41 +207,48 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testIMGXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $target   = 'http://site.com/images/picture.jpg';
         $expected = '<img src="http://site.com/images/picture.jpg" alt="" />';
         $this->assertSame($expected, img($target));
 
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
+    }
+
+    private function disableHtml5()
+    {
+        $doctypes        = new DocTypes();
+        $doctypes->html5 = false;
+        _solidus($doctypes);
+    }
+
+    private function enableHtml5()
+    {
+        $doctypes = new DocTypes();
+        _solidus($doctypes);
     }
 
     public function testIMGXHTMLWithoutProtocol(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $target   = 'assets/mugshot.jpg';
         $expected = '<img src="http://example.com/assets/mugshot.jpg" alt="" />';
         $this->assertSame($expected, img($target));
 
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testIMGXHTMLWithIndexpage(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $target   = 'assets/mugshot.jpg';
         $expected = '<img src="http://example.com/index.php/assets/mugshot.jpg" alt="" />';
         $this->assertSame($expected, img($target, true));
 
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testImgData(): void
@@ -355,16 +363,13 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testLinkTagXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $target   = 'css/mystyles.css';
         $expected = '<link href="http://example.com/css/mystyles.css" rel="stylesheet" type="text/css" />';
         $this->assertSame($expected, link_tag($target));
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testLinkTagMedia(): void
@@ -509,9 +514,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testVideoWithTracksXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<'EOH'
             <video src="http://example.com/test.mp4" controls>
@@ -531,8 +534,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $video = video($target, $message, 'controls', $tracks);
         $this->assertSame($expected, $video);
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testVideoWithTracksAndIndex(): void
@@ -581,9 +583,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testVideoMultipleSourcesXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<'EOH'
             <video class="test" controls>
@@ -613,8 +613,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
         $this->assertSame($expected, $video);
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testAudio(): void
@@ -642,9 +641,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testAudioXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<'EOH'
             <audio id="test" controls>
@@ -670,8 +667,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
         $this->assertSame($expected, $audio);
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testAudioSimple(): void
@@ -774,15 +770,12 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testSourceXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = '<source src="http://example.com/index.php/sound.mpeg" type="audio/mpeg" />';
         $this->assertSame($expected, source('sound.mpeg', 'audio/mpeg', '', true));
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testEmbed(): void
@@ -799,9 +792,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testEmbedXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<'EOH'
             <embed src="http://example.com/movie.mov" type="video/quicktime" class="test" />
@@ -812,8 +803,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $embed = embed('movie.mov', $type, 'class="test"');
         $this->assertSame($expected, $embed);
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testEmbedIndexed(): void
@@ -862,9 +852,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
     public function testObjectWithParamsXHTML(): void
     {
-        $doctypes        = config('DocTypes');
-        $default         = $doctypes->html5;
-        $doctypes->html5 = false;
+        $this->disableHtml5();
 
         $expected = <<<'EOH'
             <object data="http://example.com/movie.swf" class="test">
@@ -882,8 +870,7 @@ final class HTMLHelperTest extends CIUnitTestCase
         $object = object('movie.swf', $type, 'class="test"', $parms);
         $this->assertSame($expected, $object);
 
-        // Reset
-        $doctypes->html5 = $default;
+        $this->enableHtml5();
     }
 
     public function testObjectIndexed(): void


### PR DESCRIPTION
**Description**
Supersedes #7860

- fix the error "FactoriesCache undefined method Config\DocTypes::__set_state" when using Config Caching and html helper.
- change `_solidus()` for testing.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
