### PR TITLE
docs: add note for routes after calling resetServices()

### DIFF
--- a/user_guide_src/source/testing/overview.rst
+++ b/user_guide_src/source/testing/overview.rst
@@ -244,6 +244,10 @@ Removes all mocked classes from the Services class, bringing it back to its orig
 
 You can also use the ``$this->resetServices()`` method that ``CIUnitTestCase`` provides.
 
+.. note:: This method resets the all states of Services, and the ``RouteCollection``
+    will have no routes. If you want to use your routes to be loaded, you need to
+    call the ``loadRoutes()`` method like ``Services::routes()->loadRoutes()``.
+
 Services::resetSingle(string $name)
 -----------------------------------
 


### PR DESCRIPTION
**Description**
Fixes #8018

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
