### PR TITLE
fix: add types to View $filters and $plugins

### DIFF
--- a/app/Config/View.php
+++ b/app/Config/View.php
@@ -5,6 +5,10 @@ namespace Config;
 use CodeIgniter\Config\View as BaseView;
 use CodeIgniter\View\ViewDecoratorInterface;
 
+/**
+ * @phpstan-type ParserCallable (callable(mixed): mixed)
+ * @phpstan-type ParserCallableString (callable(mixed): mixed)&string
+ */
 class View extends BaseView
 {
     /**
@@ -30,7 +34,8 @@ class View extends BaseView
      *  { title|esc(js) }
      *  { created_on|date(Y-m-d)|esc(attr) }
      *
-     * @var array
+     * @var array<string, string>
+     * @phpstan-var array<string, ParserCallableString>
      */
     public $filters = [];
 
@@ -39,7 +44,8 @@ class View extends BaseView
      * by the core Parser by creating aliases that will be replaced with
      * any callable. Can be single or tag pair.
      *
-     * @var array
+     * @var array<string, array<string>|callable|string>
+     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
      */
     public $plugins = [];
 

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2,16 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-	'message' => '#^PHPDoc type array of property Config\\\\View\\:\\:\\$filters is not covariant with PHPDoc type array\\<string, callable\\-string\\> of overridden property CodeIgniter\\\\Config\\\\View\\:\\:\\$filters\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/app/Config/View.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array of property Config\\\\View\\:\\:\\$plugins is not covariant with PHPDoc type array\\<string, callable\\-string\\> of overridden property CodeIgniter\\\\Config\\\\View\\:\\:\\$plugins\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/app/Config/View.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\BaseModel\\:\\:chunk\\(\\) has parameter \\$userFunc with no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/BaseModel.php',
@@ -255,26 +245,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\ComposerScripts\\:\\:postUpdate\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/ComposerScripts.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Config\\\\View\\:\\:\\$coreFilters type has no signature specified for callable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Config/View.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Config\\\\View\\:\\:\\$corePlugins type has no signature specified for callable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Config/View.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Config\\\\View\\:\\:\\$filters type has no signature specified for callable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Config/View.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Config\\\\View\\:\\:\\$plugins type has no signature specified for callable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Config/View.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:_whereIn\\(\\) has parameter \\$values with no signature specified for Closure\\.$#',
@@ -1703,11 +1673,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\View\\\\Parser\\:\\:addPlugin\\(\\) has parameter \\$callback with no signature specified for callable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/View/Parser.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property Config\\\\View\\:\\:\\$plugins \\(array\\) on left side of \\?\\? is not nullable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/View/Parser.php',
 ];

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+  <file src="app/Config/View.php">
+    <UndefinedDocblockClass>
+      <code><![CDATA[array<string, ParserCallableString>]]></code>
+      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code>public $filters = [];</code>
+      <code>public $plugins = [];</code>
+      <code>public $plugins = [];</code>
+    </UndefinedDocblockClass>
+  </file>
   <file src="system/Cache/FactoriesCache/FileVarExportHandler.php">
     <UndefinedVariable>
       <code>$val</code>
@@ -26,6 +36,60 @@
       <code>$routeWithoutController</code>
       <code>$routeWithoutController</code>
     </DuplicateArrayKey>
+  </file>
+  <file src="system/Config/View.php">
+    <UndefinedDocblockClass>
+      <code><![CDATA[array<string, ParserCallableString>]]></code>
+      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code><![CDATA[protected $coreFilters = [
+        'abs'            => '\abs',
+        'capitalize'     => '\CodeIgniter\View\Filters::capitalize',
+        'date'           => '\CodeIgniter\View\Filters::date',
+        'date_modify'    => '\CodeIgniter\View\Filters::date_modify',
+        'default'        => '\CodeIgniter\View\Filters::default',
+        'esc'            => '\CodeIgniter\View\Filters::esc',
+        'excerpt'        => '\CodeIgniter\View\Filters::excerpt',
+        'highlight'      => '\CodeIgniter\View\Filters::highlight',
+        'highlight_code' => '\CodeIgniter\View\Filters::highlight_code',
+        'limit_words'    => '\CodeIgniter\View\Filters::limit_words',
+        'limit_chars'    => '\CodeIgniter\View\Filters::limit_chars',
+        'local_currency' => '\CodeIgniter\View\Filters::local_currency',
+        'local_number'   => '\CodeIgniter\View\Filters::local_number',
+        'lower'          => '\strtolower',
+        'nl2br'          => '\CodeIgniter\View\Filters::nl2br',
+        'number_format'  => '\number_format',
+        'prose'          => '\CodeIgniter\View\Filters::prose',
+        'round'          => '\CodeIgniter\View\Filters::round',
+        'strip_tags'     => '\strip_tags',
+        'title'          => '\CodeIgniter\View\Filters::title',
+        'upper'          => '\strtoupper',
+    ];]]></code>
+      <code><![CDATA[protected $corePlugins = [
+        'csp_script_nonce'  => '\CodeIgniter\View\Plugins::cspScriptNonce',
+        'csp_style_nonce'   => '\CodeIgniter\View\Plugins::cspStyleNonce',
+        'current_url'       => '\CodeIgniter\View\Plugins::currentURL',
+        'previous_url'      => '\CodeIgniter\View\Plugins::previousURL',
+        'mailto'            => '\CodeIgniter\View\Plugins::mailto',
+        'safe_mailto'       => '\CodeIgniter\View\Plugins::safeMailto',
+        'lang'              => '\CodeIgniter\View\Plugins::lang',
+        'validation_errors' => '\CodeIgniter\View\Plugins::validationErrors',
+        'route'             => '\CodeIgniter\View\Plugins::route',
+        'siteURL'           => '\CodeIgniter\View\Plugins::siteURL',
+    ];]]></code>
+      <code><![CDATA[protected $corePlugins = [
+        'csp_script_nonce'  => '\CodeIgniter\View\Plugins::cspScriptNonce',
+        'csp_style_nonce'   => '\CodeIgniter\View\Plugins::cspStyleNonce',
+        'current_url'       => '\CodeIgniter\View\Plugins::currentURL',
+        'previous_url'      => '\CodeIgniter\View\Plugins::previousURL',
+        'mailto'            => '\CodeIgniter\View\Plugins::mailto',
+        'safe_mailto'       => '\CodeIgniter\View\Plugins::safeMailto',
+        'lang'              => '\CodeIgniter\View\Plugins::lang',
+        'validation_errors' => '\CodeIgniter\View\Plugins::validationErrors',
+        'route'             => '\CodeIgniter\View\Plugins::route',
+        'siteURL'           => '\CodeIgniter\View\Plugins::siteURL',
+    ];]]></code>
+    </UndefinedDocblockClass>
   </file>
   <file src="system/Database/BasePreparedQuery.php">
     <InaccessibleProperty>
@@ -77,6 +141,14 @@
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$this->dom = &$this->domParser]]></code>
     </UnsupportedPropertyReferenceUsage>
+  </file>
+  <file src="system/View/Parser.php">
+    <UndefinedDocblockClass>
+      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code>protected $plugins = [];</code>
+      <code>protected $plugins = [];</code>
+    </UndefinedDocblockClass>
   </file>
   <file src="tests/_support/Config/Filters.php">
     <UndefinedGlobalVariable>

--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -15,6 +15,9 @@ use CodeIgniter\View\ViewDecoratorInterface;
 
 /**
  * View configuration
+ *
+ * @phpstan-type ParserCallable (callable(mixed): mixed)
+ * @phpstan-type ParserCallableString (callable(mixed): mixed)&string
  */
 class View extends BaseConfig
 {
@@ -34,8 +37,10 @@ class View extends BaseConfig
      * To prevent potential abuse, all filters MUST be defined here
      * in order for them to be available for use within the Parser.
      *
+     * @psalm-suppress UndefinedDocblockClass
+     *
      * @var array<string, string>
-     * @phpstan-var array<string, callable-string>
+     * @phpstan-var array<string, ParserCallableString>
      */
     public $filters = [];
 
@@ -44,8 +49,10 @@ class View extends BaseConfig
      * by the core Parser by creating aliases that will be replaced with
      * any callable. Can be single or tag pair.
      *
-     * @var array<string, string>
-     * @phpstan-var array<string, callable-string>
+     * @psalm-suppress UndefinedDocblockClass
+     *
+     * @var array<string, array<string>|callable|string>
+     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
      */
     public $plugins = [];
 
@@ -53,7 +60,7 @@ class View extends BaseConfig
      * Built-in View filters.
      *
      * @var array<string, string>
-     * @phpstan-var array<string, callable-string>
+     * @phpstan-var array<string, ParserCallableString>
      */
     protected $coreFilters = [
         'abs'            => '\abs',
@@ -82,8 +89,8 @@ class View extends BaseConfig
     /**
      * Built-in View plugins.
      *
-     * @var array<string, string>
-     * @phpstan-var array<string, callable-string>
+     * @var array<string, array<string>|callable|string>
+     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
      */
     protected $corePlugins = [
         'csp_script_nonce'  => '\CodeIgniter\View\Plugins::cspScriptNonce',

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -19,6 +19,9 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Class for parsing pseudo-vars
+ *
+ * @phpstan-type ParserCallable (callable(mixed): mixed)
+ * @phpstan-type ParserCallableString (callable(mixed): mixed)&string
  */
 class Parser extends View
 {
@@ -58,7 +61,8 @@ class Parser extends View
     /**
      * Stores any plugins registered at run-time.
      *
-     * @var array
+     * @var array<string, array<string>|callable|string>
+     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
      */
     protected $plugins = [];
 
@@ -78,7 +82,7 @@ class Parser extends View
     public function __construct(ViewConfig $config, ?string $viewPath = null, $loader = null, ?bool $debug = null, ?LoggerInterface $logger = null)
     {
         // Ensure user plugins override core plugins.
-        $this->plugins = $config->plugins ?? [];
+        $this->plugins = $config->plugins;
 
         parent::__construct($config, $viewPath, $loader, $debug, $logger);
     }


### PR DESCRIPTION
**Description**
See #7731 

References:
- [@phpstan-type](https://phpstan.org/writing-php-code/phpdoc-types#local-type-aliases)
- [callable](https://phpstan.org/writing-php-code/phpdoc-types#callables)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
