### PR TITLE
docs: make discoverFilters() deprecated

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -125,6 +125,8 @@ class Filters
      *
      * Sample :
      * $filters->aliases['custom-auth'] = \Acme\Blob\Filters\BlobAuth::class;
+     *
+     * @deprecated 4.4.2 Use Registrar instead.
      */
     private function discoverFilters(): void
     {

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -29,6 +29,10 @@ Changes
 Deprecations
 ************
 
+- **Filters:** The Auto-Discovery for Filters and ``Filters::discoverFilters()``
+  is deprecated. Use :ref:`registrars` instead. See :ref:`modules-filters` for
+  details.
+
 Bugs Fixed
 **********
 

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -160,6 +160,8 @@ the **Modules** config file, described above.
 When working with modules, it can be a problem if the routes in the application contain wildcards.
 In that case, see :ref:`routing-priority`.
 
+.. _modules-filters:
+
 Filters
 =======
 

--- a/user_guide_src/source/general/modules.rst
+++ b/user_guide_src/source/general/modules.rst
@@ -163,6 +163,13 @@ In that case, see :ref:`routing-priority`.
 Filters
 =======
 
+.. deprecated:: 4.4.2
+
+.. note:: This feature is deprecated. Use :ref:`registrars` instead like the
+    following:
+
+    .. literalinclude:: modules/015.php
+
 By default, :doc:`filters <../incoming/filters>` are automatically scanned for within modules.
 It can be turned off in the **Modules** config file, described above.
 

--- a/user_guide_src/source/general/modules/015.php
+++ b/user_guide_src/source/general/modules/015.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CodeIgniter\Shield\Config;
+
+use CodeIgniter\Shield\Filters\SessionAuth;
+use CodeIgniter\Shield\Filters\TokenAuth;
+
+class Registrar
+{
+    /**
+     * Registers the Shield filters.
+     */
+    public static function Filters(): array
+    {
+        return [
+            'aliases' => [
+                'session' => SessionAuth::class,
+                'tokens'  => TokenAuth::class,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/7955#issuecomment-1737177748

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
