### PR TITLE
fix: Factories caching bug

### DIFF
--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -502,12 +502,14 @@ class Factories
     {
         if (! isset(static::$aliases[$component])) {
             return [
+                'options'   => [],
                 'aliases'   => [],
                 'instances' => [],
             ];
         }
 
         return [
+            'options'   => static::$options[$component],
             'aliases'   => static::$aliases[$component],
             'instances' => self::$instances[$component],
         ];
@@ -520,9 +522,11 @@ class Factories
      */
     public static function setComponentInstances(string $component, array $data): void
     {
-        static::$aliases[$component] = $data['aliases'];
-        self::$instances[$component] = $data['instances'];
-        unset(self::$updated[$component]);
+        static::$options[$component]   = $data['options'];
+        static::$aliases[$component]   = $data['aliases'];
+        static::$instances[$component] = $data['instances'];
+
+        unset(static::$updated[$component]);
     }
 
     /**

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -100,6 +100,8 @@ class Factories
      */
     public static function define(string $component, string $alias, string $classname): void
     {
+        $component = strtolower($component);
+
         if (isset(self::$aliases[$component][$alias])) {
             if (self::$aliases[$component][$alias] === $classname) {
                 return;
@@ -130,12 +132,14 @@ class Factories
      */
     public static function __callStatic(string $component, array $arguments)
     {
+        $component = strtolower($component);
+
         // First argument is the class alias, second is options
         $alias   = trim(array_shift($arguments), '\\ ');
         $options = array_shift($arguments) ?? [];
 
         // Determine the component-specific options
-        $options = array_merge(self::getOptions(strtolower($component)), $options);
+        $options = array_merge(self::getOptions($component), $options);
 
         if (! $options['getShared']) {
             if (isset(self::$aliases[$component][$alias])) {
@@ -394,6 +398,8 @@ class Factories
      */
     public static function setOptions(string $component, array $values): array
     {
+        $component = strtolower($component);
+
         // Allow the config to replace the component name, to support "aliases"
         $values['component'] = strtolower($values['component'] ?? $component);
 
@@ -452,8 +458,9 @@ class Factories
      */
     public static function injectMock(string $component, string $alias, object $instance)
     {
-        // Force a configuration to exist for this component
         $component = strtolower($component);
+
+        // Force a configuration to exist for this component
         self::getOptions($component);
 
         $class = get_class($instance);

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -430,19 +430,19 @@ class Factories
     {
         if ($component) {
             unset(
-                static::$options[$component],
-                static::$aliases[$component],
-                static::$instances[$component],
-                static::$updated[$component]
+                self::$options[$component],
+                self::$aliases[$component],
+                self::$instances[$component],
+                self::$updated[$component]
             );
 
             return;
         }
 
-        static::$options   = [];
-        static::$aliases   = [];
-        static::$instances = [];
-        static::$updated   = [];
+        self::$options   = [];
+        self::$aliases   = [];
+        self::$instances = [];
+        self::$updated   = [];
     }
 
     /**
@@ -500,7 +500,7 @@ class Factories
      */
     public static function getComponentInstances(string $component): array
     {
-        if (! isset(static::$aliases[$component])) {
+        if (! isset(self::$aliases[$component])) {
             return [
                 'options'   => [],
                 'aliases'   => [],
@@ -509,8 +509,8 @@ class Factories
         }
 
         return [
-            'options'   => static::$options[$component],
-            'aliases'   => static::$aliases[$component],
+            'options'   => self::$options[$component],
+            'aliases'   => self::$aliases[$component],
             'instances' => self::$instances[$component],
         ];
     }
@@ -522,11 +522,11 @@ class Factories
      */
     public static function setComponentInstances(string $component, array $data): void
     {
-        static::$options[$component]   = $data['options'];
-        static::$aliases[$component]   = $data['aliases'];
-        static::$instances[$component] = $data['instances'];
+        self::$options[$component]   = $data['options'];
+        self::$aliases[$component]   = $data['aliases'];
+        self::$instances[$component] = $data['instances'];
 
-        unset(static::$updated[$component]);
+        unset(self::$updated[$component]);
     }
 
     /**

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -429,7 +429,7 @@ final class FactoriesTest extends CIUnitTestCase
     public function testSetComponentInstances(array $data)
     {
         $before = Factories::getComponentInstances('config');
-        $this->assertSame(['aliases' => [], 'instances' => []], $before);
+        $this->assertSame(['options' => [], 'aliases' => [], 'instances' => []], $before);
 
         Factories::setComponentInstances('config', $data);
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/8036#issuecomment-1758950847

- fix a bug that `$options` are not saved in cache
- refactor

**Details**
This bug is hidden. Because when restoring the cache, `Config\App` is instantiated and calls:
https://github.com/codeigniter4/CodeIgniter4/blob/da6492d90911db1df8e6c5d7adc0b340226a9636/system/Config/BaseConfig.php#L85
The above code calls `Factories::getOptions()` and it calls `setOptions()` and sets `self::$options['config']`.
Therefore after the instantiation, `Factories::$options['config']` is always set.

But [this change](https://github.com/codeigniter4/CodeIgniter4/pull/8036/files#diff-394cabe11630b173e3c22a66329b36e39d5ec3bd8317a77be2d59856c8cc4d5eL85-R85) removed `config()`. So after the instantiation, `Factories::$options['config']` will be empty.
When `$options['config']` is empty, `getOptions()` calls `setOptions()` and it calls `reset()`:
https://github.com/codeigniter4/CodeIgniter4/blob/da6492d90911db1df8e6c5d7adc0b340226a9636/system/Config/Factories.php#L401

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
