### PR TITLE
refactor: remove $_SESSION from methods and functions

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2313,7 +2313,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 7,
+	'count' => 6,
 	'path' => __DIR__ . '/system/HTTP/IncomingRequest.php',
 ];
 $ignoreErrors[] = [

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1064,13 +1064,13 @@ class CodeIgniter
         }
 
         if (isset($_SESSION)) {
-            $_SESSION['_ci_previous_url'] = URI::createURIString(
+            session()->set('_ci_previous_url', URI::createURIString(
                 $uri->getScheme(),
                 $uri->getAuthority(),
                 $uri->getPath(),
                 $uri->getQuery(),
                 $uri->getFragment()
-            );
+            ));
         }
     }
 

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -827,35 +827,42 @@ class IncomingRequest extends Request
      */
     public function getOldInput(string $key)
     {
-        // If the session hasn't been started, or no
-        // data was previously saved, we're done.
-        if (empty($_SESSION['_ci_old_input'])) {
+        // If the session hasn't been started, we're done.
+        if (! isset($_SESSION)) {
+            return null;
+        }
+
+        // Get previously saved in session
+        $old = session('_ci_old_input');
+
+        // If no data was previously saved, we're done.
+        if ($old === null) {
             return null;
         }
 
         // Check for the value in the POST array first.
-        if (isset($_SESSION['_ci_old_input']['post'][$key])) {
-            return $_SESSION['_ci_old_input']['post'][$key];
+        if (isset($old['post'][$key])) {
+            return $old['post'][$key];
         }
 
         // Next check in the GET array.
-        if (isset($_SESSION['_ci_old_input']['get'][$key])) {
-            return $_SESSION['_ci_old_input']['get'][$key];
+        if (isset($old['get'][$key])) {
+            return $old['get'][$key];
         }
 
         helper('array');
 
         // Check for an array value in POST.
-        if (isset($_SESSION['_ci_old_input']['post'])) {
-            $value = dot_array_search($key, $_SESSION['_ci_old_input']['post']);
+        if (isset($old['post'])) {
+            $value = dot_array_search($key, $old['post']);
             if ($value !== null) {
                 return $value;
             }
         }
 
         // Check for an array value in GET.
-        if (isset($_SESSION['_ci_old_input']['get'])) {
-            $value = dot_array_search($key, $_SESSION['_ci_old_input']['get']);
+        if (isset($old['get'])) {
+            $value = dot_array_search($key, $old['get']);
             if ($value !== null) {
                 return $value;
             }

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -701,12 +701,12 @@ if (! function_exists('validation_errors')) {
      */
     function validation_errors()
     {
-        session();
+        $errors = session('_ci_validation_errors');
 
         // Check the session to see if any were
         // passed along from a redirect withErrors() request.
-        if (isset($_SESSION['_ci_validation_errors']) && (ENVIRONMENT === 'testing' || ! is_cli())) {
-            return $_SESSION['_ci_validation_errors'];
+        if ($errors !== null && (ENVIRONMENT === 'testing' || ! is_cli())) {
+            return $errors;
         }
 
         $validation = Services::validation();

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -93,9 +93,7 @@ if (! function_exists('previous_url')) {
         }
 
         // Otherwise, grab a sanitized version from $_SERVER.
-        $referer ??= Services::request()->getServer('HTTP_REFERER', FILTER_SANITIZE_URL);
-
-        $referer ??= site_url('/');
+        $referer ??= request()->getServer('HTTP_REFERER', FILTER_SANITIZE_URL) ?? site_url('/');
 
         return $returnObject ? new URI($referer) : $referer;
     }

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -88,8 +88,12 @@ if (! function_exists('previous_url')) {
     {
         // Grab from the session first, if we have it,
         // since it's more reliable and safer.
+        if (isset($_SESSION)) {
+            $referer = session('_ci_previous_url');
+        }
+
         // Otherwise, grab a sanitized version from $_SERVER.
-        $referer = $_SESSION['_ci_previous_url'] ?? Services::request()->getServer('HTTP_REFERER', FILTER_SANITIZE_URL);
+        $referer ??= Services::request()->getServer('HTTP_REFERER', FILTER_SANITIZE_URL);
 
         $referer ??= site_url('/');
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -27,6 +27,8 @@ use Config\Routing;
 use Tests\Support\Filters\Customfilter;
 
 /**
+ * @runTestsInSeparateProcesses
+ *
  * @backupGlobals enabled
  *
  * @internal

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -52,13 +52,19 @@ final class MiscUrlTest extends CIUnitTestCase
         $_SERVER = [];
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @group SeparateProcess
+     */
     public function testPreviousURLUsesSessionFirst(): void
     {
         $uri1 = 'http://example.com/one?two';
         $uri2 = 'http://example.com/two?foo';
 
-        $_SERVER['HTTP_REFERER']      = $uri1;
-        $_SESSION['_ci_previous_url'] = $uri2;
+        $_SERVER['HTTP_REFERER'] = $uri1;
+        session()->set('_ci_previous_url', $uri2);
 
         $this->config->baseURL = 'http://example.com/public';
 
@@ -80,6 +86,12 @@ final class MiscUrlTest extends CIUnitTestCase
         Factories::injectMock('config', 'App', $this->config);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @group SeparateProcess
+     */
     public function testPreviousURLUsesRefererIfNeeded(): void
     {
         $uri1 = 'http://example.com/one?two';

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -42,12 +42,18 @@ final class ParserPluginTest extends CIUnitTestCase
         $this->assertSame(current_url(), $this->parser->renderString($template));
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @group SeparateProcess
+     */
     public function testPreviousURL(): void
     {
         $template = '{+ previous_url +}';
 
         // Ensure a previous URL exists to work with.
-        $_SESSION['_ci_previous_url'] = 'http://example.com/foo';
+        session()->set('_ci_previous_url', 'http://example.com/foo');
 
         $this->assertSame(previous_url(), $this->parser->renderString($template));
     }


### PR DESCRIPTION
Functions and methods should not directly call the `$_SESSION` array but use the `session()` helper to obtain their contents from the `Services::Session` library.

This avoids the need to override code if someone needs to organize the `$_SESSION` array in another way.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
