### PR TITLE
[PHPStan] Add @var string[] on array of string, detected by enable StringifyStrNeedlesRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -37,7 +37,6 @@ use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
 use Rector\Php71\Rector\FuncCall\CountOnNullRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
-use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
@@ -80,7 +79,6 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/tests/system/Filters/fixtures',
         __DIR__ . '/tests/_support',
         JsonThrowOnErrorRector::class,
-        StringifyStrNeedlesRector::class,
         YieldDataProviderRector::class,
 
         RemoveUnusedPrivateMethodRector::class => [

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -27,7 +27,8 @@ final class ControllerMethodReader
     private string $namespace;
 
     /**
-     * @var string[]
+     * @var arrray<int, string>
+     * @phpstan-var list<string>
      */
     private array $httpMethods;
 

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -26,6 +26,9 @@ final class ControllerMethodReader
      */
     private string $namespace;
 
+    /**
+     * @var string[]
+     */
     private array $httpMethods;
 
     /**

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -27,7 +27,7 @@ final class ControllerMethodReader
     private string $namespace;
 
     /**
-     * @var arrray<int, string>
+     * @var array<int, string>
      * @phpstan-var list<string>
      */
     private array $httpMethods;

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -352,7 +352,7 @@ class Email
      * Character sets valid for 7-bit encoding,
      * excluding language suffix.
      *
-     * @var array
+     * @var string[]
      */
     protected $baseCharsets = [
         'us-ascii',
@@ -862,7 +862,7 @@ class Email
         }
 
         foreach ($this->baseCharsets as $charset) {
-            if (strpos($this->charset, $charset) === 0) {
+            if (strpos($this->charset, (string) $charset) === 0) {
                 $this->encoding = '7bit';
 
                 break;

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -862,7 +862,7 @@ class Email
         }
 
         foreach ($this->baseCharsets as $charset) {
-            if (strpos($this->charset, (string) $charset) === 0) {
+            if (strpos($this->charset, $charset) === 0) {
                 $this->encoding = '7bit';
 
                 break;

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -352,7 +352,8 @@ class Email
      * Character sets valid for 7-bit encoding,
      * excluding language suffix.
      *
-     * @var string[]
+     * @var arrray<int, string>
+     * @phpstan-var list<string>
      */
     protected $baseCharsets = [
         'us-ascii',

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -352,7 +352,7 @@ class Email
      * Character sets valid for 7-bit encoding,
      * excluding language suffix.
      *
-     * @var arrray<int, string>
+     * @var array<int, string>
      * @phpstan-var list<string>
      */
     protected $baseCharsets = [

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1297,7 +1297,8 @@ class RouteCollection implements RouteCollectionInterface
          * Build our resulting string, inserting the $params in
          * the appropriate places.
          *
-         * @var string[] $patterns
+         * @var arrray<int, string> $patterns
+         * @phpstan-var list<string> $patterns
          */
         $patterns = $matches[0];
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1349,8 +1349,8 @@ class RouteCollection implements RouteCollectionInterface
          * Build our resulting string, inserting the $params in
          * the appropriate places.
          *
-         * @var arrray<int, string> $patterns
-         * @phpstan-var list<string> $patterns
+         * @var arrray<int, string> $placeholders
+         * @phpstan-var list<string> $placeholders
          */
         $placeholders = $matches[0];
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1297,7 +1297,7 @@ class RouteCollection implements RouteCollectionInterface
          * Build our resulting string, inserting the $params in
          * the appropriate places.
          *
-         * @var arrray<int, string> $patterns
+         * @var array<int, string> $patterns
          * @phpstan-var list<string> $patterns
          */
         $patterns = $matches[0];
@@ -1349,7 +1349,7 @@ class RouteCollection implements RouteCollectionInterface
          * Build our resulting string, inserting the $params in
          * the appropriate places.
          *
-         * @var arrray<int, string> $placeholders
+         * @var array<int, string> $placeholders
          * @phpstan-var list<string> $placeholders
          */
         $placeholders = $matches[0];

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1293,9 +1293,15 @@ class RouteCollection implements RouteCollectionInterface
             return '/' . ltrim($from, '/');
         }
 
-        // Build our resulting string, inserting the $params in
-        // the appropriate places.
-        foreach ($matches[0] as $index => $pattern) {
+        /**
+         * Build our resulting string, inserting the $params in
+         * the appropriate places.
+         *
+         * @var string[] $patterns
+         */
+        $patterns = $matches[0];
+
+        foreach ($patterns as $index => $pattern) {
             if (! preg_match('#^' . $pattern . '$#u', $params[$index])) {
                 throw RouterException::forInvalidParameterType();
             }
@@ -1338,9 +1344,15 @@ class RouteCollection implements RouteCollectionInterface
             $locale = $params[$placeholderCount];
         }
 
-        // Build our resulting string, inserting the $params in
-        // the appropriate places.
-        foreach ($matches[0] as $index => $placeholder) {
+        /**
+         * Build our resulting string, inserting the $params in
+         * the appropriate places.
+         *
+         * @var string[] $placeholders
+         */
+        $placeholders = $matches[0];
+
+        foreach ($placeholders as $index => $placeholder) {
             if (! isset($params[$index])) {
                 throw new InvalidArgumentException(
                     'Missing argument for "' . $placeholder . '" in route "' . $from . '".'

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1349,7 +1349,8 @@ class RouteCollection implements RouteCollectionInterface
          * Build our resulting string, inserting the $params in
          * the appropriate places.
          *
-         * @var string[] $placeholders
+         * @var arrray<int, string> $patterns
+         * @phpstan-var list<string> $patterns
          */
         $placeholders = $matches[0];
 


### PR DESCRIPTION
**Description**

with enable `StringifyStrNeedlesRector`, the cast `(string)` is applied to array data with mixed type. 

This PR apply `@var string[]` so it skipped by `StringifyStrNeedlesRector` correctly.

https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#stringifystrneedlesrector

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
