### PR TITLE
Prep for 4.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v4.4.1](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.1) (2023-09-05)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.0...v4.4.1)
+
+### Fixed Bugs
+
+* docs: add missing Config updates for Hot Reloading by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7862
+* fix: auto route legacy does not work by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7871
+* fix: Factories may not return shared instance by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7868
+* fix: replace `config(DocTypes::class)` with `new DocTypes()` by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7872
+* fix: FeatureTest may cause risky tests by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7867
+* fix: reverse routing causes ErrorException by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7880
+* fix: Email library forces to switch to TLS when setting port 465 by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7883
+* fix: [DebugBar] make CSS rotate class less broad by @sanchawebo in https://github.com/codeigniter4/CodeIgniter4/pull/7882
+* fix: FeatureTest fails when forceGlobalSecureRequests is true by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/7890
+
 ## [v4.4.0](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.0) (2023-08-25)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.3.8...v4.4.0)
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -52,7 +52,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.4.0';
+    public const CI_VERSION = '4.4.1';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/v4.4.1.rst
+++ b/user_guide_src/source/changelogs/v4.4.1.rst
@@ -1,25 +1,13 @@
 Version 4.4.1
 #############
 
-Release Date: Unreleased
+Release Date: September 5, 2023
 
 **4.4.1 release of CodeIgniter4**
 
 .. contents::
     :local:
     :depth: 3
-
-BREAKING
-********
-
-Message Changes
-***************
-
-Changes
-*******
-
-Deprecations
-************
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.4.1.rst
+++ b/user_guide_src/source/changelogs/v4.4.1.rst
@@ -24,6 +24,11 @@ Deprecations
 Bugs Fixed
 **********
 
+- **AutoRouting Legacy:** Fixed a bug that Auto Routing Legacy does not work.
+- **FeatureTest:**
+    - Fixed a bug that FeatureTest may cause risky tests.
+    - Fixed a bug that FeatureTest fails when forceGlobalSecureRequests is true.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2019-' + str(year_now) + ' CodeIgniter Foundation'
 version = '4.4'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.4.0'
+release = '4.4.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_441.rst
+++ b/user_guide_src/source/installation/upgrade_441.rst
@@ -12,15 +12,6 @@ Please refer to the upgrade instructions corresponding to your installation meth
     :local:
     :depth: 2
 
-Mandatory File Changes
-**********************
-
-Breaking Changes
-****************
-
-Breaking Enhancements
-*********************
-
 Project Files
 *************
 
@@ -33,13 +24,7 @@ the project space: `Explore on Packagist <https://packagist.org/explore/?query=c
 Content Changes
 ===============
 
-The following files received significant changes (including deprecations or visual adjustments)
-and it is recommended that you merge the updated versions with your application:
-
-Config
-------
-
-- @TODO
+Version 4.4.1 did not alter any executable code in project files.
 
 All Changes
 ===========
@@ -47,4 +32,10 @@ All Changes
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
+- app/Config/Autoload.php
+- app/Config/DocTypes.php
+- app/Config/Email.php
+- app/Config/ForeignCharacters.php
+- app/Config/Mimes.php
+- app/Config/Modules.php
+- composer.json


### PR DESCRIPTION
**Description**
Updates changelog and version references for 4.4.1.

Previous version: #7852
Release Code: TODO
New Changelog: TODO

TODO:
- [x] #7890
- [x] #7867
- [x] #7872
- [x] #7868 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
