### PR TITLE
chore: add phpstan-strict-rules disallowedConstructs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "nexusphp/tachycardia": "^1.0",
         "php-coveralls/php-coveralls": "^2.5",
         "phpstan/phpstan": "^1.10.2",
+        "phpstan/phpstan-strict-rules": "^1.5",
         "phpunit/phpcov": "^8.2",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1 || ^2.0",

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2,9 +2,89 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string\\> of property Config\\\\Modules\\:\\:\\$aliases is not the same as PHPDoc type array of overridden property CodeIgniter\\\\Modules\\\\Modules\\:\\:\\$aliases\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/app/Config/Modules.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\HTTP\\\\CLIRequest\\|CodeIgniter\\\\HTTP\\\\IncomingRequest of property App\\\\Controllers\\\\BaseController\\:\\:\\$request is not the same as PHPDoc type CodeIgniter\\\\HTTP\\\\RequestInterface of overridden property CodeIgniter\\\\Controller\\:\\:\\$request\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/app/Controllers/BaseController.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function method_exists\\(\\) with \'Composer\\\\\\\\InstalledVersions\' and \'getAllRawData\' will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Autoloader/Autoloader.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 13,
+	'path' => __DIR__ . '/system/Autoloader/FileLocator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/system/Autoloader/FileLocator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 16,
+	'path' => __DIR__ . '/system/BaseModel.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\BaseModel\\:\\:chunk\\(\\) has parameter \\$userFunc with no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/BaseModel.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Strict comparison using \\!\\=\\= between mixed and null will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/BaseModel.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/CLI/BaseCommand.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/system/CLI/CLI.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/CLI/CLI.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Cache/CacheFactory.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function property_exists\\(\\) with Config\\\\Cache and \'file\' will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Cache/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Cache/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Cache/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Variable \\$result might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Cache/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/system/CodeIgniter.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\CodeIgniter\\:\\:bootstrapEnvironment\\(\\) has no return type specified\\.$#',
@@ -77,6 +157,46 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/CodeIgniter.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/CreateDatabase.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\CreateDatabase\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/CreateDatabase.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\CreateDatabase\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/CreateDatabase.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/MigrateStatus.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\MigrateStatus\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/MigrateStatus.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$params \\(array\\<string, mixed\\>\\) of method CodeIgniter\\\\Commands\\\\Database\\\\MigrateStatus\\:\\:run\\(\\) should be contravariant with parameter \\$params \\(array\\<int\\|string, string\\|null\\>\\) of method CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:run\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/MigrateStatus.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/Seed.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\Seed\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/Seed.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:showAllTables\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
@@ -85,6 +205,21 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:showDataOfTable\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/CellGenerator.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\CellGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
@@ -97,6 +232,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Generators/CellGenerator.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/CellGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/CommandGenerator.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\CommandGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/CommandGenerator.php',
@@ -105,6 +250,16 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\CommandGenerator\\:\\:generateView\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/CommandGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/CommandGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ConfigGenerator.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ConfigGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
@@ -117,6 +272,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Generators/ConfigGenerator.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ConfigGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ControllerGenerator.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ControllerGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/ControllerGenerator.php',
@@ -125,6 +290,16 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ControllerGenerator\\:\\:generateView\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/ControllerGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ControllerGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/EntityGenerator.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\EntityGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
@@ -137,6 +312,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Generators/EntityGenerator.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/EntityGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/FilterGenerator.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\FilterGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/FilterGenerator.php',
@@ -145,6 +330,16 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\FilterGenerator\\:\\:generateView\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/FilterGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/FilterGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/MigrationGenerator.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\MigrationGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
@@ -157,6 +352,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Generators/MigrationGenerator.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/MigrationGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ModelGenerator.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ModelGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/ModelGenerator.php',
@@ -165,6 +370,16 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ModelGenerator\\:\\:generateView\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/ModelGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ModelGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ScaffoldGenerator.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ScaffoldGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
@@ -177,6 +392,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Generators/ScaffoldGenerator.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ScaffoldGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/SeederGenerator.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\SeederGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/SeederGenerator.php',
@@ -185,6 +410,16 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\SeederGenerator\\:\\:generateView\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/SeederGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/SeederGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/SessionMigrationGenerator.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\SessionMigrationGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
@@ -197,6 +432,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Generators/SessionMigrationGenerator.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/SessionMigrationGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Commands/Generators/ValidationGenerator.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ValidationGenerator\\:\\:generateClass\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Generators/ValidationGenerator.php',
@@ -204,6 +449,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Generators\\\\ValidationGenerator\\:\\:generateView\\(\\) has no return type specified\\.$#',
 	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Generators/ValidationGenerator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
 	'path' => __DIR__ . '/system/Commands/Generators/ValidationGenerator.php',
 ];
 $ignoreErrors[] = [
@@ -217,6 +467,36 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/ListCommands.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\Environment\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/Environment.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\FilterCheck\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/FilterCheck.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/Namespaces.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\Publish\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/Publish.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\Routes\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/Routes.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Implicit array creation is not allowed \\- variable \\$filters might not exist\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Utilities\\\\Routes\\\\AutoRouterImproved\\\\AutoRouteCollector\\:\\:addFilters\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php',
@@ -225,6 +505,21 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Utilities\\\\Routes\\\\AutoRouterImproved\\\\AutoRouteCollector\\:\\:addFilters\\(\\) has parameter \\$routes with no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Commands/Utilities/Routes/ControllerMethodReader.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/system/Common.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Function force_https\\(\\) has no return type specified\\.$#',
@@ -242,9 +537,59 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Common.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Common.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\ComposerScripts\\:\\:postUpdate\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/ComposerScripts.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Config/BaseService.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Config/DotEnv.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Config/Services.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Config/Services.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Controller.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$offset \\(string\\) of method CodeIgniter\\\\Cookie\\\\Cookie\\:\\:offsetSet\\(\\) should be contravariant with parameter \\$offset \\(string\\|null\\) of method ArrayAccess\\<string,bool\\|int\\|string\\>\\:\\:offsetSet\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Cookie/Cookie.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Cookie/Cookie.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function is_string\\(\\) with non\\-falsy\\-string will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/BaseBuilder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 40,
+	'path' => __DIR__ . '/system/Database/BaseBuilder.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:_whereIn\\(\\) has parameter \\$values with no signature specified for Closure\\.$#',
@@ -337,6 +682,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/BaseConnection.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 13,
+	'path' => __DIR__ . '/system/Database/BaseConnection.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\BaseConnection\\:\\:close\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/BaseConnection.php',
@@ -352,9 +702,39 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/BaseConnection.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\{code\\: int\\|string\\|null, message\\: string\\|null\\}\\) of method CodeIgniter\\\\Database\\\\BaseConnection\\:\\:error\\(\\) should be covariant with return type \\(array\\<string, int\\|string\\>\\) of method CodeIgniter\\\\Database\\\\ConnectionInterface\\<TConnection,TResult\\>\\:\\:error\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/BaseConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/BaseConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Database/BasePreparedQuery.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\BasePreparedQuery\\:\\:execute\\(\\) has parameter \\$data with no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/BasePreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 10,
+	'path' => __DIR__ . '/system/Database/BaseResult.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$className \\(class\\-string\\) of method CodeIgniter\\\\Database\\\\BaseResult\\:\\:getCustomResultObject\\(\\) should be contravariant with parameter \\$className \\(string\\) of method CodeIgniter\\\\Database\\\\ResultInterface\\<TConnection,TResult\\>\\:\\:getCustomResultObject\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/BaseResult.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Database/BaseUtils.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Config\\:\\:ensureFactory\\(\\) has no return type specified\\.$#',
@@ -369,6 +749,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Access to an undefined property CodeIgniter\\\\Database\\\\ConnectionInterface\\:\\:\\$connID\\.$#',
 	'count' => 2,
+	'path' => __DIR__ . '/system/Database/Database.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
 	'path' => __DIR__ . '/system/Database/Database.php',
 ];
 $ignoreErrors[] = [
@@ -390,6 +775,11 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Exceptions\\\\DataException\\:\\:forTableNotFound\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Exceptions/DataException.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 16,
+	'path' => __DIR__ . '/system/Database/Forge.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Forge\\:\\:_attributeAutoIncrement\\(\\) has no return type specified\\.$#',
@@ -437,6 +827,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/Migration.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/system/Database/MigrationRunner.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\MigrationRunner\\:\\:addHistory\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/MigrationRunner.php',
@@ -472,14 +867,99 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/ModelFactory.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 12,
+	'path' => __DIR__ . '/system/Database/MySQLi/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Database\\\\MySQLi\\\\Connection\\:\\:_close\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\MySQLi\\\\Connection\\:\\:\\$escapeChar is not the same as PHPDoc type array\\|string of overridden property CodeIgniter\\\\Database\\\\BaseConnection\\<mysqli,mysqli_result\\>\\:\\:\\$escapeChar\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\<string, int\\|string\\>\\) of method CodeIgniter\\\\Database\\\\MySQLi\\\\Connection\\:\\:error\\(\\) should be covariant with return type \\(array\\{code\\: int\\|string\\|null, message\\: string\\|null\\}\\) of method CodeIgniter\\\\Database\\\\BaseConnection\\<mysqli,mysqli_result\\>\\:\\:error\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/system/Database/MySQLi/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\MySQLi\\\\Forge\\:\\:\\$createDatabaseStr is not the same as PHPDoc type string\\|false of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$createDatabaseStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Forge.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\<mysqli, mysqli_result\\>\\:\\:\\$mysqli\\.$#',
 	'count' => 3,
 	'path' => __DIR__ . '/system/Database/MySQLi/PreparedQuery.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\MySQLi\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\MySQLi\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<mysqli,mysqli_stmt,mysqli_result\\>\\:\\:_prepare\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mysqli_result\\|false\\) of method CodeIgniter\\\\Database\\\\MySQLi\\\\PreparedQuery\\:\\:_getResult\\(\\) should be covariant with return type \\(object\\|resource\\|null\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<mysqli,mysqli_stmt,mysqli_result\\>\\:\\:_getResult\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Result.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\MySQLi\\\\Utils\\:\\:\\$listDatabases is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$listDatabases\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Utils.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\MySQLi\\\\Utils\\:\\:\\$optimizeTable is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$optimizeTable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/MySQLi/Utils.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Database/OCI8/Builder.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\OCI8\\\\Builder\\:\\:resetSelect\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/OCI8/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\Database\\\\OCI8\\\\Connection of property CodeIgniter\\\\Database\\\\OCI8\\\\Builder\\:\\:\\$db is not the same as PHPDoc type CodeIgniter\\\\Database\\\\BaseConnection of overridden property CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:\\$db\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Database\\\\OCI8\\\\Builder\\:\\:delete\\(\\) should be covariant with return type \\(bool\\|string\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:delete\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Database/OCI8/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\OCI8\\\\Connection\\:\\:\\$escapeChar is not the same as PHPDoc type array\\|string of overridden property CodeIgniter\\\\Database\\\\BaseConnection\\<resource,resource\\>\\:\\:\\$escapeChar\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Connection.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Database\\\\OCI8\\\\Connection\\:\\:\\$resetStmtId has no type specified\\.$#',
@@ -492,12 +972,112 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/OCI8/Connection.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\{code\\: int\\|string\\|null, message\\: string\\|null\\}\\) of method CodeIgniter\\\\Database\\\\OCI8\\\\Connection\\:\\:error\\(\\) should be covariant with return type \\(array\\<string, int\\|string\\>\\) of method CodeIgniter\\\\Database\\\\ConnectionInterface\\<resource,resource\\>\\:\\:error\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Database/OCI8/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type false of property CodeIgniter\\\\Database\\\\OCI8\\\\Forge\\:\\:\\$createDatabaseStr is not the same as PHPDoc type string\\|false of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$createDatabaseStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type false of property CodeIgniter\\\\Database\\\\OCI8\\\\Forge\\:\\:\\$createTableIfStr is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$createTableIfStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type false of property CodeIgniter\\\\Database\\\\OCI8\\\\Forge\\:\\:\\$dropDatabaseStr is not the same as PHPDoc type string\\|false of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$dropDatabaseStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type false of property CodeIgniter\\\\Database\\\\OCI8\\\\Forge\\:\\:\\$dropTableIfStr is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$dropTableIfStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\OCI8\\\\Forge\\:\\:\\$renameTableStr is not the same as PHPDoc type string\\|false of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$renameTableStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\Database\\\\OCI8\\\\Connection of property CodeIgniter\\\\Database\\\\OCI8\\\\PreparedQuery\\:\\:\\$db is not the same as PHPDoc type CodeIgniter\\\\Database\\\\BaseConnection\\<resource, resource\\> of overridden property CodeIgniter\\\\Database\\\\BasePreparedQuery\\<resource,resource,resource\\>\\:\\:\\$db\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\OCI8\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\OCI8\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<resource,resource,resource\\>\\:\\:_prepare\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\OCI8\\\\Utils\\:\\:\\$listDatabases is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$listDatabases\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/OCI8/Utils.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\BaseBuilder\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Builder\\:\\:join\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BaseBuilder\\)\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:join\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\BaseBuilder\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Builder\\:\\:orderBy\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BaseBuilder\\)\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:orderBy\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Builder\\:\\:decrement\\(\\) should be covariant with return type \\(bool\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:decrement\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Builder\\:\\:delete\\(\\) should be covariant with return type \\(bool\\|string\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:delete\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Builder\\:\\:increment\\(\\) should be covariant with return type \\(bool\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:increment\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Builder\\:\\:replace\\(\\) should be covariant with return type \\(CodeIgniter\\\\Database\\\\BaseResult\\|CodeIgniter\\\\Database\\\\Query\\|string\\|false\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:replace\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Database\\\\Postgre\\\\Connection\\:\\:_close\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Postgre\\\\Connection\\:\\:buildDSN\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Postgre\\\\Connection\\:\\:convertDSN\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\Postgre\\\\Connection\\:\\:\\$escapeChar is not the same as PHPDoc type array\\|string of overridden property CodeIgniter\\\\Database\\\\BaseConnection\\<PgSql\\\\Connection,PgSql\\\\Result\\>\\:\\:\\$escapeChar\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
 ];
@@ -522,6 +1102,21 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\<string, int\\|string\\>\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Connection\\:\\:error\\(\\) should be covariant with return type \\(array\\{code\\: int\\|string\\|null, message\\: string\\|null\\}\\) of method CodeIgniter\\\\Database\\\\BaseConnection\\<PgSql\\\\Connection,PgSql\\\\Result\\>\\:\\:error\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Database/Postgre/Forge.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Postgre\\\\Forge\\:\\:_attributeAutoIncrement\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Postgre/Forge.php',
@@ -532,9 +1127,44 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/Postgre/Forge.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\Database\\\\Postgre\\\\Connection of property CodeIgniter\\\\Database\\\\Postgre\\\\Forge\\:\\:\\$db is not the same as PHPDoc type CodeIgniter\\\\Database\\\\BaseConnection of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$db\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\|bool\\|string\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Forge\\:\\:_alterTable\\(\\) should be covariant with return type \\(array\\<string\\>\\|string\\|false\\) of method CodeIgniter\\\\Database\\\\Forge\\:\\:_alterTable\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\Postgre\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<PgSql\\\\Connection,PgSql\\\\Result,PgSql\\\\Result\\>\\:\\:_prepare\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Result.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\Postgre\\\\Utils\\:\\:\\$listDatabases is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$listDatabases\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Utils.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\Postgre\\\\Utils\\:\\:\\$optimizeTable is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$optimizeTable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Postgre/Utils.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\PreparedQueryInterface\\:\\:execute\\(\\) has parameter \\$data with no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/PreparedQueryInterface.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Database/Query.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Query\\:\\:compileBinds\\(\\) has no return type specified\\.$#',
@@ -557,8 +1187,58 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/SQLSRV/Builder.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 15,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$selectOverride \\(bool\\) of method CodeIgniter\\\\Database\\\\SQLSRV\\\\Builder\\:\\:compileSelect\\(\\) should be contravariant with parameter \\$selectOverride \\(mixed\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:compileSelect\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\BaseBuilder\\) of method CodeIgniter\\\\Database\\\\SQLSRV\\\\Builder\\:\\:maxMinAvgSum\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BaseBuilder\\)\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:maxMinAvgSum\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Database\\\\SQLSRV\\\\Builder\\:\\:delete\\(\\) should be covariant with return type \\(bool\\|string\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:delete\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Database\\\\SQLSRV\\\\Builder\\:\\:replace\\(\\) should be covariant with return type \\(CodeIgniter\\\\Database\\\\BaseResult\\|CodeIgniter\\\\Database\\\\Query\\|string\\|false\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:replace\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Database\\\\SQLSRV\\\\Connection\\:\\:_close\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLSRV\\\\Connection\\:\\:\\$escapeChar is not the same as PHPDoc type array\\|string of overridden property CodeIgniter\\\\Database\\\\BaseConnection\\<resource,resource\\>\\:\\:\\$escapeChar\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\<string, int\\|string\\>\\) of method CodeIgniter\\\\Database\\\\SQLSRV\\\\Connection\\:\\:error\\(\\) should be covariant with return type \\(array\\{code\\: int\\|string\\|null, message\\: string\\|null\\}\\) of method CodeIgniter\\\\Database\\\\BaseConnection\\<resource,resource\\>\\:\\:error\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Connection.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$schema\\.$#',
 	'count' => 13,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 6,
 	'path' => __DIR__ . '/system/Database/SQLSRV/Forge.php',
 ];
 $ignoreErrors[] = [
@@ -572,6 +1252,81 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/SQLSRV/Forge.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^PHPDoc type array of property CodeIgniter\\\\Database\\\\SQLSRV\\\\Forge\\:\\:\\$unsigned is not the same as PHPDoc type array\\|bool of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$unsigned\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLSRV\\\\Forge\\:\\:\\$createDatabaseStr is not the same as PHPDoc type string\\|false of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$createDatabaseStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLSRV\\\\Forge\\:\\:\\$createTableIfStr is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$createTableIfStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLSRV\\\\Forge\\:\\:\\$renameTableStr is not the same as PHPDoc type string\\|false of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$renameTableStr\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\Database\\\\SQLSRV\\\\Connection of property CodeIgniter\\\\Database\\\\SQLSRV\\\\PreparedQuery\\:\\:\\$db is not the same as PHPDoc type CodeIgniter\\\\Database\\\\BaseConnection\\<resource, resource\\> of overridden property CodeIgniter\\\\Database\\\\BasePreparedQuery\\<resource,resource,resource\\>\\:\\:\\$db\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\SQLSRV\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\SQLSRV\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<resource,resource,resource\\>\\:\\:_prepare\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Result.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLSRV\\\\Utils\\:\\:\\$listDatabases is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$listDatabases\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Utils.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLSRV\\\\Utils\\:\\:\\$optimizeTable is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$optimizeTable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLSRV/Utils.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Database/SQLite3/Builder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Database\\\\SQLite3\\\\Connection\\:\\:_close\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLite3\\\\Connection\\:\\:\\$escapeChar is not the same as PHPDoc type array\\|string of overridden property CodeIgniter\\\\Database\\\\BaseConnection\\<SQLite3,SQLite3Result\\>\\:\\:\\$escapeChar\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\<string, int\\|string\\>\\) of method CodeIgniter\\\\Database\\\\SQLite3\\\\Connection\\:\\:error\\(\\) should be covariant with return type \\(array\\{code\\: int\\|string\\|null, message\\: string\\|null\\}\\) of method CodeIgniter\\\\Database\\\\BaseConnection\\<SQLite3,SQLite3Result\\>\\:\\:error\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/Connection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Database/SQLite3/Forge.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\SQLite3\\\\Forge\\:\\:_attributeAutoIncrement\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/SQLite3/Forge.php',
@@ -580,6 +1335,36 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\SQLite3\\\\Forge\\:\\:_attributeType\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/SQLite3/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\Database\\\\SQLite3\\\\Connection of property CodeIgniter\\\\Database\\\\SQLite3\\\\Forge\\:\\:\\$db is not the same as PHPDoc type CodeIgniter\\\\Database\\\\BaseConnection of overridden property CodeIgniter\\\\Database\\\\Forge\\:\\:\\$db\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\|string\\|null\\) of method CodeIgniter\\\\Database\\\\SQLite3\\\\Forge\\:\\:_alterTable\\(\\) should be covariant with return type \\(array\\<string\\>\\|string\\|false\\) of method CodeIgniter\\\\Database\\\\Forge\\:\\:_alterTable\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/Forge.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\SQLite3\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\SQLite3\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<SQLite3,SQLite3Stmt,SQLite3Result\\>\\:\\:_prepare\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(SQLite3Result\\|false\\) of method CodeIgniter\\\\Database\\\\SQLite3\\\\PreparedQuery\\:\\:_getResult\\(\\) should be covariant with return type \\(object\\|resource\\|null\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<SQLite3,SQLite3Stmt,SQLite3Result\\>\\:\\:_getResult\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/PreparedQuery.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Class stdClass referenced with incorrect case\\: stdclass\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Database/SQLite3/Table.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Database/SQLite3/Table.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\SQLite3\\\\Table\\:\\:copyData\\(\\) has no return type specified\\.$#',
@@ -592,9 +1377,74 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/SQLite3/Table.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\SQLite3\\\\Utils\\:\\:\\$optimizeTable is not the same as PHPDoc type bool\\|string of overridden property CodeIgniter\\\\Database\\\\BaseUtils\\:\\:\\$optimizeTable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/SQLite3/Utils.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Seeder.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Seeder\\:\\:call\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Seeder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Database\\\\Seeder\\:\\:run\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Database/Seeder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Debug/BaseExceptionHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Debug/ExceptionHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Debug/Exceptions.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Debug/Iterator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Debug/Timer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Debug/Toolbar.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Debug/Toolbar/Collectors/Database.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Debug/Toolbar/Collectors/Database.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Debug/Toolbar/Collectors/History.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Debug/Toolbar/Collectors/Logs.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Log\\\\Logger\\:\\:\\$logCache \\(array\\) on left side of \\?\\? is not nullable\\.$#',
@@ -612,9 +1462,54 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Debug/Toolbar/Collectors/Views.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 14,
+	'path' => __DIR__ . '/system/Email/Email.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Static property CodeIgniter\\\\Email\\\\Email\\:\\:\\$func_overload \\(bool\\) in isset\\(\\) is not nullable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Email/Email.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Encryption/Encryption.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Encryption/Handlers/OpenSSLHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Encryption/Handlers/SodiumHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$value \\(bool\\|int\\|string\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:set\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\BaseCast\\:\\:set\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$value \\(bool\\|int\\|string\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:set\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\CastInterface\\:\\:set\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$value \\(int\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:get\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\BaseCast\\:\\:get\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$value \\(int\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:get\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\CastInterface\\:\\:get\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Entity/Entity.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Events\\\\Events\\:\\:on\\(\\) has parameter \\$callback with no signature specified for callable\\.$#',
@@ -627,9 +1522,39 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Events/Events.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Events/Events.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type int of property CodeIgniter\\\\Exceptions\\\\PageNotFoundException\\:\\:\\$code is not the same as PHPDoc type mixed of overridden property Exception\\:\\:\\$code\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Exceptions/PageNotFoundException.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to method SplFileInfo\\:\\:getBasename\\(\\) with incorrect case\\: getBaseName$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Files/File.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Files/File.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Files\\\\File\\:\\:\\$size \\(int\\) on left side of \\?\\? is not nullable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Files/File.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Files/File.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
@@ -637,12 +1562,92 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/HTTP/CLIRequest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 10,
+	'path' => __DIR__ . '/system/HTTP/CURLRequest.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Constructor of class CodeIgniter\\\\HTTP\\\\CURLRequest has an unused parameter \\$config\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/HTTP/CURLRequest.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/CURLRequest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 9,
+	'path' => __DIR__ . '/system/HTTP/ContentSecurityPolicy.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\DownloadResponse\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:noCache\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\Response\\)\\) of method CodeIgniter\\\\HTTP\\\\Response\\:\\:noCache\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\DownloadResponse\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:noCache\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\ResponseInterface\\)\\) of method CodeIgniter\\\\HTTP\\\\ResponseInterface\\:\\:noCache\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\DownloadResponse\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:sendBody\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\Response\\)\\) of method CodeIgniter\\\\HTTP\\\\Response\\:\\:sendBody\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\DownloadResponse\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:sendBody\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\ResponseInterface\\)\\) of method CodeIgniter\\\\HTTP\\\\ResponseInterface\\:\\:sendBody\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\ResponseInterface\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:setContentType\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\Response\\)\\) of method CodeIgniter\\\\HTTP\\\\Response\\:\\:setContentType\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\ResponseInterface\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:setContentType\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\ResponseInterface\\)\\) of method CodeIgniter\\\\HTTP\\\\ResponseInterface\\:\\:setContentType\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\Exceptions\\\\HTTPException\\) of method CodeIgniter\\\\HTTP\\\\Exceptions\\\\HTTPException\\:\\:forInvalidFile\\(\\) should be covariant with return type \\(static\\(CodeIgniter\\\\Exceptions\\\\FrameworkException\\)\\) of method CodeIgniter\\\\Exceptions\\\\FrameworkException\\:\\:forInvalidFile\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Exceptions/HTTPException.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type int of property CodeIgniter\\\\HTTP\\\\Exceptions\\\\RedirectException\\:\\:\\$code is not the same as PHPDoc type mixed of overridden property Exception\\:\\:\\$code\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Exceptions/RedirectException.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Exceptions/RedirectException.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Files/FileCollection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Files/FileCollection.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Files/UploadedFile.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\HTTP\\\\Files\\\\UploadedFile\\:\\:\\$originalMimeType is not the same as PHPDoc type string\\|null of overridden property CodeIgniter\\\\Files\\\\File\\:\\:\\$originalMimeType\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/HTTP/Files/UploadedFile.php',
 ];
@@ -657,9 +1662,44 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/HTTP/Files/UploadedFile.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Files/UploadedFile.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 7,
+	'path' => __DIR__ . '/system/HTTP/IncomingRequest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\HTTP\\\\URI of property CodeIgniter\\\\HTTP\\\\IncomingRequest\\:\\:\\$uri is not the same as PHPDoc type CodeIgniter\\\\HTTP\\\\URI\\|null of overridden property CodeIgniter\\\\HTTP\\\\OutgoingRequest\\:\\:\\$uri\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/IncomingRequest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/HTTP/Message.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\HTTP\\\\Message\\:\\:\\$protocolVersion \\(string\\) on left side of \\?\\? is not nullable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/HTTP/Message.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/Negotiate.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/HTTP/Negotiate.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\URI\\|null\\) of method CodeIgniter\\\\HTTP\\\\OutgoingRequest\\:\\:getUri\\(\\) should be covariant with return type \\(CodeIgniter\\\\HTTP\\\\URI\\) of method CodeIgniter\\\\HTTP\\\\OutgoingRequestInterface\\:\\:getUri\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/OutgoingRequest.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Variable \\$_GET on left side of \\?\\? always exists and is not nullable\\.$#',
@@ -670,6 +1710,36 @@ $ignoreErrors[] = [
 	'message' => '#^Variable \\$_POST on left side of \\?\\? always exists and is not nullable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/HTTP/RedirectResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/HTTP/Request.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/system/HTTP/Response.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/HTTP/Response.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/HTTP/SiteURI.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Strict comparison using \\!\\=\\= between mixed and null will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/SiteURI.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 15,
+	'path' => __DIR__ . '/system/HTTP/URI.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\HTTP\\\\URI\\:\\:\\$fragment \\(string\\) on left side of \\?\\? is not nullable\\.$#',
@@ -687,12 +1757,152 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/HTTP/URI.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Strict comparison using \\!\\=\\= between mixed and null will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/HTTP/URI.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/HTTP/UserAgent.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Helpers/array_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Helpers/date_helper.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Right side of && is always true\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Helpers/filesystem_helper.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Helpers/filesystem_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Variable \\$result might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Helpers/filesystem_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Helpers/form_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Helpers/form_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/system/Helpers/html_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Helpers/number_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Helpers/test_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Helpers/text_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Helpers/url_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Implicit array creation is not allowed \\- variable \\$atts might not exist\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Helpers/url_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Variable \\$atts might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Helpers/url_helper.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Honeypot/Honeypot.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/I18n/Time.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\Time\\) of method CodeIgniter\\\\I18n\\\\Time\\:\\:setTimestamp\\(\\) should be covariant with return type \\(static\\(DateTimeImmutable\\)\\) of method DateTimeImmutable\\:\\:setTimestamp\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/I18n/Time.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\Time\\) of method CodeIgniter\\\\I18n\\\\Time\\:\\:setTimezone\\(\\) should be covariant with return type \\(static\\(DateTimeImmutable\\)\\) of method DateTimeImmutable\\:\\:setTimezone\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/I18n/Time.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/I18n/Time.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\TimeLegacy\\) of method CodeIgniter\\\\I18n\\\\TimeLegacy\\:\\:setTimestamp\\(\\) should be covariant with return type \\(static\\(DateTime\\)\\) of method DateTime\\:\\:setTimestamp\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\TimeLegacy\\) of method CodeIgniter\\\\I18n\\\\TimeLegacy\\:\\:setTimezone\\(\\) should be covariant with return type \\(static\\(DateTime\\)\\) of method DateTime\\:\\:setTimezone\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Images/Handlers/BaseHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:__call\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Images/Handlers/BaseHandler.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:\\$image \\(CodeIgniter\\\\Images\\\\Image\\) in empty\\(\\) is not falsy\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Images/Handlers/BaseHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\) of method CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:fit\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Images\\\\ImageHandlerInterface\\)\\) of method CodeIgniter\\\\Images\\\\ImageHandlerInterface\\:\\:fit\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Images/Handlers/BaseHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\) of method CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:resize\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Images\\\\ImageHandlerInterface\\)\\) of method CodeIgniter\\\\Images\\\\ImageHandlerInterface\\:\\:resize\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Images/Handlers/BaseHandler.php',
 ];
@@ -702,7 +1912,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Images/Handlers/ImageMagickHandler.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^PHPDoc type string\\|null of property CodeIgniter\\\\Images\\\\Handlers\\\\ImageMagickHandler\\:\\:\\$resource is not covariant with PHPDoc type resource\\|null of overridden property CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:\\$resource\\.$#',
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 10,
+	'path' => __DIR__ . '/system/Images/Handlers/ImageMagickHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string\\|null of property CodeIgniter\\\\Images\\\\Handlers\\\\ImageMagickHandler\\:\\:\\$resource is not the same as PHPDoc type resource\\|null of overridden property CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:\\$resource\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Images/Handlers/ImageMagickHandler.php',
 ];
@@ -717,14 +1932,114 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Images/Handlers/ImageMagickHandler.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(CodeIgniter\\\\Images\\\\Handlers\\\\ImageMagickHandler\\) of method CodeIgniter\\\\Images\\\\Handlers\\\\ImageMagickHandler\\:\\:_resize\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\)\\) of method CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:_resize\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Images/Handlers/ImageMagickHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(bool\\|CodeIgniter\\\\Images\\\\Handlers\\\\ImageMagickHandler\\) of method CodeIgniter\\\\Images\\\\Handlers\\\\ImageMagickHandler\\:\\:_crop\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\)\\) of method CodeIgniter\\\\Images\\\\Handlers\\\\BaseHandler\\:\\:_crop\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Images/Handlers/ImageMagickHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Images/Image.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Log/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Strict comparison using \\=\\=\\= between true and true will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Log/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Log/Logger.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$level \\(string\\) of method CodeIgniter\\\\Log\\\\Logger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\LoggerInterface\\:\\:log\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Log/Logger.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 21,
+	'path' => __DIR__ . '/system/Model.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Model\\:\\:chunk\\(\\) has parameter \\$userFunc with no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Model.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Model\\:\\:__call\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\BaseModel\\)\\|null\\) of method CodeIgniter\\\\BaseModel\\:\\:__call\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Model.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(int\\|object\\|string\\|false\\) of method CodeIgniter\\\\Model\\:\\:insert\\(\\) should be covariant with return type \\(bool\\|int\\|string\\) of method CodeIgniter\\\\BaseModel\\:\\:insert\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Model.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Pager/Pager.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Pager/Pager.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to method CodeIgniter\\\\Pager\\\\PagerRenderer\\:\\:getNext\\(\\) with incorrect case\\: getnext$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Pager/Views/default_simple.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/RESTful/BaseResource.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type CodeIgniter\\\\HTTP\\\\CLIRequest\\|CodeIgniter\\\\HTTP\\\\IncomingRequest of property CodeIgniter\\\\RESTful\\\\BaseResource\\:\\:\\$request is not the same as PHPDoc type CodeIgniter\\\\HTTP\\\\RequestInterface of overridden property CodeIgniter\\\\Controller\\:\\:\\$request\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/RESTful/BaseResource.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/RESTful/ResourceController.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/system/Router/AutoRouter.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Router\\\\AutoRouter\\:\\:\\$cliRoutes type has no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Router/AutoRouter.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Router/AutoRouter.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type int of property CodeIgniter\\\\Router\\\\Exceptions\\\\RedirectException\\:\\:\\$code is not the same as PHPDoc type mixed of overridden property Exception\\:\\:\\$code\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Router/Exceptions/RedirectException.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/system/Router/RouteCollection.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Router\\\\RouteCollection\\:\\:add\\(\\) has parameter \\$to with no signature specified for Closure\\.$#',
@@ -812,6 +2127,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Router/RouteCollection.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Router/RouteCollection.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:add\\(\\) has parameter \\$to with no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Router/RouteCollectionInterface.php',
@@ -862,6 +2182,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Router/Router.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Router/Router.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Router/Router.php',
@@ -900,6 +2225,11 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Router\\\\RouterInterface\\:\\:handle\\(\\) return type has no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Router/RouterInterface.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Security/Security.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Session\\\\Exceptions\\\\SessionException\\:\\:forEmptySavepath\\(\\) has no return type specified\\.$#',
@@ -942,14 +2272,49 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Session/Handlers/Database/PostgreHandler.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Session/Handlers/DatabaseHandler.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Session\\\\Handlers\\\\DatabaseHandler\\:\\:setSelect\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Session/Handlers/DatabaseHandler.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Session/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Session\\\\Handlers\\\\FileHandler\\:\\:configureSessionIDRegex\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Session/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Session\\\\Handlers\\\\FileHandler\\:\\:\\$savePath is not the same as PHPDoc type array\\|string of overridden property CodeIgniter\\\\Session\\\\Handlers\\\\BaseHandler\\:\\:\\$savePath\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Session/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Variable \\$written might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Session/Handlers/FileHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Session/Handlers/MemcachedHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Session/Handlers/RedisHandler.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 13,
+	'path' => __DIR__ . '/system/Session/Session.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Session\\\\Session\\:\\:configure\\(\\) has no return type specified\\.$#',
@@ -1042,6 +2407,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Session/Session.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(bool\\) of method CodeIgniter\\\\Session\\\\Session\\:\\:markAsFlashdata\\(\\) should be covariant with return type \\(false\\) of method CodeIgniter\\\\Session\\\\SessionInterface\\:\\:markAsFlashdata\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Session/Session.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Session/Session.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Session\\\\SessionInterface\\:\\:destroy\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Session/SessionInterface.php',
@@ -1090,6 +2465,11 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Session\\\\SessionInterface\\:\\:unmarkTempdata\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Session/SessionInterface.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Test/CIDatabaseTestCase.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\CIDatabaseTestCase\\:\\:clearInsertCache\\(\\) has no return type specified\\.$#',
@@ -1202,6 +2582,21 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/CIUnitTestCase.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/CIUnitTestCase.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function is_array\\(\\) with non\\-empty\\-array will always evaluate to true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/DOMParser.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 7,
+	'path' => __DIR__ . '/system/Test/DOMParser.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Access to an undefined property object\\:\\:\\$createdField\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Fabricator.php',
@@ -1217,9 +2612,19 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/Fabricator.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Test/Fabricator.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\Fabricator\\:\\:resetCounts\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Fabricator.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 10,
+	'path' => __DIR__ . '/system/Test/FeatureTestCase.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\FeatureTestCase\\:\\:clearInsertCache\\(\\) has no return type specified\\.$#',
@@ -1342,6 +2747,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/Mock/MockCURLRequest.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:assertHas\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
@@ -1357,12 +2767,37 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:get\\(\\) should be covariant with return type \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Cache\\\\CacheInterface\\:\\:get\\(\\)$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:remember\\(\\) should be covariant with return type \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Cache\\\\Handlers\\\\BaseHandler\\:\\:remember\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockCodeIgniter\\:\\:callExit\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Mock/MockCodeIgniter.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$insert_id on object\\|resource\\|false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:_close\\(\\) should return mixed but return statement is missing\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
 ];
@@ -1379,6 +2814,36 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:\\$returnValues has no type specified\\.$#',
 	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(array\\{code\\: int\\|string\\|null, message\\: string\\|null\\}\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:error\\(\\) should be covariant with return type \\(array\\<string, int\\|string\\>\\) of method CodeIgniter\\\\Database\\\\ConnectionInterface\\<object\\|resource,object\\|resource\\>\\:\\:error\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(bool\\|CodeIgniter\\\\Database\\\\BaseResult\\|CodeIgniter\\\\Database\\\\Query\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:query\\(\\) should be covariant with return type \\(bool\\|CodeIgniter\\\\Database\\\\BaseResult\\<object\\|resource, object\\|resource\\>\\|CodeIgniter\\\\Database\\\\Query\\) of method CodeIgniter\\\\Database\\\\BaseConnection\\<object\\|resource,object\\|resource\\>\\:\\:query\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(bool\\|CodeIgniter\\\\Database\\\\BaseResult\\|CodeIgniter\\\\Database\\\\Query\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:query\\(\\) should be covariant with return type \\(bool\\|CodeIgniter\\\\Database\\\\BaseResult\\<object\\|resource, object\\|resource\\>\\|CodeIgniter\\\\Database\\\\Query\\) of method CodeIgniter\\\\Database\\\\ConnectionInterface\\<object\\|resource,object\\|resource\\>\\:\\:query\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(bool\\|object\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:execute\\(\\) should be covariant with return type \\(object\\|resource\\|false\\) of method CodeIgniter\\\\Database\\\\BaseConnection\\<object\\|resource,object\\|resource\\>\\:\\:execute\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:connect\\(\\) should be covariant with return type \\(object\\|resource\\|false\\) of method CodeIgniter\\\\Database\\\\ConnectionInterface\\<object\\|resource,object\\|resource\\>\\:\\:connect\\(\\)$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockConnection\\:\\:setDatabase\\(\\) should be covariant with return type \\(bool\\) of method CodeIgniter\\\\Database\\\\ConnectionInterface\\<object\\|resource,object\\|resource\\>\\:\\:setDatabase\\(\\)$#',
+	'count' => 2,
 	'path' => __DIR__ . '/system/Test/Mock/MockConnection.php',
 ];
 $ignoreErrors[] = [
@@ -1442,6 +2907,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/Mock/MockResourceController.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Test/Mock/MockResourcePresenter.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockResourcePresenter\\:\\:getFormat\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Mock/MockResourcePresenter.php',
@@ -1465,6 +2935,16 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockResponse\\:\\:misbehave\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Mock/MockResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockResult\\:\\:fetchAssoc\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockResult.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockResult\\:\\:fetchAssoc\\(\\) should be covariant with return type \\(array\\|false\\|null\\) of method CodeIgniter\\\\Database\\\\BaseResult\\<object\\|resource,object\\|resource\\>\\:\\:fetchAssoc\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/Mock/MockResult.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Test\\\\Mock\\\\MockSecurityConfig\\:\\:\\$excludeURIs has no type specified\\.$#',
@@ -1542,9 +3022,24 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/TestLogger.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$level \\(string\\) of method CodeIgniter\\\\Test\\\\TestLogger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\LoggerInterface\\:\\:log\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/TestLogger.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Test\\\\TestLogger\\:\\:\\$op_logs has no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/TestLogger.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/TestResponse.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method CodeIgniter\\\\Test\\\\TestResponse\\:\\:__call\\(\\) should return mixed but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Test/TestResponse.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Test\\\\TestResponse\\:\\:assertCookie\\(\\) has no return type specified\\.$#',
@@ -1657,13 +3152,58 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Throttle/Throttler.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Validation/CreditCardRules.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Validation/DotArrayFilter.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Validation/FormatRules.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 11,
+	'path' => __DIR__ . '/system/Validation/Rules.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/system/Validation/StrictRules/Rules.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/system/Validation/Validation.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Validation\\\\Validation\\:\\:isClosure\\(\\) has parameter \\$rule with no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Validation/Validation.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/Validation/Validation.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/Validation/Views/list.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Call to an undefined static method CodeIgniter\\\\Config\\\\Factories\\:\\:cells\\(\\)\\.$#',
 	'count' => 1,
+	'path' => __DIR__ . '/system/View/Cell.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 8,
 	'path' => __DIR__ . '/system/View/Cell.php',
 ];
 $ignoreErrors[] = [
@@ -1672,14 +3212,64 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/View/Cell.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/View/Filters.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 9,
+	'path' => __DIR__ . '/system/View/Parser.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\View\\\\Parser\\:\\:addPlugin\\(\\) has parameter \\$callback with no signature specified for callable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/View/Parser.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/View/Plugins.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 9,
+	'path' => __DIR__ . '/system/View/Table.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\View\\\\Table\\:\\:\\$function type has no signature specified for callable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/View/Table.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/system/View/View.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#2 \\$context \\(\'attr\'\\|\'css\'\\|\'html\'\\|\'js\'\\|\'raw\'\\|\'url\'\\|null\\) of method CodeIgniter\\\\View\\\\View\\:\\:setData\\(\\) should be contravariant with parameter \\$context \\(string\\|null\\) of method CodeIgniter\\\\View\\\\RendererInterface\\:\\:setData\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/View/View.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#3 \\$context \\(\'attr\'\\|\'css\'\\|\'html\'\\|\'js\'\\|\'raw\'\\|\'url\'\\|null\\) of method CodeIgniter\\\\View\\\\View\\:\\:setVar\\(\\) should be contravariant with parameter \\$context \\(string\\|null\\) of method CodeIgniter\\\\View\\\\RendererInterface\\:\\:setVar\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/system/View/View.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/system/View/View.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Expr\\\\New_\\) of method Utils\\\\PHPStan\\\\CheckFrameworkExceptionInstantiationViaNamedConstructorRule\\:\\:processNode\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method PHPStan\\\\Rules\\\\Rule\\<PhpParser\\\\Node\\>\\:\\:processNode\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/utils/PHPStan/CheckFrameworkExceptionInstantiationViaNamedConstructorRule.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$node \\(PhpParser\\\\Node\\\\Stmt\\) of method Utils\\\\PHPStan\\\\CheckUseStatementsAfterLicenseRule\\:\\:processNode\\(\\) should be contravariant with parameter \\$node \\(PhpParser\\\\Node\\) of method PHPStan\\\\Rules\\\\Rule\\<PhpParser\\\\Node\\>\\:\\:processNode\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/utils/PHPStan/CheckUseStatementsAfterLicenseRule.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ services:
 
 includes:
 	- phpstan-baseline.php
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
 	phpVersion: 80100
@@ -41,3 +42,6 @@ parameters:
 	checkGenericClassInNonGenericObjectType: false
 	checkMissingCallableSignature: true
 	treatPhpDocTypesAsCertain: false
+	strictRules:
+		allRules: false
+		disallowedConstructs: true


### PR DESCRIPTION
**Description**
To disallow `empty()` - it's a very loose comparison (see [manual](https://php.net/empty)), it's recommended to use more strict one. See https://github.com/codeigniter4/CodeIgniter4/pull/7896#issuecomment-1711441144

- add https://github.com/phpstan/phpstan-strict-rules
- enable the rule disallowedConstructs

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
