### PR TITLE
fix: spark may not show exceptions or show backtrace as json

### DIFF
--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\CLI;
 
 use CodeIgniter\CodeIgniter;
+use Config\App;
 use Config\Services;
 use Exception;
 
@@ -31,6 +32,10 @@ class Console
      */
     public function run()
     {
+        // Create CLIRequest
+        $appConfig = config(App::class);
+        Services::createRequest($appConfig, true);
+
         $runner  = Services::commands();
         $params  = array_merge(CLI::getSegments(), CLI::getOptions());
         $params  = $this->parseParamsForHelpOption($params);

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -34,6 +34,8 @@ Bugs Fixed
 
 - **CodeIgniter:** Fixed a bug that returned "200 OK" response status code when
   Page Not Found.
+- **Spark:** Fixed a bug that caused spark to not display exceptions in the
+  production mode or to display backtrace in json when an exception occurred.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**

Fix a bug that `spark` may not show exceptions in production mode, or show backtrace as json.

**How to Reproduce**

(1) Setup MySQL and use the default Config (no `.env`). That is `database` is an empty string and in `production` mode.

Before:
```console
$ php spark db:table

CodeIgniter v4.4.1 Command Line Tool - Server Time: 2023-09-25 02:24:59 UTC+00:00
```

After:
```console
$ php spark db:table

CodeIgniter v4.4.1 Command Line Tool - Server Time: 2023-09-25 02:23:08 UTC+00:00

[mysqli_sql_exception]

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1

at SYSTEMPATH/Database/MySQLi/Connection.php:306
```

(2) Change to `development` mode.

Before:
```console
$ php spark db:table

CodeIgniter v4.4.1 Command Line Tool - Server Time: 2023-09-25 01:52:27 UTC+00:00

{
    "title": "mysqli_sql_exception",
    "type": "mysqli_sql_exception",
    "code": 500,
    "message": "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1",
    "file": "/Users/kenji/work/codeigniter/official/CodeIgniter4/system/Database/MySQLi/Connection.php",
    "line": 306,
    "trace": [
        {
...
```

After:
```console
$ php spark db:table

CodeIgniter v4.4.1 Command Line Tool - Server Time: 2023-09-25 02:36:43 UTC+00:00


[mysqli_sql_exception]

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1

at SYSTEMPATH/Database/MySQLi/Connection.php:306

Backtrace:
  1    SYSTEMPATH/Database/MySQLi/Connection.php:306
       mysqli()->query('SHOW TABLES FROM ', 0)
...
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
