### PR TITLE
docs: add warning on PHP 7.4 EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ PHP version 7.4 or higher is required, with the following extensions installed:
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)
 
+> **Warning**
+> The end of life date for PHP 7.4 was November 28, 2022. If you are
+> still using PHP 7.4, you should upgrade immediately. The end of life date
+> for PHP 8.0 will be November 26, 2023.
+
 Additionally, make sure that the following extensions are enabled in your PHP:
 
 - json (enabled by default - don't turn it off)

--- a/admin/framework/README.md
+++ b/admin/framework/README.md
@@ -47,6 +47,11 @@ PHP version 7.4 or higher is required, with the following extensions installed:
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)
 
+> **Warning**
+> The end of life date for PHP 7.4 was November 28, 2022. If you are
+> still using PHP 7.4, you should upgrade immediately. The end of life date
+> for PHP 8.0 will be November 26, 2023.
+
 Additionally, make sure that the following extensions are enabled in your PHP:
 
 - json (enabled by default - don't turn it off)

--- a/admin/starter/README.md
+++ b/admin/starter/README.md
@@ -55,6 +55,11 @@ PHP version 7.4 or higher is required, with the following extensions installed:
 - [intl](http://php.net/manual/en/intl.requirements.php)
 - [mbstring](http://php.net/manual/en/mbstring.installation.php)
 
+> **Warning**
+> The end of life date for PHP 7.4 was November 28, 2022. If you are
+> still using PHP 7.4, you should upgrade immediately. The end of life date
+> for PHP 8.0 will be November 26, 2023.
+
 Additionally, make sure that the following extensions are enabled in your PHP:
 
 - json (enabled by default - don't turn it off)

--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -16,6 +16,10 @@ PHP and Required Extensions
   - `mbstring <https://www.php.net/manual/en/mbstring.requirements.php>`_
   - `json <https://www.php.net/manual/en/json.requirements.php>`_
 
+.. warning:: The end of life date for PHP 7.4 was November 28, 2022. If you are
+    still using PHP 7.4, you should upgrade immediately. The end of life date
+    for PHP 8.0 will be November 26, 2023.
+
 ***********************
 Optional PHP Extensions
 ***********************


### PR DESCRIPTION
**Description**
Older versions of PHP that are not supported should not be used.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
