### PR TITLE
[DebugBar] Rotate-class fix

### DIFF
--- a/admin/css/debug-toolbar/toolbar.scss
+++ b/admin/css/debug-toolbar/toolbar.scss
@@ -204,9 +204,9 @@
         z-index: 10000;
         // Endless Rotate
         .rotate {
-            animation: rotate 9s linear infinite;
+            animation: toolbar-rotate 9s linear infinite;
         }
-        @keyframes rotate {
+        @keyframes toolbar-rotate {
             to {
                 transform: rotate(360deg);
             }

--- a/admin/css/debug-toolbar/toolbar.scss
+++ b/admin/css/debug-toolbar/toolbar.scss
@@ -202,6 +202,15 @@
         // Give room for OS X scrollbar
         white-space: nowrap;
         z-index: 10000;
+        // Endless Rotate
+        .rotate {
+            animation: rotate 9s linear infinite;
+        }
+        @keyframes rotate {
+            to {
+                transform: rotate(360deg);
+            }
+        }
     }
 
     // Fixed top
@@ -500,14 +509,4 @@
 
 .debug-bar-noverflow {
     overflow: hidden;
-}
-
-/* ENDLESS ROTATE */
-.rotate {
-    animation: rotate 9s linear infinite;
-}
-@keyframes rotate {
-    to {
-        transform: rotate(360deg);
-    }
 }

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -141,9 +141,9 @@
   z-index: 10000;
 }
 #debug-bar .toolbar .rotate {
-  animation: rotate 9s linear infinite;
+  animation: toolbar-rotate 9s linear infinite;
 }
-@keyframes rotate {
+@keyframes toolbar-rotate {
   to {
     transform: rotate(360deg);
   }

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -140,6 +140,14 @@
   white-space: nowrap;
   z-index: 10000;
 }
+#debug-bar .toolbar .rotate {
+  animation: rotate 9s linear infinite;
+}
+@keyframes rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
 #debug-bar.fixed-top {
   bottom: auto;
   top: 0;
@@ -795,15 +803,4 @@
 
 .debug-bar-noverflow {
   overflow: hidden;
-}
-
-/* ENDLESS ROTATE */
-.rotate {
-  animation: rotate 9s linear infinite;
-}
-
-@keyframes rotate {
-  to {
-    transform: rotate(360deg);
-  }
 }


### PR DESCRIPTION
**Description**
Reduces the scope of the hot reload class `.rotate`.
- Changed from `.rotate` to `#debug-bar .toolbar .rotate`.
- Made animation-name less broad (`toolbar-rotate`).

Fixes #7875 