### PR TITLE
[PHP 8.3] test: update expectation for highlight code

### DIFF
--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -264,11 +264,10 @@ final class TextHelperTest extends CIUnitTestCase
     public function testHighlightCode(): void
     {
         // PHP 8.3 changes the output.
-        if (version_compare(PHP_VERSION, '8.3', '<')) {
-            $expect = "<code><span style=\"color: #000000\">\n<span style=\"color: #0000BB\">&lt;?php&nbsp;var_dump</span><span style=\"color: #007700\">(</span><span style=\"color: #0000BB\">\$this</span><span style=\"color: #007700\">);&nbsp;</span><span style=\"color: #0000BB\">?&gt;&nbsp;</span>\n</span>\n</code>";
-        } else {
-            // PHP 8.3
+        if (PHP_VERSION_ID >= 80300) {
             $expect = '<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">); </span><span style="color: #0000BB">?&gt; ?&gt;</span></code></pre>';
+        } else {
+            $expect = "<code><span style=\"color: #000000\">\n<span style=\"color: #0000BB\">&lt;?php&nbsp;var_dump</span><span style=\"color: #007700\">(</span><span style=\"color: #0000BB\">\$this</span><span style=\"color: #007700\">);&nbsp;</span><span style=\"color: #0000BB\">?&gt;&nbsp;</span>\n</span>\n</code>";
         }
 
         $this->assertSame($expect, highlight_code('<?php var_dump($this); ?>'));

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -263,7 +263,14 @@ final class TextHelperTest extends CIUnitTestCase
 
     public function testHighlightCode(): void
     {
-        $expect = "<code><span style=\"color: #000000\">\n<span style=\"color: #0000BB\">&lt;?php&nbsp;var_dump</span><span style=\"color: #007700\">(</span><span style=\"color: #0000BB\">\$this</span><span style=\"color: #007700\">);&nbsp;</span><span style=\"color: #0000BB\">?&gt;&nbsp;</span>\n</span>\n</code>";
+        // PHP 8.3 changes the output.
+        if (version_compare(PHP_VERSION, '8.3', '<')) {
+            $expect = "<code><span style=\"color: #000000\">\n<span style=\"color: #0000BB\">&lt;?php&nbsp;var_dump</span><span style=\"color: #007700\">(</span><span style=\"color: #0000BB\">\$this</span><span style=\"color: #007700\">);&nbsp;</span><span style=\"color: #0000BB\">?&gt;&nbsp;</span>\n</span>\n</code>";
+        } else {
+            // PHP 8.3
+            $expect = '<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">); </span><span style="color: #0000BB">?&gt; ?&gt;</span></code></pre>';
+        }
+
         $this->assertSame($expect, highlight_code('<?php var_dump($this); ?>'));
     }
 

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -183,17 +183,16 @@ final class ParserFilterTest extends CIUnitTestCase
             EOF;
 
         // PHP 8.3 changes the output.
-        if (version_compare(PHP_VERSION, '8.3', '<')) {
+        if (PHP_VERSION_ID >= 80300) {
+            $expected = <<<'EOF'
+                <pre><code style="color: #000000"><span style="color: #0000BB">Sincerely ?&gt;</span></code></pre>
+                EOF;
+        } else {
             $expected = <<<'EOF'
                 <code><span style="color: #000000">
                 <span style="color: #0000BB">Sincerely&nbsp;</span>
                 </span>
                 </code>
-                EOF;
-        } else {
-            // PHP 8.3
-            $expected = <<<'EOF'
-                <pre><code style="color: #000000"><span style="color: #0000BB">Sincerely ?&gt;</span></code></pre>
                 EOF;
         }
 

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -181,6 +181,22 @@ final class ParserFilterTest extends CIUnitTestCase
             </span>
             </code>
             EOF;
+
+        // PHP 8.3 changes the output.
+        if (version_compare(PHP_VERSION, '8.3', '<')) {
+            $expected = <<<'EOF'
+                <code><span style="color: #000000">
+                <span style="color: #0000BB">Sincerely&nbsp;</span>
+                </span>
+                </code>
+                EOF;
+        } else {
+            // PHP 8.3
+            $expected = <<<'EOF'
+                <pre><code style="color: #000000"><span style="color: #0000BB">Sincerely ?&gt;</span></code></pre>
+                EOF;
+        }
+
         $this->assertSame($expected, $parser->renderString($template));
     }
 


### PR DESCRIPTION
**Description**
See #7850

E.g.,
```
1) CodeIgniter\Helpers\TextHelperTest::testHighlightCode
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'<code><span style="color: #000000">
-<span style="color: #0000BB">&lt;?php&nbsp;var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">);&nbsp;</span><span style="color: #0000BB">?&gt;&nbsp;</span>
-</span>
-</code>'
+'<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php var_dump</span><span style="color: #007700">(</span><span style="color: #0000BB">$this</span><span style="color: #007700">); </span><span style="color: #0000BB">?&gt; ?&gt;</span></code></pre>'

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Helpers/TextHelperTest.php:267
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6035726283/job/16376653028?pr=7886

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
