### PR TITLE
[PHP 8.3] refactor: ReflectionProperty::setValue() signature deprecation

### DIFF
--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -74,7 +74,12 @@ trait ReflectionHelper
     public static function setPrivateProperty($obj, $property, $value)
     {
         $refProperty = self::getAccessibleRefProperty($obj, $property);
-        $refProperty->setValue($obj, $value);
+
+        if (is_object($obj)) {
+            $refProperty->setValue($obj, $value);
+        } else {
+            $refProperty->setValue(null, $value);
+        }
     }
 
     /**

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -438,13 +438,13 @@ final class CLITest extends CIUnitTestCase
     {
         $height = new ReflectionProperty(CLI::class, 'height');
         $height->setAccessible(true);
-        $height->setValue(null);
+        $height->setValue(null, null);
 
         $this->assertIsInt(CLI::getHeight());
 
         $width = new ReflectionProperty(CLI::class, 'width');
         $width->setAccessible(true);
-        $width->setValue(null);
+        $width->setValue(null, null);
 
         $this->assertIsInt(CLI::getWidth());
     }


### PR DESCRIPTION
**Description**
See #7850

- update deprecated code in PHP 8.3

E.g.,
```
 1) CodeIgniter\CLI\CLITest::testWindow
ErrorException: Calling ReflectionProperty::setValue() with a single argument is deprecated

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/CLI/CLITest.php:441
```
See https://github.com/codeigniter4/CodeIgniter4/actions/runs/6035726283/job/16376653028?pr=7886

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
