### PR TITLE
refactor: remove deprecated properties and methods in CodeIgniter class

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -183,7 +183,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 6,
+	'count' => 5,
 	'path' => __DIR__ . '/system/CodeIgniter.php',
 ];
 $ignoreErrors[] = [

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -360,6 +360,8 @@ class CodeIgniter
         $this->spoofRequestMethod();
 
         try {
+            $this->forceSecureAccess();
+
             $this->response = $this->handleRequest($routes, config(Cache::class), $returnResponse);
         } catch (ResponsableInterface|DeprecatedRedirectException $e) {
             $this->outputBufferingEnd();
@@ -435,8 +437,6 @@ class CodeIgniter
      */
     protected function handleRequest(?RouteCollectionInterface $routes, Cache $cacheConfig, bool $returnResponse = false)
     {
-        $this->forceSecureAccess();
-
         if ($this->request instanceof IncomingRequest && strtolower($this->request->getMethod()) === 'cli') {
             return $this->response->setStatusCode(405)->setBody('Method Not Allowed');
         }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -809,7 +809,7 @@ class CodeIgniter
      */
     protected function determinePath()
     {
-        return method_exists($this->request, 'getPath') ? $this->request->getPath() : $this->request->getUri()->getPath();
+        return $this->request->getPath();
     }
 
     /**

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -136,25 +136,6 @@ class CodeIgniter
     protected static $cacheTTL = 0;
 
     /**
-     * Request path to use.
-     *
-     * @var string
-     *
-     * @deprecated No longer used.
-     */
-    protected $path;
-
-    /**
-     * Should the Response instance "pretend"
-     * to keep from setting headers/cookies/etc
-     *
-     * @var bool
-     *
-     * @deprecated No longer used.
-     */
-    protected $useSafeOutput = false;
-
-    /**
      * Context
      *  web:     Invoked by HTTP request
      *  php-cli: Invoked by CLI via `php public/index.php`
@@ -381,22 +362,6 @@ class CodeIgniter
         }
 
         $this->sendResponse();
-    }
-
-    /**
-     * Set our Response instance to "pretend" mode so that things like
-     * cookies and headers are not actually sent, allowing PHP 7.2+ to
-     * not complain when ini_set() function is used.
-     *
-     * @return $this
-     *
-     * @deprecated No longer used.
-     */
-    public function useSafeOutput(bool $safe = true)
-    {
-        $this->useSafeOutput = $safe;
-
-        return $this;
     }
 
     /**
@@ -844,28 +809,7 @@ class CodeIgniter
      */
     protected function determinePath()
     {
-        if (! empty($this->path)) {
-            return $this->path;
-        }
-
         return method_exists($this->request, 'getPath') ? $this->request->getPath() : $this->request->getUri()->getPath();
-    }
-
-    /**
-     * Allows the request path to be set from outside the class,
-     * instead of relying on CLIRequest or IncomingRequest for the path.
-     *
-     * This is not used now.
-     *
-     * @return $this
-     *
-     * @deprecated No longer used.
-     */
-    public function setPath(string $path)
-    {
-        $this->path = $path;
-
-        return $this;
     }
 
     /**

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -357,8 +357,6 @@ class CodeIgniter
         $this->getRequestObject();
         $this->getResponseObject();
 
-        $this->spoofRequestMethod();
-
         try {
             $this->forceSecureAccess();
 
@@ -642,6 +640,8 @@ class CodeIgniter
     protected function getRequestObject()
     {
         if ($this->request instanceof Request) {
+            $this->spoofRequestMethod();
+
             return;
         }
 
@@ -652,6 +652,8 @@ class CodeIgniter
         }
 
         $this->request = Services::request();
+
+        $this->spoofRequestMethod();
     }
 
     /**

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -414,7 +414,7 @@ class CodeIgniter
 
         $routeFilters = $this->tryToRouteIt($routes);
 
-        $uri = $this->determinePath();
+        $uri = $this->request->getPath();
 
         if ($this->enableFilters) {
             // Start up the filters
@@ -780,14 +780,14 @@ class CodeIgniter
         // $routes is defined in Config/Routes.php
         $this->router = Services::router($routes, $this->request);
 
-        $path = $this->determinePath();
+        $uri = $this->request->getPath();
 
         $this->benchmark->stop('bootstrap');
         $this->benchmark->start('routing');
 
         $this->outputBufferingStart();
 
-        $this->controller = $this->router->handle($path);
+        $this->controller = $this->router->handle($uri);
         $this->method     = $this->router->methodName();
 
         // If a {locale} segment was matched in the final route,
@@ -806,6 +806,8 @@ class CodeIgniter
      * on the CLI/IncomingRequest path.
      *
      * @return string
+     *
+     * @deprecated 4.5.0 No longer used.
      */
     protected function determinePath()
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -171,7 +171,7 @@ class CodeIgniter
     /**
      * Whether to return Response object or send response.
      *
-     * @deprecated No longer used.
+     * @deprecated 4.4.0 No longer used.
      */
     protected bool $returnResponse = false;
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -336,6 +336,8 @@ class CodeIgniter
      * tries to route the response, loads the controller and generally
      * makes all the pieces work together.
      *
+     * @param bool $returnResponse Used for testing purposes only.
+     *
      * @return ResponseInterface|void
      */
     public function run(?RouteCollectionInterface $routes = null, bool $returnResponse = false)
@@ -621,6 +623,9 @@ class CodeIgniter
      * @param CLIRequest|IncomingRequest $request
      *
      * @return $this
+     *
+     * @internal Used for testing purposes only.
+     * @testTag
      */
     public function setRequest($request)
     {

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -87,7 +87,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argv'] = ['index.php'];
         $_SERVER['argc'] = 1;
 
-        $response = $this->codeigniter->useSafeOutput(true)->run(null, true);
+        $response = $this->codeigniter->run(null, true);
 
         $this->assertStringContainsString('Welcome to CodeIgniter', $response->getBody());
     }
@@ -164,7 +164,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
-        $response = $this->codeigniter->useSafeOutput(true)->run($routes, true);
+        $response = $this->codeigniter->run($routes, true);
 
         $this->assertStringContainsString('Oops', $response->getBody());
     }

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -109,6 +109,14 @@ Model
 - ``Model::idValue()``
 - ``Model::classToArray()``
 
+CodeIgniter
+-----------
+
+- ``$path``
+- ``$useSafeOutput``
+- ``useSafeOutput()``
+- ``setPath()``
+
 Enhancements
 ************
 
@@ -168,6 +176,9 @@ Changes
 
 Deprecations
 ************
+
+- **CodeIgniter:** The ``determinePath()`` method has been deprecated. No longer
+  used.
 
 Bugs Fixed
 **********


### PR DESCRIPTION
**Description**
- remove deprecated properties and methods

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
