### PR TITLE
perf: autoloader

### DIFF
--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -19,6 +19,9 @@
         "phpunit/phpunit": "^9.1"
     },
     "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        },
         "exclude-from-classmap": [
             "**/Database/Migrations/**"
         ]

--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -46,7 +46,6 @@ class Autoload extends AutoloadConfig
      */
     public $psr4 = [
         APP_NAMESPACE => APPPATH, // For custom app namespace
-        'Config'      => APPPATH . 'Config',
     ];
 
     /**

--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -30,22 +30,18 @@ class Autoload extends AutoloadConfig
      * their location on the file system. These are used by the autoloader
      * to locate files the first time they have been instantiated.
      *
-     * The '/app' and '/system' directories are already mapped for you.
-     * you may change the name of the 'App' namespace if you wish,
+     * The 'Config' (APPPATH . 'Config') and 'CodeIgniter' (SYSTEMPATH) are
+     * already mapped for you.
+     *
+     * You may change the name of the 'App' namespace if you wish,
      * but this should be done prior to creating any namespaced classes,
      * else you will need to modify all of those classes for this to work.
-     *
-     * Prototype:
-     *   $psr4 = [
-     *       'CodeIgniter' => SYSTEMPATH,
-     *       'App'         => APPPATH
-     *   ];
      *
      * @var array<string, array<int, string>|string>
      * @phpstan-var array<string, string|list<string>>
      */
     public $psr4 = [
-        APP_NAMESPACE => APPPATH, // For custom app namespace
+        APP_NAMESPACE => APPPATH,
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,8 @@
     "autoload": {
         "psr-4": {
             "App\\": "app/",
-            "Config\\": "app/Config/",
-            "CodeIgniter\\": "system/"
+            "CodeIgniter\\": "system/",
+            "Config\\": "app/Config/"
         },
         "exclude-from-classmap": [
             "**/Database/Migrations/**"

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,8 @@
     },
     "autoload": {
         "psr-4": {
+            "App\\": "app/",
+            "Config\\": "app/Config/",
             "CodeIgniter\\": "system/"
         },
         "exclude-from-classmap": [

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/",
             "CodeIgniter\\": "system/",
             "Config\\": "app/Config/"
         },

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -430,13 +430,6 @@ class Autoloader
         $this->addNamespace($newPaths);
     }
 
-    private function loadComposerClassmap(ClassLoader $composer): void
-    {
-        $classes = $composer->getClassMap();
-
-        $this->classmap = array_merge($this->classmap, $classes);
-    }
-
     /**
      * Locates autoload information from Composer, if available.
      *

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -93,6 +93,7 @@ class AutoloadConfig
     protected $corePsr4 = [
         'CodeIgniter' => SYSTEMPATH,
         'App'         => APPPATH, // To ensure filters, etc still found,
+        'Config'      => APPPATH . 'Config',
     ];
 
     /**

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -92,7 +92,6 @@ class AutoloadConfig
      */
     protected $corePsr4 = [
         'CodeIgniter' => SYSTEMPATH,
-        'App'         => APPPATH, // To ensure filters, etc still found,
         'Config'      => APPPATH . 'Config',
     ];
 

--- a/tests/system/Commands/Utilities/NamespacesTest.php
+++ b/tests/system/Commands/Utilities/NamespacesTest.php
@@ -56,8 +56,8 @@ final class NamespacesTest extends CIUnitTestCase
             | Namespace     | Path                    | Found? |
             +---------------+-------------------------+--------+
             | CodeIgniter   | ROOTPATH/system         | Yes    |
-            | App           | ROOTPATH/app            | Yes    |
             | Config        | APPPATH/Config          | Yes    |
+            | App           | ROOTPATH/app            | Yes    |
             | Tests\Support | ROOTPATH/tests/_support | Yes    |
             +---------------+-------------------------+--------+
             EOL;

--- a/tests/system/Config/ConfigTest.php
+++ b/tests/system/Config/ConfigTest.php
@@ -46,13 +46,6 @@ final class ConfigTest extends CIUnitTestCase
         $this->assertSame($Config2, $Config);
     }
 
-    public function testCreateNonConfig(): void
-    {
-        $Config = Config::get('Constants', false);
-
-        $this->assertNull($Config);
-    }
-
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -116,9 +116,9 @@ Helpers and Functions
 Others
 ======
 
-- **Autoloader:** Autoloading performance when using Composer has been improved;
-  changing the ``autoload.psr4`` setting in **composer.json** may also improve
-  the performance of your app. See :ref:`autoloader-composer-support-improve-performance`.
+- **Autoloader:** Autoloading performance when using Composer has been improved.
+  Adding the ``App`` namespace in the ``autoload.psr4`` setting in **composer.json**
+  may also improve the performance of your app. See :ref:`autoloader-application-namespace`.
 
 Message Changes
 ***************

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -116,6 +116,10 @@ Helpers and Functions
 Others
 ======
 
+- **Autoloader:** Autoloading performance when using Composer has been improved;
+  changing the ``autoload.psr4`` setting in **composer.json** may also improve
+  the performance of your app. See :ref:`autoloader-composer-support-improve-performance`.
+
 Message Changes
 ***************
 

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -117,7 +117,7 @@ Improve Performance
 
 .. versionadded:: 4.5.0
 
-When you use Composer, you could improve the performance of autoloading with
+When you use Composer, you may improve the performance of autoloading with
 Composer's classmap dump.
 
 Add your ``App`` namespace in your **composer.json**, and run ``composer dump-autoload``.

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -13,6 +13,7 @@ classes that your project is using. Keeping track of where every single file is,
 hard-coding that location into your files in a series of ``requires()`` is a massive
 headache and very error-prone. That's where autoloaders come in.
 
+***********************
 CodeIgniter4 Autoloader
 ***********************
 
@@ -36,12 +37,14 @@ beginning of the framework's execution.
     file name case is incorrect, the autoloader cannot find the file on the
     server.
 
+*************
 Configuration
 *************
 
 Initial configuration is done in **app/Config/Autoload.php**. This file contains two primary
 arrays: one for the classmap, and one for PSR-4 compatible namespaces.
 
+**********
 Namespaces
 **********
 
@@ -76,6 +79,7 @@ You will need to modify any existing files that are referencing the current name
     expect. This allows the core system files to always be able to locate them, even when the application
     namespace has changed.
 
+********
 Classmap
 ********
 
@@ -87,6 +91,7 @@ third-party libraries that are not namespaced:
 
 The key of each row is the name of the class that you want to locate. The value is the path to locate it at.
 
+****************
 Composer Support
 ****************
 

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -64,8 +64,23 @@ The value is the location to the directory the classes can be found in.
 
         php spark namespaces
 
+.. _autoloader-application-namespace:
+
+Application Namespace
+=====================
+
 By default, the application directory is namespace to the ``App`` namespace. You must namespace the controllers,
 libraries, or models in the application directory, and they will be found under the ``App`` namespace.
+
+Config Namespace
+----------------
+
+Config files are namespaced in the ``Config`` namespace, not in ``App\Config`` as you might
+expect. This allows the core system files to always be able to locate them, even when the application
+namespace has changed.
+
+Changing App Namespace
+----------------------
 
 You may change this namespace by editing the **app/Config/Constants.php** file and setting the
 new namespace value under the ``APP_NAMESPACE`` setting:
@@ -73,11 +88,27 @@ new namespace value under the ``APP_NAMESPACE`` setting:
 .. literalinclude:: autoloader/002.php
    :lines: 2-
 
-You will need to modify any existing files that are referencing the current namespace.
+And if you use Composer autoloader, you also need to change the ``App`` namespace
+in your **composer.json**, and run ``composer dump-autoload``.
 
-.. important:: Config files are namespaced in the ``Config`` namespace, not in ``App\Config`` as you might
-    expect. This allows the core system files to always be able to locate them, even when the application
-    namespace has changed.
+.. code-block:: text
+
+    {
+        ...
+        "autoload": {
+            "psr-4": {
+                "App\\": "app/"    <-- Change
+            },
+            ...
+        },
+        ...
+    }
+
+.. note:: Since v4.5.0 appstarter, the ``App\\`` namespace has been added to
+    **composer.json**'s ``autoload.psr-4``. If your **composer.json** does not
+    have it, adding it may improve your app's autoloading performance.
+
+You will need to modify any existing files that are referencing the current namespace.
 
 ********
 Classmap
@@ -109,28 +140,3 @@ autoloader will be the first one to get a chance to locate the file.
 
 .. note:: Prior to v4.5.0, if the same namespace was defined in both CodeIgniter and Composer, CodeIgniter's autoloader was
     the first one to get a chance to locate the file.
-
-.. _autoloader-composer-support-improve-performance:
-
-Improve Performance
-===================
-
-.. versionadded:: 4.5.0
-
-When you use Composer, you may improve the performance of autoloading with
-Composer's classmap dump.
-
-Add your ``App`` namespace in your **composer.json**, and run ``composer dump-autoload``.
-
-.. code-block:: text
-
-    {
-        ...
-        "autoload": {
-            "psr-4": {
-                "App\\": "app/",
-            },
-            ...
-        },
-        ...
-    }

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -90,9 +90,14 @@ The key of each row is the name of the class that you want to locate. The value 
 Composer Support
 ****************
 
-Composer support is automatically initialized by default. By default, it looks for Composer's autoload file at
+Composer support is automatically initialized by default.
+
+By default, it looks for Composer's autoload file at
 ``ROOTPATH . 'vendor/autoload.php'``. If you need to change the location of that file for any reason, you can modify
 the value defined in **app/Config/Constants.php**.
 
-.. note:: If the same namespace is defined in both CodeIgniter and Composer, CodeIgniter's autoloader will be
+If the same namespace is defined in both CodeIgniter and Composer, Composer's
+autoloader will be the first one to get a chance to locate the file.
+
+.. note:: Prior to v4.5.0, if the same namespace was defined in both CodeIgniter and Composer, CodeIgniter's autoloader was
     the first one to get a chance to locate the file.

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -101,8 +101,36 @@ By default, it looks for Composer's autoload file at
 ``ROOTPATH . 'vendor/autoload.php'``. If you need to change the location of that file for any reason, you can modify
 the value defined in **app/Config/Constants.php**.
 
+Priority of Autoloaders
+=======================
+
 If the same namespace is defined in both CodeIgniter and Composer, Composer's
 autoloader will be the first one to get a chance to locate the file.
 
 .. note:: Prior to v4.5.0, if the same namespace was defined in both CodeIgniter and Composer, CodeIgniter's autoloader was
     the first one to get a chance to locate the file.
+
+.. _autoloader-composer-support-improve-performance:
+
+Improve Performance
+===================
+
+.. versionadded:: 4.5.0
+
+When you use Composer, you could improve the performance of autoloading with
+Composer's classmap dump.
+
+Add your ``App`` namespace in your **composer.json**, and run ``composer dump-autoload``.
+
+.. code-block:: text
+
+    {
+        ...
+        "autoload": {
+            "psr-4": {
+                "App\\": "app/",
+            },
+            ...
+        },
+        ...
+    }

--- a/user_guide_src/source/concepts/autoloader/001.php
+++ b/user_guide_src/source/concepts/autoloader/001.php
@@ -8,8 +8,7 @@ class Autoload extends AutoloadConfig
 {
     // ...
     public $psr4 = [
-        APP_NAMESPACE => APPPATH, // For custom app namespace
-        'Config'      => APPPATH . 'Config',
+        APP_NAMESPACE => APPPATH,
     ];
 
     // ...

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -93,6 +93,7 @@ For example, assume that we have the following namespaces defined in our Autoloa
 configuration file:
 
 .. literalinclude:: migration/004.php
+    :lines: 2-
 
 This will look for any migrations located at both **APPPATH/Database/Migrations** and
 **ROOTPATH/MyCompany/Database/Migrations**. This makes it simple to include migrations in your

--- a/user_guide_src/source/dbmgmt/migration/004.php
+++ b/user_guide_src/source/dbmgmt/migration/004.php
@@ -1,6 +1,6 @@
 <?php
 
 $psr4 = [
-    'App'       => APPPATH,
-    'MyCompany' => ROOTPATH . 'MyCompany',
+    APP_NAMESPACE => APPPATH,
+    'MyCompany'   => ROOTPATH . 'MyCompany',
 ];

--- a/user_guide_src/source/general/modules/001.php
+++ b/user_guide_src/source/general/modules/001.php
@@ -6,9 +6,9 @@ use CodeIgniter\Config\AutoloadConfig;
 
 class Autoload extends AutoloadConfig
 {
+    // ...
     public $psr4 = [
-        APP_NAMESPACE => APPPATH, // For custom namespace
-        'Config'      => APPPATH . 'Config',
+        APP_NAMESPACE => APPPATH,
         'Acme\Blog'   => ROOTPATH . 'acme/Blog',
     ];
 


### PR DESCRIPTION
**Description**
To improve the performance of autoloader.
Benchmark: https://github.com/codeigniter4/CodeIgniter4/pull/8005#issuecomment-1747641598 and https://github.com/codeigniter4/CodeIgniter4/pull/8005#issuecomment-1747686877

- add `App` and `Config` namespaces to `composer.json`
- change the priority of the autoloaders
  Before: 1. CI classmap loader, 2. CI PSR-4 autoloader, 3. Composer autoloader
  After: 1. Composer autoloader, 2. CI classmap loader, 3. CI PSR-4 autoloader

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
