### PR TITLE
feat: new Required Filters

### DIFF
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -130,7 +130,7 @@ class App extends BaseConfig
      * If true, this will force every request made to this application to be
      * made via a secure connection (HTTPS). If the incoming request is not
      * secure, the user will be redirected to a secure version of the page
-     * and the HTTP Strict Transport Security header will be set.
+     * and the HTTP Strict Transport Security (HSTS) header will be set.
      */
     public bool $forceGlobalSecureRequests = false;
 

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -38,17 +38,22 @@ class Filters extends BaseConfig
      * The filters listed here are special. They are applied before and after
      * other kinds of filters, and always applied even if a route does not exist.
      *
-     * @var array<string, array<int, string>>
+     * Filters set by default provide framework functionality. If removed,
+     * those functions will no longer work.
+     *
+     * @see https://codeigniter.com/user_guide/incoming/filters.html#provided-filters
+     *
+     * @var array<string, list<string>>
      */
     public array $required = [
         'before' => [
-            'forcehttps',
-            'pagecache',
+            'forcehttps', // Force Global Secure Requests
+            'pagecache',  // Web Page Caching
         ],
         'after' => [
-            'pagecache',
-            'performance',
-            'toolbar',
+            'pagecache',   // Web Page Caching
+            'performance', // Performance Metrics
+            'toolbar',     // Debug Toolbar
         ],
     ];
 

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -7,6 +7,8 @@ use CodeIgniter\Filters\CSRF;
 use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\Filters\Honeypot;
 use CodeIgniter\Filters\InvalidChars;
+use CodeIgniter\Filters\PageCache;
+use CodeIgniter\Filters\PerformanceMetrics;
 use CodeIgniter\Filters\SecureHeaders;
 
 class Filters extends BaseConfig
@@ -24,6 +26,27 @@ class Filters extends BaseConfig
         'honeypot'      => Honeypot::class,
         'invalidchars'  => InvalidChars::class,
         'secureheaders' => SecureHeaders::class,
+        'pagecache'     => PageCache::class,
+        'performance'   => PerformanceMetrics::class,
+    ];
+
+    /**
+     * List of special required filters.
+     *
+     * The filters listed here is special. They are applied before and after
+     * other kinds of filters, and always applied even if a route does not exist.
+     *
+     * @var array<string, array<int, string>>
+     */
+    public array $required = [
+        'before' => [
+            'pagecache',
+        ],
+        'after' => [
+            'pagecache',
+            'performance',
+            'toolbar',
+        ],
     ];
 
     /**
@@ -39,7 +62,6 @@ class Filters extends BaseConfig
             // 'invalidchars',
         ],
         'after' => [
-            'toolbar',
             // 'honeypot',
             // 'secureheaders',
         ],

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -5,6 +5,7 @@ namespace Config;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Filters\CSRF;
 use CodeIgniter\Filters\DebugToolbar;
+use CodeIgniter\Filters\ForceHTTPS;
 use CodeIgniter\Filters\Honeypot;
 use CodeIgniter\Filters\InvalidChars;
 use CodeIgniter\Filters\PageCache;
@@ -26,6 +27,7 @@ class Filters extends BaseConfig
         'honeypot'      => Honeypot::class,
         'invalidchars'  => InvalidChars::class,
         'secureheaders' => SecureHeaders::class,
+        'forcehttps'    => ForceHTTPS::class,
         'pagecache'     => PageCache::class,
         'performance'   => PerformanceMetrics::class,
     ];
@@ -40,6 +42,7 @@ class Filters extends BaseConfig
      */
     public array $required = [
         'before' => [
+            'forcehttps',
             'pagecache',
         ],
         'after' => [

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -33,7 +33,7 @@ class Filters extends BaseConfig
     /**
      * List of special required filters.
      *
-     * The filters listed here is special. They are applied before and after
+     * The filters listed here are special. They are applied before and after
      * other kinds of filters, and always applied even if a route does not exist.
      *
      * @var array<string, array<int, string>>

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1923,7 +1923,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];
 $ignoreErrors[] = [

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -376,14 +376,14 @@ class CodeIgniter
 
         $this->runRequiredAfterFilters($filters);
 
+        // Is there a post-system event?
+        Events::trigger('post_system');
+
         if ($returnResponse) {
             return $this->response;
         }
 
         $this->sendResponse();
-
-        // Is there a post-system event?
-        Events::trigger('post_system');
     }
 
     /**

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -17,6 +17,7 @@ use CodeIgniter\Debug\Timer;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
@@ -339,30 +340,86 @@ class CodeIgniter
         $this->getRequestObject();
         $this->getResponseObject();
 
-        try {
-            $this->forceSecureAccess();
+        Events::trigger('pre_system');
 
-            $this->response = $this->handleRequest($routes, config(Cache::class), $returnResponse);
-        } catch (ResponsableInterface|DeprecatedRedirectException $e) {
-            $this->outputBufferingEnd();
-            if ($e instanceof DeprecatedRedirectException) {
-                $e = new RedirectException($e->getMessage(), $e->getCode(), $e);
+        $this->benchmark->stop('bootstrap');
+
+        $this->benchmark->start('required_before_filters');
+        // Start up the filters
+        $filters = Services::filters();
+        // Run required before filters
+        $possibleResponse = $this->runRequiredBeforeFilters($filters);
+
+        // If a ResponseInterface instance is returned then send it back to the client and stop
+        if ($possibleResponse instanceof ResponseInterface) {
+            $this->response = $possibleResponse;
+        } else {
+            try {
+                $this->forceSecureAccess();
+
+                $this->response = $this->handleRequest($routes, config(Cache::class), $returnResponse);
+            } catch (ResponsableInterface|DeprecatedRedirectException $e) {
+                $this->outputBufferingEnd();
+                if ($e instanceof DeprecatedRedirectException) {
+                    $e = new RedirectException($e->getMessage(), $e->getCode(), $e);
+                }
+
+                $this->response = $e->getResponse();
+            } catch (PageNotFoundException $e) {
+                $this->response = $this->display404errors($e);
+            } catch (Throwable $e) {
+                $this->outputBufferingEnd();
+
+                throw $e;
             }
-
-            $this->response = $e->getResponse();
-        } catch (PageNotFoundException $e) {
-            $this->response = $this->display404errors($e);
-        } catch (Throwable $e) {
-            $this->outputBufferingEnd();
-
-            throw $e;
         }
+
+        $this->runRequiredAfterFilters($filters);
 
         if ($returnResponse) {
             return $this->response;
         }
 
         $this->sendResponse();
+
+        // Is there a post-system event?
+        Events::trigger('post_system');
+    }
+
+    /**
+     * Run required before filters.
+     */
+    private function runRequiredBeforeFilters(Filters $filters): ?ResponseInterface
+    {
+        $possibleResponse = $filters->runRequired('before');
+        $this->benchmark->stop('required_before_filters');
+
+        // If a ResponseInterface instance is returned then send it back to the client and stop
+        if ($possibleResponse instanceof ResponseInterface) {
+            return $possibleResponse;
+        }
+
+        return null;
+    }
+
+    /**
+     * Run required after filters.
+     */
+    private function runRequiredAfterFilters(Filters $filters): void
+    {
+        $filters->setResponse($this->response);
+
+        // After filter debug toolbar requires 'total_execution'.
+        $this->totalTime = $this->benchmark->getElapsedTime('total_execution');
+
+        // Run required after filters
+        $this->benchmark->start('required_after_filters');
+        $response = $filters->runRequired('after');
+        $this->benchmark->stop('required_after_filters');
+
+        if ($response instanceof ResponseInterface) {
+            $this->response = $response;
+        }
     }
 
     /**
@@ -405,20 +462,11 @@ class CodeIgniter
             return $this->response->setStatusCode(405)->setBody('Method Not Allowed');
         }
 
-        Events::trigger('pre_system');
-
-        // Check for a cached page. Execution will stop
-        // if the page has been cached.
-        if (($response = $this->displayCache($cacheConfig)) instanceof ResponseInterface) {
-            return $response;
-        }
-
         $routeFilters = $this->tryToRouteIt($routes);
 
         $uri = $this->request->getPath();
 
         if ($this->enableFilters) {
-            // Start up the filters
             $filters = Services::filters();
 
             // If any filters were specified within the routes file,
@@ -478,9 +526,6 @@ class CodeIgniter
             $filters = Services::filters();
             $filters->setResponse($this->response);
 
-            // After filter debug toolbar requires 'total_execution'.
-            $this->totalTime = $this->benchmark->getElapsedTime('total_execution');
-
             // Run "after" filters
             $this->benchmark->start('after_filters');
             $response = $filters->run($uri, 'after');
@@ -496,20 +541,12 @@ class CodeIgniter
             ! $this->response instanceof DownloadResponse
             && ! $this->response instanceof RedirectResponse
         ) {
-            // Cache it without the performance metrics replaced
-            // so that we can have live speed updates along the way.
-            // Must be run after filters to preserve the Response headers.
-            $this->pageCache->make($this->request, $this->response);
-
             // Save our current URI as the previous URI in the session
             // for safer, more accurate use with `previous_url()` helper function.
             $this->storePreviousURL(current_url(true));
         }
 
         unset($uri);
-
-        // Is there a post-system event?
-        Events::trigger('post_system');
 
         return $this->response;
     }
@@ -668,6 +705,7 @@ class CodeIgniter
      *
      * @throws Exception
      *
+     * @deprecated 4.5.0 PageCache required filter is used. No longer used.
      * @deprecated 4.4.2 The parameter $config is deprecated. No longer used.
      */
     public function displayCache(Cache $config)
@@ -750,6 +788,8 @@ class CodeIgniter
 
     /**
      * Replaces the elapsed_time and memory_usage tag.
+     *
+     * @deprecated 4.5.0 PerformanceMetrics required filter is used. No longer used.
      */
     public function displayPerformanceMetrics(string $output): string
     {
@@ -774,6 +814,8 @@ class CodeIgniter
      */
     protected function tryToRouteIt(?RouteCollectionInterface $routes = null)
     {
+        $this->benchmark->start('routing');
+
         if ($routes === null) {
             $routes = Services::routes()->loadRoutes();
         }
@@ -782,9 +824,6 @@ class CodeIgniter
         $this->router = Services::router($routes, $this->request);
 
         $uri = $this->request->getPath();
-
-        $this->benchmark->stop('bootstrap');
-        $this->benchmark->start('routing');
 
         $this->outputBufferingStart();
 
@@ -1052,13 +1091,6 @@ class CodeIgniter
      */
     protected function sendResponse()
     {
-        // Update the performance metrics
-        $body = $this->response->getBody();
-        if ($body !== null) {
-            $output = $this->displayPerformanceMetrics($body);
-            $this->response->setBody($output);
-        }
-
         $this->response->send();
     }
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -407,9 +407,6 @@ class CodeIgniter
     {
         $filters->setResponse($this->response);
 
-        // After filter debug toolbar requires 'total_execution'.
-        $this->totalTime = $this->benchmark->getElapsedTime('total_execution');
-
         // Run required after filters
         $this->benchmark->start('required_after_filters');
         $response = $filters->runRequired('after');
@@ -760,6 +757,9 @@ class CodeIgniter
      */
     public function getPerformanceStats(): array
     {
+        // After filter debug toolbar requires 'total_execution'.
+        $this->totalTime = $this->benchmark->getElapsedTime('total_execution');
+
         return [
             'startTime' => $this->startTime,
             'totalTime' => $this->totalTime,

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -340,6 +340,20 @@ class CodeIgniter
         $this->getRequestObject();
         $this->getResponseObject();
 
+        try {
+            $this->forceSecureAccess();
+        } catch (RedirectException $e) {
+            $this->response = $e->getResponse();
+
+            if ($returnResponse) {
+                return $this->response;
+            }
+
+            $this->sendResponse();
+
+            return;
+        }
+
         Events::trigger('pre_system');
 
         $this->benchmark->stop('bootstrap');
@@ -355,8 +369,6 @@ class CodeIgniter
             $this->response = $possibleResponse;
         } else {
             try {
-                $this->forceSecureAccess();
-
                 $this->response = $this->handleRequest($routes, config(Cache::class), $returnResponse);
             } catch (ResponsableInterface|DeprecatedRedirectException $e) {
                 $this->outputBufferingEnd();

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -340,20 +340,6 @@ class CodeIgniter
         $this->getRequestObject();
         $this->getResponseObject();
 
-        try {
-            $this->forceSecureAccess();
-        } catch (RedirectException $e) {
-            $this->response = $e->getResponse();
-
-            if ($returnResponse) {
-                return $this->response;
-            }
-
-            $this->sendResponse();
-
-            return;
-        }
-
         Events::trigger('pre_system');
 
         $this->benchmark->stop('bootstrap');
@@ -700,6 +686,8 @@ class CodeIgniter
      *                      should be enforced for this URL.
      *
      * @return void
+     *
+     * @deprecated 4.5.0 No longer used. Moved to ForceHTTPS filter.
      */
     protected function forceSecureAccess($duration = 31_536_000)
     {

--- a/system/Config/Filters.php
+++ b/system/Config/Filters.php
@@ -1,8 +1,16 @@
 <?php
 
-namespace Config;
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
 
-use CodeIgniter\Config\Filters as BaseFilters;
+namespace CodeIgniter\Config;
+
 use CodeIgniter\Filters\CSRF;
 use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\Filters\ForceHTTPS;
@@ -12,7 +20,10 @@ use CodeIgniter\Filters\PageCache;
 use CodeIgniter\Filters\PerformanceMetrics;
 use CodeIgniter\Filters\SecureHeaders;
 
-class Filters extends BaseFilters
+/**
+ * Filters configuration
+ */
+class Filters extends BaseConfig
 {
     /**
      * Configures aliases for Filter classes to
@@ -82,7 +93,7 @@ class Filters extends BaseFilters
      * particular HTTP method (GET, POST, etc.).
      *
      * Example:
-     * 'POST' => ['foo', 'bar']
+     * 'post' => ['foo', 'bar']
      *
      * If you use this, you should disable auto-routing because auto-routing
      * permits any HTTP method to access a controller. Accessing the controller

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -64,9 +64,17 @@ class Routes extends BaseCollector
             try {
                 $method = new ReflectionMethod($router->controllerName(), $router->methodName());
             } catch (ReflectionException $e) {
-                // If we're here, the method doesn't exist
-                // and is likely calculated in _remap.
-                $method = new ReflectionMethod($router->controllerName(), '_remap');
+                try {
+                    // If we're here, the method doesn't exist
+                    // and is likely calculated in _remap.
+                    $method = new ReflectionMethod($router->controllerName(), '_remap');
+                } catch (ReflectionException) {
+                    // If we're here, page cache is returned. The router is not executed.
+                    return [
+                        'matchedRoute' => [],
+                        'routes'       => [],
+                    ];
+                }
             }
         }
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -264,7 +264,7 @@ class Filters
     {
         // For backward compatibility. For users who do not update Config\Filters.
         if (! isset($this->config->required[$position])) {
-            $baseConfig = config(BaseFiltersConfig::class);
+            $baseConfig = config(BaseFiltersConfig::class); // @phpstan-ignore-line
             $filters    = $baseConfig->required[$position];
             $aliases    = $baseConfig->aliases;
         } else {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -300,55 +300,21 @@ class Filters
             }
         }
 
-        foreach ($filtersClass[$position] as $className) {
-            $class = new $className();
+        if ($position === 'before') {
+            $result = $this->runBefore($filterClasses[$position]);
 
-            if (! $class instanceof FilterInterface) {
-                throw FilterException::forIncorrectInterface(get_class($class));
-            }
-
-            if ($position === 'before') {
-                $result = $class->before(
-                    $this->request,
-                    $this->argumentsClass[$className] ?? null
-                );
-
-                if ($result instanceof RequestInterface) {
-                    $this->request = $result;
-
-                    continue;
-                }
-
-                // If the response object was sent back,
-                // then send it and quit.
-                if ($result instanceof ResponseInterface) {
-                    // short circuit - bypass any other filters
-                    return $result;
-                }
-                // Ignore an empty result
-                if (empty($result)) {
-                    continue;
-                }
-
+            // If the response object was sent back,
+            // then send it and quit.
+            if ($result instanceof ResponseInterface) {
+                // short circuit - bypass any other filters
                 return $result;
             }
 
-            if ($position === 'after') {
-                $result = $class->after(
-                    $this->request,
-                    $this->response,
-                    $this->argumentsClass[$className] ?? null
-                );
-
-                if ($result instanceof ResponseInterface) {
-                    $this->response = $result;
-
-                    continue;
-                }
-            }
+            return $result;
         }
 
-        return $position === 'before' ? $this->request : $this->response;
+        // After
+        return $this->runAfter($filterClasses[$position]);
     }
 
     /**

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -266,25 +266,10 @@ class Filters
             return $position === 'before' ? $this->request : $this->response;
         }
 
+        }
+
         // Set the toolbar filter to the last position to be executed
-        $afters = [];
-        $found  = false;
-
-        foreach ($this->config->required['after'] as $alias) {
-            if ($alias === 'toolbar') {
-                $found = true;
-
-                continue;
-            }
-
-            $afters[] = $alias;
-        }
-
-        if ($found) {
-            $afters[] = 'toolbar';
-        }
-
-        $this->config->required['after'] = $afters;
+        $this->config->required['after'] = $this->setToolbarToLast($this->config->required['after']);
 
         $filterClasses = [];
 
@@ -306,6 +291,33 @@ class Filters
 
         // After
         return $this->runAfter($filterClasses[$position]);
+    }
+
+    /**
+     * Set the toolbar filter to the last position to be executed.
+     *
+     * @param list<string> $filters `after` filter array
+     */
+    private function setToolbarToLast(array $filters): array
+    {
+        $afters = [];
+        $found  = false;
+
+        foreach ($filters as $alias) {
+            if ($alias === 'toolbar') {
+                $found = true;
+
+                continue;
+            }
+
+            $afters[] = $alias;
+        }
+
+        if ($found) {
+            $afters[] = 'toolbar';
+        }
+
+        return $afters;
     }
 
     /**
@@ -342,13 +354,7 @@ class Filters
         }
 
         // Set the toolbar filter to the last position to be executed
-        if (in_array('toolbar', $this->filters['after'], true)
-            && ($count = count($this->filters['after'])) > 1
-            && $this->filters['after'][$count - 1] !== 'toolbar'
-        ) {
-            array_splice($this->filters['after'], array_search('toolbar', $this->filters['after'], true), 1);
-            $this->filters['after'][] = 'toolbar';
-        }
+        $this->filters['after'] = $this->setToolbarToLast($this->filters['after']);
 
         $this->processAliasesToClass('before');
         $this->processAliasesToClass('after');

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -164,6 +164,7 @@ class Filters
      * uri and position.
      *
      * @param string $uri URI path relative to baseURL
+     * @phpstan-param 'before'|'after' $position
      *
      * @return RequestInterface|ResponseInterface|string|null
      *
@@ -186,11 +187,8 @@ class Filters
             return $result;
         }
 
-        if ($position === 'after') {
-            $result = $this->runAfter($this->filtersClass[$position]);
-        }
-
-        return $result;
+        // After
+        return $this->runAfter($this->filtersClass[$position]);
     }
 
     /**
@@ -263,6 +261,8 @@ class Filters
      * Runs required filters for the specified position.
      *
      * @return RequestInterface|ResponseInterface|string|null
+     *
+     * @phpstan-param 'before'|'after' $position
      *
      * @throws FilterException
      */

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Filters;
 
+use CodeIgniter\Config\Filters as BaseFiltersConfig;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\HTTP\RequestInterface;
@@ -141,7 +142,7 @@ class Filters
             $className = $locator->getClassname($file);
 
             // Don't include our main Filter config again...
-            if ($className === FiltersConfig::class) {
+            if ($className === FiltersConfig::class || $className === BaseFiltersConfig::class) {
                 continue;
             }
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -286,7 +286,7 @@ class Filters
             $this->config->required['after'][] = 'toolbar';
         }
 
-        $filtersClass = [];
+        $filterClasses = [];
 
         foreach ($this->config->required[$position] as $alias) {
             if (! array_key_exists($alias, $this->config->aliases)) {
@@ -294,9 +294,9 @@ class Filters
             }
 
             if (is_array($this->config->aliases[$alias])) {
-                $filtersClass[$position] = array_merge($filtersClass[$position], $this->config->aliases[$alias]);
+                $filterClasses[$position] = array_merge($filterClasses[$position], $this->config->aliases[$alias]);
             } else {
-                $filtersClass[$position][] = $this->config->aliases[$alias];
+                $filterClasses[$position][] = $this->config->aliases[$alias];
             }
         }
 
@@ -717,7 +717,7 @@ class Filters
      */
     protected function processAliasesToClass(string $position)
     {
-        $filtersClass = [];
+        $filterClasses = [];
 
         foreach ($this->filters[$position] as $alias => $rules) {
             if (is_numeric($alias) && is_string($rules)) {
@@ -729,18 +729,18 @@ class Filters
             }
 
             if (is_array($this->config->aliases[$alias])) {
-                $filtersClass = [...$filtersClass, ...$this->config->aliases[$alias]];
+                $filterClasses = [...$filterClasses, ...$this->config->aliases[$alias]];
             } else {
-                $filtersClass[] = $this->config->aliases[$alias];
+                $filterClasses[] = $this->config->aliases[$alias];
             }
         }
 
-        // when using enableFilter() we already write the class name in $filtersClass as well as the
+        // when using enableFilter() we already write the class name in $filterClasses as well as the
         // alias in $filters. This leads to duplicates when using route filters.
         if ($position === 'before') {
-            $this->filtersClass[$position] = array_merge($filtersClass, $this->filtersClass[$position]);
+            $this->filtersClass[$position] = array_merge($filterClasses, $this->filtersClass[$position]);
         } else {
-            $this->filtersClass[$position] = array_merge($this->filtersClass[$position], $filtersClass);
+            $this->filtersClass[$position] = array_merge($this->filtersClass[$position], $filterClasses);
         }
 
         // Since some filters like rate limiters rely on being executed once a request we filter em here.

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -264,18 +264,24 @@ class Filters
         }
 
         // Set the toolbar filter to the last position to be executed
-        if (
-            in_array('toolbar', $this->config->required['after'], true)
-            && ($count = count($this->config->required['after'])) > 1
-            && $this->config->required['after'][$count - 1] !== 'toolbar'
-        ) {
-            array_splice(
-                $this->config->required['after'],
-                array_search('toolbar', $this->config->required['after'], true),
-                1
-            );
-            $this->config->required['after'][] = 'toolbar';
+        $afters = [];
+        $found  = false;
+
+        foreach ($this->config->required['after'] as $alias) {
+            if ($alias === 'toolbar') {
+                $found = true;
+
+                continue;
+            }
+
+            $afters[] = $alias;
         }
+
+        if ($found) {
+            $afters[] = 'toolbar';
+        }
+
+        $this->config->required['after'] = $afters;
 
         $filterClasses = [];
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -277,8 +277,13 @@ class Filters
         }
 
         if ($position === 'after') {
-            // Set the toolbar filter to the last position to be executed
-            $filters = $this->setToolbarToLast($filters);
+            if (in_array('toolbar', $this->filters['after'], true)) {
+                // It was already run in globals filters. So remove it.
+                $filters = $this->setToolbarToLast($filters, true);
+            } else {
+                // Set the toolbar filter to the last position to be executed
+                $filters = $this->setToolbarToLast($filters);
+            }
         }
 
         $filterClasses = [];
@@ -307,8 +312,9 @@ class Filters
      * Set the toolbar filter to the last position to be executed.
      *
      * @param list<string> $filters `after` filter array
+     * @param bool         $remove  if true, remove `toolbar` filter
      */
-    private function setToolbarToLast(array $filters): array
+    private function setToolbarToLast(array $filters, bool $remove = false): array
     {
         $afters = [];
         $found  = false;
@@ -323,7 +329,7 @@ class Filters
             $afters[] = $alias;
         }
 
-        if ($found) {
+        if ($found && ! $remove) {
             $afters[] = 'toolbar';
         }
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -233,6 +233,10 @@ class Filters
      */
     public function runRequired(string $position = 'before')
     {
+        if (! isset($this->config->required[$position]) || $this->config->required[$position] === []) {
+            return $position === 'before' ? $this->request : $this->response;
+        }
+
         // Set the toolbar filter to the last position to be executed
         if (
             in_array('toolbar', $this->config->required['after'], true)

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -256,6 +256,8 @@ class Filters
      * @phpstan-param 'before'|'after' $position
      *
      * @throws FilterException
+     *
+     * @internal
      */
     public function runRequired(string $position = 'before')
     {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -175,16 +175,7 @@ class Filters
         $this->initialize(strtolower($uri));
 
         if ($position === 'before') {
-            $result = $this->runBefore($this->filtersClass[$position]);
-
-            // If the response object was sent back,
-            // then send it and quit.
-            if ($result instanceof ResponseInterface) {
-                // short circuit - bypass any other filters
-                return $result;
-            }
-
-            return $result;
+            return $this->runBefore($this->filtersClass[$position]);
         }
 
         // After
@@ -301,16 +292,7 @@ class Filters
         }
 
         if ($position === 'before') {
-            $result = $this->runBefore($filterClasses[$position]);
-
-            // If the response object was sent back,
-            // then send it and quit.
-            if ($result instanceof ResponseInterface) {
-                // short circuit - bypass any other filters
-                return $result;
-            }
-
-            return $result;
+            return $this->runBefore($filterClasses[$position]);
         }
 
         // After

--- a/system/Filters/ForceHTTPS.php
+++ b/system/Filters/ForceHTTPS.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Filters;
+
+use CodeIgniter\HTTP\Exceptions\RedirectException;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+use Config\App;
+use Config\Services;
+
+/**
+ * Force HTTPS filter
+ */
+class ForceHTTPS implements FilterInterface
+{
+    /**
+     * Force Secure Site Access? If the config value 'forceGlobalSecureRequests'
+     * is true, will enforce that all requests to this site are made through
+     * HTTPS. Will redirect the user to the current page with HTTPS, as well
+     * as set the HTTP Strict Transport Security (HSTS) header for those browsers
+     * that support it.
+     *
+     * @param array|null $arguments
+     *
+     * @return ResponseInterface|void
+     */
+    public function before(RequestInterface $request, $arguments = null)
+    {
+        $config = config(App::class);
+
+        if ($config->forceGlobalSecureRequests !== true) {
+            return;
+        }
+
+        $response = Services::response();
+
+        try {
+            force_https(YEAR, $request, $response);
+        } catch (RedirectException $e) {
+            return $e->getResponse();
+        }
+    }
+
+    /**
+     * We don't have anything to do here.
+     *
+     * @param array|null $arguments
+     *
+     * @return void
+     */
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+    {
+    }
+}

--- a/system/Filters/PageCache.php
+++ b/system/Filters/PageCache.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Filters;
+
+use CodeIgniter\Cache\ResponseCache;
+use CodeIgniter\HTTP\CLIRequest;
+use CodeIgniter\HTTP\DownloadResponse;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+use Config\Services;
+
+/**
+ * Page Cache filter
+ */
+class PageCache implements FilterInterface
+{
+    private ResponseCache $pageCache;
+
+    public function __construct()
+    {
+        $this->pageCache = Services::responsecache();
+    }
+
+    /**
+     * Checks page cache and return if found.
+     *
+     * @param array|null $arguments
+     */
+    public function before(RequestInterface $request, $arguments = null)
+    {
+        assert($request instanceof CLIRequest || $request instanceof IncomingRequest);
+
+        $response = Services::response();
+
+        $cachedResponse = $this->pageCache->get($request, $response);
+
+        if ($cachedResponse instanceof ResponseInterface) {
+            return $cachedResponse;
+        }
+    }
+
+    /**
+     * Cache the page.
+     *
+     * @param array|null $arguments
+     *
+     * @return void
+     */
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+    {
+        assert($request instanceof CLIRequest || $request instanceof IncomingRequest);
+
+        if (
+            ! $response instanceof DownloadResponse
+            && ! $response instanceof RedirectResponse
+        ) {
+            // Cache it without the performance metrics replaced
+            // so that we can have live speed updates along the way.
+            // Must be run after filters to preserve the Response headers.
+            $this->pageCache->make($request, $response);
+        }
+    }
+}

--- a/system/Filters/PageCache.php
+++ b/system/Filters/PageCache.php
@@ -36,6 +36,8 @@ class PageCache implements FilterInterface
      * Checks page cache and return if found.
      *
      * @param array|null $arguments
+     *
+     * @return ResponseInterface|void
      */
     public function before(RequestInterface $request, $arguments = null)
     {

--- a/system/Filters/PerformanceMetrics.php
+++ b/system/Filters/PerformanceMetrics.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Filters;
+
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\ResponseInterface;
+use Config\Services;
+
+/**
+ * Performance Metrics filter
+ */
+class PerformanceMetrics implements FilterInterface
+{
+    /**
+     * We don't need to do anything here.
+     *
+     * @param array|null $arguments
+     */
+    public function before(RequestInterface $request, $arguments = null)
+    {
+    }
+
+    /**
+     * Replaces the performance metrics.
+     *
+     * @param array|null $arguments
+     *
+     * @return void
+     */
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
+    {
+        $body = $response->getBody();
+
+        if ($body !== null) {
+            $benchmark = Services::timer();
+
+            $output = str_replace(
+                [
+                    '{elapsed_time}',
+                    '{memory_usage}',
+                ],
+                [
+                    (string) $benchmark->getElapsedTime('total_execution'),
+                    number_format(memory_get_peak_usage() / 1024 / 1024, 3),
+                ],
+                $body
+            );
+
+            $response->setBody($output);
+        }
+    }
+}

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -440,8 +440,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
-        $config = new App();
+        $filterConfig                       = config(FiltersConfig::class);
+        $filterConfig->required['before'][] = 'forcehttps';
 
+        $config                            = config(App::class);
         $config->forceGlobalSecureRequests = true;
 
         $codeigniter = new MockCodeIgniter($config);

--- a/tests/system/Commands/FilterCheckTest.php
+++ b/tests/system/Commands/FilterCheckTest.php
@@ -45,7 +45,7 @@ final class FilterCheckTest extends CIUnitTestCase
         command('filter:check get /');
 
         $this->assertStringContainsString(
-            '|GET|/||toolbar|',
+            '|GET|/|||',
             str_replace(' ', '', $this->getBuffer())
         );
     }

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -61,16 +61,16 @@ final class RoutesTest extends CIUnitTestCase
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             | Method  | Route   | Name          | Handler                                | Before Filters | After Filters |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
-            | GET     | /       | »             | \App\Controllers\Home::index           |                | toolbar       |
-            | GET     | closure | »             | (Closure)                              |                | toolbar       |
-            | GET     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | POST    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | GET     | /       | »             | \App\Controllers\Home::index           |                |               |
+            | GET     | closure | »             | (Closure)                              |                |               |
+            | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | CLI     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             EOL;
@@ -87,16 +87,16 @@ final class RoutesTest extends CIUnitTestCase
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             | Method  | Route   | Name          | Handler ↓                              | Before Filters | After Filters |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
-            | GET     | closure | »             | (Closure)                              |                | toolbar       |
-            | GET     | /       | »             | \App\Controllers\Home::index           |                | toolbar       |
-            | GET     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | POST    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | GET     | closure | »             | (Closure)                              |                |               |
+            | GET     | /       | »             | \App\Controllers\Home::index           |                |               |
+            | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | CLI     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             EOL;
@@ -114,17 +114,17 @@ final class RoutesTest extends CIUnitTestCase
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             | Method  | Route   | Name          | Handler                                | Before Filters | After Filters |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
-            | GET     | /       | »             | \App\Controllers\Blog::index           |                | toolbar       |
-            | GET     | closure | »             | (Closure)                              |                | toolbar       |
-            | GET     | all     | »             | \App\Controllers\AllDomain::index      |                | toolbar       |
-            | GET     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | POST    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | GET     | /       | »             | \App\Controllers\Blog::index           |                |               |
+            | GET     | closure | »             | (Closure)                              |                |               |
+            | GET     | all     | »             | \App\Controllers\AllDomain::index      |                |               |
+            | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | CLI     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             EOL;
@@ -142,17 +142,17 @@ final class RoutesTest extends CIUnitTestCase
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             | Method  | Route   | Name          | Handler                                | Before Filters | After Filters |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
-            | GET     | /       | »             | \App\Controllers\Sub::index            |                | toolbar       |
-            | GET     | closure | »             | (Closure)                              |                | toolbar       |
-            | GET     | all     | »             | \App\Controllers\AllDomain::index      |                | toolbar       |
-            | GET     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | POST    | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | GET     | /       | »             | \App\Controllers\Sub::index            |                |               |
+            | GET     | closure | »             | (Closure)                              |                |               |
+            | GET     | all     | »             | \App\Controllers\AllDomain::index      |                |               |
+            | GET     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | HEAD    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | POST    | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | PUT     | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | DELETE  | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | OPTIONS | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | TRACE   | testing | testing-index | \App\Controllers\TestController::index |                |               |
+            | CONNECT | testing | testing-index | \App\Controllers\TestController::index |                |               |
             | CLI     | testing | testing-index | \App\Controllers\TestController::index |                |               |
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             EOL;
@@ -174,19 +174,19 @@ final class RoutesTest extends CIUnitTestCase
             +------------+--------------------------------+---------------+-----------------------------------------------------+----------------+---------------+
             | Method     | Route                          | Name          | Handler                                             | Before Filters | After Filters |
             +------------+--------------------------------+---------------+-----------------------------------------------------+----------------+---------------+
-            | GET        | /                              | »             | \App\Controllers\Home::index                        |                | toolbar       |
-            | GET        | closure                        | »             | (Closure)                                           |                | toolbar       |
-            | GET        | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
-            | HEAD       | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
-            | POST       | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
-            | PUT        | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
-            | DELETE     | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
-            | OPTIONS    | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
-            | TRACE      | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
-            | CONNECT    | testing                        | testing-index | \App\Controllers\TestController::index              |                | toolbar       |
+            | GET        | /                              | »             | \App\Controllers\Home::index                        |                |               |
+            | GET        | closure                        | »             | (Closure)                                           |                |               |
+            | GET        | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | HEAD       | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | POST       | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | PUT        | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | DELETE     | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | OPTIONS    | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | TRACE      | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
+            | CONNECT    | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
             | CLI        | testing                        | testing-index | \App\Controllers\TestController::index              |                |               |
-            | GET(auto)  | newautorouting[/..]            |               | \Tests\Support\Controllers\Newautorouting::getIndex |                | toolbar       |
-            | POST(auto) | newautorouting/save/../..[/..] |               | \Tests\Support\Controllers\Newautorouting::postSave |                | toolbar       |
+            | GET(auto)  | newautorouting[/..]            |               | \Tests\Support\Controllers\Newautorouting::getIndex |                |               |
+            | POST(auto) | newautorouting/save/../..[/..] |               | \Tests\Support\Controllers\Newautorouting::postSave |                |               |
             +------------+--------------------------------+---------------+-----------------------------------------------------+----------------+---------------+
             EOL;
         $this->assertStringContainsString($expected, $this->getBuffer());
@@ -205,20 +205,20 @@ final class RoutesTest extends CIUnitTestCase
             +---------+------------------+---------------+----------------------------------------+----------------+---------------+
             | Method  | Route            | Name          | Handler                                | Before Filters | After Filters |
             +---------+------------------+---------------+----------------------------------------+----------------+---------------+
-            | GET     | /                | »             | \App\Controllers\Home::index           |                | toolbar       |
-            | GET     | closure          | »             | (Closure)                              |                | toolbar       |
-            | GET     | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | HEAD    | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | POST    | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | PUT     | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | DELETE  | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | OPTIONS | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | TRACE   | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
-            | CONNECT | testing          | testing-index | \App\Controllers\TestController::index |                | toolbar       |
+            | GET     | /                | »             | \App\Controllers\Home::index           |                |               |
+            | GET     | closure          | »             | (Closure)                              |                |               |
+            | GET     | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | HEAD    | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | POST    | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | PUT     | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | DELETE  | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | OPTIONS | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | TRACE   | testing          | testing-index | \App\Controllers\TestController::index |                |               |
+            | CONNECT | testing          | testing-index | \App\Controllers\TestController::index |                |               |
             | CLI     | testing          | testing-index | \App\Controllers\TestController::index |                |               |
-            | auto    | /                |               | \App\Controllers\Home::index           |                | toolbar       |
-            | auto    | home             |               | \App\Controllers\Home::index           |                | toolbar       |
-            | auto    | home/index[/...] |               | \App\Controllers\Home::index           |                | toolbar       |
+            | auto    | /                |               | \App\Controllers\Home::index           |                |               |
+            | auto    | home             |               | \App\Controllers\Home::index           |                |               |
+            | auto    | home/index[/...] |               | \App\Controllers\Home::index           |                |               |
             +---------+------------------+---------------+----------------------------------------+----------------+---------------+
             EOL;
         $this->assertStringContainsString($expected, $this->getBuffer());

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
@@ -66,7 +66,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
                 '',
                 '\\Tests\\Support\\Controllers\\Newautorouting::getIndex',
                 '',
-                'toolbar',
+                '',
             ],
             1 => [
                 'POST(auto)',
@@ -74,7 +74,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
                 '',
                 '\\Tests\\Support\\Controllers\\Newautorouting::postSave',
                 'honeypot',
-                'toolbar',
+                '',
             ],
         ];
         $this->assertSame($expected, $routes);
@@ -94,7 +94,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
                 '',
                 '\\Tests\\Support\\Controllers\\Newautorouting::getIndex',
                 '',
-                'toolbar',
+                '',
             ],
             1 => [
                 'POST(auto)',
@@ -102,7 +102,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
                 '',
                 '\\Tests\\Support\\Controllers\\Newautorouting::postSave',
                 '',
-                'toolbar',
+                '',
             ],
         ];
         $this->assertSame($expected, $routes);

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -36,7 +36,6 @@ final class FilterCollectorTest extends CIUnitTestCase
             'before' => [
             ],
             'after' => [
-                'toolbar',
             ],
         ];
         $this->assertSame($expected, $filters);

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -39,6 +39,7 @@ final class FilterTestTraitTest extends CIUnitTestCase
         // Apply the Custom Filter
         $this->filtersConfig->aliases['test-customfilter'] = Customfilter::class;
         $this->filtersConfig->globals['before']            = ['test-customfilter'];
+        $this->filtersConfig->globals['after']             = ['secureheaders'];
     }
 
     public function testDidRunTraitSetUp(): void
@@ -110,7 +111,7 @@ final class FilterTestTraitTest extends CIUnitTestCase
     public function testAssertFilter(): void
     {
         $this->assertFilter('/', 'before', 'test-customfilter');
-        $this->assertFilter('/', 'after', 'toolbar');
+        $this->assertFilter('/', 'after', 'secureheaders');
     }
 
     public function testAssertNotFilter(): void

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -260,7 +260,7 @@ Helpers and Functions
 Required Filters
 ================
 
-The :ref:`Required Filters <filters-required>` has been introduced. They are new
+New :ref:`Required Filters <filters-required>` have been introduced. They are
 special filters that are applied before and after other kinds of filters, and
 always applied even if a route does not exist.
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -255,6 +255,35 @@ Libraries
 Helpers and Functions
 =====================
 
+Controller Filters
+==================
+
+The :ref:`Required Filters <filters-required>` has been introduced. They are new
+special filters that are applied before and after other kinds of filters, and
+always applied even if a route does not exist.
+
+The following existing functionalities have been reimplemented as Required Filters.
+
+- :ref:`Force Global Secure Requests <forcehttps>`
+- :doc:`../general/caching`
+- :ref:`performancemetrics`
+- :ref:`the-debug-toolbar`
+
+The Benchmark **Timers** used by Debug Toolbar now collect *Required Before Filters*
+and *Required After Filters* data.
+
+The benchmark points have been changed:
+
+- Before
+
+   - ``bootstrap``: Creating Request and Response objects, Event ``pre_system``, Instantiating RouteCollection object, Loading Routes files, Instantiating Router object,
+   - ``routing``: Routing,
+- After
+
+   - ``bootstrap``: Creating Request and Response objects, Event ``pre_system``.
+   - ``required_before_filters``: Instantiating Filters object, Running *Required Before Filters*.
+   - ``routing``: Instantiating RouteCollection object, Loading Routes files, Instantiating Router object, Routing,
+
 Others
 ======
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -255,8 +255,10 @@ Libraries
 Helpers and Functions
 =====================
 
-Controller Filters
-==================
+.. _v450-required-filters:
+
+Required Filters
+================
 
 The :ref:`Required Filters <filters-required>` has been introduced. They are new
 special filters that are applied before and after other kinds of filters, and

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -275,9 +275,55 @@ See :ref:`URI Routing <routing-spark-routes>` for details.
 Provided Filters
 ****************
 
-The filters bundled with CodeIgniter4 are: :doc:`Honeypot <../libraries/honeypot>`, :ref:`CSRF <cross-site-request-forgery>`, ``InvalidChars``, ``SecureHeaders``, and :ref:`DebugToolbar <the-debug-toolbar>`.
+The filters bundled with CodeIgniter4 are:
+
+- ``csrf`` => :ref:`CSRF <cross-site-request-forgery>`
+- ``toolbar`` => :ref:`DebugToolbar <the-debug-toolbar>`
+- ``honeypot`` => :doc:`Honeypot <../libraries/honeypot>`
+- ``invalidchars`` => :ref:`invalidchars`
+- ``secureheaders`` => :ref:`secureheaders`
+- ``forcehttps`` => :ref:`forcehttps`
+- ``pagecache`` => :doc:`PageCache <../general/caching>`
+- ``performance`` => :ref:`performancemetrics`
 
 .. note:: The filters are executed in the order defined in the config file. However, if enabled, ``DebugToolbar`` is always executed last because it should be able to capture everything that happens in the other filters.
+
+.. _forcehttps:
+
+ForceHTTPS
+==========
+
+.. versionadded:: 4.5.0
+
+This filter provides the "Force Global Secure Requests" feature.
+
+If you set ``Config\App:$forceGlobalSecureRequests`` to true, this will force
+every request made to this application to be made via a secure connection (HTTPS).
+If the incoming request is not secure, the user will be redirected to a secure
+version of the page and the HTTP Strict Transport Security (HSTS) header will be
+set.
+
+.. _performancemetrics:
+
+PerformanceMetrics
+==================
+
+.. versionadded:: 4.5.0
+
+This filter provides the pseudo-variables for performance metrics.
+
+If you would like to display the total elapsed time from the moment CodeIgniter
+starts to the moment right before the final output is sent to the browser,
+simply place this pseudo-variable in one of your view::
+
+    {elapsed_time}
+
+If you would like to show your memory usage in your view files, use this
+pseudo-variable::
+
+    {memory_usage}
+
+If you don't need this feature, remove ``'performance'`` from ``$required['after']``.
 
 .. _invalidchars:
 

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -4,7 +4,7 @@ Controller Filters
 
 .. contents::
     :local:
-    :depth: 2
+    :depth: 3
 
 Controller Filters allow you to perform actions either before or after the controllers execute. Unlike :doc:`events <../extending/events>`,
 you can choose the specific URIs or routes in which the filters will be applied to. Before filters may

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -225,8 +225,10 @@ Filter Execution Order
 
 Filters are executed in the following order:
 
-- **Before Filters**: globals → methods → filters → route
-- **After Filters**: route → filters → globals
+- **Before Filters**: required → globals → methods → filters → route
+- **After Filters**: route → filters → globals → required
+
+.. note:: The *required* filters can be used since v4.5.0.
 
 .. note:: Prior to v4.5.0, the filters that are specified to a route
     (in **app/Config/Routes.php**) are executed before the filters specified in

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -116,10 +116,33 @@ You can combine multiple filters into one alias, making complex sets of filters 
 
 You should define as many aliases as you need.
 
+.. _filters-required:
+
+$required
+---------
+
+.. versionadded:: 4.5.0
+
+The second section allows you to define **Required Filters**.
+They are special filters that are applied to every request made by the
+framework. They are applied before and after other kinds of filters that are
+explained below.
+
+.. note:: The Required Filters are always executed even if a route does not exist.
+
+You should take care with how many you use here, since it could have performance
+implications to have too many run on every request. But the filters set by default
+provide framework functionality. If removed, those functions will no longer work.
+See :ref:`provided-filters` for details.
+
+Filters can be specified by adding their alias to either the ``before`` or ``after`` array:
+
+.. literalinclude:: filters/013.php
+
 $globals
 --------
 
-The second section allows you to define any filters that should be applied to every valid request made by the framework.
+The third section allows you to define any filters that should be applied to every valid request made by the framework.
 
 You should take care with how many you use here, since it could have performance implications to have too many
 run on every request.
@@ -243,6 +266,8 @@ The output is like the following:
 You can also see the routes and filters by the ``spark routes`` command,
 but it might not show accurate filters when you use regular expressions for routes.
 See :ref:`URI Routing <routing-spark-routes>` for details.
+
+.. _provided-filters:
 
 ****************
 Provided Filters

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -314,7 +314,7 @@ This filter provides the pseudo-variables for performance metrics.
 
 If you would like to display the total elapsed time from the moment CodeIgniter
 starts to the moment right before the final output is sent to the browser,
-simply place this pseudo-variable in one of your view::
+simply place this pseudo-variable in one of your views::
 
     {elapsed_time}
 

--- a/user_guide_src/source/incoming/filters/013.php
+++ b/user_guide_src/source/incoming/filters/013.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class Filters extends BaseConfig
+{
+    // ...
+    public array $required = [
+        'before' => [
+            'forcehttps', // Force Global Secure Requests
+            'pagecache',  // Web Page Caching
+        ],
+        'after' => [
+            'pagecache',   // Web Page Caching
+            'performance', // Performance Metrics
+            'toolbar',     // Debug Toolbar
+        ],
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -15,6 +15,40 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Mandatory File Changes
 **********************
 
+Config Files
+============
+
+app/Config/Filters.php
+----------------------
+
+Required Filters have been added, so add that settings. See
+:ref:`Upgrading <v450-required-filters>` for details.
+
+Add the following items in the ``$aliases`` property::
+
+    public array $aliases = [
+        // ...
+        'forcehttps'    => \CodeIgniter\Filters\ForceHTTPS::class,
+        'pagecache'     => \CodeIgniter\Filters\PageCache::class,
+        'performance'   => \CodeIgniter\Filters\PerformanceMetrics::class,
+    ];
+
+Add the new property ``$required``, and set the following::
+
+    public array $required = [
+        'before' => [
+            'forcehttps', // Force Global Secure Requests
+            'pagecache',  // Web Page Caching
+        ],
+        'after' => [
+            'pagecache',   // Web Page Caching
+            'performance', // Performance Metrics
+            'toolbar',     // Debug Toolbar
+        ],
+    ];
+
+Remove  ``'toolbar'`` from the ``$global['after']``.
+
 Breaking Changes
 ****************
 

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -21,7 +21,7 @@ Config Files
 app/Config/Filters.php
 ----------------------
 
-Required Filters have been added, so add that settings. See
+Required Filters have been added, so add that setting. See
 :ref:`Upgrading <v450-required-filters>` for details.
 
 Add the following items in the ``$aliases`` property::

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -15,40 +15,6 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Mandatory File Changes
 **********************
 
-Config Files
-============
-
-app/Config/Filters.php
-----------------------
-
-Required Filters have been added, so add that setting. See
-:ref:`Upgrading <v450-required-filters>` for details.
-
-Add the following items in the ``$aliases`` property::
-
-    public array $aliases = [
-        // ...
-        'forcehttps'    => \CodeIgniter\Filters\ForceHTTPS::class,
-        'pagecache'     => \CodeIgniter\Filters\PageCache::class,
-        'performance'   => \CodeIgniter\Filters\PerformanceMetrics::class,
-    ];
-
-Add the new property ``$required``, and set the following::
-
-    public array $required = [
-        'before' => [
-            'forcehttps', // Force Global Secure Requests
-            'pagecache',  // Web Page Caching
-        ],
-        'after' => [
-            'pagecache',   // Web Page Caching
-            'performance', // Performance Metrics
-            'toolbar',     // Debug Toolbar
-        ],
-    ];
-
-Remove  ``'toolbar'`` from the ``$global['after']``.
-
 Breaking Changes
 ****************
 
@@ -250,6 +216,44 @@ and it is recommended that you merge the updated versions with your application:
 
 Config
 ------
+
+app/Config/Filters.php
+^^^^^^^^^^^^^^^^^^^^^^
+
+Required Filters have been added, so the following changes were made. See also
+:ref:`Upgrading <v450-required-filters>`.
+
+The base class has been changed::
+
+    class Filters extends \CodeIgniter\Config\Filters
+
+The following items are added in the ``$aliases`` property::
+
+    public array $aliases = [
+        // ...
+        'forcehttps'    => \CodeIgniter\Filters\ForceHTTPS::class,
+        'pagecache'     => \CodeIgniter\Filters\PageCache::class,
+        'performance'   => \CodeIgniter\Filters\PerformanceMetrics::class,
+    ];
+
+A new property ``$required`` is added, and set as the following::
+
+    public array $required = [
+        'before' => [
+            'forcehttps', // Force Global Secure Requests
+            'pagecache',  // Web Page Caching
+        ],
+        'after' => [
+            'pagecache',   // Web Page Caching
+            'performance', // Performance Metrics
+            'toolbar',     // Debug Toolbar
+        ],
+    ];
+
+The  ``'toolbar'`` in the ``$global['after']`` was removed.
+
+Others
+^^^^^^
 
 - app/Config/Database.php
     - The default value of ``charset`` in ``$default`` has been change to ``utf8mb4``.

--- a/user_guide_src/source/testing/debugging.rst
+++ b/user_guide_src/source/testing/debugging.rst
@@ -70,7 +70,9 @@ constant ``CI_DEBUG`` is defined and its value is truthy. This is defined in the
 .. note:: The Debug Toolbar is not displayed when your ``baseURL`` setting (in **app/Config/App.php** or ``app.baseURL`` in **.env**) does not match your actual URL.
 
 The toolbar itself is displayed as an :doc:`After Filter </incoming/filters>`. You can stop it from ever
-running by removing it from the ``$globals`` property of **app/Config/Filters.php**.
+running by removing ``'toolbar'`` from the ``$required`` (or ``$globals``) property of **app/Config/Filters.php**.
+
+.. note:: Prior to v4.5.0, the toolbar was set to ``$globals`` by default.
 
 Choosing What to Show
 ---------------------


### PR DESCRIPTION
~~Needs #8050~~

**Description**
- add "Required Filters" that always run (before filters) before Page Cache check and routing
- add `ForceHTTPS`, `PageCache` and `PerformanceMetrics` as "Required Filters"
- fix benchmark points

![Changes](https://github.com/codeigniter4/CodeIgniter4/assets/87955/eb8251f3-127c-4bc4-ac0c-f4b90e4647ef)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
