### PR TITLE
fix: error on `Config\Kint` with Config Caching

### DIFF
--- a/app/Config/Kint.php
+++ b/app/Config/Kint.php
@@ -2,7 +2,6 @@
 
 namespace Config;
 
-use CodeIgniter\Config\BaseConfig;
 use Kint\Parser\ConstructablePluginInterface;
 use Kint\Renderer\AbstractRenderer;
 use Kint\Renderer\Rich\TabPluginInterface;
@@ -18,7 +17,7 @@ use Kint\Renderer\Rich\ValuePluginInterface;
  *
  * @see https://kint-php.github.io/kint/ for details on these settings.
  */
-class Kint extends BaseConfig
+class Kint
 {
     /*
     |--------------------------------------------------------------------------

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -296,7 +296,7 @@ class CodeIgniter
 
     private function configureKint(): void
     {
-        $config = config(KintConfig::class);
+        $config = new KintConfig();
 
         Kint::$depth_limit         = $config->maxDepth;
         Kint::$display_called_from = $config->displayCalledFrom;

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -106,6 +106,9 @@ Config
 - app/Config/Feature.php
     - ``Config\Feature::$multipleFilters`` has been removed, because now
       :ref:`multiple-filters` are always enabled.
+- app/Config/Kint.php
+    - It no longer extends ``BaseConfig`` because enabling
+      :ref:`factories-config-caching` could cause errors.
 
 All Changes
 ===========


### PR DESCRIPTION
**Description**
We do not need to share the Config file, or change the values with `.env`.
And if we enable Config Caching, it cannot be loaded from `FactoriesCache` when we run `composer install --no-dev`. 
https://github.com/codeigniter4/CodeIgniter4/blob/efb12a8f2952f9f545fb637653993d523ce86cd7/public/index.php#L51-L53
Because the autoloader for Kint is registered in `CodeIgniter::initialize()`.
https://github.com/codeigniter4/CodeIgniter4/blob/efb12a8f2952f9f545fb637653993d523ce86cd7/system/CodeIgniter.php#L279-L291

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
