### PR TITLE
feat: db:table shows db config

### DIFF
--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -102,6 +102,8 @@ class ShowTableInfo extends BaseCommand
         $this->db       = Database::connect();
         $this->DBPrefix = $this->db->getPrefix();
 
+        $this->showDBConfig();
+
         $tables = $this->db->listTables();
 
         if (array_key_exists('desc', $params)) {
@@ -143,6 +145,22 @@ class ShowTableInfo extends BaseCommand
         }
 
         $this->showDataOfTable($tableName, $limitRows, $limitFieldValue);
+    }
+
+    private function showDBConfig(): void
+    {
+        $data = [[
+            'hostname' => $this->db->hostname,
+            'database' => $this->db->getDatabase(),
+            'username' => $this->db->username,
+            'DBDriver' => $this->db->getPlatform(),
+            'DBPrefix' => $this->DBPrefix,
+            'port'     => $this->db->port,
+        ]];
+        CLI::table(
+            $data,
+            ['hostname', 'database', 'username', 'DBDriver', 'DBPrefix', 'port']
+        );
     }
 
     private function removeDBPrefix(): void

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -45,6 +45,7 @@ use Throwable;
  * @property int        $transDepth
  * @property bool       $transFailure
  * @property bool       $transStatus
+ * @property string     $username
  *
  * @template TConnection
  * @template TResult

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -70,12 +70,8 @@ final class ShowTableInfoTest extends CIUnitTestCase
 
         $result = $this->getNormalizedResult();
 
-        $expected = <<<'EOL'
-            +-----------+----------+----------+----------+----------+------+
-            | hostname  | database | username | DBDriver | DBPrefix | port |
-            +-----------+----------+----------+----------+----------+------+
-            EOL;
-        $this->assertStringContainsString($expected, $result);
+        $expectedPattern = '/\| hostname[[:blank:]]+\| database[[:blank:]]+\| username[[:blank:]]+\| DBDriver[[:blank:]]+\| DBPrefix[[:blank:]]+\| port[[:blank:]]+\|/';
+        $this->assertMatchesRegularExpression($expectedPattern, $result);
     }
 
     public function testDbTableShow(): void

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -64,6 +64,20 @@ final class ShowTableInfoTest extends CIUnitTestCase
         $this->assertMatchesRegularExpression($expectedPattern, $result);
     }
 
+    public function testDbTableShowsDBConfig(): void
+    {
+        command('db:table');
+
+        $result = $this->getNormalizedResult();
+
+        $expected = <<<'EOL'
+            +-----------+----------+----------+----------+----------+------+
+            | hostname  | database | username | DBDriver | DBPrefix | port |
+            +-----------+----------+----------+----------+----------+------+
+            EOL;
+        $this->assertStringContainsString($expected, $result);
+    }
+
     public function testDbTableShow(): void
     {
         command('db:table --show');


### PR DESCRIPTION
**Description**
To make it easy to see which database is being connected to.

```console
$ php spark db:table

CodeIgniter v4.4.1 Command Line Tool - Server Time: 2023-09-25 02:52:48 UTC+00:00

+-----------+----------+----------+----------+----------+------+
| hostname  | database | username | DBDriver | DBPrefix | port |
+-----------+----------+----------+----------+----------+------+
| localhost | ci4      | root     | MySQLi   |          | 3306 |
+-----------+----------+----------+----------+----------+------+

Here is the list of your database tables:
...
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
