### PR TITLE
fix: add dbgroup to model template only when specified as an option

### DIFF
--- a/system/Commands/Generators/ModelGenerator.php
+++ b/system/Commands/Generators/ModelGenerator.php
@@ -101,9 +101,6 @@ class ModelGenerator extends BaseCommand
             $baseClass = $match[1];
         }
 
-        // Add or remove the DBGroup line based on the presence of the dbgroup option
-        $addDBGroupLine = is_string($dbGroup);
-
         $table  = is_string($table) ? $table : plural(strtolower($baseClass));
         $return = is_string($return) ? $return : 'array';
 
@@ -131,6 +128,6 @@ class ModelGenerator extends BaseCommand
             $return = "'{$return}'";
         }
 
-        return $this->parseTemplate($class, ['{dbGroup}', '{table}', '{return}'], [$dbGroup, $table, $return], compact('addDBGroupLine'));
+        return $this->parseTemplate($class, ['{dbGroup}', '{table}', '{return}'], [$dbGroup, $table, $return], compact('dbGroup'));
     }
 }

--- a/system/Commands/Generators/ModelGenerator.php
+++ b/system/Commands/Generators/ModelGenerator.php
@@ -102,7 +102,7 @@ class ModelGenerator extends BaseCommand
         }
 
         // Add or remove the DBGroup line based on the presence of the dbgroup option
-        $addDBGroupLine = is_string($dbGroup) ? true : false;
+        $addDBGroupLine = is_string($dbGroup);
 
         $table  = is_string($table) ? $table : plural(strtolower($baseClass));
         $return = is_string($return) ? $return : 'array';

--- a/system/Commands/Generators/ModelGenerator.php
+++ b/system/Commands/Generators/ModelGenerator.php
@@ -101,9 +101,11 @@ class ModelGenerator extends BaseCommand
             $baseClass = $match[1];
         }
 
-        $table   = is_string($table) ? $table : plural(strtolower($baseClass));
-        $dbGroup = is_string($dbGroup) ? $dbGroup : 'default';
-        $return  = is_string($return) ? $return : 'array';
+        // Add or remove the DBGroup line based on the presence of the dbgroup option
+        $addDBGroupLine = is_string($dbGroup) ? true : false;
+
+        $table  = is_string($table) ? $table : plural(strtolower($baseClass));
+        $return = is_string($return) ? $return : 'array';
 
         if (! in_array($return, ['array', 'object', 'entity'], true)) {
             // @codeCoverageIgnoreStart
@@ -129,6 +131,6 @@ class ModelGenerator extends BaseCommand
             $return = "'{$return}'";
         }
 
-        return $this->parseTemplate($class, ['{table}', '{dbGroup}', '{return}'], [$table, $dbGroup, $return]);
+        return $this->parseTemplate($class, ['{dbGroup}', '{table}', '{return}'], [$dbGroup, $table, $return], compact('addDBGroupLine'));
     }
 }

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -6,7 +6,7 @@ use CodeIgniter\Model;
 
 class {class} extends Model
 {
-<?php if ($addDBGroupLine): ?>
+<?php if (is_string($dbGroup)): ?>
     protected $DBGroup          = '{dbGroup}';
 <?php endif; ?>
     protected $table            = '{table}';

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -6,7 +6,9 @@ use CodeIgniter\Model;
 
 class {class} extends Model
 {
+<?php if ($addDBGroupLine): ?>
     protected $DBGroup          = '{dbGroup}';
+<?php endif; ?>
     protected $table            = '{table}';
     protected $primaryKey       = 'id';
     protected $useAutoIncrement = true;

--- a/tests/system/Commands/ModelGeneratorTest.php
+++ b/tests/system/Commands/ModelGeneratorTest.php
@@ -52,7 +52,6 @@ final class ModelGeneratorTest extends CIUnitTestCase
         $this->assertFileExists($file);
         $this->assertStringContainsString('extends Model', $this->getFileContent($file));
         $this->assertStringContainsString('protected $table            = \'users\';', $this->getFileContent($file));
-        $this->assertStringContainsString('protected $DBGroup          = \'default\';', $this->getFileContent($file));
         $this->assertStringContainsString('protected $returnType       = \'array\';', $this->getFileContent($file));
     }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
The property `$DBGroup` should only be added to the generated model template when specified as an option: `--dbgroup`.
Fixes #8073 

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
