### PR TITLE
fix: `spark routes` may show incorrect route names

### DIFF
--- a/system/Router/DefinedRouteCollector.php
+++ b/system/Router/DefinedRouteCollector.php
@@ -57,7 +57,7 @@ final class DefinedRouteCollector
                         $handler = $view ? '(View) ' . $view : '(Closure)';
                     }
 
-                    $routeName = $this->routeCollection->getRoutesOptions($route)['as'] ?? $route;
+                    $routeName = $this->routeCollection->getRoutesOptions($route, $method)['as'] ?? $route;
 
                     yield [
                         'method'  => $method,

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -87,4 +87,45 @@ final class DefinedRouteCollectorTest extends CIUnitTestCase
         ];
         $this->assertSame($expected, $definedRoutes);
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/8039
+     */
+    public function testCollectSameFromWithDifferentVerb()
+    {
+        $routes = $this->createRouteCollection();
+        $routes->get('login', 'AuthController::showLogin', ['as' => 'loginShow']);
+        $routes->post('login', 'AuthController::login', ['as' => 'login']);
+        $routes->get('logout', 'AuthController::logout', ['as' => 'logout']);
+
+        $collector = new DefinedRouteCollector($routes);
+
+        $definedRoutes = [];
+
+        foreach ($collector->collect() as $route) {
+            $definedRoutes[] = $route;
+        }
+
+        $expected = [
+            [
+                'method'  => 'get',
+                'route'   => 'login',
+                'name'    => 'loginShow',
+                'handler' => '\\App\\Controllers\\AuthController::showLogin',
+            ],
+            [
+                'method'  => 'get',
+                'route'   => 'logout',
+                'name'    => 'logout',
+                'handler' => '\\App\\Controllers\\AuthController::logout',
+            ],
+            [
+                'method'  => 'post',
+                'route'   => 'login',
+                'name'    => 'login',
+                'handler' => '\\App\\Controllers\\AuthController::login',
+            ],
+        ];
+        $this->assertSame($expected, $definedRoutes);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.4.2.rst
+++ b/user_guide_src/source/changelogs/v4.4.2.rst
@@ -46,6 +46,7 @@ Bugs Fixed
   production mode or to display backtrace in json when an exception occurred.
 - **Forge:** Fixed a bug where adding a Primary Key to an existing table was
   ignored if there were no other Keys added too.
+- **Routing:** Fixed a bug that ``spark routes`` may show incorrect route names.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
Fixes #8039

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
