### PR TITLE
fix: CSP style nonce is added even if honeypot is not attached

### DIFF
--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -89,16 +89,16 @@ class Honeypot
 
         $prepField = $this->prepareTemplate($this->config->template);
 
-        $body = $response->getBody();
-        $body = str_ireplace('</form>', $prepField . '</form>', $body);
+        $bodyBefore = $response->getBody();
+        $bodyAfter  = str_ireplace('</form>', $prepField . '</form>', $bodyBefore);
 
-        if ($response->getCSP()->enabled()) {
+        if ($response->getCSP()->enabled() && ($bodyBefore !== $bodyAfter)) {
             // Add style tag for the container tag in the head tag.
-            $style = '<style ' . csp_style_nonce() . '>#' . $this->config->containerId . ' { display:none }</style>';
-            $body  = str_ireplace('</head>', $style . '</head>', $body);
+            $style     = '<style ' . csp_style_nonce() . '>#' . $this->config->containerId . ' { display:none }</style>';
+            $bodyAfter = str_ireplace('</head>', $style . '</head>', $bodyAfter);
         }
 
-        $response->setBody($body);
+        $response->setBody($bodyAfter);
     }
 
     /**

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -100,6 +100,24 @@ final class HoneypotTest extends CIUnitTestCase
         $this->assertMatchesRegularExpression($regex, $this->response->getBody());
     }
 
+    public function testNotAttachHoneypotWithCSP(): void
+    {
+        $this->resetServices();
+
+        $config             = new App();
+        $config->CSPEnabled = true;
+        Factories::injectMock('config', 'App', $config);
+        $this->response = Services::response($config, false);
+
+        $this->config   = new HoneypotConfig();
+        $this->honeypot = new Honeypot($this->config);
+
+        $this->response->setBody('<head></head><body></body>');
+        $this->honeypot->attachHoneypot($this->response);
+
+        $this->assertSame('<head></head><body></body>', $this->response->getBody());
+    }
+
     public function testHasntContent(): void
     {
         unset($_POST[$this->config->name]);


### PR DESCRIPTION
**Description**
Fixes  #8020 
See https://github.com/codeigniter4/CodeIgniter4/issues/8020#issuecomment-1754561573

The tag like this was added before `</head>` tag in every page. 
```html
<style nonce="ccdd15247e8da0a5b9023a5e">#hpc { display:none }</style>
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
