### PR TITLE
fix: FilterTestTrait::getFilterCaller() does not support Filter classes as array

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -15,8 +15,9 @@ class Filters extends BaseConfig
      * Configures aliases for Filter classes to
      * make reading things nicer and simpler.
      *
-     * @var array<string, string>
-     * @phpstan-var array<string, class-string>
+     * @var array<string, array<int, string>|string> [filter_name => classname]
+     *                                               or [filter_name => [classname1, classname2, ...]]
+     * @phpstan-var array<string, class-string|list<class-string>>
      */
     public array $aliases = [
         'csrf'          => CSRF::class,

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -132,26 +132,68 @@ trait FilterTestTrait
                     throw new RuntimeException("No filter found with alias '{$filter}'");
                 }
 
-                $filter = $this->filtersConfig->aliases[$filter];
+                $filterClasses = $this->filtersConfig->aliases[$filter];
             }
 
-            // Get an instance
-            $filter = new $filter();
+            $filterClasses = (array) $filterClasses;
         }
 
-        if (! $filter instanceof FilterInterface) {
-            throw FilterException::forIncorrectInterface(get_class($filter));
+        foreach ($filterClasses as $class) {
+            // Get an instance
+            $filter = new $class();
+
+            if (! $filter instanceof FilterInterface) {
+                throw FilterException::forIncorrectInterface(get_class($filter));
+            }
         }
 
         $request = clone $this->request;
 
         if ($position === 'before') {
-            return static fn (?array $params = null) => $filter->before($request, $params);
+            return static function (?array $params = null) use ($filterClasses, $request) {
+                foreach ($filterClasses as $class) {
+                    $filter = new $class();
+
+                    $result = $filter->before($request, $params);
+
+                    // @TODO The following logic is in Filters class.
+                    //       Should use Filters class.
+                    if ($result instanceof RequestInterface) {
+                        $request = $result;
+
+                        continue;
+                    }
+                    if ($result instanceof ResponseInterface) {
+                        return $result;
+                    }
+                    if (empty($result)) {
+                        continue;
+                    }
+                }
+
+                return $result;
+            };
         }
 
         $response = clone $this->response;
 
-        return static fn (?array $params = null) => $filter->after($request, $response, $params);
+        return static function (?array $params = null) use ($filterClasses, $request, $response) {
+            foreach ($filterClasses as $class) {
+                $filter = new $class();
+
+                $result = $filter->after($request, $response, $params);
+
+                // @TODO The following logic is in Filters class.
+                //       Should use Filters class.
+                if ($result instanceof ResponseInterface) {
+                    $response = $result;
+
+                    continue;
+                }
+            }
+
+            return $result;
+        };
     }
 
     /**

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -68,6 +68,7 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $result = $caller();
 
         $this->assertSame('http://hellowworld.com', $result->getBody());
+        $this->assertNull(Services::response()->getBody());
 
         $this->resetServices();
     }

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Test;
 
 use CodeIgniter\HTTP\RequestInterface;
+use Config\Services;
 use Tests\Support\Filters\Customfilter;
 
 /**
@@ -60,6 +61,16 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $this->expectExceptionMessage('Invalid filter position passed: banana');
 
         $this->getFilterCaller('test-customfilter', 'banana');
+    }
+
+    public function testCallerSupportArray(): void
+    {
+        $this->filtersConfig->aliases['test-customfilter'] = [Customfilter::class];
+
+        $caller = $this->getFilterCaller('test-customfilter', 'before');
+        $result = $caller();
+
+        $this->assertSame('http://hellowworld.com', $result->getBody());
     }
 
     public function testCallerUsesClonedInstance(): void


### PR DESCRIPTION
**Description**
The `$aliases` values can be an array.
See https://codeigniter4.github.io/CodeIgniter4/incoming/filters.html#aliases

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
