### PR TITLE
chore: fix: event trigger label conflict

### DIFF
--- a/.github/workflows/label-conflict.yml
+++ b/.github/workflows/label-conflict.yml
@@ -1,4 +1,4 @@
-name: Auto Label Conflicts
+name: Auto Comment Conflicts
 on:
   pull_request:
     branches:
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  auto-label-conflict:
+  auto-comment-conflict:
     if: github.event.label.name == 'stale'
     runs-on: ubuntu-latest
     permissions:
@@ -23,7 +23,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            :wave: Hi,
+            :wave: Hi, @${{ github.event.pull_request.user.login }}!
 
             We detected conflicts in your PR against the base branch :speak_no_evil:
             You may want to sync :arrows_counterclockwise: your branch with upstream!

--- a/.github/workflows/label-conflict.yml
+++ b/.github/workflows/label-conflict.yml
@@ -1,9 +1,5 @@
 name: Auto Label Conflicts
-on:
-  pull_request:
-    branches:
-      - 'develop'
-      - '4.*'
+on: pull_request_target
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -15,13 +11,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto-label:
+  auto-label-conflict:
     runs-on: ubuntu-latest
     steps:
       - uses: prince-chrismc/label-merge-conflicts-action@v3
         with:
           conflict_label_name: 'stale'
-          github_token: ${{ github.token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # --- Optional Inputs ---
           # To make sure the merge commit exactly matches the branch

--- a/.github/workflows/label-conflict.yml
+++ b/.github/workflows/label-conflict.yml
@@ -1,31 +1,27 @@
 name: Auto Label Conflicts
-on: pull_request_target
+on:
+  pull_request:
+    branches:
+      - 'develop'
+      - '4.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-
 jobs:
   auto-label-conflict:
+    if: github.event.label.name == 'stale'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: prince-chrismc/label-merge-conflicts-action@v3
+      - name: Add comment for PR with conflict
+        uses: peter-evans/create-or-update-comment@v3
         with:
-          conflict_label_name: 'stale'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-          # --- Optional Inputs ---
-          # To make sure the merge commit exactly matches the branch
-          detect_merge_changes: true # or true to handle as conflicts
-          # By default a comment will be left, adding `conflict_comment: ''` will disable comments
-          # The optional `${author}` will be replaced with the username of the pull request
-          conflict_comment: |
-            :wave: Hi, @${author},
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            :wave: Hi,
 
             We detected conflicts in your PR against the base branch :speak_no_evil:
             You may want to sync :arrows_counterclockwise: your branch with upstream!

--- a/.github/workflows/label-conflict.yml
+++ b/.github/workflows/label-conflict.yml
@@ -16,6 +16,7 @@ jobs:
     if: github.event.label.name == 'stale'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Add comment for PR with conflict

--- a/.github/workflows/label-conflict.yml
+++ b/.github/workflows/label-conflict.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'develop'
       - '4.*'
+    types:
+      - labeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/label-conflict.yml
+++ b/.github/workflows/label-conflict.yml
@@ -13,11 +13,11 @@ concurrency:
 
 jobs:
   auto-comment-conflict:
-    if: github.event.label.name == 'stale'
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+    if: github.event.label.name == 'stale'
+    runs-on: ubuntu-latest
     steps:
       - name: Add comment for PR with conflict
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/label-conflict.yml
+++ b/.github/workflows/label-conflict.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Add comment for PR with conflict
         uses: peter-evans/create-or-update-comment@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             :wave: Hi, @${{ github.event.pull_request.user.login }}!


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Based on https://github.com/actions/labeler#permissions and https://github.com/prince-chrismc/label-merge-conflicts-action#faq---how-do-i-fix-resource-not-accessible-by-integration must using event `pull_request_target`

> In order to add labels to pull requests, the GitHub labeler action requires write permissions on the pull-request. However, when the action runs on a pull request from a forked repository, GitHub only grants read access tokens for pull_request events, at most. If you encounter an Error: HttpError: Resource not accessible by integration, it's likely due to these permission constraints. To resolve this issue, you can modify the on: section of your workflow to use [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) instead of pull_request (see example [above](https://github.com/actions/labeler#create-workflow)). This change allows the action to have write access, because pull_request_target alters the [context of the action](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) and safely grants additional permissions.

Follow-up #7928

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
