### PR TITLE
docs: update Backward Compatibility Notes

### DIFF
--- a/user_guide_src/source/installation/backward_compatibility_notes.rst
+++ b/user_guide_src/source/installation/backward_compatibility_notes.rst
@@ -13,7 +13,8 @@ However, the code is not mature and bug fixes may break compatibility in minor r
 What are not Breaking Changes
 *****************************
 
-- The deprecated Config items are not covered by backwards compatibility (BC) promise. It may be removed in the next
-  **minor** version or later.
+- The deprecated items are not covered by backwards compatibility (BC) promise. It may be removed in the next next
+  **minor** version or later. For example, if an item has been deprecated since 4.3.x,
+  it may be removed in 4.5.0.
 - System messages defined in **system/Language/en/** are strictly for internal framework use and are not covered by backwards compatibility (BC) promise. If developers are relying on language string output they should be checking it against the function call (``lang('...')``), not the content.
 - `Named arguments <https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments>`_ are not covered by backwards compatibility (BC) promise. We may choose to rename method/function parameter names when necessary in order to improve the  codebase.


### PR DESCRIPTION
**Description**
I would like to remove depreciated features to clean up the code. E.g. #7903

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
