### PR TITLE
test: use PHP_VERSION_ID instead of PHP_VERSION

### DIFF
--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -172,7 +172,7 @@ final class TimerTest extends CIUnitTestCase
 
     public function testRecordThrowsErrorOnCallableWithParams(): void
     {
-        if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
+        if (PHP_VERSION_ID >= 80000) {
             $this->expectException(ArgumentCountError::class);
         } else {
             $this->expectException(ErrorException::class);

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -304,10 +304,10 @@ final class ArrayHelperTest extends CIUnitTestCase
     public function testArraySortByMultipleKeysFailsInconsistentArraySizes($data): void
     {
         // PHP 8 changes this error type
-        if (version_compare(PHP_VERSION, '8.0', '<')) {
-            $this->expectException(ErrorException::class);
-        } else {
+        if (PHP_VERSION_ID >= 80000) {
             $this->expectException(ValueError::class);
+        } else {
+            $this->expectException(ErrorException::class);
         }
 
         $this->expectExceptionMessage('Array sizes are inconsistent');


### PR DESCRIPTION
**Description**
To make the code easy to understand.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
