### PR TITLE
fix: CI returns "200 OK" when PageNotFound

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -979,8 +979,7 @@ class CodeIgniter
         // Display 404 Errors
         $this->response->setStatusCode($e->getCode());
 
-        echo $this->outputBufferingEnd();
-        flush();
+        $this->outputBufferingEnd();
 
         // Throws new PageNotFoundException and remove exception message on production.
         throw PageNotFoundException::forPageNotFound(

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -32,6 +32,9 @@ Deprecations
 Bugs Fixed
 **********
 
+- **CodeIgniter:** Fixed a bug that returned "200 OK" response status code when
+  Page Not Found.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
Fixes #8009

Navigate to `http://localhost:8080/404`, you will get "200 OK" status code.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
