### PR TITLE
fix: Services::request() should call AppServices instead static

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -521,7 +521,7 @@ class Services extends BaseService
         }
 
         // @TODO remove the following code for backward compatibility
-        return static::incomingrequest($config, $getShared);
+        return AppServices::incomingrequest($config, $getShared);
     }
 
     /**


### PR DESCRIPTION
`CodeIgniter\Config\Services::request()` should return `Config\Services::incomingrequest()` instead of `static::incomingrequest()` to allow override the `IncomingRequest`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
