### PR TITLE
perf: defer instantiation of Validation in Model

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -33,7 +33,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 15,
+	'count' => 14,
 	'path' => __DIR__ . '/system/BaseModel.php',
 ];
 $ignoreErrors[] = [

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1463,7 +1463,7 @@ abstract class BaseModel
 
         $rules = $this->getValidationRules();
 
-        if (empty($rules)) {
+        if ($rules === []) {
             return true;
         }
 


### PR DESCRIPTION
**Description**
Closes  #7935

- defer instantiation of Validation in Model

Memory Usage:
```
before: 17392
 after:  7216
```
```php
<?php

namespace App\Controllers;

use CodeIgniter\Model;

class Home extends BaseController
{
    public function index(): string
    {
        $before = memory_get_usage();
        $model = new Model();
        $after = memory_get_usage();

        return $after - $before;
    }
}
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
