### PR TITLE
docs: add description of incompatible behavior in Validation

### DIFF
--- a/user_guide_src/source/installation/upgrade_validations.rst
+++ b/user_guide_src/source/installation/upgrade_validations.rst
@@ -18,6 +18,8 @@ What has been changed
   Use :ref:`Rule Classes <validation-using-rule-classes>` or
   :ref:`Closure Rule <validation-using-closure-rule>`
   instead.
+- In CI3, Callbacks/Callable rules were prioritized, but in CI4, Closure Rules are
+  not prioritized, and are checked in the order in which they are listed.
 - CI4 validation format rules do not permit empty string.
 - CI4 validation never changes your data.
 - Since v4.3.0, :php:func:`validation_errors()` has been introduced, but the API is different from CI3's.


### PR DESCRIPTION
**Description**
- add description of incompatible behavior

See https://github.com/bcit-ci/CodeIgniter/blob/63d037565dd782795021dcbd3b1ca6f8c8a509e4/system/libraries/Form_validation.php#L503-L508

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
