### PR TITLE
docs: fix typo in upgrade_440

### DIFF
--- a/user_guide_src/source/installation/upgrade_440.rst
+++ b/user_guide_src/source/installation/upgrade_440.rst
@@ -91,7 +91,7 @@ When Passing Classname with Namespace to Factories
 The behavior of passing a classname with a namespace to Factories has been changed.
 See :ref:`ChangeLog <v440-factories>` for details.
 
-If you have code like ``model('\Myth\Auth\Models\UserModel::class')`` or
+If you have code like ``model(\Myth\Auth\Models\UserModel::class)`` or
 ``model('Myth\Auth\Models\UserModel')`` (the code may be in the third-party packages),
 and you expect to load your ``App\Models\UserModel``, you need to define the
 classname to be loaded before the first loading of that class::


### PR DESCRIPTION
**Description**
- The `'` should be removed.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
