### PR TITLE
test: fix BaseConfigTest

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -84,6 +84,18 @@ class BaseConfig
     }
 
     /**
+     * @internal For testing purposes only.
+     * @testTag
+     */
+    public static function reset(): void
+    {
+        static::$registrars   = [];
+        static::$override     = true;
+        static::$didDiscovery = false;
+        static::$moduleConfig = null;
+    }
+
+    /**
      * Will attempt to get environment variables with names
      * that match the properties of the child class.
      *

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -276,11 +276,14 @@ final class BaseConfigTest extends CIUnitTestCase
         /** @var MockObject&Modules $modules */
         $modules = $this->createMock(Modules::class);
         $modules->method('shouldDiscover')->with('registrars')->willReturn(false);
-
         RegistrarConfig::setModules($modules);
+
         $config = new RegistrarConfig();
 
         $this->assertSame([], $config::$registrars);
+
+        // Reset Modules Config.
+        RegistrarConfig::setModules(new Modules());
     }
 
     public function testRedoingDiscoveryWillStillSetDidDiscoveryPropertyToTrue(): void
@@ -295,5 +298,8 @@ final class BaseConfigTest extends CIUnitTestCase
         $config = new RegistrarConfig();
 
         $this->assertTrue($this->getPrivateProperty($config, 'didDiscovery'));
+
+        // Reset locator.
+        $this->resetServices();
     }
 }

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -271,6 +271,9 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->assertSame('bar', $config->foo);
     }
 
+    /**
+     * @psalm-suppress UndefinedClass
+     */
     public function testDiscoveryNotEnabledWillNotPopulateRegistrarsArray(): void
     {
         /** @var MockObject&Modules $modules */
@@ -286,6 +289,9 @@ final class BaseConfigTest extends CIUnitTestCase
         RegistrarConfig::setModules(new Modules());
     }
 
+    /**
+     * @psalm-suppress UndefinedClass
+     */
     public function testRedoingDiscoveryWillStillSetDidDiscoveryPropertyToTrue(): void
     {
         /** @var FileLocator&MockObject $locator */

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -49,8 +49,17 @@ final class BaseConfigTest extends CIUnitTestCase
             require $this->fixturesFolder . '/Encryption.php';
         }
 
-        BaseConfig::$registrars = [];
-        BaseConfig::setModules(new Modules()); // reset to clean copy of Modules
+        BaseConfig::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // This test modifies BaseConfig::$modules, so should reset.
+        BaseConfig::reset();
+        // This test modifies Services locator, so should reset.
+        $this->resetServices();
     }
 
     public function testBasicValues(): void
@@ -284,9 +293,6 @@ final class BaseConfigTest extends CIUnitTestCase
         $config = new RegistrarConfig();
 
         $this->assertSame([], $config::$registrars);
-
-        // Reset Modules Config.
-        RegistrarConfig::setModules(new Modules());
     }
 
     /**
@@ -304,8 +310,5 @@ final class BaseConfigTest extends CIUnitTestCase
         $config = new RegistrarConfig();
 
         $this->assertTrue($this->getPrivateProperty($config, 'didDiscovery'));
-
-        // Reset locator.
-        $this->resetServices();
     }
 }


### PR DESCRIPTION
**Description**
Closes #8094
Follow-up #8036

- add `BaseConfig::reset()` for testing
- reset state after testing

```console
$ ./phpunit tests/system/Config/
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.24
Configuration: /.../CodeIgniter4/phpunit.xml

................................................................................................................................. 129 / 140 ( 92%)
...........                                                                                                                       140 / 140 (100%)

Time: 00:05.899, Memory: 22.00 MB

OK (140 tests, 241 assertions)
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
