### PR TITLE
docs: db_commands.rst typo code-block

### DIFF
--- a/user_guide_src/source/dbmgmt/db_commands.rst
+++ b/user_guide_src/source/dbmgmt/db_commands.rst
@@ -38,7 +38,7 @@ When you have a table named ``my_table``, you can see the field names and the re
 
 .. code-block:: console
 
-    .. code-block:: consolephp spark db:table my_table
+    php spark db:table my_table
 
 If the table ``my_table`` is not in the database, CodeIgniter displays a list of available tables to select.
 


### PR DESCRIPTION
**Description**
Typo fix.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
