### PR TITLE
refactor: remove deprecated Request::isValidIP()

### DIFF
--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -11,7 +11,6 @@
 
 namespace CodeIgniter\HTTP;
 
-use CodeIgniter\Validation\FormatRules;
 use Config\App;
 
 /**
@@ -48,21 +47,6 @@ class Request extends OutgoingRequest implements RequestInterface
         if (empty($this->uri)) {
             $this->uri = new URI();
         }
-    }
-
-    /**
-     * Validate an IP address
-     *
-     * @param string $ip    IP Address
-     * @param string $which IP protocol: 'ipv4' or 'ipv6'
-     *
-     * @deprecated 4.0.5 Use Validation instead
-     *
-     * @codeCoverageIgnore
-     */
-    public function isValidIP(?string $ip = null, ?string $which = null): bool
-    {
-        return (new FormatRules())->valid_ip($ip, $which);
     }
 
     /**

--- a/system/HTTP/RequestInterface.php
+++ b/system/HTTP/RequestInterface.php
@@ -27,16 +27,6 @@ interface RequestInterface extends OutgoingRequestInterface
     public function getIPAddress(): string;
 
     /**
-     * Validate an IP address
-     *
-     * @param string $ip    IP Address
-     * @param string $which IP protocol: 'ipv4' or 'ipv6'
-     *
-     * @deprecated Use Validation instead
-     */
-    public function isValidIP(string $ip, ?string $which = null): bool;
-
-    /**
      * Fetch an item from the $_SERVER array.
      * Supplied by RequestTrait.
      *

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -517,64 +517,6 @@ final class CLIRequestTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->fetchGlobal('post', 'clients[]'));
     }
 
-    public static function provideValidIPAddress(): iterable
-    {
-        return [
-            'empty' => [
-                false,
-                '',
-            ],
-            'zero' => [
-                false,
-                0,
-            ],
-            'large_ipv4' => [
-                false,
-                '256.256.256.999',
-                'ipv4',
-            ],
-            'good_ipv4' => [
-                true,
-                '100.100.100.0',
-                'ipv4',
-            ],
-            'good_default' => [
-                true,
-                '100.100.100.0',
-            ],
-            'zeroed_ipv4' => [
-                true,
-                '0.0.0.0',
-            ],
-            'large_ipv6' => [
-                false,
-                'h123:0000:0000:0000:0000:0000:0000:0000',
-                'ipv6',
-            ],
-            'good_ipv6' => [
-                true,
-                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-            ],
-            'confused_ipv6' => [
-                false,
-                '255.255.255.255',
-                'ipv6',
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideValidIPAddress
-     *
-     * @param mixed      $expected
-     * @param mixed      $address
-     * @param mixed|null $type
-     */
-    public function testValidIPAddress($expected, $address, $type = null): void
-    {
-        $this->assertSame($expected, $this->request->isValidIP($address, $type));
-    }
-
     public function testGetIPAddressDefault(): void
     {
         $this->assertSame('0.0.0.0', $this->request->getIPAddress());

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -533,64 +533,6 @@ final class RequestTest extends CIUnitTestCase
         $this->assertSame($expected, $this->request->fetchGlobal('post', 'people[0]', FILTER_VALIDATE_INT));
     }
 
-    public static function provideValidIPAddress(): iterable
-    {
-        return [
-            'empty' => [
-                false,
-                '',
-            ],
-            'zero' => [
-                false,
-                0,
-            ],
-            'large_ipv4' => [
-                false,
-                '256.256.256.999',
-                'ipv4',
-            ],
-            'good_ipv4' => [
-                true,
-                '100.100.100.0',
-                'ipv4',
-            ],
-            'good_default' => [
-                true,
-                '100.100.100.0',
-            ],
-            'zeroed_ipv4' => [
-                true,
-                '0.0.0.0',
-            ],
-            'large_ipv6' => [
-                false,
-                'h123:0000:0000:0000:0000:0000:0000:0000',
-                'ipv6',
-            ],
-            'good_ipv6' => [
-                true,
-                '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-            ],
-            'confused_ipv6' => [
-                false,
-                '255.255.255.255',
-                'ipv6',
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideValidIPAddress
-     *
-     * @param mixed      $expected
-     * @param mixed      $address
-     * @param mixed|null $type
-     */
-    public function testValidIPAddress($expected, $address, $type = null): void
-    {
-        $this->assertSame($expected, $this->request->isValidIP($address, $type));
-    }
-
     public function testGetIPAddressDefault(): void
     {
         $this->assertSame('0.0.0.0', $this->request->getIPAddress());

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -137,6 +137,8 @@ Others
 ------
 
 - **IncomingRequest::** The visibility of the deprecated properties ``$uri`` and
+- **RequestInterface:** The deprecated ``isValidIP()`` method has been removed.
+- **Request:** The deprecated ``isValidIP()`` method has been removed.
   ``$config`` has been changed to protected.
 - **Config:** The deprecated ``CodeIgniter\Config\Config`` class has been removed.
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -136,7 +136,7 @@ Spark Commands
 Others
 ------
 
-- **IncomingRequest::** The visibility of the deprecated properties ``$uri`` and
+- **IncomingRequest:** The visibility of the deprecated properties ``$uri`` and
 - **RequestInterface:** The deprecated ``isValidIP()`` method has been removed.
 - **Request:** The deprecated ``isValidIP()`` method has been removed.
   ``$config`` has been changed to protected.


### PR DESCRIPTION
**Description**
- remove deprecated `Request::isValidIP()` and `RequestInterface::isValidIP()`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
