### PR TITLE
chore: add PHP 8.3 to test-phpunit.yml

### DIFF
--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -59,6 +59,10 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+        include:
+          - php-version: '8.3'
+            composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -70,6 +74,7 @@ jobs:
       enable-coverage: ${{ matrix.php-version == needs.coverage-php-version.outputs.version }}
       enable-profiling: ${{ matrix.php-version == needs.coverage-php-version.outputs.version }}
       extra-extensions: imagick, redis, memcached
+      extra-composer-options: ${{ matrix.composer-option }}
 
   database-live-tests:
     needs:
@@ -84,6 +89,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
         db-platform:
           - MySQLi
           - OCI8
@@ -96,6 +102,8 @@ jobs:
           - php-version: '7.4'
             db-platform: MySQLi
             mysql-version: '8.0'
+          - php-version: '8.3'
+            composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -109,6 +117,7 @@ jobs:
       enable-coverage: ${{ matrix.php-version == needs.coverage-php-version.outputs.version }}
       enable-profiling: ${{ matrix.php-version == needs.coverage-php-version.outputs.version }}
       extra-extensions: mysqli, oci8, pgsql, sqlsrv-5.10.1, sqlite3
+      extra-composer-options: ${{ matrix.composer-option }}
 
   separate-process-tests:
     needs:
@@ -122,6 +131,10 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+        include:
+          - php-version: '8.3'
+            composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -133,6 +146,7 @@ jobs:
       enable-coverage: true # needs xdebug for assertHeaderEmitted() tests
       enable-profiling: ${{ matrix.php-version == needs.coverage-php-version.outputs.version }}
       extra-extensions: mysqli, oci8, pgsql, sqlsrv-5.10.1, sqlite3
+      extra-composer-options: ${{ matrix.composer-option }}
 
   cache-live-tests:
     needs:
@@ -146,6 +160,10 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+        include:
+          - php-version: '8.3'
+            composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -157,6 +175,7 @@ jobs:
       enable-coverage: ${{ matrix.php-version == needs.coverage-php-version.outputs.version }}
       enable-profiling: ${{ matrix.php-version == needs.coverage-php-version.outputs.version }}
       extra-extensions: redis, memcached
+      extra-composer-options: ${{ matrix.composer-option }}
 
   coveralls:
     name: Upload coverage results to Coveralls


### PR DESCRIPTION
**Description**
See #7850

- add PHP 8.3 to test-phpunit.yml

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
