### PR TITLE
fix: change make:command default $group to `App`

### DIFF
--- a/system/Commands/Generators/CommandGenerator.php
+++ b/system/Commands/Generators/CommandGenerator.php
@@ -67,7 +67,7 @@ class CommandGenerator extends BaseCommand
     protected $options = [
         '--command'   => 'The command name. Default: "command:name"',
         '--type'      => 'The command type. Options [basic, generator]. Default: "basic".',
-        '--group'     => 'The command group. Default: [basic -> "CodeIgniter", generator -> "Generators"].',
+        '--group'     => 'The command group. Default: [basic -> "App", generator -> "Generators"].',
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',
         '--suffix'    => 'Append the component title to the class name (e.g. User => UserCommand).',
         '--force'     => 'Force overwrite existing file.',
@@ -106,7 +106,7 @@ class CommandGenerator extends BaseCommand
         }
 
         if (! is_string($group)) {
-            $group = $type === 'generator' ? 'Generators' : 'CodeIgniter';
+            $group = $type === 'generator' ? 'Generators' : 'App';
         }
 
         return $this->parseTemplate(

--- a/tests/system/Commands/CommandGeneratorTest.php
+++ b/tests/system/Commands/CommandGeneratorTest.php
@@ -52,7 +52,7 @@ final class CommandGeneratorTest extends CIUnitTestCase
         $file = APPPATH . 'Commands/Deliver.php';
         $this->assertFileExists($file);
         $contents = $this->getFileContents($file);
-        $this->assertStringContainsString('protected $group = \'CodeIgniter\';', $contents);
+        $this->assertStringContainsString('protected $group = \'App\';', $contents);
         $this->assertStringContainsString('protected $name = \'command:name\';', $contents);
     }
 
@@ -72,7 +72,7 @@ final class CommandGeneratorTest extends CIUnitTestCase
         $file = APPPATH . 'Commands/Deliver.php';
         $this->assertFileExists($file);
         $contents = $this->getFileContents($file);
-        $this->assertStringContainsString('protected $group = \'CodeIgniter\';', $contents);
+        $this->assertStringContainsString('protected $group = \'App\';', $contents);
         $this->assertStringContainsString('protected $name = \'command:name\';', $contents);
     }
 

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -86,7 +86,7 @@ Argument:
 Options:
 ========
 * ``--command``: The command name to run in spark. Defaults to ``command:name``.
-* ``--group``: The group/namespace of the command. Defaults to ``CodeIgniter`` for basic commands, and ``Generators`` for generator commands.
+* ``--group``: The group/namespace of the command. Defaults to ``App`` for basic commands, and ``Generators`` for generator commands.
 * ``--type``: The type of command, whether a ``basic`` command or a ``generator`` command. Defaults to ``basic``.
 * ``--namespace``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
 * ``--suffix``: Append the component suffix to the generated class name.


### PR DESCRIPTION
**Description**
`CodeIgniter` is already used for the framework commands.

```
CodeIgniter
  env                Retrieves the current environment, or set a new one.
  filter:check       Check filters for a route.
  help               Displays basic usage information.
  list               Lists the available commands.
  namespaces         Verifies your namespaces are setup correctly.
  publish            Discovers and executes all predefined Publisher classes.
  routes             Displays all routes.
  serve              Launches the CodeIgniter PHP-Development Server.
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
