### PR TITLE
docs: Improve publisher.rst

### DIFF
--- a/user_guide_src/source/libraries/publisher.rst
+++ b/user_guide_src/source/libraries/publisher.rst
@@ -120,6 +120,8 @@ to keep up with. You can create a publication definition in your project to sync
 
 .. literalinclude:: publisher/009.php
 
+.. note:: Directory ``$destination`` must be created before executing the command.
+
 Now add the dependency via Composer and call ``spark publish`` to run the publication:
 
 .. code-block:: console

--- a/user_guide_src/source/libraries/publisher/009.php
+++ b/user_guide_src/source/libraries/publisher/009.php
@@ -13,7 +13,7 @@ class BootstrapPublisher extends Publisher
      *
      * @var string
      */
-    protected $source = 'vendor/twbs/bootstrap/';
+    protected $source = VENDORPATH . 'twbs/bootstrap/';
 
     /**
      * FCPATH is always the default destination,


### PR DESCRIPTION
**Description**
1. Fix `$source`, because `realpath('twbs/bootstrap/') `will return `false` and the command will throw an exception. 
2. Added a note that `$destination` must exist. For the same reason - there is an `is_dir()` check inside. When there is no folder, the command will throw an exception

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
