### PR TITLE
fix: set_cookie() $expire type

### DIFF
--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -322,7 +322,7 @@ interface ResponseInterface extends MessageInterface
      *
      * @param array|string $name     Cookie name or array containing binds
      * @param string       $value    Cookie value
-     * @param string       $expire   Cookie expiration time in seconds
+     * @param int          $expire   Cookie expiration time in seconds
      * @param string       $domain   Cookie domain (e.g.: '.yourdomain.com')
      * @param string       $path     Cookie path (default: '/')
      * @param string       $prefix   Cookie name prefix
@@ -335,7 +335,7 @@ interface ResponseInterface extends MessageInterface
     public function setCookie(
         $name,
         $value = '',
-        $expire = '',
+        $expire = 0,
         $domain = '',
         $path = '/',
         $prefix = '',

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -581,14 +581,11 @@ trait ResponseTrait
             return $this;
         }
 
-        /** @var CookieConfig|null $cookieConfig */
         $cookieConfig = config(CookieConfig::class);
 
-        if ($cookieConfig instanceof CookieConfig) {
-            $secure ??= $cookieConfig->secure;
-            $httponly ??= $cookieConfig->httponly;
-            $samesite ??= $cookieConfig->samesite;
-        }
+        $secure ??= $cookieConfig->secure;
+        $httponly ??= $cookieConfig->httponly;
+        $samesite ??= $cookieConfig->samesite;
 
         if (is_array($name)) {
             // always leave 'name' in last place, as the loop will break otherwise, due to ${$item}

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -554,7 +554,7 @@ trait ResponseTrait
      *
      * @param array|Cookie|string $name     Cookie name / array containing binds / Cookie object
      * @param string              $value    Cookie value
-     * @param string              $expire   Cookie expiration time in seconds
+     * @param int                 $expire   Cookie expiration time in seconds
      * @param string              $domain   Cookie domain (e.g.: '.yourdomain.com')
      * @param string              $path     Cookie path (default: '/')
      * @param string              $prefix   Cookie name prefix ('': the default prefix)
@@ -567,7 +567,7 @@ trait ResponseTrait
     public function setCookie(
         $name,
         $value = '',
-        $expire = '',
+        $expire = 0,
         $domain = '',
         $path = '/',
         $prefix = '',
@@ -700,7 +700,7 @@ trait ResponseTrait
         }
 
         if (! $found) {
-            $this->setCookie($name, '', '', $domain, $path, $prefix);
+            $this->setCookie($name, '', 0, $domain, $path, $prefix);
         }
 
         return $this;

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -26,7 +26,7 @@ if (! function_exists('set_cookie')) {
      *
      * @param array|Cookie|string $name     Cookie name / array containing binds / Cookie object
      * @param string              $value    The value of the cookie
-     * @param string              $expire   The number of seconds until expiration
+     * @param int                 $expire   The number of seconds until expiration
      * @param string              $domain   For site-wide cookie. Usually: .yourdomain.com
      * @param string              $path     The cookie path
      * @param string              $prefix   The cookie prefix ('': the default prefix)
@@ -41,7 +41,7 @@ if (! function_exists('set_cookie')) {
     function set_cookie(
         $name,
         string $value = '',
-        string $expire = '',
+        int $expire = 0,
         string $domain = '',
         string $path = '/',
         string $prefix = '',

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -57,6 +57,8 @@ Interface Changes
     or implemented these interfaces, all these changes are backward compatible
     and require no intervention.
 
+- **ResponseInterface:** The default value of the third parameter ``$expire`` of
+  the ``ResponseInterface::setCookie()`` has been fixed from ``''`` to ``0``.
 - **Logger:** The `psr/log <https://packagist.org/packages/psr/log>`_ package has
   been upgraded to v2.0.0.
 
@@ -64,6 +66,15 @@ Interface Changes
 
 Method Signature Changes
 ========================
+
+Setting Cookies
+---------------
+
+The third parameter ``$expire`` in :php:func:`set_cookie()` and
+:php:meth:`CodeIgniter\\HTTP\\Response::setCookie()` has been fixed.
+
+The type has been changed from ``string`` to ``int``, and the default value has
+been changed from ``''`` to  ``0``.
 
 FileLocatorInterface
 --------------------

--- a/user_guide_src/source/helpers/cookie_helper.rst
+++ b/user_guide_src/source/helpers/cookie_helper.rst
@@ -21,7 +21,7 @@ Available Functions
 
 The following functions are available:
 
-.. php:function:: set_cookie($name[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = false[, $httpOnly = false[, $sameSite = '']]]]]]]])
+.. php:function:: set_cookie($name[, $value = ''[, $expire = 0[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = false[, $httpOnly = false[, $sameSite = '']]]]]]]])
 
     :param    array|Cookie|string    $name: Cookie name *or* associative array of all of the parameters available to this function *or* an instance of ``CodeIgniter\Cookie\Cookie``
     :param    string    $value: Cookie value

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -453,7 +453,7 @@ The methods provided by the parent class that are available are:
         followed by the response body. For the main application response, you do not need to call
         this as it is handled automatically by CodeIgniter.
 
-    .. php:method:: setCookie($name = ''[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = false[, $httponly = false[, $samesite = null]]]]]]]])
+    .. php:method:: setCookie($name = ''[, $value = ''[, $expire = 0[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = false[, $httponly = false[, $samesite = null]]]]]]]])
 
         :param array|Cookie|string $name: Cookie name *or* associative array of all of the parameters available to this method *or* an instance of ``CodeIgniter\Cookie\Cookie``
         :param string $value: Cookie value
@@ -481,7 +481,7 @@ The methods provided by the parent class that are available are:
         .. literalinclude:: response/023.php
 
         Only the ``name`` and ``value`` are required. To delete a cookie set it with the
-        ``expire`` blank.
+        ``value`` blank.
 
         The ``expire`` is set in **seconds**, which will be added to the current
         time. Do not include the time, but rather only the number of seconds

--- a/user_guide_src/source/outgoing/response/023.php
+++ b/user_guide_src/source/outgoing/response/023.php
@@ -3,7 +3,7 @@
 $cookie = [
     'name'     => 'The Cookie Name',
     'value'    => 'The Value',
-    'expire'   => '86500',
+    'expire'   => 86500,
     'domain'   => '.some-domain.com',
     'path'     => '/',
     'prefix'   => 'myprefix_',


### PR DESCRIPTION
**Description**
In the docs, the param `$expire` is "Number of seconds until expiration", and the type is `int`:
https://www.codeigniter.com/user_guide/helpers/cookie_helper.html#set_cookie

So it should be `int`, not `string`.

The param `$expires_or_options` for `setcookie()` is also `int`.
https://www.php.net/manual/en/function.setcookie.php

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
