### PR TITLE
fix: [Validation] exact_length does not pass int values

### DIFF
--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -63,6 +63,10 @@ class Rules
      */
     public function exact_length($str, string $val): bool
     {
+        if (is_int($str) || is_float($str)) {
+            $str = (string) $str;
+        }
+
         if (! is_string($str)) {
             return false;
         }

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -398,8 +398,10 @@ class RulesTest extends CIUnitTestCase
 
     /**
      * @dataProvider provideExactLength
+     *
+     * @param int|string|null $data
      */
-    public function testExactLength(?string $data, bool $expected): void
+    public function testExactLength($data, bool $expected): void
     {
         $this->validation->setRules(['foo' => 'exact_length[3]']);
         $this->assertSame($expected, $this->validation->run(['foo' => $data]));
@@ -408,10 +410,13 @@ class RulesTest extends CIUnitTestCase
     public static function provideExactLength(): iterable
     {
         yield from [
-            'null'    => [null, false],
-            'exact'   => ['bar', true],
-            'less'    => ['ba', false],
-            'greater' => ['bars', false],
+            'null'        => [null, false],
+            'exact'       => ['bar', true],
+            'exact_int'   => [123, true],
+            'less'        => ['ba', false],
+            'less_int'    => [12, false],
+            'greater'     => ['bars', false],
+            'greater_int' => [1234, false],
         ];
     }
 


### PR DESCRIPTION
**Description**
From Slack

- `exact_length` in traditional rules passes int values
- but `exact_length` in strict rules passes only string values
- it is not intuitive that the rule `‘required|numeric|exact_length[10]` is invalid, and if you pass `1234567890`, you will get the error "The XXX field must be exactly 10 characters in length."

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
