### PR TITLE
Add note that setRules() overwrites any previously set rules

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -311,6 +311,9 @@ To give a labeled error message you can set up as:
 
 .. _validation-withrequest:
 
+.. note:: ``setRules()`` will overwrite any rules that were set previously. To add more than one
+    rule to an existing set of rules, use ``setRule()`` multiple times.
+
 Setting Rules for Array Data
 ============================
 


### PR DESCRIPTION
Update validation documentation with a note that ``setRules()`` overwrites any previously set rules