### PR TITLE
fix: check for CSRF token in the raw body

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2422,11 +2422,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Router/RouterInterface.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/system/Security/Security.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Session\\\\Exceptions\\\\SessionException\\:\\:forEmptySavepath\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Session/Exceptions/SessionException.php',

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -354,7 +354,8 @@ class Security implements SecurityInterface
         $body = (string) $request->getBody();
 
         if ($body !== '') {
-            if (! empty($json = json_decode($body)) && json_last_error() === JSON_ERROR_NONE) {
+            $json = json_decode($body);
+            if (! empty($json) && json_last_error() === JSON_ERROR_NONE) {
                 return $json->{$this->config->tokenName} ?? null;
             }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -324,7 +324,8 @@ class Security implements SecurityInterface
             $request->setGlobal('post', $_POST);
         } else {
             $body = $request->getBody() ?? '';
-            if (! empty($json = json_decode($body)) && json_last_error() === JSON_ERROR_NONE) {
+            $json = json_decode($body);
+            if (! empty($json) && json_last_error() === JSON_ERROR_NONE) {
                 // We kill this since we're done and we don't want to pollute the JSON data.
                 unset($json->{$this->config->tokenName});
                 $request->setBody(json_encode($json));

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -325,7 +325,7 @@ class Security implements SecurityInterface
         } else {
             $body = $request->getBody() ?? '';
             $json = json_decode($body);
-            if (! empty($json) && json_last_error() === JSON_ERROR_NONE) {
+            if ($json !== null && json_last_error() === JSON_ERROR_NONE) {
                 // We kill this since we're done and we don't want to pollute the JSON data.
                 unset($json->{$this->config->tokenName});
                 $request->setBody(json_encode($json));
@@ -356,7 +356,7 @@ class Security implements SecurityInterface
 
         if ($body !== '') {
             $json = json_decode($body);
-            if (! empty($json) && json_last_error() === JSON_ERROR_NONE) {
+            if ($json !== null && json_last_error() === JSON_ERROR_NONE) {
                 return $json->{$this->config->tokenName} ?? null;
             }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -348,7 +348,9 @@ class Security implements SecurityInterface
             return $tokenValue;
         }
 
-        if ($request->hasHeader($this->config->headerName) && ! empty($request->header($this->config->headerName)->getValue())) {
+        if ($request->hasHeader($this->config->headerName)
+            && $request->header($this->config->headerName)->getValue() !== ''
+            && $request->header($this->config->headerName)->getValue() !== []) {
             return $request->header($this->config->headerName)->getValue();
         }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -318,16 +318,22 @@ class Security implements SecurityInterface
     {
         assert($request instanceof Request);
 
-        $json = json_decode($request->getBody() ?? '');
-
         if (isset($_POST[$this->config->tokenName])) {
             // We kill this since we're done and we don't want to pollute the POST array.
             unset($_POST[$this->config->tokenName]);
             $request->setGlobal('post', $_POST);
-        } elseif (isset($json->{$this->config->tokenName})) {
-            // We kill this since we're done and we don't want to pollute the JSON data.
-            unset($json->{$this->config->tokenName});
-            $request->setBody(json_encode($json));
+        } else {
+            $body = $request->getBody() ?? '';
+            if (! empty($json = json_decode($body)) && json_last_error() === JSON_ERROR_NONE) {
+                // We kill this since we're done and we don't want to pollute the JSON data.
+                unset($json->{$this->config->tokenName});
+                $request->setBody(json_encode($json));
+            } else {
+                parse_str($body, $parsed);
+                // We kill this since we're done and we don't want to pollute the BODY data.
+                unset($parsed[$this->config->tokenName]);
+                $request->setBody(http_build_query($parsed));
+            }
         }
     }
 
@@ -335,7 +341,7 @@ class Security implements SecurityInterface
     {
         assert($request instanceof IncomingRequest);
 
-        // Does the token exist in POST, HEADER or optionally php:://input - json data.
+        // Does the token exist in POST, HEADER or optionally php:://input - json data or PUT, DELETE, PATCH - raw data.
 
         if ($tokenValue = $request->getPost($this->config->tokenName)) {
             return $tokenValue;
@@ -346,10 +352,15 @@ class Security implements SecurityInterface
         }
 
         $body = (string) $request->getBody();
-        $json = json_decode($body);
 
-        if ($body !== '' && ! empty($json) && json_last_error() === JSON_ERROR_NONE) {
-            return $json->{$this->config->tokenName} ?? null;
+        if ($body !== '') {
+            if (! empty($json = json_decode($body)) && json_last_error() === JSON_ERROR_NONE) {
+                return $json->{$this->config->tokenName} ?? null;
+            }
+
+            parse_str($body, $parsed);
+
+            return $parsed[$this->config->tokenName] ?? null;
         }
 
         return null;

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -246,6 +246,19 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $this->assertLogged('info', 'CSRF token verified.');
     }
 
+    public function testCSRFVerifyPUTBodyReturnsSelfOnMatch(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
+        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request->setBody("csrf_test_name={$this->randomizedToken}&foo=bar");
+
+        $security = $this->createSecurity();
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+    }
+
     public function testCSRFVerifyJsonThrowsExceptionOnNoMatch(): void
     {
         $this->expectException(SecurityException::class);

--- a/tests/system/Security/SecurityCSRFSessionTest.php
+++ b/tests/system/Security/SecurityCSRFSessionTest.php
@@ -201,6 +201,19 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         $this->assertLogged('info', 'CSRF token verified.');
     }
 
+    public function testCSRFVerifyPUTBodyReturnsSelfOnMatch(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
+        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request->setBody('csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a&foo=bar');
+
+        $security = $this->createSecurity();
+
+        $this->assertInstanceOf(Security::class, $security->verify($request));
+        $this->assertLogged('info', 'CSRF token verified.');
+    }
+
     public function testCSRFVerifyJsonThrowsExceptionOnNoMatch(): void
     {
         $this->expectException(SecurityException::class);

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -29,6 +29,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Security:** Fixed a bug where the CSRF token wasn't checked if we sent it in the raw body (not JSON format) for PUT, PATCH, and DELETE requests.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -22,14 +22,13 @@ Changes
   command was removed. It did not work from the beginning. Also, the rollback
   command returns the database(s) state to a specified batch number and cannot
   specify only a specific database group.
+- **Security:** The presence of the CSRF token is now also checked in the raw body (not JSON format) for PUT, PATCH, and DELETE type of requests.
 
 Deprecations
 ************
 
 Bugs Fixed
 **********
-
-- **Security:** Fixed a bug where the CSRF token wasn't checked if we sent it in the raw body (not JSON format) for PUT, PATCH, and DELETE requests.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -204,6 +204,7 @@ The order of checking the availability of the CSRF token is as follows:
 1. ``$_POST`` array
 2. HTTP header
 3. ``php://input`` (JSON request) - bear in mind that this approach is the slowest one since we have to decode JSON and then re-encode it
+4. ``php://input`` (raw body) - for PUT, PATCH, and DELETE type of requests
 
 *********************
 Other Helpful Methods

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -206,6 +206,8 @@ The order of checking the availability of the CSRF token is as follows:
 3. ``php://input`` (JSON request) - bear in mind that this approach is the slowest one since we have to decode JSON and then re-encode it
 4. ``php://input`` (raw body) - for PUT, PATCH, and DELETE type of requests
 
+.. note:: ``php://input`` (raw body) is checked since v4.4.2.
+
 *********************
 Other Helpful Methods
 *********************


### PR DESCRIPTION
**Description**
CSRF check for PUT, PATCH, and DELETE type of requests is made only for JSON data. This PR fixes that by adding the raw input data to check.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
