### PR TITLE
fix: reverse route for `''` is not `false`

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1156,6 +1156,10 @@ class RouteCollection implements RouteCollectionInterface
      */
     public function reverseRoute(string $search, ...$params)
     {
+        if ($search === '') {
+            return false;
+        }
+
         // Named routes get higher priority.
         foreach ($this->routesNames as $verb => $collection) {
             if (array_key_exists($search, $collection)) {

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -38,6 +38,7 @@ final class MiscUrlTest extends CIUnitTestCase
         parent::setUp();
 
         Services::reset(true);
+        Services::routes()->loadRoutes();
 
         // Set a common base configuration (overriden by individual tests)
         $this->config            = new App();

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -52,6 +52,16 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
         return (new RouteCollection($loader, $moduleConfig, new Routing()))->setHTTPVerb('get');
     }
 
+    public function testReverseRoutingEmptyString(): void
+    {
+        $routes = $this->getCollector();
+
+        $routes->add('/', 'Home::index');
+
+        $match = $routes->reverseRoute('');
+        $this->assertFalse($match);
+    }
+
     public function testReverseRoutingFindsSimpleMatch(): void
     {
         $routes = $this->getCollector();


### PR DESCRIPTION
**Description**

By default, the following code returns `http://localhost:8080/index.php/` (the first route).
```php
<?php

namespace App\Controllers;

class Home extends BaseController
{
    public function index(): string
    {
        dd(url_to(''));
    }
}
```

There is a test case for an empty string: https://github.com/codeigniter4/CodeIgniter4/blob/0d9460602e79958fc5067473f27486f8d9ad9955/tests/system/Helpers/URLHelper/MiscUrlTest.php#L866
But it passes because no route is registered at the test execution.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
