### PR TITLE
docs: fix or remove @param

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -177,7 +177,7 @@ class CLI
      * Named options must be in the following formats:
      * php index.php user -v --v -name=John --name=John
      *
-     * @param string $prefix
+     * @param string $prefix You may specify a string with which to prompt the user.
      */
     public static function input(?string $prefix = null): string
     {

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -781,7 +781,7 @@ class Services extends BaseService
     /**
      * The URI class provides a way to model and manipulate URIs.
      *
-     * @param string $uri
+     * @param string|null $uri The URI string
      *
      * @return URI The current URI if $uri is null.
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -706,7 +706,6 @@ class BaseBuilder
      *
      * @param array|RawSql|string $key
      * @param mixed               $value
-     * @param bool                $escape
      *
      * @return $this
      */

--- a/system/Database/Migration.php
+++ b/system/Database/Migration.php
@@ -41,8 +41,6 @@ abstract class Migration
 
     /**
      * Constructor.
-     *
-     * @param Forge $forge
      */
     public function __construct(?Forge $forge = null)
     {
@@ -53,8 +51,6 @@ abstract class Migration
 
     /**
      * Returns the database group name this migration uses.
-     *
-     * @return string
      */
     public function getDBGroup(): ?string
     {

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -167,8 +167,6 @@ class Query implements QueryInterface
      * for it's start and end values. If no end value is present, will
      * use the current time to determine total duration.
      *
-     * @param float $end
-     *
      * @return $this
      */
     public function setDuration(float $start, ?float $end = null)

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -346,9 +346,6 @@ class Toolbar
     /**
      * Prepare for debugging..
      *
-     * @param RequestInterface  $request
-     * @param ResponseInterface $response
-     *
      * @return void
      */
     public function prepare(?RequestInterface $request = null, ?ResponseInterface $response = null)

--- a/system/Encryption/Exceptions/EncryptionException.php
+++ b/system/Encryption/Exceptions/EncryptionException.php
@@ -45,8 +45,6 @@ class EncryptionException extends RuntimeException implements ExceptionInterface
     /**
      * Thrown when the handler requested is unknown.
      *
-     * @param string $driver
-     *
      * @return static
      */
     public static function forUnKnownHandler(?string $driver = null)

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -136,7 +136,7 @@ class Entity implements JsonSerializable
      * properties, using any `setCamelCasedProperty()` methods
      * that may or may not exist.
      *
-     * @param array $data
+     * @param array<string, array|bool|float|int|object|string|null> $data
      *
      * @return $this
      */

--- a/system/Format/Exceptions/FormatException.php
+++ b/system/Format/Exceptions/FormatException.php
@@ -36,7 +36,7 @@ class FormatException extends RuntimeException implements ExceptionInterface
      * Thrown in JSONFormatter when the json_encode produces
      * an error code other than JSON_ERROR_NONE and JSON_ERROR_RECURSION.
      *
-     * @param string $error
+     * @param string $error The error message
      *
      * @return static
      */

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -778,8 +778,6 @@ class URI
     /**
      * Sets the port portion of the URI.
      *
-     * @param int $port
-     *
      * @return $this
      *
      * @TODO PSR-7: Should be `withPort($port)`.

--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -112,8 +112,6 @@ class UserAgent
 
     /**
      * Is Browser
-     *
-     * @param string $key
      */
     public function isBrowser(?string $key = null): bool
     {
@@ -132,8 +130,6 @@ class UserAgent
 
     /**
      * Is Robot
-     *
-     * @param string $key
      */
     public function isRobot(?string $key = null): bool
     {
@@ -152,8 +148,6 @@ class UserAgent
 
     /**
      * Is Mobile
-     *
-     * @param string $key
      */
     public function isMobile(?string $key = null): bool
     {

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -549,8 +549,6 @@ abstract class BaseHandler implements ImageHandlerInterface
      *  - bottom
      *  - bottom-right
      *
-     * @param int $height
-     *
      * @return BaseHandler
      */
     public function fit(int $width, ?int $height = null, string $position = 'center')

--- a/system/Images/ImageHandlerInterface.php
+++ b/system/Images/ImageHandlerInterface.php
@@ -132,7 +132,7 @@ interface ImageHandlerInterface
      *    $image->resize(100, 200, true)
      *          ->save($target);
      *
-     * @param string $target
+     * @param string|null $target The path to save the file to.
      *
      * @return bool
      */

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -149,8 +149,6 @@ class ChromeLoggerHandler extends BaseHandler
     /**
      * Attaches the header and the content to the passed in request object.
      *
-     * @param ResponseInterface $response
-     *
      * @return void
      */
     public function sendLogs(?ResponseInterface &$response = null)

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -387,8 +387,6 @@ class Pager implements PagerInterface
     /**
      * Ensures that an array exists for the group specified.
      *
-     * @param int $perPage
-     *
      * @return void
      */
     protected function ensureGroup(string $group, ?int $perPage = null)

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -28,8 +28,9 @@ interface RouteCollectionInterface
     /**
      * Adds a single route to the collection.
      *
-     * @param array|Closure|string $to
-     * @param array                $options
+     * @param string               $from    The route path (with placeholders or regex)
+     * @param array|Closure|string $to      The route handler
+     * @param array|null           $options The route options
      *
      * @return RouteCollectionInterface
      */
@@ -44,7 +45,7 @@ interface RouteCollectionInterface
      * multiple placeholders added at once.
      *
      * @param array|string $placeholder
-     * @param string       $pattern
+     * @param string|null  $pattern     The regex pattern
      *
      * @return RouteCollectionInterface
      */

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -101,9 +101,6 @@ class DOMParser
 
     /**
      * Checks to see if the text is found within the result.
-     *
-     * @param string $search
-     * @param string $element
      */
     public function see(?string $search = null, ?string $element = null): bool
     {
@@ -121,8 +118,6 @@ class DOMParser
 
     /**
      * Checks to see if the text is NOT found within the result.
-     *
-     * @param string $search
      */
     public function dontSee(?string $search = null, ?string $element = null): bool
     {

--- a/system/Test/FeatureTestCase.php
+++ b/system/Test/FeatureTestCase.php
@@ -51,8 +51,6 @@ class FeatureTestCase extends CIUnitTestCase
      *    ['get', 'home', 'Home::index']
      * ]
      *
-     * @param array $routes
-     *
      * @return $this
      */
     protected function withRoutes(?array $routes = null)

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -39,7 +39,7 @@ trait FeatureTestTrait
      *    ['get', 'home', 'Home::index']
      * ]
      *
-     * @param array $routes
+     * @param array|null $routes Array to set routes
      *
      * @return $this
      */

--- a/system/Validation/CreditCardRules.php
+++ b/system/Validation/CreditCardRules.php
@@ -236,8 +236,6 @@ class CreditCardRules
 
     /**
      * Checks the given number to see if the number passing a Luhn check.
-     *
-     * @param string $number
      */
     protected function isValidLuhn(?string $number = null): bool
     {

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -176,8 +176,6 @@ class FormatRules
      * timezone_identifiers_list function.
      *
      * @see http://php.net/manual/en/datetimezone.listidentifiers.php
-     *
-     * @param string $str
      */
     public function timezone(?string $str = null): bool
     {
@@ -189,8 +187,6 @@ class FormatRules
      *
      * Tests a string for characters outside of the Base64 alphabet
      * as defined by RFC 2045 http://www.faqs.org/rfcs/rfc2045
-     *
-     * @param string $str
      */
     public function valid_base64(?string $str = null): bool
     {
@@ -203,8 +199,6 @@ class FormatRules
 
     /**
      * Valid JSON
-     *
-     * @param string $str
      */
     public function valid_json(?string $str = null): bool
     {
@@ -215,8 +209,6 @@ class FormatRules
 
     /**
      * Checks for a correctly formatted email address
-     *
-     * @param string $str
      */
     public function valid_email(?string $str = null): bool
     {
@@ -233,8 +225,6 @@ class FormatRules
      *
      * Example:
      *     valid_emails[one@example.com,two@example.com]
-     *
-     * @param string $str
      */
     public function valid_emails(?string $str = null): bool
     {

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -204,8 +204,6 @@ class Rules
 
     /**
      * Does not equal the static value provided.
-     *
-     * @param string $str
      */
     public function not_equals(?string $str, string $val): bool
     {
@@ -214,8 +212,6 @@ class Rules
 
     /**
      * Value should not be within an array of values.
-     *
-     * @param string $value
      */
     public function not_in_list(?string $value, string $list): bool
     {

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -28,7 +28,7 @@ class Services extends BaseServices
     /**
      * The URI class provides a way to model and manipulate URIs.
      *
-     * @param string $uri
+     * @param string|null $uri The URI string
      *
      * @return URI
      */


### PR DESCRIPTION
**Description**
php-cs-fixer has been modified to remove these tags.

```
  23) tests/_support/Config/Services.php (no_superfluous_phpdoc_tags, phpdoc_trim_consecutive_blank_line_separation)
      ---------- begin diff ----------
--- /home/runner/work/CodeIgniter4/CodeIgniter4/tests/_support/Config/Services.php
+++ /home/runner/work/CodeIgniter4/CodeIgniter4/tests/_support/Config/Services.php
@@ -28,8 +28,6 @@
     /**
      * The URI class provides a way to model and manipulate URIs.
      *
-     * @param string $uri
-     *
      * @return URI
      */
     public static function uri(?string $uri = null, bool $getShared = true)

      ----------- end diff -----------


Found 23 of 875 files that can be fixed in 92.546 seconds, 46.000 MB memory used
Error: Process completed with exit code 8.
```
See https://github.com/codeigniter4/CodeIgniter4/actions/runs/6018752536/job/16327489927#step:8:487

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
