### PR TITLE
fix: lang() may return false

### DIFF
--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Language;
 
 use Config\Services;
+use InvalidArgumentException;
 use MessageFormatter;
 
 /**
@@ -191,7 +192,14 @@ class Language
             return $message;
         }
 
-        return MessageFormatter::formatMessage($this->locale, $message, $args);
+        $formatted = MessageFormatter::formatMessage($this->locale, $message, $args);
+        if ($formatted === false) {
+            throw new InvalidArgumentException(
+                lang('Language.invalidMessageFormat', [$message, implode(',', $args)])
+            );
+        }
+
+        return $formatted;
     }
 
     /**

--- a/system/Language/en/Language.php
+++ b/system/Language/en/Language.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+// "Language" language settings
+return [
+    'invalidMessageFormat' => 'Invalid message format: "{0}", args: "{1}"',
+];

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Language;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLanguage;
 use Config\Services;
+use InvalidArgumentException;
 use MessageFormatter;
 use Tests\Support\Language\SecondMockLanguage;
 
@@ -124,6 +125,28 @@ final class LanguageTest extends CIUnitTestCase
         ]);
 
         $this->assertSame(['45 related books.'], $this->lang->getLine('books.bookList', [91 / 2]));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/shield/issues/851
+     */
+    public function testGetLineInvalidFormatMessage(): void
+    {
+        // No intl extension? then we can't test this - go away....
+        if (! class_exists(MessageFormatter::class)) {
+            $this->markTestSkipped('No intl support.');
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid message format: "تم الكشف عن كلمة المرور {0} بسبب اختراق البيانات وشوهدت {1 ، عدد} مرة في {2} في كلمات المرور المخترقة.", args: "password,hits,wording"'
+        );
+
+        $this->lang->setData('Auth', [
+            'errorPasswordPwned' => 'تم الكشف عن كلمة المرور {0} بسبب اختراق البيانات وشوهدت {1 ، عدد} مرة في {2} في كلمات المرور المخترقة.',
+        ]);
+
+        $this->lang->getLine('Auth.errorPasswordPwned', ['password', 'hits', 'wording']);
     }
 
     /**

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -142,6 +142,8 @@ final class LanguageTest extends CIUnitTestCase
             'Invalid message format: "تم الكشف عن كلمة المرور {0} بسبب اختراق البيانات وشوهدت {1 ، عدد} مرة في {2} في كلمات المرور المخترقة.", args: "password,hits,wording"'
         );
 
+        $this->lang->setLocale('ar');
+
         $this->lang->setData('Auth', [
             'errorPasswordPwned' => 'تم الكشف عن كلمة المرور {0} بسبب اختراق البيانات وشوهدت {1 ، عدد} مرة في {2} في كلمات المرور المخترقة.',
         ]);

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -15,6 +15,8 @@ BREAKING
 Message Changes
 ***************
 
+- Added ``Language.invalidMessageFormat`` error message.
+
 Changes
 *******
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/shield/issues/851

- fix `Language::formatMessage()`
- add lang item `Language.invalidMessageFormat`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
