### PR TITLE
Drop PHP 7.4 support

### DIFF
--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '7.4'
           - '8.0'
+          - '8.1'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         php-version:
           - '8.0'
-          - '8.1'
+          - '8.2'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -55,7 +55,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'
@@ -85,7 +84,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'
@@ -99,7 +97,7 @@ jobs:
         mysql-version:
           - '5.7'
         include:
-          - php-version: '7.4'
+          - php-version: '8.0'
             db-platform: MySQLi
             mysql-version: '8.0'
           - php-version: '8.3'
@@ -127,7 +125,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'
@@ -156,7 +153,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'

--- a/.github/workflows/test-rector.yml
+++ b/.github/workflows/test-rector.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0', '8.2']
         paths:
           - app
           - system

--- a/.github/workflows/test-rector.yml
+++ b/.github/workflows/test-rector.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['8.0', '8.1']
         paths:
           - app
           - system

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -80,13 +80,10 @@ $config = Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
     'admin@codeigniter.com'
 );
 
-// @TODO: remove this check when support for PHP 7.4 is dropped
-if (PHP_VERSION_ID >= 80000) {
-    $config
-        ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
-        ->setRules(array_merge($config->getRules(), [
-            NoCodeSeparatorCommentFixer::name() => true,
-        ]));
-}
+$config
+    ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
+    ->setRules(array_merge($config->getRules(), [
+        NoCodeSeparatorCommentFixer::name() => true,
+    ]));
 
 return $config;

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -62,13 +62,10 @@ $options = [
 
 $config = Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
 
-// @TODO: remove this check when support for PHP 7.4 is dropped
-if (PHP_VERSION_ID >= 80000) {
-    $config
-        ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
-        ->setRules(array_merge($config->getRules(), [
-            NoCodeSeparatorCommentFixer::name() => true,
-        ]));
-}
+$config
+    ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
+    ->setRules(array_merge($config->getRules(), [
+        NoCodeSeparatorCommentFixer::name() => true,
+    ]));
 
 return $config;

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -67,13 +67,10 @@ $options = [
 
 $config = Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
 
-// @TODO: remove this check when support for PHP 7.4 is dropped
-if (PHP_VERSION_ID >= 80000) {
-    $config
-        ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
-        ->setRules(array_merge($config->getRules(), [
-            NoCodeSeparatorCommentFixer::name() => true,
-        ]));
-}
+$config
+    ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
+    ->setRules(array_merge($config->getRules(), [
+        NoCodeSeparatorCommentFixer::name() => true,
+    ]));
 
 return $config;

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ## Server Requirements
 
-PHP version 7.4 or higher is required, with the following extensions installed:
+PHP version 8.0 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)

--- a/admin/framework/README.md
+++ b/admin/framework/README.md
@@ -42,7 +42,7 @@ Please read the [*Contributing to CodeIgniter*](https://github.com/codeigniter4/
 
 ## Server Requirements
 
-PHP version 7.4 or higher is required, with the following extensions installed:
+PHP version 8.0 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -10,7 +10,7 @@
         "slack": "https://codeigniterchat.slack.com"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/admin/starter/.github/workflows/phpunit.yml
+++ b/admin/starter/.github/workflows/phpunit.yml
@@ -2,7 +2,7 @@ name: PHPUnit
 
 on:
   pull_request:
-    branches: 
+    branches:
       - develop
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['8.0', '8.1']
 
     runs-on: ubuntu-latest
 

--- a/admin/starter/.github/workflows/phpunit.yml
+++ b/admin/starter/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0', '8.2']
 
     runs-on: ubuntu-latest
 

--- a/admin/starter/README.md
+++ b/admin/starter/README.md
@@ -50,7 +50,7 @@ Problems with it can be raised on our forum, or as issues in the main repository
 
 ## Server Requirements
 
-PHP version 7.4 or higher is required, with the following extensions installed:
+PHP version 8.0 or higher is required, with the following extensions installed:
 
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -10,7 +10,7 @@
         "slack": "https://codeigniterchat.slack.com"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "codeigniter4/framework": "^4.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "slack": "https://codeigniterchat.slack.com"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/contributing/pull_request.md
+++ b/contributing/pull_request.md
@@ -136,7 +136,7 @@ See [Contribution CSS](./css.md).
 
 ### Compatibility
 
-CodeIgniter4 requires [PHP 7.4](https://php.net/releases/7_4_0.php).
+CodeIgniter4 requires [PHP 8.0](https://php.net/releases/8_0_0.php).
 
 ### Backwards Compatibility
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,7 @@
 <?php
 
 // Check PHP version.
-$minPhpVersion = '7.4'; // If you update this, don't forget to update `spark`.
+$minPhpVersion = '8.0'; // If you update this, don't forget to update `spark`.
 if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
     $message = sprintf(
         'Your PHP version must be %s or higher to run CodeIgniter. Current version: %s',

--- a/spark
+++ b/spark
@@ -27,7 +27,7 @@ if (strpos(PHP_SAPI, 'cgi') === 0) {
 }
 
 // Check PHP version.
-$minPhpVersion = '7.4'; // If you update this, don't forget to update `public/index.php`.
+$minPhpVersion = '8.0'; // If you update this, don't forget to update `public/index.php`.
 if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
     $message = sprintf(
         'Your PHP version must be %s or higher to run CodeIgniter. Current version: %s',

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -343,11 +343,7 @@ class Autoloader
             );
         }
         if ($result === false) {
-            if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
-                $message = preg_last_error_msg();
-            } else {
-                $message = 'Regex error. error code: ' . preg_last_error();
-            }
+            $message = preg_last_error_msg();
 
             throw new RuntimeException($message . '. filename: "' . $filename . '"');
         }

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\Debug;
 
 use ArgumentCountError;
 use CodeIgniter\Test\CIUnitTestCase;
-use ErrorException;
 use RuntimeException;
 
 /**
@@ -172,11 +171,7 @@ final class TimerTest extends CIUnitTestCase
 
     public function testRecordThrowsErrorOnCallableWithParams(): void
     {
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(ArgumentCountError::class);
-        } else {
-            $this->expectException(ErrorException::class);
-        }
+        $this->expectException(ArgumentCountError::class);
 
         $timer = new Timer();
         $timer->record('error', 'strlen');

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -12,7 +12,6 @@
 namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use ErrorException;
 use ValueError;
 
 /**
@@ -303,13 +302,7 @@ final class ArrayHelperTest extends CIUnitTestCase
      */
     public function testArraySortByMultipleKeysFailsInconsistentArraySizes($data): void
     {
-        // PHP 8 changes this error type
-        if (PHP_VERSION_ID >= 80000) {
-            $this->expectException(ValueError::class);
-        } else {
-            $this->expectException(ErrorException::class);
-        }
-
+        $this->expectException(ValueError::class);
         $this->expectExceptionMessage('Array sizes are inconsistent');
 
         $sortColumns = [

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -12,6 +12,7 @@ Release Date: Unreleased
 Highlights
 **********
 
+- Update minimal PHP requirement to 8.0.
 - TBD
 
 BREAKING

--- a/user_guide_src/source/installation/installing_composer.rst
+++ b/user_guide_src/source/installation/installing_composer.rst
@@ -139,11 +139,11 @@ Next Minor Version
 If you want to use the next minor version branch, after using the ``builds`` command
 edit **composer.json** manually.
 
-If you try the ``4.4`` branch, change the version to ``4.4.x-dev``::
+If you try the ``4.6`` branch, change the version to ``4.6.x-dev``::
 
     "require": {
-        "php": "^7.4 || ^8.0",
-        "codeigniter4/codeigniter4": "4.4.x-dev"
+        "php": "^8.0",
+        "codeigniter4/codeigniter4": "4.6.x-dev"
     },
 
 And run ``composer update`` to sync your vendor

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -41,7 +41,7 @@ Downloads
 Namespaces
 ==========
 
-- CI4 is built for PHP 7.4+, and everything in the framework is namespaced,
+- CI4 is built for PHP 8.0+, and everything in the framework is namespaced,
   except for the helper and lang files.
 
 Application Structure

--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -10,7 +10,7 @@ Server Requirements
 PHP and Required Extensions
 ***************************
 
-`PHP <https://www.php.net/>`_ version 7.4 or newer is required, with the following PHP extensions are enabled:
+`PHP <https://www.php.net/>`_ version 8.0 or newer is required, with the following PHP extensions are enabled:
 
   - `intl <https://www.php.net/manual/en/intl.requirements.php>`_
   - `mbstring <https://www.php.net/manual/en/mbstring.requirements.php>`_


### PR DESCRIPTION
**Description**
See #6921
Supersedes #6922

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
