### PR TITLE
chore: add PHPStan matchingInheritedMethodNames rule

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,3 +36,4 @@ parameters:
 	strictRules:
 		allRules: false
 		disallowedConstructs: true
+		matchingInheritedMethodNames: true


### PR DESCRIPTION
**Description**
We already follow the rule.
See https://github.com/phpstan/phpstan-strict-rules/blob/1.5.x/src/Rules/Methods/WrongCaseOfInheritedMethodRule.php

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
