### PR TITLE
Fix: [Session] the problem of secondary retrieving values ​​in RedisHandler

### DIFF
--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -223,7 +223,7 @@ class RedisHandler extends BaseHandler
 
                 if (($pingReply === true) || ($pingReply === '+PONG')) {
                     if (isset($this->lockKey)) {
-                        $this->redis->del($this->lockKey);
+                        $this->releaseLock();
                     }
 
                     if (! $this->redis->close()) {

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -168,4 +168,26 @@ final class RedisHandlerTest extends CIUnitTestCase
         $handler = $this->getInstance();
         $this->assertSame(1, $handler->gc(3600));
     }
+
+    /**
+     * See https://github.com/codeigniter4/CodeIgniter4/issues/7695
+     */
+    public function testSecondaryReadAfterClose(): void
+    {
+        $handler = $this->getInstance();
+        $handler->open($this->sessionSavePath, $this->sessionName);
+
+        $expected = <<<'DATA'
+            __ci_last_regenerate|i:1664607454;_ci_previous_url|s:32:"http://localhost:8080/index.php/";key|s:5:"value";
+            DATA;
+        $this->assertSame($expected, $handler->read('555556b43phsnnf8if6bo33b635e4447'));
+
+        $handler->close();
+
+        $handler->open($this->sessionSavePath, $this->sessionName);
+
+        $this->assertSame($expected, $handler->read('555556b43phsnnf8if6bo33b635e4447'));
+
+        $handler->close();
+    }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
See #7695 
The close function not only needs to delete the lock from redis but also needs to clear the variable value by using releaseLock function.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
