### PR TITLE
docs: [CLI] make public properties deprecated 

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -44,6 +44,7 @@ class CLI
      * @var bool
      *
      * @deprecated 4.4.2 Should be protected.
+     * @TODO Fix to camelCase in the next major version.
      */
     public static $readline_support = false;
 
@@ -53,6 +54,7 @@ class CLI
      * @var string
      *
      * @deprecated 4.4.2 Should be protected.
+     * @TODO Fix to camelCase in the next major version.
      */
     public static $wait_msg = 'Press any key to continue...';
 
@@ -67,6 +69,8 @@ class CLI
      * Foreground color list
      *
      * @var array<string, string>
+     *
+     * @TODO Fix to camelCase in the next major version.
      */
     protected static $foreground_colors = [
         'black'        => '0;30',
@@ -92,6 +96,8 @@ class CLI
      * Background color list
      *
      * @var array<string, string>
+     *
+     * @TODO Fix to camelCase in the next major version.
      */
     protected static $background_colors = [
         'black'      => '40',

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -42,6 +42,8 @@ class CLI
      * Is the readline library on the system?
      *
      * @var bool
+     *
+     * @deprecated 4.4.2 Should be protected.
      */
     public static $readline_support = false;
 
@@ -49,6 +51,8 @@ class CLI
      * The message displayed at prompts.
      *
      * @var string
+     *
+     * @deprecated 4.4.2 Should be protected.
      */
     public static $wait_msg = 'Press any key to continue...';
 

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -32,6 +32,8 @@ Deprecations
 - **Filters:** The Auto-Discovery for Filters and ``Filters::discoverFilters()``
   is deprecated. Use :ref:`registrars` instead. See :ref:`modules-filters` for
   details.
+- **CLI:** The public property ``CLI::$readline_support`` and ``CLI::$wait_msg``
+  are deprecated. These methods will be protected.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
No need to be public.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
