### PR TITLE
docs: fix directory separator in comments

### DIFF
--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -106,7 +106,7 @@ class IncomingRequest extends Request
 
     /**
      * The current locale of the application.
-     * Default value is set in Config\App.php
+     * Default value is set in app/Config/App.php
      *
      * @var string
      */
@@ -522,7 +522,7 @@ class IncomingRequest extends Request
     }
 
     /**
-     * Returns the default locale as set in Config\App.php
+     * Returns the default locale as set in app/Config/App.php
      */
     public function getDefaultLocale(): string
     {


### PR DESCRIPTION
**Description**
- fix comments

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
