### PR TITLE
fix: route options are not merged (inner filter overrides outer filter)

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -771,7 +771,10 @@ class RouteCollection implements RouteCollectionInterface
         $callback = array_pop($params);
 
         if ($params && is_array($params[0])) {
-            $this->currentOptions = array_shift($params);
+            $this->currentOptions = array_merge(
+                $this->currentOptions ?? [],
+                array_shift($params)
+            );
         }
 
         if (is_callable($callback)) {

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -337,6 +337,104 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutes());
     }
 
+    public function testGroupNestedWithOuterOptionsWithoutInnerOptions(): void
+    {
+        $routes = $this->getCollector();
+
+        $routes->group(
+            'admin',
+            ['namespace' => 'Admin', 'filter' => ['csrf']],
+            static function ($routes) {
+                $routes->get('dashboard', static function () {
+                });
+
+                $routes->group('profile', static function ($routes) {
+                    $routes->get('/', static function () {
+                    });
+                });
+            }
+        );
+
+        $expected = [
+            'admin/dashboard' => [
+                'namespace' => 'Admin',
+                'filter'    => ['csrf'],
+            ],
+            'admin/profile' => [
+                'namespace' => 'Admin',
+                'filter'    => ['csrf'],
+            ],
+        ];
+        $this->assertSame($expected, $routes->getRoutesOptions());
+    }
+
+    public function testGroupNestedWithOuterAndInnerOption(): void
+    {
+        $routes = $this->getCollector();
+
+        $routes->group(
+            'admin',
+            ['filter' => ['csrf']],
+            static function ($routes) {
+                $routes->get('dashboard', static function () {
+                });
+
+                $routes->group(
+                    'profile',
+                    ['filter' => ['honeypot']],
+                    static function ($routes) {
+                        $routes->get('/', static function () {
+                        });
+                    }
+                );
+            }
+        );
+
+        $expected = [
+            'admin/dashboard' => [
+                'filter' => ['csrf'],
+            ],
+            'admin/profile' => [
+                'filter' => ['honeypot'],
+            ],
+        ];
+        $this->assertSame($expected, $routes->getRoutesOptions());
+    }
+
+    public function testGroupNestedWithoutOuterOptionWithInnerOption(): void
+    {
+        $routes = $this->getCollector();
+
+        $routes->group(
+            'admin',
+            ['filter' => 'csrf'],
+            static function ($routes) {
+                $routes->get('dashboard', static function () {
+                });
+
+                $routes->group(
+                    'profile',
+                    ['namespace' => 'Admin'],
+                    static function ($routes) {
+                        $routes->get('/', static function () {
+                        });
+                    }
+                );
+            }
+        );
+
+        $expected = [
+            'admin/dashboard' => [
+                'filter' => 'csrf',
+            ],
+            'admin/profile' => [
+                'filter'    => 'csrf',
+                'namespace' => 'Admin',
+            ],
+        ];
+        $this->assertSame($expected, $routes->getRoutesOptions());
+    }
+
     public function testGroupingWorksWithEmptyStringPrefix(): void
     {
         $routes = $this->getCollector();

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -27,6 +27,13 @@ Filter Execution Order
 The order in which Controller Filters are executed has changed. See
 :ref:`Upgrading Guide <upgrade-450-filter-execution-order>` for details.
 
+Nested Route Groups and Options
+-------------------------------
+
+Due to a bug fix, the behavior has changed so that options passed to the outer
+``group()`` are merged with the options of the inner ``group()``.
+See :ref:`Upgrading Guide <upgrade-450-nested-route-groups-and-options>` for details.
+
 Others
 ------
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -544,7 +544,15 @@ It is possible to nest groups within groups for finer organization if you need i
 
 This would handle the URL at **admin/users/list**.
 
-.. note:: Options passed to the outer ``group()`` (for example ``namespace`` and ``filter``) are not merged with the inner ``group()`` options.
+Options array passed to the outer ``group()`` are merged with the inner
+``group()`` options array. But note that if you specify the same key in the
+inner ``group()`` options, the value is overwritten.
+
+The above code runs ``myfilter:config`` for ``admin``, and only ``myfilter:region``
+for ``admin/users/list``.
+
+.. note:: Prior to v4.5.0, due to a bug, options passed to the outer ``group()``
+    are not merged with the inner ``group()`` options.
 
 .. _routing-priority:
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -535,6 +535,8 @@ given route config options:
 
 .. literalinclude:: routing/027.php
 
+.. _routing-nesting-groups:
+
 Nesting Groups
 ==============
 

--- a/user_guide_src/source/incoming/routing/026.php
+++ b/user_guide_src/source/incoming/routing/026.php
@@ -1,7 +1,8 @@
 <?php
 
-$routes->group('admin', static function ($routes) {
-    $routes->group('users', static function ($routes) {
+$routes->group('admin', ['filter' => 'myfilter:config'], static function ($routes) {
+    $routes->get('/', 'Admin\Admin::index');
+    $routes->group('users', ['filter' => 'myfilter:region'], static function ($routes) {
         $routes->get('list', 'Admin\Users::list');
     });
 });

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -18,6 +18,37 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+.. _upgrade-450-nested-route-groups-and-options:
+
+Nested Route Groups and Options
+===============================
+
+A bug that prevented options passed to outer ``group()`` from being merged with
+options in inner ``group()`` has been fixed.
+
+Check and correct your route configuration as it could change the values of the
+options applied.
+
+For example,
+
+.. code-block:: php
+
+    $routes->group('admin', ['filter' => 'csrf'], static function ($routes) {
+        $routes->get('/', static function () {
+            // ...
+        });
+
+        $routes->group('users', ['namespace' => 'Users'], static function ($routes) {
+            $routes->get('/', static function () {
+                // ...
+            });
+        });
+    });
+
+Now the ``csrf`` filter is executed for both the route ``admin`` and ``admin/users``.
+In previous versions, it is executed only for the route ``admin``.
+See also :ref:`routing-nesting-groups`.
+
 Method Signature Changes
 ========================
 


### PR DESCRIPTION
**Description**
Fixes #7963

- merge outer `group()` options with inner `group()` options
- outer group filter option is not merged with inner group filter option. See https://github.com/codeigniter4/CodeIgniter4/pull/7981/files#diff-9e755caf334ca07345b43d4fdc3986ac1f9bb9594c6f78ebdec59bc780699b73R375-R400

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
