### PR TITLE
test: fix assertion in BaseConnectionTest::testStoresConnectionTimings()

### DIFF
--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -122,7 +122,7 @@ final class BaseConnectionTest extends CIUnitTestCase
         $db->initialize();
 
         $this->assertGreaterThan($start, $db->getConnectStart());
-        $this->assertGreaterThan(0.0, $db->getConnectDuration());
+        $this->assertGreaterThanOrEqual(0.0, $db->getConnectDuration());
     }
 
     /**


### PR DESCRIPTION
**Description**
Fixes #7864

```
There was 1 failure:

1) CodeIgniter\Database\BaseConnectionTest::testStoresConnectionTimings Failed asserting that '0.000000' is greater than 0.0.

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Database/BaseConnectionTest.php:125
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
