### PR TITLE
fix: FeatureTest fails when forceGlobalSecureRequests is true

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -292,6 +292,9 @@ trait FeatureTestTrait
 
         if ($config->forceGlobalSecureRequests) {
             $_SERVER['HTTPS'] = 'test';
+            $server           = $request->getServer();
+            $server['HTTPS']  = 'test';
+            $request->setGlobal('server', $server);
         }
 
         return $request;

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -15,6 +15,8 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Response;
+use CodeIgniter\Test\Mock\MockCodeIgniter;
+use Config\App;
 use Config\Routing;
 use Config\Services;
 
@@ -628,5 +630,20 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $response = $this->get('home/index');
 
         $response->assertOK();
+    }
+
+    public function testForceGlobalSecureRequests()
+    {
+        $config                            = config(App::class);
+        $config->forceGlobalSecureRequests = true;
+        Factories::injectMock('config', App::class, $config);
+
+        $this->app = new MockCodeIgniter($config);
+        $this->app->initialize();
+
+        $response = $this->get('/');
+
+        // Do not redirect.
+        $response->assertStatus(200);
     }
 }


### PR DESCRIPTION
**Description**
- fix bug that HTTP tests fail (do redirect) when forceGlobalSecureRequests is true

See https://github.com/codeigniter4projects/website/pull/393#pullrequestreview-1604257604

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
