### PR TITLE
docs: fix event points descriptions

### DIFF
--- a/user_guide_src/source/changelogs/v4.4.3.rst
+++ b/user_guide_src/source/changelogs/v4.4.3.rst
@@ -24,6 +24,9 @@ Deprecations
 Bugs Fixed
 **********
 
+- **UserGuide:** Fixed the descriptions for ``pre_system`` and ``post_system``
+  in :ref:`event-points`.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -82,6 +82,8 @@ You can stop simulation by passing false:
 
 .. literalinclude:: events/008.php
 
+.. _event-points:
+
 Event Points
 ============
 

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -87,9 +87,12 @@ Event Points
 
 The following is a list of available event points within the CodeIgniter core code:
 
-* **pre_system** Called very early during system execution. Only the benchmark and events class have been loaded at this point. No routing or other processes have happened.
+* **pre_system** Called early during system execution. The URI, Request, and
+  Response have been instantiated, but page cache checking, routing, and execution
+  of "before" controller filters have not yet occurred.
 * **post_controller_constructor** Called immediately after your controller is instantiated, but prior to any method calls happening.
-* **post_system** Called after the final rendered page is sent to the browser, at the end of system execution after the finalized data is sent to the browser.
+* **post_system** Called right before the final rendered page is sent to the browser,
+  at the end of system execution, after the execution of "after" controller filters.
 * **email** Called after an email sent successfully from ``CodeIgniter\Email\Email``. Receives an array of the ``Email`` class's properties as a parameter.
 * **DBQuery** Called after a database query whether successful or not. Receives the ``Query`` object.
 * **migrate** Called after a successful migration call to ``latest()`` or ``regress()``. Receives the current properties of ``MigrationRunner`` as well as the name of the method.

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -153,6 +153,12 @@ Hooks
 - Instead of CI3's ``$hook['post_controller_constructor']`` you now use
   ``Events::on('post_controller_constructor', ['MyClass', 'MyFunction']);``, with the namespace ``CodeIgniter\Events\Events;``.
 - Events are always enabled, and are available globally.
+- The hook point ``pre_controller`` and ``post_controller`` have been removed.
+  Use :doc:`../incoming/filters` instead.
+- The hook point ``display_override`` and ``cache_override`` have been removed.
+  Because the base methods have been removed.
+- The hook point ``post_system`` has moved just before sending the final rendered
+  page.
 
 Extending the Framework
 =======================


### PR DESCRIPTION
**Description**
Supersedes #8055
Fixes #8049

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
