### PR TITLE
refactor: update PHPUnit to 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,5 +126,6 @@ nb-configuration.xml
 /results/
 /phpunit*.xml
 /.phpunit.*.cache
+/.phpunit.cache
 
 /.php-cs-fixer.php

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -23,7 +23,7 @@
         "kint-php/kint": "^5.0.4",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpunit": "^10.5.11",
         "predis/predis": "^1.1 || ^2.0"
     },
     "suggest": {

--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -23,7 +23,7 @@
         "kint-php/kint": "^5.0.4",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
-        "phpunit/phpunit": "^10.5.11",
+        "phpunit/phpunit": "^10.5.16",
         "predis/predis": "^1.1 || ^2.0"
     },
     "suggest": {

--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -1,51 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		bootstrap="system/Test/bootstrap.php"
-		backupGlobals="false"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		stopOnError="false"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
-		<include>
-			<directory suffix=".php">./app</directory>
-		</include>
-		<exclude>
-			<directory suffix=".php">./app/Views</directory>
-			<file>./app/Config/Routes.php</file>
-		</exclude>
-		<report>
-			<clover outputFile="build/logs/clover.xml"/>
-			<html outputDirectory="build/logs/html"/>
-			<php outputFile="build/logs/coverage.serialized"/>
-			<text outputFile="php://stdout" showUncoveredFiles="false"/>
-		</report>
-	</coverage>
-	<testsuites>
-		<testsuite name="App">
-			<directory>./tests</directory>
-		</testsuite>
-	</testsuites>
-	<logging>
-		<testdoxHtml outputFile="build/logs/testdox.html"/>
-		<testdoxText outputFile="build/logs/testdox.txt"/>
-		<junit outputFile="build/logs/logfile.xml"/>
-	</logging>
-	<php>
-		<server name="app.baseURL" value="http://example.com/"/>
-		<!-- Directory containing phpunit.xml -->
-		<const name="HOMEPATH" value="./"/>
-		<!-- Directory containing the Paths config file -->
-		<const name="CONFIGPATH" value="./app/Config/"/>
-		<!-- Directory containing the front controller (index.php) -->
-		<const name="PUBLICPATH" value="./public/"/>
-		<!-- Database configuration -->
-		<!-- Uncomment to provide your own database for testing
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="system/Test/bootstrap.php" backupGlobals="false" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage includeUncoveredFiles="true">
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/logs/html"/>
+      <php outputFile="build/logs/coverage.serialized"/>
+      <text outputFile="php://stdout" showUncoveredFiles="false"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="App">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <testdoxHtml outputFile="build/logs/testdox.html"/>
+    <testdoxText outputFile="build/logs/testdox.txt"/>
+    <junit outputFile="build/logs/logfile.xml"/>
+  </logging>
+  <php>
+    <server name="app.baseURL" value="http://example.com/"/>
+    <!-- Directory containing phpunit.xml -->
+    <const name="HOMEPATH" value="./"/>
+    <!-- Directory containing the Paths config file -->
+    <const name="CONFIGPATH" value="./app/Config/"/>
+    <!-- Directory containing the front controller (index.php) -->
+    <const name="PUBLICPATH" value="./public/"/>
+    <!-- Database configuration -->
+    <!-- Uncomment to provide your own database for testing
 		<env name="database.tests.hostname" value="localhost"/>
 		<env name="database.tests.database" value="tests"/>
 		<env name="database.tests.username" value="tests_user"/>
@@ -53,5 +35,14 @@
 		<env name="database.tests.DBDriver" value="MySQLi"/>
 		<env name="database.tests.DBPrefix" value="tests_"/>
 		-->
-	</php>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">./app/Views</directory>
+      <file>./app/Config/Routes.php</file>
+    </exclude>
+  </source>
 </phpunit>

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "fakerphp/faker": "^1.9",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^10.5.11"
+        "phpunit/phpunit": "^10.5.16"
     },
     "autoload": {
         "psr-4": {

--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "fakerphp/faker": "^1.9",
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^9.1"
+        "phpunit/phpunit": "^10.5.11"
     },
     "autoload": {
         "psr-4": {

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -1,51 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
-        backupGlobals="false"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true" processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">./app/Views</directory>
-            <file>./app/Config/Routes.php</file>
-        </exclude>
-        <report>
-            <clover outputFile="build/logs/clover.xml"/>
-            <html outputDirectory="build/logs/html"/>
-            <php outputFile="build/logs/coverage.serialized"/>
-            <text outputFile="php://stdout" showUncoveredFiles="false"/>
-        </report>
-    </coverage>
-    <testsuites>
-        <testsuite name="App">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <testdoxHtml outputFile="build/logs/testdox.html"/>
-        <testdoxText outputFile="build/logs/testdox.txt"/>
-        <junit outputFile="build/logs/logfile.xml"/>
-    </logging>
-    <php>
-        <server name="app.baseURL" value="http://example.com/"/>
-        <!-- Directory containing phpunit.xml -->
-        <const name="HOMEPATH" value="./"/>
-        <!-- Directory containing the Paths config file -->
-        <const name="CONFIGPATH" value="./app/Config/"/>
-        <!-- Directory containing the front controller (index.php) -->
-        <const name="PUBLICPATH" value="./public/"/>
-        <!-- Database configuration -->
-        <!-- Uncomment to provide your own database for testing
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php" backupGlobals="false" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage includeUncoveredFiles="true">
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/logs/html"/>
+      <php outputFile="build/logs/coverage.serialized"/>
+      <text outputFile="php://stdout" showUncoveredFiles="false"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="App">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <testdoxHtml outputFile="build/logs/testdox.html"/>
+    <testdoxText outputFile="build/logs/testdox.txt"/>
+    <junit outputFile="build/logs/logfile.xml"/>
+  </logging>
+  <php>
+    <server name="app.baseURL" value="http://example.com/"/>
+    <!-- Directory containing phpunit.xml -->
+    <const name="HOMEPATH" value="./"/>
+    <!-- Directory containing the Paths config file -->
+    <const name="CONFIGPATH" value="./app/Config/"/>
+    <!-- Directory containing the front controller (index.php) -->
+    <const name="PUBLICPATH" value="./public/"/>
+    <!-- Database configuration -->
+    <!-- Uncomment to provide your own database for testing
         <env name="database.tests.hostname" value="localhost"/>
         <env name="database.tests.database" value="tests"/>
         <env name="database.tests.username" value="tests_user"/>
@@ -53,5 +35,14 @@
         <env name="database.tests.DBDriver" value="MySQLi"/>
         <env name="database.tests.DBPrefix" value="tests_"/>
         -->
-    </php>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">./app/Views</directory>
+      <file>./app/Config/Routes.php</file>
+    </exclude>
+  </source>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "kint-php/kint": "^5.0.4",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
-        "nexusphp/tachycardia": "^1.0",
+        "nexusphp/tachycardia": "^2.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10.2",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan": "^1.10.2",
         "phpstan/phpstan-strict-rules": "^1.5",
         "phpunit/phpcov": "^9.0.2",
-        "phpunit/phpunit": "^10.5.11",
+        "phpunit/phpunit": "^10.5.16",
         "predis/predis": "^1.1 || ^2.0",
         "rector/rector": "1.0.4",
         "vimeo/psalm": "^5.0"

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan": "^1.10.2",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "phpunit/phpcov": "^8.2",
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpcov": "^9.0.2",
+        "phpunit/phpunit": "^10.5.11",
         "predis/predis": "^1.1 || ^2.0",
         "rector/rector": "1.0.4",
         "vimeo/psalm": "^5.0"

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -11197,26 +11197,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Cache/FactoriesCacheFileVarExportHandlerTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Cache\\\\Handlers\\\\AbstractHandlerTest\\:\\:\\$dummy has no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Cache/Handlers/AbstractHandlerTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Cache\\\\Handlers\\\\AbstractHandlerTest\\:\\:\\$key1 has no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Cache/Handlers/AbstractHandlerTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Cache\\\\Handlers\\\\AbstractHandlerTest\\:\\:\\$key2 has no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Cache/Handlers/AbstractHandlerTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Cache\\\\Handlers\\\\AbstractHandlerTest\\:\\:\\$key3 has no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Cache/Handlers/AbstractHandlerTest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Cache\\\\Handlers\\\\BaseHandlerTest\\:\\:provideValidateKeyInvalidType\\(\\) return type has no value type specified in iterable type iterable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Cache/Handlers/BaseHandlerTest.php',
@@ -12462,31 +12442,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Database/DatabaseTestCaseTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Database\\\\Live\\\\AbstractGetFieldDataTest\\:\\:assertSameFieldData\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Database/Live/AbstractGetFieldDataTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Database\\\\Live\\\\AbstractGetFieldDataTest\\:\\:assertSameFieldData\\(\\) has parameter \\$actual with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Database/Live/AbstractGetFieldDataTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Database\\\\Live\\\\AbstractGetFieldDataTest\\:\\:assertSameFieldData\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Database/Live/AbstractGetFieldDataTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Database\\\\Live\\\\AbstractGetFieldDataTest\\:\\:createTableForDefault\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Database/Live/AbstractGetFieldDataTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Database\\\\Live\\\\AbstractGetFieldDataTest\\:\\:createTableForType\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Database/Live/AbstractGetFieldDataTest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Database\\\\Live\\\\ConnectTest\\:\\:\\$group1 has no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Database/Live/ConnectTest.php',
@@ -12655,11 +12610,6 @@ $ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Database\\\\Live\\\\SQLite3\\\\AlterTableTest\\:\\:\\$forge \\(CodeIgniter\\\\Database\\\\SQLite3\\\\Forge\\) does not accept CodeIgniter\\\\Database\\\\Forge\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Database/Live/SQLite3/AlterTableTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Database\\\\Live\\\\SQLite3\\\\GetFieldDataTest\\:\\:createTableCompositePrimaryKey\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Database/Live/SQLite3/GetFieldDataTest.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^PHPDoc type CodeIgniter\\\\Database\\\\SQLite3\\\\Connection of property CodeIgniter\\\\Database\\\\Live\\\\SQLite3\\\\GetIndexDataTest\\:\\:\\$db is not the same as PHPDoc type CodeIgniter\\\\Database\\\\BaseConnection of overridden property CodeIgniter\\\\Test\\\\CIUnitTestCase\\:\\:\\$db\\.$#',
@@ -13068,11 +13018,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to an undefined method CodeIgniter\\\\Events\\\\Events\\:\\:unInitialize\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Events/EventsTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/Events/EventsTest\\.php\\:285\\:\\:\\$logged has no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Events/EventsTest.php',
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <html outputDirectory="build/coverage/html" highLowerBound="80"/>
-            <text outputFile="build/coverage/text/coverage.txt"/>
+            <text outputFile="build/coverage/coverage.txt"/>
         </report>
     </coverage>
     <extensions>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,27 +12,17 @@
             <text outputFile="build/coverage/text/coverage.txt"/>
         </report>
     </coverage>
-    <testsuites>
-        <testsuite name="System">
-            <directory>tests/system</directory>
-        </testsuite>
-    </testsuites>
     <extensions>
         <bootstrap class="Nexus\PHPUnit\Tachycardia\TachycardiaExtension">
             <parameter name="time-limit" value="0.50" />
             <parameter name="report-count" value="30" />
         </bootstrap>
     </extensions>
-    <php>
-        <server name="app.baseURL" value="http://example.com/"/>
-        <server name="CODEIGNITER_SCREAM_DEPRECATIONS" value="1"/>
-        <!-- Directory containing phpunit.xml -->
-        <const name="HOMEPATH" value="./"/>
-        <!-- Directory containing the Paths config file -->
-        <const name="CONFIGPATH" value="./app/Config/"/>
-        <!-- Directory containing the front controller (index.php) -->
-        <const name="PUBLICPATH" value="./public/"/>
-    </php>
+    <testsuites>
+        <testsuite name="System">
+            <directory>tests/system</directory>
+        </testsuite>
+    </testsuites>
     <source>
         <include>
             <directory suffix=".php">system</directory>
@@ -51,4 +41,14 @@
             <file>system/Test/FeatureTestCase.php</file>
         </exclude>
     </source>
+    <php>
+        <server name="app.baseURL" value="http://example.com/"/>
+        <server name="CODEIGNITER_SCREAM_DEPRECATIONS" value="1"/>
+        <!-- Directory containing phpunit.xml -->
+        <const name="HOMEPATH" value="./"/>
+        <!-- Directory containing the Paths config file -->
+        <const name="CONFIGPATH" value="./app/Config/"/>
+        <!-- Directory containing the front controller (index.php) -->
+        <const name="PUBLICPATH" value="./public/"/>
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,51 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="system/Test/bootstrap.php"
-         backupGlobals="false"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         cacheResultFile="build/.phpunit.cache/test-results"
-         colors="true"
-         columns="max"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-
-    <coverage cacheDirectory="build/.phpunit.cache/code-coverage"
-              processUncoveredFiles="true"
-              ignoreDeprecatedCodeUnits="true">
-        <include>
-            <directory suffix=".php">system</directory>
-        </include>
-
-        <exclude>
-            <directory>system/Commands/Generators/Views</directory>
-            <directory>system/Debug/Toolbar/Views</directory>
-            <directory>system/Pager/Views</directory>
-            <directory>system/ThirdParty</directory>
-            <directory>system/Validation/Views</directory>
-            <file>system/bootstrap.php</file>
-            <file>system/ComposerScripts.php</file>
-            <file>system/Config/Routes.php</file>
-            <file>system/Test/bootstrap.php</file>
-            <file>system/Test/ControllerTester.php</file>
-            <file>system/Test/FeatureTestCase.php</file>
-        </exclude>
-
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         bootstrap="system/Test/bootstrap.php" backupGlobals="false"
+         beStrictAboutOutputDuringTests="true" colors="true" columns="max"
+         failOnRisky="true" failOnWarning="true"
+         cacheDirectory=".phpunit.cache">
+    <coverage ignoreDeprecatedCodeUnits="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <html outputDirectory="build/coverage/html" highLowerBound="80"/>
             <text outputFile="build/coverage/text/coverage.txt"/>
         </report>
     </coverage>
-
     <testsuites>
         <testsuite name="System">
             <directory>tests/system</directory>
         </testsuite>
     </testsuites>
-
     <extensions>
         <extension class="Nexus\PHPUnit\Extension\Tachycardia">
             <arguments>
@@ -66,7 +37,6 @@
             </arguments>
         </extension>
     </extensions>
-
     <php>
         <server name="app.baseURL" value="http://example.com/"/>
         <server name="CODEIGNITER_SCREAM_DEPRECATIONS" value="1"/>
@@ -77,4 +47,22 @@
         <!-- Directory containing the front controller (index.php) -->
         <const name="PUBLICPATH" value="./public/"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">system</directory>
+        </include>
+        <exclude>
+            <directory>system/Commands/Generators/Views</directory>
+            <directory>system/Debug/Toolbar/Views</directory>
+            <directory>system/Pager/Views</directory>
+            <directory>system/ThirdParty</directory>
+            <directory>system/Validation/Views</directory>
+            <file>system/bootstrap.php</file>
+            <file>system/ComposerScripts.php</file>
+            <file>system/Config/Routes.php</file>
+            <file>system/Test/bootstrap.php</file>
+            <file>system/Test/ControllerTester.php</file>
+            <file>system/Test/FeatureTestCase.php</file>
+        </exclude>
+    </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,24 +18,10 @@
         </testsuite>
     </testsuites>
     <extensions>
-        <extension class="Nexus\PHPUnit\Extension\Tachycardia">
-            <arguments>
-                <array>
-                    <element key="timeLimit">
-                        <double>0.50</double>
-                    </element>
-                    <element key="reportable">
-                        <integer>30</integer>
-                    </element>
-                    <element key="precision">
-                        <integer>2</integer>
-                    </element>
-                    <element key="tabulate">
-                        <boolean>false</boolean>
-                    </element>
-                </array>
-            </arguments>
-        </extension>
+        <bootstrap class="Nexus\PHPUnit\Tachycardia\TachycardiaExtension">
+            <parameter name="time-limit" value="0.50" />
+            <parameter name="report-count" value="30" />
+        </bootstrap>
     </extensions>
     <php>
         <server name="app.baseURL" value="http://example.com/"/>

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -67,7 +67,7 @@ class SeeInDatabase extends Constraint
         return sprintf(
             "a row in the table [%s] matches the attributes \n%s\n\n%s",
             $table,
-            $this->toString(JSON_PRETTY_PRINT),
+            $this->toString(false, JSON_PRETTY_PRINT),
             $this->getAdditionalInfo($table)
         );
     }
@@ -113,7 +113,7 @@ class SeeInDatabase extends Constraint
      *
      * @param int $options
      */
-    public function toString($options = 0): string
+    public function toString(bool $exportObjects = false, $options = 0): string
     {
         return json_encode($this->data, $options);
     }

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -396,6 +396,10 @@ final class AutoloaderTest extends CIUnitTestCase
      */
     public function testLoadHelpers(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $config            = new Autoload();
         $config->helpers[] = 'form';
 

--- a/tests/system/Cache/Handlers/AbstractHandlerTestCase.php
+++ b/tests/system/Cache/Handlers/AbstractHandlerTestCase.php
@@ -19,7 +19,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 /**
  * @internal
  */
-abstract class AbstractHandlerTest extends CIUnitTestCase
+abstract class AbstractHandlerTestCase extends CIUnitTestCase
 {
     protected BaseHandler $handler;
     protected static $key1  = 'key1';

--- a/tests/system/Cache/Handlers/AbstractHandlerTestCase.php
+++ b/tests/system/Cache/Handlers/AbstractHandlerTestCase.php
@@ -22,10 +22,10 @@ use CodeIgniter\Test\CIUnitTestCase;
 abstract class AbstractHandlerTestCase extends CIUnitTestCase
 {
     protected BaseHandler $handler;
-    protected static $key1  = 'key1';
-    protected static $key2  = 'key2';
-    protected static $key3  = 'key3';
-    protected static $dummy = 'dymmy';
+    protected static string $key1  = 'key1';
+    protected static string $key2  = 'key2';
+    protected static string $key3  = 'key3';
+    protected static string $dummy = 'dymmy';
 
     public function testGetMetaDataMiss(): void
     {

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -23,7 +23,7 @@ use Config\Cache;
  *
  * @group Others
  */
-final class FileHandlerTest extends AbstractHandlerTest
+final class FileHandlerTest extends AbstractHandlerTestCase
 {
     private static string $directory = 'FileHandler';
     private Cache $config;

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -23,7 +23,7 @@ use Exception;
  *
  * @internal
  */
-final class MemcachedHandlerTest extends AbstractHandlerTest
+final class MemcachedHandlerTest extends AbstractHandlerTestCase
 {
     private Cache $config;
 

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -22,7 +22,7 @@ use Config\Cache;
  *
  * @internal
  */
-final class PredisHandlerTest extends AbstractHandlerTest
+final class PredisHandlerTest extends AbstractHandlerTestCase
 {
     private Cache $config;
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -22,7 +22,7 @@ use Config\Cache;
  *
  * @internal
  */
-final class RedisHandlerTest extends AbstractHandlerTest
+final class RedisHandlerTest extends AbstractHandlerTestCase
 {
     private Cache $config;
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -52,6 +52,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         parent::setUp();
         $this->resetServices();
 
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 
         $this->codeigniter = new MockCodeIgniter(new App());

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -41,6 +41,10 @@ final class GenerateKeyTest extends CIUnitTestCase
         }
 
         $this->resetEnvironment();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     protected function tearDown(): void

--- a/tests/system/CommonFunctionsSendTest.php
+++ b/tests/system/CommonFunctionsSendTest.php
@@ -27,6 +27,10 @@ final class CommonFunctionsSendTest extends CIUnitTestCase
         parent::setUp();
 
         unset($_ENV['foo'], $_SERVER['foo']);
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     /**

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -275,6 +275,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testSessionInstance(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->injectSessionMock();
 
         $this->assertInstanceOf(Session::class, session());
@@ -286,6 +290,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testSessionVariable(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->injectSessionMock();
 
         $_SESSION['notbogus'] = 'Hi there';
@@ -299,6 +307,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testSessionVariableNotThere(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->injectSessionMock();
 
         $_SESSION['bogus'] = 'Hi there';
@@ -423,6 +435,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testOldInput(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->injectSessionMock();
         // setup from RedirectResponseTest...
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -458,6 +474,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testOldInputSerializeData(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->injectSessionMock();
         // setup from RedirectResponseTest...
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -493,6 +513,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testOldInputArray(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->injectSessionMock();
         // setup from RedirectResponseTest...
         $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -610,6 +634,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testTrace(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         ob_start();
         trace();
         $content = ob_get_clean();
@@ -633,6 +661,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testForceHttpsNullRequestAndResponse(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->assertNull(Services::response()->header('Location'));
 
         Services::response()->setCookie('force', 'cookie');
@@ -748,6 +780,10 @@ final class CommonFunctionsTest extends CIUnitTestCase
      */
     public function testTraceWithCSP(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->resetServices();
 
         /** @var App $config */

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -795,6 +795,11 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         Kint::$cli_detection = false;
 
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        // `$app->initialize()` sets error handler.
+        restore_error_handler();
+
         $this->expectOutputRegex('/<style class="kint-rich-style" nonce="[0-9a-z]{24}">/u');
         trace();
     }

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -52,6 +52,10 @@ final class BaseConfigTest extends CIUnitTestCase
         }
 
         BaseConfig::reset();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     protected function tearDown(): void

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -43,6 +43,10 @@ final class DotEnvTest extends CIUnitTestCase
         $file = 'unreadable.env';
         $path = rtrim($this->fixturesFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $file;
         chmod($path, 0644);
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     protected function tearDown(): void

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -63,6 +63,10 @@ final class ServicesTest extends CIUnitTestCase
         parent::setUp();
 
         $this->original = $_SERVER;
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     protected function tearDown(): void

--- a/tests/system/Database/Live/AbstractGetFieldDataTestCase.php
+++ b/tests/system/Database/Live/AbstractGetFieldDataTestCase.php
@@ -17,6 +17,7 @@ use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Database;
+use stdClass;
 
 abstract class AbstractGetFieldDataTestCase extends CIUnitTestCase
 {
@@ -56,7 +57,7 @@ abstract class AbstractGetFieldDataTestCase extends CIUnitTestCase
         $this->forge->dropTable($this->table, true);
     }
 
-    protected function createTableForDefault()
+    protected function createTableForDefault(): void
     {
         $this->forge->dropTable($this->table, true);
 
@@ -98,7 +99,7 @@ abstract class AbstractGetFieldDataTestCase extends CIUnitTestCase
         $this->forge->createTable($this->table);
     }
 
-    protected function createTableForType()
+    protected function createTableForType(): void
     {
         $this->forge->dropTable($this->table, true);
 
@@ -158,7 +159,11 @@ abstract class AbstractGetFieldDataTestCase extends CIUnitTestCase
 
     abstract public function testGetFieldDataDefault(): void;
 
-    protected function assertSameFieldData(array $expected, array $actual)
+    /**
+     * @param list<stdClass> $expected
+     * @param list<stdClass> $actual
+     */
+    protected function assertSameFieldData(array $expected, array $actual): void
     {
         $expectedArray = json_decode(json_encode($expected), true);
         array_sort_by_multiple_keys($expectedArray, ['name' => SORT_ASC]);

--- a/tests/system/Database/Live/AbstractGetFieldDataTestCase.php
+++ b/tests/system/Database/Live/AbstractGetFieldDataTestCase.php
@@ -18,7 +18,7 @@ use CodeIgniter\Database\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Database;
 
-abstract class AbstractGetFieldDataTest extends CIUnitTestCase
+abstract class AbstractGetFieldDataTestCase extends CIUnitTestCase
 {
     /**
      * @var BaseConnection

--- a/tests/system/Database/Live/MySQLi/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/MySQLi/GetFieldDataTestCase.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\MySQLi;
 
-use CodeIgniter\Database\Live\AbstractGetFieldDataTest;
+use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
 
 /**
@@ -21,7 +21,7 @@ use Config\Database;
  *
  * @internal
  */
-final class GetFieldDataTest extends AbstractGetFieldDataTest
+final class GetFieldDataTestCase extends AbstractGetFieldDataTestCase
 {
     protected function createForge(): void
     {

--- a/tests/system/Database/Live/OCI8/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/OCI8/GetFieldDataTestCase.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\OCI8;
 
-use CodeIgniter\Database\Live\AbstractGetFieldDataTest;
+use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
 use LogicException;
 use stdClass;
@@ -23,7 +23,7 @@ use stdClass;
  *
  * @internal
  */
-final class GetFieldDataTest extends AbstractGetFieldDataTest
+final class GetFieldDataTestCase extends AbstractGetFieldDataTestCase
 {
     protected function createForge(): void
     {

--- a/tests/system/Database/Live/Postgre/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/Postgre/GetFieldDataTestCase.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\Postgre;
 
-use CodeIgniter\Database\Live\AbstractGetFieldDataTest;
+use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
 
 /**
@@ -21,7 +21,7 @@ use Config\Database;
  *
  * @internal
  */
-final class GetFieldDataTest extends AbstractGetFieldDataTest
+final class GetFieldDataTestCase extends AbstractGetFieldDataTestCase
 {
     protected function createForge(): void
     {

--- a/tests/system/Database/Live/SQLSRV/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/SQLSRV/GetFieldDataTestCase.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\SQLSRV;
 
-use CodeIgniter\Database\Live\AbstractGetFieldDataTest;
+use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
 
 /**
@@ -21,7 +21,7 @@ use Config\Database;
  *
  * @internal
  */
-final class GetFieldDataTest extends AbstractGetFieldDataTest
+final class GetFieldDataTestCase extends AbstractGetFieldDataTestCase
 {
     protected function createForge(): void
     {

--- a/tests/system/Database/Live/SQLite3/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/SQLite3/GetFieldDataTestCase.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\SQLite3;
 
-use CodeIgniter\Database\Live\AbstractGetFieldDataTest;
+use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
 
 /**
@@ -21,7 +21,7 @@ use Config\Database;
  *
  * @internal
  */
-final class GetFieldDataTest extends AbstractGetFieldDataTest
+final class GetFieldDataTestCase extends AbstractGetFieldDataTestCase
 {
     protected function createForge(): void
     {

--- a/tests/system/Database/Live/SQLite3/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/SQLite3/GetFieldDataTestCase.php
@@ -105,7 +105,7 @@ final class GetFieldDataTestCase extends AbstractGetFieldDataTestCase
         $this->assertSameFieldData($expected, $fields);
     }
 
-    protected function createTableCompositePrimaryKey()
+    protected function createTableCompositePrimaryKey(): void
     {
         $this->forge->dropTable($this->table, true);
 

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -36,6 +36,10 @@ final class EventsTest extends CIUnitTestCase
         $this->manager = new MockEvents();
 
         Events::removeAllListeners();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     protected function tearDown(): void

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -287,7 +287,7 @@ final class EventsTest extends CIUnitTestCase
     public function testHandleEventCallableClass(): void
     {
         $box = new class () {
-            public $logged;
+            public string $logged;
 
             public function hold(string $value): void
             {

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -49,6 +49,10 @@ final class HoneypotTest extends CIUnitTestCase
         unset($_POST[$this->honey->name]);
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST[$this->honey->name] = 'hey';
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     public function testBeforeTriggered(): void

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -33,6 +33,15 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
     private ?Response $response         = null;
     private ?ContentSecurityPolicy $csp = null;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+    }
+
     // Having this method as setUp() doesn't work - can't find Config\App !?
     protected function prepare(bool $CSPEnabled = true): void
     {

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -26,6 +26,15 @@ use DateTimeZone;
  */
 final class DownloadResponseTest extends CIUnitTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+    }
+
     protected function tearDown(): void
     {
         if (isset($_SERVER['HTTP_USER_AGENT'])) {

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -42,6 +42,10 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->request = $this->createRequest($config);
 
         $_POST = $_GET = $_SERVER = $_REQUEST = $_ENV = $_COOKIE = $_SESSION = [];
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     private function createRequest(?App $config = null, $body = null, ?string $path = null): IncomingRequest

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -60,6 +60,10 @@ final class RedirectResponseTest extends CIUnitTestCase
             new UserAgent()
         );
         Services::injectMock('request', $this->request);
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     public function testRedirectToFullURI(): void

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -50,6 +50,10 @@ final class ResponseSendTest extends CIUnitTestCase
      */
     public function testHeadersMissingDate(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $response = new Response(new App());
         $response->pretend(false);
 
@@ -83,6 +87,10 @@ final class ResponseSendTest extends CIUnitTestCase
      */
     public function testHeadersWithCSP(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $this->resetFactories();
         $this->resetServices();
 
@@ -119,6 +127,10 @@ final class ResponseSendTest extends CIUnitTestCase
      */
     public function testRedirectResponseCookies(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $loginTime = time();
 
         $response = new Response(new App());

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -34,6 +34,10 @@ final class FormHelperTest extends CIUnitTestCase
         parent::setUp();
 
         helper('form');
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     private function setRequest(): void

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -63,6 +63,10 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testPreviousURLUsesSessionFirst(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $uri1 = 'http://example.com/one?two';
         $uri2 = 'http://example.com/two?foo';
 
@@ -97,6 +101,10 @@ final class MiscUrlTest extends CIUnitTestCase
      */
     public function testPreviousURLUsesRefererIfNeeded(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $uri1 = 'http://example.com/one?two';
 
         $_SERVER['HTTP_REFERER'] = $uri1;

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -60,6 +60,10 @@ final class ResourceControllerTest extends CIUnitTestCase
 
         $this->resetServices(true);
         $this->resetFactories();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     private function createCodeigniter(): void

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -54,6 +54,10 @@ final class ResourcePresenterTest extends CIUnitTestCase
 
         $this->resetServices(true);
         $this->resetFactories();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     private function createCodeigniter(): void

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -69,6 +69,10 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         Factories::injectMock('config', 'Security', $this->config);
 
         $this->injectSession($this->hash);
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     private function createSession($options = []): Session

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -32,6 +32,7 @@ use Config\Cookie;
 use Config\Logger as LoggerConfig;
 use Config\Security as SecurityConfig;
 use Config\Session as SessionConfig;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
 /**
  * @runTestsInSeparateProcesses
@@ -170,8 +171,11 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $security->verify($request);
     }
 
+    #[WithoutErrorHandler]
     public function testCSRFVerifyPostInvalidToken(): void
     {
+        Services::exceptions()->initialize();
+
         $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('The action you requested is not allowed.');
 

--- a/tests/system/Security/SecurityCSRFSessionTest.php
+++ b/tests/system/Security/SecurityCSRFSessionTest.php
@@ -62,6 +62,10 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         Factories::injectMock('config', 'Security', $this->config);
 
         $this->injectSession($this->hash);
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     private function createSession($options = []): Session

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -40,6 +40,10 @@ final class SessionTest extends CIUnitTestCase
 
         $_COOKIE  = [];
         $_SESSION = [];
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
     }
 
     protected function getInstance($options = [])

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -39,6 +39,15 @@ final class ControllerTestTraitTest extends CIUnitTestCase
 {
     use ControllerTestTrait;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+    }
+
     public function testBadController(): void
     {
         $this->expectException('InvalidArgumentException');

--- a/tests/system/Test/TestCaseEmissionsTest.php
+++ b/tests/system/Test/TestCaseEmissionsTest.php
@@ -48,6 +48,10 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
      */
     public function testHeadersEmitted(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $response = new Response(new App());
         $response->pretend(false);
 
@@ -76,6 +80,10 @@ final class TestCaseEmissionsTest extends CIUnitTestCase
      */
     public function testHeadersNotEmitted(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $response = new Response(new App());
         $response->pretend(false);
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1593,7 +1593,9 @@ class ValidationTest extends CIUnitTestCase
     {
         // to test if placeholderReplacementResultDetermination() works we provoke and expect an exception
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that \'filter[{id}]\' [ASCII](length: 12) does not contain "{id}" [ASCII](length: 4).');
+        $this->expectExceptionMessage(
+            'Failed asserting that \'filter[{id}]\' [ASCII](length: 12) does not contain "{id}" [ASCII](length: 4).'
+        );
 
         $this->validation->setRule('foo', 'foo-label', 'required|filter[{id}]');
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1593,7 +1593,7 @@ class ValidationTest extends CIUnitTestCase
     {
         // to test if placeholderReplacementResultDetermination() works we provoke and expect an exception
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Failed asserting that \'filter[{id}]\' does not contain "{id}".');
+        $this->expectExceptionMessage('Failed asserting that \'filter[{id}]\' [ASCII](length: 12) does not contain "{id}" [ASCII](length: 4).');
 
         $this->validation->setRule('foo', 'foo-label', 'required|filter[{id}]');
 

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -52,6 +52,10 @@ final class ParserPluginTest extends CIUnitTestCase
      */
     public function testPreviousURL(): void
     {
+        // Workaround for errors on PHPUnit 10 and PHP 8.3.
+        // See https://github.com/sebastianbergmann/phpunit/issues/5403#issuecomment-1906810619
+        restore_error_handler();
+
         $template = '{+ previous_url +}';
 
         // Ensure a previous URL exists to work with.


### PR DESCRIPTION
> [!IMPORTANT]  
**This PR will be merged just prior to the release of v4.5.0.**

**Description**
PHPUnit requires PHP 8.1 or later.
https://packagist.org/packages/phpunit/phpunit#10.4.1

https://phpunit.de/announcements/phpunit-10.html

**TODO**
- [x] update `nexusphp/tachycardia`
- [ ] fix errors on PHP 8.3

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
