### PR TITLE
fix: filter exec order

### DIFF
--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -13,4 +13,9 @@ class Feature extends BaseConfig
      * Use improved new auto routing instead of the default legacy version.
      */
     public bool $autoRoutesImproved = false;
+
+    /**
+     * Use filter execution order in 4.4 or before.
+     */
+    public bool $oldFilterOrder = false;
 }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -31,6 +31,7 @@ use CodeIgniter\Router\RouteCollectionInterface;
 use CodeIgniter\Router\Router;
 use Config\App;
 use Config\Cache;
+use Config\Feature;
 use Config\Kint as KintConfig;
 use Config\Services;
 use Exception;
@@ -458,6 +459,11 @@ class CodeIgniter
             // we need to ensure it's active for the current request
             if ($routeFilter !== null) {
                 $filters->enableFilters($routeFilter, 'before');
+
+                if (! config(Feature::class)->oldFilterOrder) {
+                    $routeFilter = array_reverse($routeFilter);
+                }
+
                 $filters->enableFilters($routeFilter, 'after');
             }
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -447,7 +447,7 @@ class CodeIgniter
             return $response;
         }
 
-        $routeFilter = $this->tryToRouteIt($routes);
+        $routeFilters = $this->tryToRouteIt($routes);
 
         $uri = $this->determinePath();
 
@@ -457,14 +457,14 @@ class CodeIgniter
 
             // If any filters were specified within the routes file,
             // we need to ensure it's active for the current request
-            if ($routeFilter !== null) {
-                $filters->enableFilters($routeFilter, 'before');
+            if ($routeFilters !== null) {
+                $filters->enableFilters($routeFilters, 'before');
 
                 if (! config(Feature::class)->oldFilterOrder) {
-                    $routeFilter = array_reverse($routeFilter);
+                    $routeFilters = array_reverse($routeFilters);
                 }
 
-                $filters->enableFilters($routeFilter, 'after');
+                $filters->enableFilters($routeFilters, 'after');
             }
 
             // Run "before" filters

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -15,6 +15,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\Router\Router;
+use Config\Feature;
 use Config\Services;
 
 /**
@@ -52,7 +53,13 @@ final class FilterFinder
         // Add route filters
         try {
             $routeFilters = $this->getRouteFilters($uri);
+
             $this->filters->enableFilters($routeFilters, 'before');
+
+            if (! config(Feature::class)->oldFilterOrder) {
+                $routeFilters = array_reverse($routeFilters);
+            }
+
             $this->filters->enableFilters($routeFilters, 'after');
 
             $this->filters->initialize($uri);

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -15,6 +15,7 @@ use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
+use Config\Feature;
 use Config\Filters as FiltersConfig;
 use Config\Modules;
 use Config\Services;
@@ -245,9 +246,15 @@ class Filters
             return $this;
         }
 
-        $this->processFilters($uri);
-        $this->processMethods();
-        $this->processGlobals($uri);
+        if (config(Feature::class)->oldFilterOrder) {
+            $this->processGlobals($uri);
+            $this->processMethods();
+            $this->processFilters($uri);
+        } else {
+            $this->processFilters($uri);
+            $this->processMethods();
+            $this->processGlobals($uri);
+        }
 
         // Set the toolbar filter to the last position to be executed
         if (in_array('toolbar', $this->filters['after'], true)
@@ -464,7 +471,11 @@ class Filters
         }
 
         if (isset($filters['before'])) {
-            $this->filters['before'] = array_merge($filters['before'], $this->filters['before']);
+            if (config(Feature::class)->oldFilterOrder) {
+                $this->filters['before'] = array_merge($this->filters['before'], $filters['before']);
+            } else {
+                $this->filters['before'] = array_merge($filters['before'], $this->filters['before']);
+            }
         }
 
         if (isset($filters['after'])) {
@@ -487,7 +498,11 @@ class Filters
         $method = strtolower($this->request->getMethod()) ?? 'cli';
 
         if (array_key_exists($method, $this->config->methods)) {
-            $this->filters['before'] = array_merge($this->config->methods[$method], $this->filters['before']);
+            if (config(Feature::class)->oldFilterOrder) {
+                $this->filters['before'] = array_merge($this->filters['before'], $this->config->methods[$method]);
+            } else {
+                $this->filters['before'] = array_merge($this->config->methods[$method], $this->filters['before']);
+            }
         }
     }
 
@@ -541,7 +556,11 @@ class Filters
         }
 
         if (isset($filters['before'])) {
-            $this->filters['before'] = array_merge($filters['before'], $this->filters['before']);
+            if (config(Feature::class)->oldFilterOrder) {
+                $this->filters['before'] = array_merge($this->filters['before'], $filters['before']);
+            } else {
+                $this->filters['before'] = array_merge($filters['before'], $this->filters['before']);
+            }
         }
 
         if (isset($filters['after'])) {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -564,6 +564,10 @@ class Filters
         }
 
         if (isset($filters['after'])) {
+            if (! config(Feature::class)->oldFilterOrder) {
+                $filters['after'] = array_reverse($filters['after']);
+            }
+
             $this->filters['after'] = array_merge($this->filters['after'], $filters['after']);
         }
     }

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -245,9 +245,9 @@ class Filters
             return $this;
         }
 
-        $this->processGlobals($uri);
-        $this->processMethods();
         $this->processFilters($uri);
+        $this->processMethods();
+        $this->processGlobals($uri);
 
         // Set the toolbar filter to the last position to be executed
         if (in_array('toolbar', $this->filters['after'], true)
@@ -436,6 +436,8 @@ class Filters
         // Add any global filters, unless they are excluded for this URI
         $sets = ['before', 'after'];
 
+        $filters = [];
+
         foreach ($sets as $set) {
             if (isset($this->config->globals[$set])) {
                 // look at each alias in the group
@@ -455,10 +457,18 @@ class Filters
                     }
 
                     if ($keep) {
-                        $this->filters[$set][] = $alias;
+                        $filters[$set][] = $alias;
                     }
                 }
             }
+        }
+
+        if (isset($filters['before'])) {
+            $this->filters['before'] = array_merge($filters['before'], $this->filters['before']);
+        }
+
+        if (isset($filters['after'])) {
+            $this->filters['after'] = array_merge($this->filters['after'], $filters['after']);
         }
     }
 
@@ -477,7 +487,7 @@ class Filters
         $method = strtolower($this->request->getMethod()) ?? 'cli';
 
         if (array_key_exists($method, $this->config->methods)) {
-            $this->filters['before'] = array_merge($this->filters['before'], $this->config->methods[$method]);
+            $this->filters['before'] = array_merge($this->config->methods[$method], $this->filters['before']);
         }
     }
 
@@ -497,6 +507,8 @@ class Filters
         $uri = strtolower(trim($uri, '/ '));
 
         // Add any filters that apply to this URI
+        $filters = [];
+
         foreach ($this->config->filters as $alias => $settings) {
             // Look for inclusion rules
             if (isset($settings['before'])) {
@@ -506,7 +518,7 @@ class Filters
                     // Get arguments and clean name
                     [$name, $arguments] = $this->getCleanName($alias);
 
-                    $this->filters['before'][] = $name;
+                    $filters['before'][] = $name;
 
                     $this->registerArguments($name, $arguments);
                 }
@@ -519,13 +531,21 @@ class Filters
                     // Get arguments and clean name
                     [$name, $arguments] = $this->getCleanName($alias);
 
-                    $this->filters['after'][] = $name;
+                    $filters['after'][] = $name;
 
                     // The arguments may have already been registered in the before filter.
                     // So disable check.
                     $this->registerArguments($name, $arguments, false);
                 }
             }
+        }
+
+        if (isset($filters['before'])) {
+            $this->filters['before'] = array_merge($filters['before'], $this->filters['before']);
+        }
+
+        if (isset($filters['after'])) {
+            $this->filters['after'] = array_merge($this->filters['after'], $filters['after']);
         }
     }
 
@@ -563,6 +583,8 @@ class Filters
      */
     protected function processAliasesToClass(string $position)
     {
+        $filtersClass = [];
+
         foreach ($this->filters[$position] as $alias => $rules) {
             if (is_numeric($alias) && is_string($rules)) {
                 $alias = $rules;
@@ -573,14 +595,20 @@ class Filters
             }
 
             if (is_array($this->config->aliases[$alias])) {
-                $this->filtersClass[$position] = array_merge($this->filtersClass[$position], $this->config->aliases[$alias]);
+                $filtersClass = array_merge($filtersClass, $this->config->aliases[$alias]);
             } else {
-                $this->filtersClass[$position][] = $this->config->aliases[$alias];
+                $filtersClass[] = $this->config->aliases[$alias];
             }
         }
 
         // when using enableFilter() we already write the class name in $filtersClass as well as the
         // alias in $filters. This leads to duplicates when using route filters.
+        if ($position === 'before') {
+            $this->filtersClass[$position] = array_merge($filtersClass, $this->filtersClass[$position]);
+        } else {
+            $this->filtersClass[$position] = array_merge($this->filtersClass[$position], $filtersClass);
+        }
+
         // Since some filters like rate limiters rely on being executed once a request we filter em here.
         $this->filtersClass[$position] = array_values(array_unique($this->filtersClass[$position]));
     }

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -210,8 +210,8 @@ final class FilterFinderTest extends CIUnitTestCase
                     'global2',
                 ],
                 'after' => [
-                    'global1',
                     'global2',
+                    'global1',
                 ],
             ],
             'methods' => [
@@ -239,12 +239,12 @@ final class FilterFinderTest extends CIUnitTestCase
                 'route2',
             ],
             'after' => [
-                'route1',
                 'route2',
-                'filter1',
+                'route1',
                 'filter2',
-                'global1',
+                'filter1',
                 'global2',
+                'global1',
             ],
         ];
         $this->assertSame($expected, $filters);

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -145,7 +145,7 @@ final class FilterFinderTest extends CIUnitTestCase
         $filters = $finder->find('admin');
 
         $expected = [
-            'before' => ['honeypot', 'csrf'],
+            'before' => ['csrf', 'honeypot'],
             'after'  => ['honeypot', 'toolbar'],
         ];
         $this->assertSame($expected, $filters);
@@ -163,7 +163,7 @@ final class FilterFinderTest extends CIUnitTestCase
         $filters = $finder->find('admin');
 
         $expected = [
-            'before' => [InvalidChars::class, 'csrf'],
+            'before' => ['csrf', InvalidChars::class],
             'after'  => [InvalidChars::class, 'toolbar'],
         ];
         $this->assertSame($expected, $filters);
@@ -181,7 +181,7 @@ final class FilterFinderTest extends CIUnitTestCase
         $filters = $finder->find('admin');
 
         $expected = [
-            'before' => ['honeypot', InvalidChars::class, 'csrf'],
+            'before' => ['csrf', 'honeypot', InvalidChars::class],
             'after'  => ['honeypot', InvalidChars::class, 'toolbar'],
         ];
         $this->assertSame($expected, $filters);

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -183,7 +183,7 @@ final class FilterFinderTest extends CIUnitTestCase
 
         $expected = [
             'before' => ['csrf', 'honeypot', InvalidChars::class],
-            'after'  => ['honeypot', InvalidChars::class, 'toolbar'],
+            'after'  => [InvalidChars::class, 'honeypot', 'toolbar'],
         ];
         $this->assertSame($expected, $filters);
     }

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -406,8 +406,8 @@ final class FiltersTest extends CIUnitTestCase
         $expected = [
             'before' => ['bar'],
             'after'  => [
-                'bazg',
                 'foof',
+                'bazg',
                 'toolbar',
             ],
         ];
@@ -1049,8 +1049,8 @@ final class FiltersTest extends CIUnitTestCase
                 'frak',
             ],
             'after' => [
-                'baz',
                 'frak',
+                'baz',
             ],
         ];
         $this->assertSame($expected, $filters->initialize($uri)->getFilters());

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -21,6 +21,15 @@ BREAKING
 Behavior Changes
 ================
 
+Filter Execution Order
+----------------------
+
+The order in which Controller Filters are executed has changed. See
+:ref:`Upgrading Guide <upgrade-450-filter-execution-order>` for details.
+
+Others
+------
+
 - **Logger:** The :php:func:`log_message()` function and the logger methods in
   ``CodeIgniter\Log\Logger`` now do not return ``bool`` values. The return types
   have been fixed to ``void`` to follow the PSR-3 interface.

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -85,10 +85,10 @@ There are two ways to configure filters when they get run. One is done in
 If you want to specify filter to a specific route, use **app/Config/Routes.php**
 and see :ref:`URI Routing <applying-filters>`.
 
-The filters that are specified to a route (in **app/Config/Routes.php**) are
-executed before the filters specified in **app/Config/Filters.php**.
-
 .. Note:: The safest way to apply filters is to :ref:`disable auto-routing <use-defined-routes-only>`, and :ref:`set filters to routes <applying-filters>`.
+
+app/Config/Filters.php
+======================
 
 The **app/Config/Filters.php** file contains four properties that allow you to
 configure exactly when the filters run.
@@ -99,7 +99,7 @@ configure exactly when the filters run.
     it can be accessible with ``blog``, ``blog/index``, and ``blog/index/1``, etc.
 
 $aliases
-========
+--------
 
 The ``$aliases`` array is used to associate a simple name with one or more fully-qualified class names that are the
 filters to run:
@@ -117,7 +117,7 @@ You can combine multiple filters into one alias, making complex sets of filters 
 You should define as many aliases as you need.
 
 $globals
-========
+--------
 
 The second section allows you to define any filters that should be applied to every request made by the framework.
 You should take care with how many you use here, since it could have performance implications to have too many
@@ -126,7 +126,7 @@ run on every request. Filters can be specified by adding their alias to either t
 .. literalinclude:: filters/005.php
 
 Except for a Few URIs
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 There are times where you want to apply a filter to almost every request, but have a few that should be left alone.
 One common example is if you need to exclude a few URI's from the CSRF protection filter to allow requests from
@@ -143,7 +143,7 @@ URI paths, you can use an array of URI path patterns:
 .. literalinclude:: filters/007.php
 
 $methods
-========
+--------
 
 .. Warning:: If you use ``$methods`` filters, you should :ref:`disable Auto Routing (Legacy) <use-defined-routes-only>`
     because :ref:`auto-routing-legacy` permits any HTTP method to access a controller.
@@ -161,7 +161,7 @@ In addition to the standard HTTP methods, this also supports one special case: `
 all requests that were run from the command line.
 
 $filters
-========
+--------
 
 This property is an array of filter aliases. For each alias, you can specify ``before`` and ``after`` arrays that contain
 a list of URI path (relative to BaseURL) patterns that filter should apply to:
@@ -171,7 +171,7 @@ a list of URI path (relative to BaseURL) patterns that filter should apply to:
 .. _filters-filters-filter-arguments:
 
 Filter Arguments
-----------------
+^^^^^^^^^^^^^^^^
 
 .. versionadded:: 4.4.0
 
@@ -183,6 +183,22 @@ In this example, when the URI matches ``admin/*'``, the array ``['admin', 'super
 will be passed in ``$arguments`` to the ``group`` filter's ``before()`` methods.
 When the URI matches ``admin/users/*'``, the array ``['users.manage']``
 will be passed in ``$arguments`` to the ``permission`` filter's ``before()`` methods.
+
+Filter Execution Order
+======================
+
+.. important:: Starting with v4.5.0, the order in which filters are executed has
+    changed. If you wish to maintain the same execution order as in previous versions,
+    you must set ``true`` to ``Config\Feature::$oldFilterOrder``.
+
+Filters are executed in the following order:
+
+- **Before Filters**: globals → methods → filters → route
+- **After Filters**: route → filters → globals
+
+.. note:: Prior to v4.5.0, the filters that are specified to a route
+    (in **app/Config/Routes.php**) are executed before the filters specified in
+    **app/Config/Filters.php**.
 
 ******************
 Confirming Filters

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -200,8 +200,9 @@ Filters are executed in the following order:
 
 .. note:: Prior to v4.5.0, the filters that are specified to a route
     (in **app/Config/Routes.php**) are executed before the filters specified in
-    **app/Config/Filters.php**. See
-    :ref:`Upgrading Guide <upgrade-450-filter-execution-order>` for details.
+    **app/Config/Filters.php**. And the After Filters in Route filters and Filters
+    filters execution order were not reversed.
+    See :ref:`Upgrading Guide <upgrade-450-filter-execution-order>` for details.
 
 ******************
 Confirming Filters

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -184,6 +184,8 @@ will be passed in ``$arguments`` to the ``group`` filter's ``before()`` methods.
 When the URI matches ``admin/users/*'``, the array ``['users.manage']``
 will be passed in ``$arguments`` to the ``permission`` filter's ``before()`` methods.
 
+.. _filter-execution-order:
+
 Filter Execution Order
 ======================
 
@@ -198,7 +200,8 @@ Filters are executed in the following order:
 
 .. note:: Prior to v4.5.0, the filters that are specified to a route
     (in **app/Config/Routes.php**) are executed before the filters specified in
-    **app/Config/Filters.php**.
+    **app/Config/Filters.php**. See
+    :ref:`Upgrading Guide <upgrade-450-filter-execution-order>` for details.
 
 ******************
 Confirming Filters

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -25,6 +25,26 @@ Some method signature changes have been made. Classes that extend them should
 update their APIs to reflect the changes. See :ref:`ChangeLog <v450-method-signature-changes>`
 for details.
 
+.. _upgrade-450-filter-execution-order:
+
+Filter Execution Order
+======================
+
+The order in which Controller Filters are executed has changed.
+
+Before Filters::
+
+    Previous: route → globals → methods → filters
+         Now: globals → methods → filters → route
+
+After Filters::
+
+    Previous: route → globals → filters
+         Now: route → filters → globals
+
+If you wish to maintain the same execution order as in previous versions, set
+``true`` to ``Config\Feature::$oldFilterOrder``. See also :ref:`filter-execution-order`.
+
 Removed Deprecated Items
 ========================
 

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -31,19 +31,46 @@ Filter Execution Order
 ======================
 
 The order in which Controller Filters are executed has changed.
-
-Before Filters::
-
-    Previous: route → globals → methods → filters
-         Now: globals → methods → filters → route
-
-After Filters::
-
-    Previous: route → globals → filters
-         Now: route → filters → globals
-
 If you wish to maintain the same execution order as in previous versions, set
 ``true`` to ``Config\Feature::$oldFilterOrder``. See also :ref:`filter-execution-order`.
+
+1. The order of execution of filter groups has been changed.
+
+    Before Filters::
+
+        Previous: route → globals → methods → filters
+             Now: globals → methods → filters → route
+
+    After Filters::
+
+        Previous: route → globals → filters
+             Now: route → filters → globals
+
+2. The After Filters in *Route* filters and *Filters* filters execution order is now
+reversed.
+
+    When you have the following configuration:
+
+    .. code-block:: php
+
+        // In app/Config/Routes.php
+        $routes->get('/', 'Home::index', ['filter' => ['route1', 'route2']]);
+
+        // In app/Config/Filters.php
+        public array $filters = [
+            'filter1' => ['before' => '*', 'after' => '*'],
+            'filter2' => ['before' => '*', 'after' => '*'],
+        ];
+
+    Before Filters::
+
+        Previous: route1 → route2 → filter1 → filter2
+             Now: filter1 → filter2 → route1 → route2
+
+    After Filters::
+
+        Previous: route1 → route2 → filter1 → filter2
+             Now: route2 → route1 → filter2 → filter1
 
 Removed Deprecated Items
 ========================


### PR DESCRIPTION
**Description**
Supersedes #7404

The **globals** before filters should be applied first. 
CSRF filter or Auth filter is often defined as globals before filter, and they should run first.
The current order of execution is different from what developers normally assume, and thus may cause security issues.
See https://forum.codeigniter.com/showthread.php?tid=86619, https://github.com/codeigniter4/shield/issues/798

- change filter exec order
  - (1) filter group order
  - (2) after filter order will be reversed in **route** filters and **filters** filters
- add `Config\Feature::$oldFilterOrder` for backward compatibility

### (1)

before filters:
```
Previous: route → globals → methods → filters
     Now: globals → methods → filters → route
```

after filters:
```
Previous: route → globals → filters
     Now: route → filters → globals
```

### (2)

<details>
  <summary>
  Configuration
  </summary>

```diff
diff --git a/app/Config/Filters.php b/app/Config/Filters.php
index 8c02a4acd3..26590b0897 100644
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -24,6 +24,14 @@ class Filters extends BaseConfig
         'honeypot'      => Honeypot::class,
         'invalidchars'  => InvalidChars::class,
         'secureheaders' => SecureHeaders::class,
+        'global1'       => 'Dummy',
+        'global2'       => 'Dummy',
+        'method1'       => 'Dummy',
+        'method2'       => 'Dummy',
+        'filter1'       => 'Dummy',
+        'filter2'       => 'Dummy',
+        'route1'        => 'Dummy',
+        'route2'        => 'Dummy',
     ];
 
     /**
@@ -35,11 +43,15 @@ class Filters extends BaseConfig
      */
     public array $globals = [
         'before' => [
+            'global1',
+            'global2',
             // 'honeypot',
             // 'csrf',
             // 'invalidchars',
         ],
         'after' => [
+            'global2',
+            'global1',
             'toolbar',
             // 'honeypot',
             // 'secureheaders',
@@ -57,7 +69,9 @@ class Filters extends BaseConfig
      * permits any HTTP method to access a controller. Accessing the controller
      * with a method you don't expect could bypass the filter.
      */
-    public array $methods = [];
+    public array $methods = [
+        'get' => ['method1', 'method2'],
+    ];
 
     /**
      * List of filter aliases that should run on any
@@ -66,5 +80,8 @@ class Filters extends BaseConfig
      * Example:
      * 'isLoggedIn' => ['before' => ['account/*', 'profiles/*']]
      */
-    public array $filters = [];
+    public array $filters = [
+        'filter1' => ['before' => '*', 'after' => '*'],
+        'filter2' => ['before' => '*', 'after' => '*'],
+    ];
 }
diff --git a/app/Config/Routes.php b/app/Config/Routes.php
index fc4914a692..95a7d1a150 100644
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -5,4 +5,4 @@ use CodeIgniter\Router\RouteCollection;
 /**
  * @var RouteCollection $routes
  */
-$routes->get('/', 'Home::index');
+$routes->get('/', 'Home::index', ['filter' => ['route1', 'route2']]);
```
</details>

Previous:
```
+--------+-------+---------------------------------------------------------------+-------------------------------------------------------+
| Method | Route | Before Filters                                                | After Filters                                         |
+--------+-------+---------------------------------------------------------------+-------------------------------------------------------+
| GET    | /     | route1 route2 global1 global2 method1 method2 filter1 filter2 | route1 route2 global2 global1 filter1 filter2 toolbar |
+--------+-------+---------------------------------------------------------------+-------------------------------------------------------+
```

Now:
```
+--------+-------+---------------------------------------------------------------+-------------------------------------------------------+
| Method | Route | Before Filters                                                | After Filters                                         |
+--------+-------+---------------------------------------------------------------+-------------------------------------------------------+
| GET    | /     | global1 global2 method1 method2 filter1 filter2 route1 route2 | route2 route1 filter2 filter1 global2 global1 toolbar |
+--------+-------+---------------------------------------------------------------+-------------------------------------------------------+
```

Ref #6262

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
