### PR TITLE
fix: `FileLocator::findQualifiedNameFromPath()` behavior

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -273,7 +273,7 @@ class FileLocator
             }
 
             if (mb_strpos($path, $namespace['path']) === 0) {
-                $className = '\\' . $namespace['prefix'] . '\\' .
+                $className = $namespace['prefix'] . '\\' .
                         ltrim(str_replace(
                             '/',
                             '\\',

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -274,11 +274,14 @@ class FileLocator
 
             if (mb_strpos($path, $namespace['path']) === 0) {
                 $className = $namespace['prefix'] . '\\' .
-                        ltrim(str_replace(
+                    ltrim(
+                        str_replace(
                             '/',
                             '\\',
                             mb_substr($path, mb_strlen($namespace['path']))
-                        ), '\\');
+                        ),
+                        '\\'
+                    );
 
                 // Remove the file extension (.php)
                 $className = mb_substr($className, 0, -4);

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -278,7 +278,7 @@ final class FileLocatorTest extends CIUnitTestCase
     public function testFindQNameFromPathSimple(): void
     {
         $ClassName = $this->locator->findQualifiedNameFromPath(SYSTEMPATH . 'HTTP/Header.php');
-        $expected  = '\\' . Header::class;
+        $expected  = Header::class;
 
         $this->assertSame($expected, $ClassName);
     }

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -33,6 +33,8 @@ Others
 - **Logger:** The :php:func:`log_message()` function and the logger methods in
   ``CodeIgniter\Log\Logger`` now do not return ``bool`` values. The return types
   have been fixed to ``void`` to follow the PSR-3 interface.
+- **Autoloader:** The prefix ``\`` in the fully qualified classname returned by
+  ``FileLocator::findQualifiedNameFromPath()`` has been removed.
 
 Interface Changes
 =================

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -72,6 +72,14 @@ reversed.
         Previous: route1 → route2 → filter1 → filter2
              Now: route2 → route1 → filter2 → filter1
 
+FileLocator::findQualifiedNameFromPath()
+========================================
+
+In previous versions, ``FileLocator::findQualifiedNameFromPath()`` returns Fully
+Qualified Classnames with a leading ``\``. Now the leading ``\`` has been removed.
+
+If you have code that expects a leading ``\``, fix it.
+
 Removed Deprecated Items
 ========================
 


### PR DESCRIPTION
**Description**
- With this PR, `FileLocator::findQualifiedNameFromPath()` returns a FQCN without leading `\`

FQCN should not start with `\`.
`get_class()` of `::class` returns FQCN without leading `\`.
The following code does not work as expected.:
```php
$class = FileLocator::findQualifiedNameFromPath(...);
if ($class === Foo::class) {
    // do something
}
```


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
