### PR TITLE
[4.5] refactor: Filters by rector

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -621,7 +621,7 @@ class Filters
             }
 
             if (is_array($this->config->aliases[$alias])) {
-                $filtersClass = array_merge($filtersClass, $this->config->aliases[$alias]);
+                $filtersClass = [...$filtersClass, ...$this->config->aliases[$alias]];
             } else {
                 $filtersClass[] = $this->config->aliases[$alias];
             }


### PR DESCRIPTION
**Description**
```diff
1 file with changes
===================

1) system/Filters/Filters.php:620

    ---------- begin diff ----------
@@ @@
             }

             if (is_array($this->config->aliases[$alias])) {
-                $filtersClass = array_merge($filtersClass, $this->config->aliases[$alias]);
+                $filtersClass = [...$filtersClass, ...$this->config->aliases[$alias]];
             } else {
                 $filtersClass[] = $this->config->aliases[$alias];
             }
    ----------- end diff -----------

Applied rules:
 * LongArrayToShortArrayRector
 * ArraySpreadInsteadOfArrayMergeRector (https://wiki.php.net/rfc/spread_operator_for_array)
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6601535164/job/17932652976

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
