### PR TITLE
fix: file sort order in Files DebugBar

### DIFF
--- a/system/Debug/Toolbar/Collectors/Files.php
+++ b/system/Debug/Toolbar/Collectors/Files.php
@@ -62,13 +62,13 @@ class Files extends BaseCollector
 
             if (strpos($path, 'SYSTEMPATH') !== false) {
                 $coreFiles[] = [
-                    'name' => basename($file),
                     'path' => $path,
+                    'name' => basename($file),
                 ];
             } else {
                 $userFiles[] = [
-                    'name' => basename($file),
                     'path' => $path,
+                    'name' => basename($file),
                 ];
             }
         }


### PR DESCRIPTION
**Description**
Sort by full path.

Before:
![Screenshot 2023-10-16 18 27 44](https://github.com/codeigniter4/CodeIgniter4/assets/87955/2789e91c-d288-4d6a-9c90-d5490e28b565)

After:
![Screenshot 2023-10-16 18 27 26](https://github.com/codeigniter4/CodeIgniter4/assets/87955/9570ce80-9223-4ff3-88e3-6bfe8ab877a5)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
