### PR TITLE
Prep for 4.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v4.4.3](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.1) (2023-10-26)
+## [v4.4.3](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.3) (2023-10-26)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.2...v4.4.3)
 
 ### SECURITY
@@ -17,7 +17,7 @@
 * docs: fix event points descriptions by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8076
 * docs: fix helper loading by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8084
 
-## [v4.4.2](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.1) (2023-10-19)
+## [v4.4.2](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.2) (2023-10-19)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.1...v4.4.2)
 
 ### Fixed Bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v4.4.3](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.1) (2023-10-26)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.2...v4.4.3)
+
+### SECURITY
+
+* *Detailed Error Report is Displayed in Production Environment* was fixed. See the [Security advisory](https://github.com/codeigniter4/CodeIgniter4/security/advisories/GHSA-hwxf-qxj7-7rfj) for more information.
+
+### Fixed Bugs
+
+* fix: FilterTestTrait::getFilterCaller() does not support Filter classes as array by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8058
+* fix: add dbgroup to model template only when specified as an option by @sammyskills in https://github.com/codeigniter4/CodeIgniter4/pull/8077
+* Update phpstan-codeigniter and fix errors on Modules by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/8036
+* fix: [Validation] exact_length does not pass int values by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8088
+* fix: [Table] field named `data` will produce bugged output by @ping-yee in https://github.com/codeigniter4/CodeIgniter4/pull/8054
+* docs: fix event points descriptions by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8076
+* docs: fix helper loading by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8084
+
 ## [v4.4.2](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.1) (2023-10-19)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.1...v4.4.2)
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -54,7 +54,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.4.2';
+    public const CI_VERSION = '4.4.3';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/v4.4.3.rst
+++ b/user_guide_src/source/changelogs/v4.4.3.rst
@@ -1,7 +1,7 @@
 Version 4.4.3
 #############
 
-Release Date: Unreleased
+Release Date: October 26, 2023
 
 **4.4.3 release of CodeIgniter4**
 
@@ -15,18 +15,6 @@ SECURITY
 - *Detailed Error Report is Displayed in Production Environment* was fixed.
   See the `Security advisory GHSA-hwxf-qxj7-7rfj <https://github.com/codeigniter4/CodeIgniter4/security/advisories/GHSA-hwxf-qxj7-7rfj>`_
   for more information.
-
-BREAKING
-********
-
-Message Changes
-***************
-
-Changes
-*******
-
-Deprecations
-************
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2019-' + str(year_now) + ' CodeIgniter Foundation'
 version = '4.4'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.4.2'
+release = '4.4.3'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_443.rst
+++ b/user_guide_src/source/installation/upgrade_443.rst
@@ -23,12 +23,6 @@ The following file received significant changes and
 
 - app/Views/errors/html/error_exception.php
 
-Breaking Changes
-****************
-
-Breaking Enhancements
-*********************
-
 Project Files
 *************
 
@@ -38,24 +32,12 @@ these files being outside of the **system** scope they will not be changed witho
 There are some third-party CodeIgniter modules available to assist with merging changes to
 the project space: `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
 
-Content Changes
-===============
-
-The following files received significant changes (including deprecations or visual adjustments)
-and it is recommended that you merge the updated versions with your application:
-
-Config
-------
-
-- @TODO
-
 All Changes
 ===========
 
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
 - app/Config/Boot/development.php
 - app/Config/Boot/production.php
 - app/Config/Boot/testing.php


### PR DESCRIPTION
**Description**
Updates changelog and version references for 4.4.3.

Previous version: #8061
Release Code: TODO
New Changelog: TODO

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
