### PR TITLE
fix: PHPStan errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -38,3 +38,8 @@ parameters:
 		booleansInConditions: true
 		disallowedConstructs: true
 		matchingInheritedMethodNames: true
+	ignoreErrors:
+		- '#^Call to function config with Config\\.+\:\:class is discouraged\.$#'
+	codeigniter:
+		additionalConfigNamespaces:
+			- CodeIgniter\Config\

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -377,7 +377,7 @@ class Factories
             // Handle Config as a special case to prevent logic loops
             ? self::$configOptions
             // Load values from the best Factory configuration (will include Registrars)
-            : config(Factory::class)->{$component} ?? [];
+            : config('Factory')->{$component} ?? [];
 
         // The setOptions() reset the component. So getOptions() may reset
         // the component.


### PR DESCRIPTION
**Description**
See https://github.com/CodeIgniter/phpstan-codeigniter/releases/tag/v1.4.0

```
  ------ ----------------------------------------------------------------------- 
  Line   system/CLI/BaseCommand.php                                             
 ------ ----------------------------------------------------------------------- 
  127    Call to function config with Config\Exceptions::class is discouraged.  
         💡 Use config('Exceptions') instead to allow overriding.               
 ------ ----------------------------------------------------------------------- 
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6490312938/job/17625890673

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
