### PR TITLE
chore: add names to github workflows

### DIFF
--- a/.github/workflows/test-autoreview.yml
+++ b/.github/workflows/test-autoreview.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   auto-review-tests:
+    name: AutoReview
     uses: ./.github/workflows/reusable-serviceless-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
       job-name: Automatic Code Review [PHP 8.1]

--- a/.github/workflows/test-autoreview.yml
+++ b/.github/workflows/test-autoreview.yml
@@ -1,4 +1,4 @@
-name: Automatic Code Review
+name: AutoReview
 
 on:
   pull_request:
@@ -23,10 +23,10 @@ permissions:
 
 jobs:
   auto-review-tests:
-    name: AutoReview
+    name: Automatic Code Review
     uses: ./.github/workflows/reusable-serviceless-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
-      job-name: Automatic Code Review [PHP 8.1]
+      job-name: PHP 8.1
       php-version: '8.1'
       job-id: auto-review-tests
       group-name: AutoReview

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -109,7 +109,7 @@ jobs:
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
-      job-name: Database Live Tests
+      job-name:
       php-version: ${{ matrix.php-version }}
       job-id: database-live-tests
       db-platform: ${{ matrix.db-platform }}
@@ -141,7 +141,7 @@ jobs:
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
-      job-name: Separate Process Tests
+      job-name:
       php-version: ${{ matrix.php-version }}
       job-id: separate-process-tests
       group-name: SeparateProcess

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -50,6 +50,7 @@ jobs:
           echo "version=8.1" >> $GITHUB_OUTPUT
 
   sanity-tests:
+    name: Others
     needs: coverage-php-version
 
     strategy:
@@ -77,6 +78,7 @@ jobs:
       extra-composer-options: ${{ matrix.composer-option }}
 
   database-live-tests:
+    name: DatabaseLive
     needs:
       - coverage-php-version
       - sanity-tests
@@ -120,6 +122,7 @@ jobs:
       extra-composer-options: ${{ matrix.composer-option }}
 
   separate-process-tests:
+    name: SeparateProcess
     needs:
       - coverage-php-version
       - sanity-tests
@@ -149,6 +152,7 @@ jobs:
       extra-composer-options: ${{ matrix.composer-option }}
 
   cache-live-tests:
+    name: CacheLive
     needs:
       - coverage-php-version
       - sanity-tests


### PR DESCRIPTION
**Description**
Shorten the names to allow elapsed time to be displayed on PR pages.

Before:
![Screenshot 2023-10-27 10 34 33](https://github.com/codeigniter4/CodeIgniter4/assets/87955/36e26be8-f076-403d-baa2-777617d840a1)

After:
![Screenshot 2023-10-27 11 38 47](https://github.com/codeigniter4/CodeIgniter4/assets/87955/01c1ee8e-e1aa-4063-9435-61f053b71deb)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
