### PR TITLE
docs: add `()` after method names

### DIFF
--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -33,7 +33,7 @@ as the second parameter of the ``setStatusCode()`` method:
 .. literalinclude:: response/002.php
 
 You can set format an array into either JSON or XML and set the content type header to the appropriate mime with the
-``setJSON`` and ``setXML`` methods. Typically, you will send an array of data to be converted:
+``setJSON()`` and ``setXML()`` methods. Typically, you will send an array of data to be converted:
 
 .. literalinclude:: response/003.php
 


### PR DESCRIPTION

**Description**
For consistency.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
