### PR TITLE
Refactor: Apply PHPStan rule "Short ternary operator is not allowed" to RouteCollection

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2317,11 +2317,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Router/RouteCollection.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/system/Router/RouteCollection.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:add\\(\\) has parameter \\$to with no signature specified for Closure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Router/RouteCollectionInterface.php',

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1700,9 +1700,7 @@ class RouteCollection implements RouteCollectionInterface
      */
     protected function loadRoutesOptions(?string $verb = null): array
     {
-        if (null === $verb || $verb === '') {
-            $verb = $this->getHTTPVerb();
-        }
+        $verb ??= $this->getHTTPVerb();
 
         $options = $this->routesOptions[$verb] ?? [];
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -302,7 +302,8 @@ class RouteCollection implements RouteCollectionInterface
 
         // Normalize the path string in routeFiles array.
         foreach ($this->routeFiles as $routeKey => $routesFile) {
-            $this->routeFiles[$routeKey] = realpath($routesFile) ?: $routesFile;
+            $realpath                    = realpath($routesFile);
+            $this->routeFiles[$routeKey] = ($realpath === false) ? $routesFile : $realpath;
         }
     }
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1700,7 +1700,9 @@ class RouteCollection implements RouteCollectionInterface
      */
     protected function loadRoutesOptions(?string $verb = null): array
     {
-        $verb = $verb ?: $this->getHTTPVerb();
+        if (null === $verb || $verb === '') {
+            $verb = $this->getHTTPVerb();
+        }
 
         $options = $this->routesOptions[$verb] ?? [];
 


### PR DESCRIPTION
Apply PHPStan rule "Short ternary operator is not allowed" to RouteCollection

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
