### PR TITLE
feat: add Method/Route logging in exceptionHandler()

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -125,16 +125,21 @@ class Exceptions
 
         [$statusCode, $exitCode] = $this->determineCodes($exception);
 
+        $this->request = Services::request();
+
         if ($this->config->log === true && ! in_array($statusCode, $this->config->ignoreCodes, true)) {
-            log_message('critical', "{message}\nin {exFile} on line {exLine}.\n{trace}", [
-                'message' => $exception->getMessage(),
-                'exFile'  => clean_path($exception->getFile()), // {file} refers to THIS file
-                'exLine'  => $exception->getLine(), // {line} refers to THIS line
-                'trace'   => self::renderBacktrace($exception->getTrace()),
+            $uri       = $this->request->getPath() === '' ? '/' : $this->request->getPath();
+            $routeInfo = '[Method: ' . strtoupper($this->request->getMethod()) . ', Route: ' . $uri . ']';
+
+            log_message('critical', "{message}\n{routeInfo}\nin {exFile} on line {exLine}.\n{trace}", [
+                'message'   => $exception->getMessage(),
+                'routeInfo' => $routeInfo,
+                'exFile'    => clean_path($exception->getFile()), // {file} refers to THIS file
+                'exLine'    => $exception->getLine(), // {line} refers to THIS line
+                'trace'     => self::renderBacktrace($exception->getTrace()),
             ]);
         }
 
-        $this->request  = Services::request();
         $this->response = Services::response();
 
         // Get the first exception.


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=88724&pid=413505#pid413505

- add HTTP method and Route in Exception logging

E.g.,
```
CRITICAL - 2023-10-27 21:16:26 --> Allowed memory size of 8388608 bytes exhausted (tried to allocate 20971552 bytes)
[Method: GET, Route: /]
in APPPATH/Controllers/Home.php on line 9.
 1 [internal function]: CodeIgniter\Debug\Exceptions->shutdownHandler()
```
```
CRITICAL - 2023-10-27 21:16:49 --> Allowed memory size of 8388608 bytes exhausted (tried to allocate 20971552 bytes)
[Method: GET, Route: test]
in APPPATH/Controllers/Home.php on line 9.
 1 [internal function]: CodeIgniter\Debug\Exceptions->shutdownHandler()
```
```
CRITICAL - 2023-10-27 23:23:20 --> Allowed memory size of 8388608 bytes exhausted (tried to allocate 10485792 bytes)
[Method: CLI, Route: app:sample]
in APPPATH/Commands/Sample.php on line 59.
 1 [internal function]: CodeIgniter\Debug\Exceptions->shutdownHandler()
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
