### PR TITLE
[Rector] Testing Rector dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpcov": "^8.2",
         "phpunit/phpunit": "^9.1",
         "predis/predis": "^1.1 || ^2.0",
-        "rector/rector": "0.18.2",
+        "rector/rector": "dev-main",
         "vimeo/psalm": "^5.0"
     },
     "suggest": {

--- a/rector.php
+++ b/rector.php
@@ -38,7 +38,6 @@ use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
-use Rector\PHPUnit\CodeQuality\Rector\Class_\ConstructClassMethodToSetUpTestCaseRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
@@ -57,7 +56,7 @@ return static function (RectorConfig $rectorConfig): void {
         PHPUnitSetList::PHPUNIT_100,
     ]);
 
-    $rectorConfig->parallel(240, 8, 1);
+    $rectorConfig->parallel();
 
     // paths to refactor; solid alternative to CLI arguments
     $rectorConfig->paths([__DIR__ . '/app', __DIR__ . '/system', __DIR__ . '/tests', __DIR__ . '/utils']);
@@ -83,13 +82,6 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker
             __DIR__ . '/tests/system/Test/ReflectionHelperTest.php',
-        ],
-
-        ConstructClassMethodToSetUpTestCaseRector::class => [
-            // breaks the constructor
-            __DIR__ . '/system/Test/TestResponse.php',
-            // See https://github.com/rectorphp/rector/issues/8188
-            __DIR__ . '/system/Test/ControllerResponse.php',
         ],
 
         RemoveUnusedConstructorParamRector::class => [


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

Hi @kenjis @paulbalandan could you test the rector/rector:dev-main with clean up parallel config below and verify if the performance drawback resolved without setting `$jobSize` config in the `parallel()` config below?

If that works, we can remove passing arguments in the `parallel()` config in next rector release.

Current rector dev-main changed the parallel process by @staabm . I mention you here so you can have fast feedback here in case we found a different use case.

Thank you. 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
