### PR TITLE
fix: incorrect return type for Model::objectToRawArray()

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -72,11 +72,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/BaseModel.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in an if condition, array\\|null given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/BaseModel.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in an if condition, int given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/BaseModel.php',

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1657,7 +1657,7 @@ abstract class BaseModel
         $properties = $this->objectToRawArray($data, $onlyChanged, $recursive);
 
         // Convert any Time instances to appropriate $dateFormat
-        if ($properties) {
+        if ($properties !== []) {
             $properties = array_map(function ($value) {
                 if ($value instanceof Time) {
                     return $this->timeToDate($value);
@@ -1678,12 +1678,13 @@ abstract class BaseModel
      * @param bool          $onlyChanged Only Changed Property
      * @param bool          $recursive   If true, inner entities will be casted as array as well
      *
-     * @return array|null Array
+     * @return array Array with raw values.
      *
      * @throws ReflectionException
      */
-    protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
+    protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): array
     {
+        // @TODO Should define Interface or Class. Entity has toRawArray() now.
         if (method_exists($data, 'toRawArray')) {
             $properties = $data->toRawArray($onlyChanged, $recursive);
         } else {

--- a/system/Model.php
+++ b/system/Model.php
@@ -783,11 +783,11 @@ class Model extends BaseModel
      * @param object|string $data
      * @param bool          $recursive If true, inner entities will be cast as array as well
      *
-     * @return array|null Array
+     * @return array Array with raw values.
      *
      * @throws ReflectionException
      */
-    protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
+    protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): array
     {
         $properties = parent::objectToRawArray($data, $onlyChanged);
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -35,8 +35,19 @@ Interface Changes
 - **Logger:** The `psr/log <https://packagist.org/packages/psr/log>`_ package has
   been upgraded to v2.0.0.
 
+.. _v450-method-signature-changes:
+
 Method Signature Changes
 ========================
+
+Return Type Changes
+-------------------
+
+- **Model:** The return type of the ``objectToRawArray()`` method in the ``Model``
+  and ``BaseModel`` classes has been changed to ``array``.
+
+Others
+------
 
 - **Logger:** The method signatures of the methods in ``CodeIgniter\Log\Logger``
   that implements the PSR-3 interface have been fixed. The ``bool`` return

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -44,7 +44,7 @@ Return Type Changes
 -------------------
 
 - **Model:** The return type of the ``objectToRawArray()`` method in the ``Model``
-  and ``BaseModel`` classes has been changed to ``array``.
+  and ``BaseModel`` classes has been changed from ``?array`` to ``array``.
 
 Others
 ------

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -18,11 +18,18 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+Method Signature Changes
+========================
+
+Some method signature changes have been made. Classes that extend them should
+update their APIs to reflect the changes. See :ref:`ChangeLog <v450-method-signature-changes>`
+for details.
+
 Removed Deprecated Items
 ========================
 
 Some deprecated items have been removed. If you extend these classes and are
-using them, upgrade your code. See :ref:`v450-removed-deprecated-items` for details.
+using them, upgrade your code. See :ref:`ChangeLog <v450-removed-deprecated-items>` for details.
 
 Breaking Enhancements
 *********************


### PR DESCRIPTION
**Description**
- fix incorrect return types

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
