### PR TITLE
Entity rework

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2057,26 +2057,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Encryption/Handlers/SodiumHandler.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$value \\(bool\\|int\\|string\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:set\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\BaseCast\\:\\:set\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$value \\(bool\\|int\\|string\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:set\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\CastInterface\\:\\:set\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$value \\(int\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:get\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\BaseCast\\:\\:get\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$value \\(int\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\IntBoolCast\\:\\:get\\(\\) should be contravariant with parameter \\$value \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Entity\\\\Cast\\\\CastInterface\\:\\:get\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Entity/Cast/IntBoolCast.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 4,
 	'path' => __DIR__ . '/system/Entity/Entity.php',

--- a/rector.php
+++ b/rector.php
@@ -77,6 +77,12 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/tests/system/Config/fixtures',
         __DIR__ . '/tests/system/Filters/fixtures',
         __DIR__ . '/tests/_support',
+
+        // Error: ] Could not process "tests/system/Entity/EntityLiveTest.php" file, due
+        //         to:
+        //         "Call to a member function getValue() on bool". On line: 172
+        __DIR__ . '/tests/system/Entity/EntityLiveTest.php',
+
         JsonThrowOnErrorRector::class,
         YieldDataProviderRector::class,
 

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -17,6 +17,7 @@ use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\Query;
+use CodeIgniter\Entity\Entity;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
@@ -1684,8 +1685,11 @@ abstract class BaseModel
      */
     protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): array
     {
+        if ($data instanceof Entity) {
+            $properties = $data->toDatabase($onlyChanged, $recursive);
+        }
         // @TODO Should define Interface or Class. Entity has toRawArray() now.
-        if (method_exists($data, 'toRawArray')) {
+        elseif (method_exists($data, 'toRawArray')) {
             $properties = $data->toRawArray($onlyChanged, $recursive);
         } else {
             $mirror = new ReflectionClass($data);
@@ -1706,7 +1710,7 @@ abstract class BaseModel
     }
 
     /**
-     * Transform data to array.
+     * Transform data to array that can be save to database.
      *
      * @param array|object|null $data Data
      * @param string            $type Type of data (insert|update)

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -148,7 +148,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->fromDatabase($data);
         }
 
         return $this->resultID->fetch_object($className);

--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -103,7 +103,7 @@ class Result extends BaseResult
             return $row;
         }
         if (is_subclass_of($className, Entity::class)) {
-            return (new $className())->injectRawData((array) $row);
+            return (new $className())->fromDatabase((array) $row);
         }
 
         $instance = new $className();

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -114,7 +114,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->fromDatabase($data);
         }
 
         return pg_fetch_object($this->resultID, null, $className);

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -154,7 +154,7 @@ class Result extends BaseResult
     protected function fetchObject(string $className = 'stdClass')
     {
         if (is_subclass_of($className, Entity::class)) {
-            return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
+            return empty($data = $this->fetchAssoc()) ? false : (new $className())->fromDatabase($data);
         }
 
         return sqlsrv_fetch_object($this->resultID, $className);

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -142,7 +142,7 @@ class Result extends BaseResult
         $classObj = new $className();
 
         if (is_subclass_of($className, Entity::class)) {
-            return $classObj->injectRawData($row);
+            return $classObj->fromDatabase($row);
         }
 
         $classSet = Closure::bind(function ($key, $value) {

--- a/system/Entity/Cast/ArrayCast.php
+++ b/system/Entity/Cast/ArrayCast.php
@@ -19,9 +19,13 @@ class ArrayCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): array
+    public static function fromDatabase($value, array $params = []): array
     {
-        if (is_string($value) && (strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)) {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
+        if ((strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)) {
             $value = unserialize($value);
         }
 
@@ -31,8 +35,12 @@ class ArrayCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function set($value, array $params = []): string
+    public static function toDatabase($value, array $params = []): string
     {
+        if (! is_array($value) && ! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return serialize($value);
     }
 }

--- a/system/Entity/Cast/ArrayCast.php
+++ b/system/Entity/Cast/ArrayCast.php
@@ -26,7 +26,7 @@ class ArrayCast extends BaseCast
         }
 
         if ((strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)) {
-            $value = unserialize($value);
+            $value = unserialize($value, ['allowed_classes' => false]);
         }
 
         return (array) $value;

--- a/system/Entity/Cast/BaseCast.php
+++ b/system/Entity/Cast/BaseCast.php
@@ -11,6 +11,8 @@
 
 namespace CodeIgniter\Entity\Cast;
 
+use TypeError;
+
 /**
  * Class BaseCast
  */
@@ -67,5 +69,17 @@ abstract class BaseCast implements CastInterface
     public static function fromDatabase($value, array $params = [])
     {
         return $value;
+    }
+
+    /**
+     * Throws TypeError
+     *
+     * @param mixed $value
+     *
+     * @return never
+     */
+    protected static function invalidTypeValueError($value)
+    {
+        throw new TypeError('Invalid type value: ' . var_export($value, true));
     }
 }

--- a/system/Entity/Cast/BaseCast.php
+++ b/system/Entity/Cast/BaseCast.php
@@ -17,7 +17,8 @@ namespace CodeIgniter\Entity\Cast;
 abstract class BaseCast implements CastInterface
 {
     /**
-     * Get
+     * Returns value when getting the Entity property.
+     * This method is normally returns the value as it is.
      *
      * @param array|bool|float|int|object|string|null $value  Data
      * @param array                                   $params Additional param
@@ -30,7 +31,7 @@ abstract class BaseCast implements CastInterface
     }
 
     /**
-     * Set
+     * Returns value for Entity property when setting the Entity property.
      *
      * @param array|bool|float|int|object|string|null $value  Data
      * @param array                                   $params Additional param
@@ -38,6 +39,32 @@ abstract class BaseCast implements CastInterface
      * @return array|bool|float|int|object|string|null
      */
     public static function set($value, array $params = [])
+    {
+        return $value;
+    }
+
+    /**
+     * Takes the Entity property value, returns its value for database.
+     *
+     * @param array|bool|float|int|object|string|null $value  Data
+     * @param array                                   $params Additional param
+     *
+     * @return bool|float|int|string|null
+     */
+    public static function toDatabase($value, array $params = [])
+    {
+        return $value;
+    }
+
+    /**
+     * Takes value from database, returns its value for the Entity property.
+     *
+     * @param bool|float|int|string|null $value  Data
+     * @param array                      $params Additional param
+     *
+     * @return array|bool|float|int|object|string|null
+     */
+    public static function fromDatabase($value, array $params = [])
     {
         return $value;
     }

--- a/system/Entity/Cast/BooleanCast.php
+++ b/system/Entity/Cast/BooleanCast.php
@@ -19,8 +19,20 @@ class BooleanCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): bool
+    public static function set($value, array $params = []): bool
     {
+        return (bool) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function fromDatabase($value, array $params = []): bool
+    {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return (bool) $value;
     }
 }

--- a/system/Entity/Cast/CSVCast.php
+++ b/system/Entity/Cast/CSVCast.php
@@ -19,16 +19,24 @@ class CSVCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): array
+    public static function fromDatabase($value, array $params = []): array
     {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return explode(',', $value);
     }
 
     /**
      * {@inheritDoc}
      */
-    public static function set($value, array $params = []): string
+    public static function toDatabase($value, array $params = []): string
     {
+        if (! is_array($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return implode(',', $value);
     }
 }

--- a/system/Entity/Cast/CastInterface.php
+++ b/system/Entity/Cast/CastInterface.php
@@ -13,11 +13,15 @@ namespace CodeIgniter\Entity\Cast;
 
 /**
  * Interface CastInterface
+ *
+ * [App Code] --- set() --> [Entity] --- toDatabase() ---> [Database]
+ * [App Code] <-- get() --- [Entity] <-- fromDatabase() -- [Database]
  */
 interface CastInterface
 {
     /**
-     * Get
+     * Returns value when getting the Entity property.
+     * This method is normally returns the value as it is.
      *
      * @param array|bool|float|int|object|string|null $value  Data
      * @param array                                   $params Additional param
@@ -27,7 +31,7 @@ interface CastInterface
     public static function get($value, array $params = []);
 
     /**
-     * Set
+     * Returns value for the Entity property when setting the Entity property.
      *
      * @param array|bool|float|int|object|string|null $value  Data
      * @param array                                   $params Additional param
@@ -35,4 +39,24 @@ interface CastInterface
      * @return array|bool|float|int|object|string|null
      */
     public static function set($value, array $params = []);
+
+    /**
+     * Takes the Entity property value, returns its value for database.
+     *
+     * @param array|bool|float|int|object|string|null $value  Data
+     * @param array                                   $params Additional param
+     *
+     * @return bool|float|int|string|null
+     */
+    public static function toDatabase($value, array $params = []);
+
+    /**
+     * Takes value from database, returns its value for the Entity property.
+     *
+     * @param bool|float|int|string|null $value  Data
+     * @param array                      $params Additional param
+     *
+     * @return array|bool|float|int|object|string|null
+     */
+    public static function fromDatabase($value, array $params = []);
 }

--- a/system/Entity/Cast/DatetimeCast.php
+++ b/system/Entity/Cast/DatetimeCast.php
@@ -27,7 +27,7 @@ class DatetimeCast extends BaseCast
      *
      * @throws Exception
      */
-    public static function get($value, array $params = [])
+    public static function set($value, array $params = [])
     {
         if ($value instanceof Time) {
             return $value;
@@ -45,6 +45,34 @@ class DatetimeCast extends BaseCast
             return Time::parse($value);
         }
 
-        return $value;
+        self::invalidTypeValueError($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Time
+     *
+     * @throws Exception
+     */
+    public static function fromDatabase($value, array $params = [])
+    {
+        if (is_string($value)) {
+            return Time::parse($value);
+        }
+
+        self::invalidTypeValueError($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function toDatabase($value, array $params = []): string
+    {
+        if (! $value instanceof Time) {
+            self::invalidTypeValueError($value);
+        }
+
+        return (string) $value;
     }
 }

--- a/system/Entity/Cast/FloatCast.php
+++ b/system/Entity/Cast/FloatCast.php
@@ -19,7 +19,15 @@ class FloatCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): float
+    public static function set($value, array $params = []): float
+    {
+        return (float) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function fromDatabase($value, array $params = []): float
     {
         return (float) $value;
     }

--- a/system/Entity/Cast/IntBoolCast.php
+++ b/system/Entity/Cast/IntBoolCast.php
@@ -19,18 +19,38 @@ namespace CodeIgniter\Entity\Cast;
 final class IntBoolCast extends BaseCast
 {
     /**
-     * @param int $value
+     * {@inheritDoc}
      */
-    public static function get($value, array $params = []): bool
+    public static function set($value, array $params = []): bool
     {
+        if (! is_bool($value) && ! is_int($value) && ! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return (bool) $value;
     }
 
     /**
-     * @param bool|int|string $value
+     * {@inheritDoc}
      */
-    public static function set($value, array $params = []): int
+    public static function fromDatabase($value, array $params = []): bool
     {
+        if (! is_int($value) && ! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
+        return (bool) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function toDatabase($value, array $params = []): int
+    {
+        if (! is_bool($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return (int) $value;
     }
 }

--- a/system/Entity/Cast/IntegerCast.php
+++ b/system/Entity/Cast/IntegerCast.php
@@ -19,8 +19,20 @@ class IntegerCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): int
+    public static function set($value, array $params = []): int
     {
+        return (int) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function fromDatabase($value, array $params = []): int
+    {
+        if (! is_string($value) && ! is_int($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return (int) $value;
     }
 }

--- a/system/Entity/Cast/JsonCast.php
+++ b/system/Entity/Cast/JsonCast.php
@@ -23,16 +23,20 @@ class JsonCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = [])
+    public static function fromDatabase($value, array $params = [])
     {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         $associative = in_array('array', $params, true);
 
-        $tmp = $value !== null ? ($associative ? [] : new stdClass()) : null;
+        // @TODO Can $value be null?
+        $tmp = ($associative ? [] : new stdClass());
 
         if (function_exists('json_decode')
             && (
-                (is_string($value)
-                    && strlen($value) > 1
+                (strlen($value) > 1
                     && in_array($value[0], ['[', '{', '"'], true))
                 || is_numeric($value)
             )
@@ -49,8 +53,10 @@ class JsonCast extends BaseCast
 
     /**
      * {@inheritDoc}
+     *
+     * @param mixed $value
      */
-    public static function set($value, array $params = []): string
+    public static function toDatabase($value, array $params = []): string
     {
         if (function_exists('json_encode')) {
             try {

--- a/system/Entity/Cast/ObjectCast.php
+++ b/system/Entity/Cast/ObjectCast.php
@@ -40,23 +40,23 @@ class ObjectCast extends BaseCast
         }
 
         // @TODO How to implement?
-        return serialize($value);
+        return serialize((array) $value);
     }
 
     /**
      * {@inheritDoc}
      */
-    public static function fromDatabase($value, array $params = []): array
+    public static function fromDatabase($value, array $params = []): object
     {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }
 
         // @TODO How to implement?
-        if ((strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)) {
-            $value = unserialize($value);
+        if ((strpos($value, 'a:') === 0)) {
+            return (object) unserialize($value, ['allowed_classes' => false]);
         }
 
-        return (array) $value;
+        self::invalidTypeValueError($value);
     }
 }

--- a/system/Entity/Cast/ObjectCast.php
+++ b/system/Entity/Cast/ObjectCast.php
@@ -11,6 +11,8 @@
 
 namespace CodeIgniter\Entity\Cast;
 
+use stdClass;
+
 /**
  * Class ObjectCast
  */
@@ -19,8 +21,42 @@ class ObjectCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): object
+    public static function set($value, array $params = []): object
     {
+        if (! is_array($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         return (object) $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function toDatabase($value, array $params = [])
+    {
+        if (! $value instanceof stdClass) {
+            self::invalidTypeValueError($value);
+        }
+
+        // @TODO How to implement?
+        return serialize($value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function fromDatabase($value, array $params = []): array
+    {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
+        // @TODO How to implement?
+        if ((strpos($value, 'a:') === 0 || strpos($value, 's:') === 0)) {
+            $value = unserialize($value);
+        }
+
+        return (array) $value;
     }
 }

--- a/system/Entity/Cast/StringCast.php
+++ b/system/Entity/Cast/StringCast.php
@@ -19,7 +19,7 @@ class StringCast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): string
+    public static function set($value, array $params = []): string
     {
         return (string) $value;
     }

--- a/system/Entity/Cast/TimestampCast.php
+++ b/system/Entity/Cast/TimestampCast.php
@@ -20,9 +20,15 @@ class TimestampCast extends BaseCast
 {
     /**
      * {@inheritDoc}
+     *
+     * @return int
      */
-    public static function get($value, array $params = [])
+    public static function set($value, array $params = [])
     {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
         $value = strtotime($value);
 
         if ($value === false) {

--- a/system/Entity/Cast/URICast.php
+++ b/system/Entity/Cast/URICast.php
@@ -21,8 +21,16 @@ class URICast extends BaseCast
     /**
      * {@inheritDoc}
      */
-    public static function get($value, array $params = []): URI
+    public static function set($value, array $params = []): URI
     {
-        return $value instanceof URI ? $value : new URI($value);
+        if ($value instanceof URI) {
+            return $value;
+        }
+
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
+        return new URI($value);
     }
 }

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -568,7 +568,9 @@ class Entity implements JsonSerializable
             $value = $this->mutateDate($value);
         }
 
-        $value = $this->castAs($value, $dbColumn, 'set');
+        if ($this->_cast) {
+            $value = $this->castAs($value, $dbColumn, 'set');
+        }
 
         // if a setter method exists for this key, use that method to
         // insert this value. should be outside $isNullable check,

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -45,7 +45,7 @@ class Entity implements JsonSerializable
      *
      * Example:
      *  $datamap = [
-     *      'class_property_name' => 'db_column_name'
+     *      class_property_alias => db_column_name
      *  ];
      *
      * @var array<string, string>
@@ -110,7 +110,7 @@ class Entity implements JsonSerializable
     protected $attributes = [];
 
     /**
-     * Holds original copies of all class vars so we can determine
+     * Holds original copies of all attributes, so we can determine
      * what's actually been changed and not accidentally write
      * nulls where we shouldn't.
      *

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -454,6 +454,7 @@ class Entity implements JsonSerializable
         $type = $type === 'json-array' ? 'json[array]' : $type;
 
         if (! in_array($method, ['get', 'set', 'toDatabase', 'fromDatabase'], true)) {
+            /** @psalm-suppress NoValue */
             throw CastException::forInvalidMethod($method);
         }
 

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -260,10 +260,8 @@ class Entity implements JsonSerializable
             }
 
             // Cast values
-            if ($this->_cast) {
-                if (isset($this->casts[$key])) {
-                    $value = $this->castAs($value, $key, 'toDatabase');
-                }
+            if ($this->_cast && isset($this->casts[$key])) {
+                $value = $this->castAs($value, $key, 'toDatabase');
             }
 
             if ($recursive) {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -103,18 +103,21 @@ class Entity implements JsonSerializable
     ];
 
     /**
-     * Holds the current values of all class vars.
+     * Holds the current values of all class properties.
+     * The values are PHP representation, not the raw values from database.
      *
-     * @var array
+     * @var array<string, mixed>
      */
-    protected $attributes = [];
+    protected $attributes = [
+        // db_column_name => PHP_value
+    ];
 
     /**
      * Holds original copies of all attributes, so we can determine
      * what's actually been changed and not accidentally write
      * nulls where we shouldn't.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $original = [];
 
@@ -441,7 +444,7 @@ class Entity implements JsonSerializable
      */
     protected function mutateDate($value)
     {
-        return DatetimeCast::get($value);
+        return DatetimeCast::set($value);
     }
 
     /**

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -119,7 +119,7 @@ class Entity implements JsonSerializable
     protected $original = [];
 
     /**
-     * Holds info whenever properties have to be casted
+     * Holds info whenever properties have to be cast.
      */
     private bool $_cast = true;
 
@@ -158,7 +158,7 @@ class Entity implements JsonSerializable
     /**
      * General method that will return all public and protected values
      * of this entity as an array. All values are accessed through the
-     * __get() magic method so will have any casts, etc applied to them.
+     * __get() magic method so will have any casts, etc. applied to them.
      *
      * @param bool $onlyChanged If true, only return values that have changed since object creation
      * @param bool $cast        If true, properties will be cast.

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -204,7 +204,7 @@ class Entity implements JsonSerializable
     }
 
     /**
-     * Returns the raw values of the current attributes.
+     * Returns the values for database of the current attributes.
      *
      * @param bool $onlyChanged If true, only return values that have changed since object creation
      * @param bool $recursive   If true, inner entities will be cast as array as well.
@@ -213,41 +213,7 @@ class Entity implements JsonSerializable
      */
     public function toRawArray(bool $onlyChanged = false, bool $recursive = false): array
     {
-        $return = [];
-
-        if (! $onlyChanged) {
-            if ($recursive) {
-                return array_map(static function ($value) use ($onlyChanged, $recursive) {
-                    if ($value instanceof self) {
-                        $value = $value->toRawArray($onlyChanged, $recursive);
-                    } elseif (is_callable([$value, 'toRawArray'])) {
-                        $value = $value->toRawArray();
-                    }
-
-                    return $value;
-                }, $this->attributes);
-            }
-
-            return $this->attributes;
-        }
-
-        foreach ($this->attributes as $key => $value) {
-            if (! $this->hasChanged($key)) {
-                continue;
-            }
-
-            if ($recursive) {
-                if ($value instanceof self) {
-                    $value = $value->toRawArray($onlyChanged, $recursive);
-                } elseif (is_callable([$value, 'toRawArray'])) {
-                    $value = $value->toRawArray();
-                }
-            }
-
-            $return[$key] = $value;
-        }
-
-        return $return;
+        return $this->toDatabase($onlyChanged, $recursive);
     }
 
     /**

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -402,14 +402,18 @@ class Entity implements JsonSerializable
      * Converts the given string|timestamp|DateTime|Time instance
      * into the "CodeIgniter\I18n\Time" object.
      *
-     * @param DateTime|float|int|string|Time $value
+     * @param DateTime|float|int|string|Time|null $value
      *
-     * @return Time
+     * @return Time|null
      *
      * @throws Exception
      */
     protected function mutateDate($value)
     {
+        if ($value === null) {
+            return null;
+        }
+
         return DatetimeCast::set($value);
     }
 

--- a/tests/_support/Entity/Database/Migrations/2023-09-29-103000_CreateUsersTable.php
+++ b/tests/_support/Entity/Database/Migrations/2023-09-29-103000_CreateUsersTable.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Entity\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateUsersTable extends Migration
+{
+    public function up(): void
+    {
+        $this->forge->addField([
+            'id'         => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
+            'username'   => ['type' => 'varchar', 'constraint' => 30, 'null' => true],
+            'active'     => ['type' => 'tinyint', 'constraint' => 1, 'null' => 0, 'default' => 0],
+            'memo'       => ['type' => 'text', 'null' => true],
+            'created_at' => ['type' => 'datetime', 'null' => true],
+            'updated_at' => ['type' => 'datetime', 'null' => true],
+            'deleted_at' => ['type' => 'datetime', 'null' => true],
+        ]);
+        $this->forge->addPrimaryKey('id');
+        $this->forge->addUniqueKey('username');
+        $this->forge->createTable('users');
+    }
+
+    public function down(): void
+    {
+        $this->forge->dropTable('users');
+    }
+}

--- a/tests/system/Entity/EntityLiveTest.php
+++ b/tests/system/Entity/EntityLiveTest.php
@@ -11,12 +11,12 @@
 
 namespace CodeIgniter\Entity;
 
-use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Model;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Services;
+use stdClass;
 
 /**
  * @internal
@@ -85,8 +85,6 @@ final class EntityLiveTest extends CIUnitTestCase
      */
     public function testCastObject(): void
     {
-        $this->expectException(DatabaseException::class);
-
         $entity = new class () extends Entity {
             protected $casts = [
                 'id'     => 'int',
@@ -103,5 +101,10 @@ final class EntityLiveTest extends CIUnitTestCase
         };
         $entity->fill(['username' => 'johnsmith', 'active' => false, 'memo' => ['foo', 'bar']]);
         $model->save($entity);
+
+        $user = $model->asObject(get_class($entity))->find(1);
+
+        $this->assertInstanceOf(stdClass::class, $user->memo);
+        $this->assertSame(['foo', 'bar'], (array) $user->memo);
     }
 }

--- a/tests/system/Entity/EntityLiveTest.php
+++ b/tests/system/Entity/EntityLiveTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Entity;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Model;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Services;
+
+/**
+ * @internal
+ *
+ * @group DatabaseLive
+ */
+final class EntityLiveTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    protected $namespace = 'Tests\Support\Entity';
+
+    protected function setUp(): void
+    {
+        $this->setUpMethods[] = 'setUpAddNamespace';
+
+        parent::setUp();
+    }
+
+    protected function setUpAddNamespace(): void
+    {
+        Services::autoloader()->addNamespace(
+            'Tests\Support\Entity',
+            SUPPORTPATH . 'Entity'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->regressDatabase();
+    }
+
+    public function testEntityReturnsValuesWithCorrectTypes()
+    {
+        $entity = new class () extends Entity {
+            protected $casts = [
+                'id'     => 'int',
+                'active' => 'int-bool',
+                'memo'   => 'json',
+            ];
+        };
+        $model = new class () extends Model {
+            protected $table         = 'users';
+            protected $allowedFields = [
+                'username', 'active', 'memo',
+            ];
+            protected $useTimestamps = true;
+        };
+        $entity->fill(['username' => 'johnsmith', 'active' => false, 'memo' => ['foo', 'bar']]);
+        $model->save($entity);
+
+        $user = $model->asObject(get_class($entity))->find(1);
+
+        $this->assertSame(1, $user->id);
+        $this->assertSame('johnsmith', $user->username);
+        $this->assertFalse($user->active);
+        $this->assertSame(['foo', 'bar'], $user->memo);
+        $this->assertInstanceOf(Time::class, $user->created_at);
+        $this->assertInstanceOf(Time::class, $user->updated_at);
+    }
+
+    /**
+     * @TODO Fix the object cast handler implementation.
+     */
+    public function testCastObject(): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $entity = new class () extends Entity {
+            protected $casts = [
+                'id'     => 'int',
+                'active' => 'int-bool',
+                'memo'   => 'object',
+            ];
+        };
+        $model = new class () extends Model {
+            protected $table         = 'users';
+            protected $allowedFields = [
+                'username', 'active', 'memo',
+            ];
+            protected $useTimestamps = true;
+        };
+        $entity->fill(['username' => 'johnsmith', 'active' => false, 'memo' => ['foo', 'bar']]);
+        $model->save($entity);
+    }
+}

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -1339,4 +1339,49 @@ final class EntityTest extends CIUnitTestCase
             ];
         };
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/5905
+     */
+    public function testHasChangedCastsItem()
+    {
+        $data = [
+            'id'   => '1',
+            'name' => 'John',
+            'age'  => '35',
+        ];
+        $entity = new class ($data) extends Entity {
+            protected $casts = [
+                'id'   => 'integer',
+                'name' => 'string',
+                'age'  => 'integer',
+            ];
+        };
+        $entity->syncOriginal();
+
+        $entity->age = 35;
+
+        $this->assertFalse($entity->hasChanged('age'));
+    }
+
+    public function testHasChangedCastsWholeEntity()
+    {
+        $data = [
+            'id'   => '1',
+            'name' => 'John',
+            'age'  => '35',
+        ];
+        $entity = new class ($data) extends Entity {
+            protected $casts = [
+                'id'   => 'integer',
+                'name' => 'string',
+                'age'  => 'integer',
+            ];
+        };
+        $entity->syncOriginal();
+
+        $entity->age = 35;
+
+        $this->assertFalse($entity->hasChanged());
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #5905
Supersedes #6284

- Now all `Entity::$attributes` have (cast) PHP values, not raw values from database
- add `CastInterface::toDatabase()` and `CastInterface::fromDatabase()`
- add `Entity::toDatabase()` to return array for database and `Entity::fromDatabase()` to rebuild Entity from database data

```
[App Code] --- set() --> [Entity] --- toDatabase() ---> [Database]
[App Code] <-- get() --- [Entity] <-- fromDatabase() -- [Database]
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
