### PR TITLE
docs: improve curlrequest.rst

### DIFF
--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -214,7 +214,7 @@ cookie
 ======
 
 This specifies the filename that CURL should use to read cookie values from, and
-to save cookie values to. This is done using the CURL_COOKIEJAR and CURL_COOKIEFILE options.
+to save cookie values to. This is done using the ``CURL_COOKIEJAR`` and ``CURL_COOKIEFILE`` options.
 An example:
 
 .. literalinclude:: curlrequest/021.php
@@ -223,8 +223,10 @@ debug
 =====
 
 When ``debug`` is passed and set to ``true``, this will enable additional debugging to echo to STDERR during the
-script execution. This is done by passing CURLOPT_VERBOSE and echoing the output. So, when you're running a built-in
-server via ``spark serve`` you will see the output in the console. Otherwise, the output will be written to
+script execution.
+
+This is done by passing ``CURLOPT_VERBOSE`` and echoing the output. So, when you're running a built-in
+server via ``spark serve``, you will see the output in the console. Otherwise, the output will be written to
 the server's error log.
 
 .. literalinclude:: curlrequest/034.php

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -272,8 +272,11 @@ further headers arrays or calls to ``setHeader()``.
 http_errors
 ===========
 
-By default, CURLRequest will fail if the HTTP code returned is greater than or equal to 400. You can set
-``http_errors`` to ``false`` to return the content instead:
+By default, CURLRequest will throw ``HTTPException`` if the HTTP code returned is
+greater than or equal to 400.
+
+If you want to see the response body, you can set ``http_errors`` to ``false`` to
+return the content instead:
 
 .. literalinclude:: curlrequest/026.php
 

--- a/user_guide_src/source/libraries/curlrequest/026.php
+++ b/user_guide_src/source/libraries/curlrequest/026.php
@@ -1,8 +1,9 @@
 <?php
 
 $client->request('GET', '/status/500');
-// Will fail verbosely
+// If the response code is 500, an HTTPException is thrown,
+// and a detailed error report is displayed if in development mode.
 
-$res = $client->request('GET', '/status/500', ['http_errors' => false]);
-echo $res->getStatusCode();
-// 500
+$response = $client->request('GET', '/status/500', ['http_errors' => false]);
+echo $response->getStatusCode(); // 500
+echo $response->getBody();       // You can see the response body.


### PR DESCRIPTION
**Description**
Feedback in Slack.

By default, you cannot see the response body when the response code is 400 or greater.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
