### PR TITLE
chore: update laminas-escaper to ^2.13

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -14,7 +14,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "laminas/laminas-escaper": "^2.9",
+        "laminas/laminas-escaper": "^2.13",
         "psr/log": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "laminas/laminas-escaper": "^2.9",
+        "laminas/laminas-escaper": "^2.13",
         "psr/log": "^2.0"
     },
     "require-dev": {

--- a/system/ThirdParty/Escaper/Escaper.php
+++ b/system/ThirdParty/Escaper/Escaper.php
@@ -157,9 +157,21 @@ class Escaper
         $this->htmlSpecialCharsFlags = ENT_QUOTES | ENT_SUBSTITUTE;
 
         // set matcher callbacks
-        $this->htmlAttrMatcher = [$this, 'htmlAttrMatcher'];
-        $this->jsMatcher       = [$this, 'jsMatcher'];
-        $this->cssMatcher      = [$this, 'cssMatcher'];
+        $this->htmlAttrMatcher =
+            /** @param array<array-key, string> $matches */
+            function (array $matches): string {
+                return $this->htmlAttrMatcher($matches);
+            };
+        $this->jsMatcher       =
+            /** @param array<array-key, string> $matches */
+            function (array $matches): string {
+                return $this->jsMatcher($matches);
+            };
+        $this->cssMatcher      =
+            /** @param array<array-key, string> $matches */
+            function (array $matches): string {
+                return $this->cssMatcher($matches);
+            };
     }
 
     /**


### PR DESCRIPTION
**Description**
Closes #8029

laminas-escaper 2.13 requires PHP 8.1 or later.
https://packagist.org/packages/laminas/laminas-escaper#2.13.0

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
