### PR TITLE
docs: deprecate CodeIgniter::displayCache() param

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -334,7 +334,7 @@ class CodeIgniter
      * This is "the loop" if you will. The main entry point into the script
      * that gets the required class instances, fires off the filters,
      * tries to route the response, loads the controller and generally
-     * makes all of the pieces work together.
+     * makes all the pieces work together.
      *
      * @return ResponseInterface|void
      */
@@ -724,7 +724,7 @@ class CodeIgniter
     /**
      * Tells the app that the final output should be cached.
      *
-     * @deprecated 4.4.0 Moved to ResponseCache::setTtl(). to No longer used.
+     * @deprecated 4.4.0 Moved to ResponseCache::setTtl(). No longer used.
      *
      * @return void
      */
@@ -796,7 +796,7 @@ class CodeIgniter
      * match a route against the current URI. If the route is a
      * "redirect route", will also handle the redirect.
      *
-     * @param RouteCollectionInterface|null $routes An collection interface to use in place
+     * @param RouteCollectionInterface|null $routes A collection interface to use in place
      *                                              of the config file.
      *
      * @return string|string[]|null Route filters, that is, the filters specified in the routes file

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -703,6 +703,8 @@ class CodeIgniter
      * @return false|ResponseInterface
      *
      * @throws Exception
+     *
+     * @deprecated 4.4.2 The parameter $config is deprecated. No longer used.
      */
     public function displayCache(Cache $config)
     {

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -34,6 +34,8 @@ Deprecations
   details.
 - **CLI:** The public property ``CLI::$readline_support`` and ``CLI::$wait_msg``
   are deprecated. These methods will be protected.
+- **CodeIgniter:** The parameter ``$config`` for the ``displayCache()`` method is
+  deprecated. It was not used.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
It is already not used.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
