### PR TITLE
refactor: replace deprecated `Services::request(config, false)`

### DIFF
--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -51,7 +51,7 @@ final class FilterCollector
             ];
         }
 
-        $request = Services::incommingrequest(null, false);
+        $request = Services::incomingrequest(null, false);
         $request->setMethod($method);
 
         $router  = $this->createRouter($request);

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -51,7 +51,7 @@ final class FilterCollector
             ];
         }
 
-        $request = Services::request(null, false);
+        $request = Services::incommingrequest(null, false);
         $request->setMethod($method);
 
         $router  = $this->createRouter($request);

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -109,7 +109,7 @@ trait ControllerTestTrait
             $tempUri = Services::uri();
             Services::injectMock('uri', $this->uri);
 
-            $this->withRequest(Services::request($this->appConfig, false));
+            $this->withRequest(Services::incommingrequest($this->appConfig, false));
 
             // Restore the URI service
             Services::injectMock('uri', $tempUri);

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -105,7 +105,7 @@ trait ControllerTestTrait
         }
 
         if (empty($this->request)) {
-            // Do some acrobatics so we can use the Request service with our own URI
+            // Do some acrobatics, so we can use the Request service with our own URI
             $tempUri = Services::uri();
             Services::injectMock('uri', $this->uri);
 

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -109,7 +109,7 @@ trait ControllerTestTrait
             $tempUri = Services::uri();
             Services::injectMock('uri', $this->uri);
 
-            $this->withRequest(Services::incommingrequest($this->appConfig, false));
+            $this->withRequest(Services::incomingrequest($this->appConfig, false));
 
             // Restore the URI service
             Services::injectMock('uri', $tempUri);

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -108,7 +108,7 @@ trait ControllerTester
             $tempUri = Services::uri();
             Services::injectMock('uri', $this->uri);
 
-            $this->withRequest(Services::incommingrequest($this->appConfig, false)->setBody($this->body));
+            $this->withRequest(Services::incomingrequest($this->appConfig, false)->setBody($this->body));
 
             // Restore the URI service
             Services::injectMock('uri', $tempUri);

--- a/system/Test/ControllerTester.php
+++ b/system/Test/ControllerTester.php
@@ -108,7 +108,7 @@ trait ControllerTester
             $tempUri = Services::uri();
             Services::injectMock('uri', $this->uri);
 
-            $this->withRequest(Services::request($this->appConfig, false)->setBody($this->body));
+            $this->withRequest(Services::incommingrequest($this->appConfig, false)->setBody($this->body));
 
             // Restore the URI service
             Services::injectMock('uri', $tempUri);

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -289,7 +289,7 @@ trait FeatureTestTrait
 
         Services::injectMock('uri', $uri);
 
-        $request = Services::request($config, false);
+        $request = Services::incommingrequest($config, false);
 
         $request->setMethod($method);
         $request->setProtocolVersion('1.1');

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -289,7 +289,7 @@ trait FeatureTestTrait
 
         Services::injectMock('uri', $uri);
 
-        $request = Services::incommingrequest($config, false);
+        $request = Services::incomingrequest($config, false);
 
         $request->setMethod($method);
         $request->setProtocolVersion('1.1');


### PR DESCRIPTION
**Description**
`Services::request()` returns the current Request object.
The parameter `$config` and `$getShared` are deprecated.

https://github.com/codeigniter4/CodeIgniter4/blob/0cd39937d7a8dbd8074237596024adce0fe3c2af/system/Config/Services.php#L508-L525

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
