### PR TITLE
Fix: Routing::loadRoutes() in windows do not validate correctly $routesFiles

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -319,6 +319,10 @@ class RouteCollection implements RouteCollectionInterface
             return $this;
         }
 
+        // Normalize the path string in routesFile
+        $realpath   = realpath($routesFile);
+        $routesFile = ($realpath === false) ? $routesFile : $realpath;
+
         // Include the passed in routesFile if it doesn't exist.
         // Only keeping that around for BC purposes for now.
         $routeFiles = $this->routeFiles;


### PR DESCRIPTION
This occours because the argument definition is `string $routesFile = APPPATH . 'Config/Routes.php'` (using an slash `/`) and in the constructor `$this->routeFiles` is initialized with `realpath($routesFile)`.

When validating if `$routesFile` exist in the `$routeFiles` array it do not exist, so add it to the `$routeFiles[]` duplicating the path.

**expected**:
```
$routeFiles = [
    0 => 'D:\projects\tests\app\Config\Routes.php',
];
```

**result**: 
```
$routeFiles = [
    0 => 'D:\projects\tests\app\Config\Routes.php',
    1 => 'D:\projects\tests\app\Config/Routes.php',
];
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
