### PR TITLE
fix: add a primary key to an existing table

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1238,7 +1238,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 16,
+	'count' => 13,
 	'path' => __DIR__ . '/system/Database/Forge.php',
 ];
 $ignoreErrors[] = [

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1084,12 +1084,10 @@ class Forge
 
         if (! empty($this->keys)) {
             $sqls = $this->_processIndexes($this->db->DBPrefix . $table, true);
+        }
 
-            $pk = $this->_processPrimaryKeys($table, true);
-
-            if ($pk !== '') {
-                $sqls[] = $pk;
-            }
+        if (! empty($this->primaryKeys)) {
+            $sqls[] = $this->_processPrimaryKeys($table, true);
         }
 
         $this->foreignKeys = $fk;

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1073,7 +1073,7 @@ class Forge
         $sqls = [];
         $fk   = $this->foreignKeys;
 
-        if (empty($this->fields)) {
+        if ($this->fields === []) {
             $this->fields = array_flip(array_map(
                 static fn ($columnName) => $columnName->name,
                 $this->db->getFieldData($this->db->DBPrefix . $table)
@@ -1082,18 +1082,18 @@ class Forge
 
         $fields = $this->fields;
 
-        if (! empty($this->keys)) {
+        if ($this->keys !== []) {
             $sqls = $this->_processIndexes($this->db->DBPrefix . $table, true);
         }
 
-        if (! empty($this->primaryKeys)) {
+        if ($this->primaryKeys !== []) {
             $sqls[] = $this->_processPrimaryKeys($table, true);
         }
 
         $this->foreignKeys = $fk;
         $this->fields      = $fields;
 
-        if (! empty($this->foreignKeys)) {
+        if ($this->foreignKeys !== []) {
             $sqls = array_merge($sqls, $this->_processForeignKeys($table, true));
         }
 

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -42,6 +42,8 @@ Bugs Fixed
   Page Not Found.
 - **Spark:** Fixed a bug that caused spark to not display exceptions in the
   production mode or to display backtrace in json when an exception occurred.
+- **Forge:** Fixed a bug where adding a Primary Key to an existing table was
+  ignored if there were no other Keys added too.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
Fixes: #8019

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
