### PR TITLE
docs: fix @param array type for Commands

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -197,27 +197,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Database/CreateDatabase.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\CreateDatabase\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Database/CreateDatabase.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\CreateDatabase\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Database/CreateDatabase.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Database/MigrateStatus.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in a negated boolean, array\\<int\\<0, max\\>, array\\<int, mixed\\>\\> given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Database/MigrateStatus.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\MigrateStatus\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Database/MigrateStatus.php',
 ];
@@ -232,27 +217,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Database/Seed.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\Seed\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Database/Seed.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:showAllTables\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:showDataOfTable\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Database\\\\ShowTableInfo\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Database/ShowTableInfo.php',
 ];
@@ -757,24 +727,9 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Commands/Utilities/Environment.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\Environment\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Utilities/Environment.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\FilterCheck\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Utilities/FilterCheck.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Utilities/Namespaces.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\Publish\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Utilities/Publish.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Accessing offset \'HTTP_HOST\' directly on \\$_SERVER is discouraged\\.$#',
@@ -794,11 +749,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in an if condition, string\\|null given\\.$#',
 	'count' => 3,
-	'path' => __DIR__ . '/system/Commands/Utilities/Routes.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Commands\\\\Utilities\\\\Routes\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
-	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Utilities/Routes.php',
 ];
 $ignoreErrors[] = [

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -19,14 +19,14 @@ use Throwable;
 /**
  * BaseCommand is the base class used in creating CLI commands.
  *
- * @property array           $arguments
- * @property Commands        $commands
- * @property string          $description
- * @property string          $group
- * @property LoggerInterface $logger
- * @property string          $name
- * @property array           $options
- * @property string          $usage
+ * @property array<string, string> $arguments
+ * @property Commands              $commands
+ * @property string                $description
+ * @property string                $group
+ * @property LoggerInterface       $logger
+ * @property string                $name
+ * @property array<string, string> $options
+ * @property string                $usage
  */
 abstract class BaseCommand
 {
@@ -62,14 +62,14 @@ abstract class BaseCommand
     /**
      * the Command's options description
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [];
 
     /**
      * the Command's Arguments description
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [];
 

--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -52,7 +52,7 @@ class ClearCache extends BaseCommand
     /**
      * the Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'driver' => 'The cache driver to use',

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -53,7 +53,7 @@ class Migrate extends BaseCommand
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '-n'    => 'Set migration namespace',

--- a/system/Commands/Database/MigrateRefresh.php
+++ b/system/Commands/Database/MigrateRefresh.php
@@ -52,7 +52,7 @@ class MigrateRefresh extends BaseCommand
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '-n'    => 'Set migration namespace',

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -54,7 +54,7 @@ class MigrateRollback extends BaseCommand
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '-b' => 'Specify a batch to roll back to; e.g. "3" to return to batch #3',

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -52,7 +52,7 @@ class GenerateKey extends BaseCommand
     /**
      * The command's options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--force'  => 'Force overwrite existing key in `.env` file.',

--- a/system/Commands/Generators/CellGenerator.php
+++ b/system/Commands/Generators/CellGenerator.php
@@ -52,7 +52,7 @@ class CellGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The cell class name.',
@@ -61,7 +61,7 @@ class CellGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',

--- a/system/Commands/Generators/CommandGenerator.php
+++ b/system/Commands/Generators/CommandGenerator.php
@@ -53,7 +53,7 @@ class CommandGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The command class name.',
@@ -62,7 +62,7 @@ class CommandGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--command'   => 'The command name. Default: "command:name"',

--- a/system/Commands/Generators/ConfigGenerator.php
+++ b/system/Commands/Generators/ConfigGenerator.php
@@ -52,7 +52,7 @@ class ConfigGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The config class name.',
@@ -61,7 +61,7 @@ class ConfigGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',

--- a/system/Commands/Generators/ControllerGenerator.php
+++ b/system/Commands/Generators/ControllerGenerator.php
@@ -56,7 +56,7 @@ class ControllerGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The controller class name.',
@@ -65,7 +65,7 @@ class ControllerGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--bare'      => 'Extends from CodeIgniter\Controller instead of BaseController.',

--- a/system/Commands/Generators/EntityGenerator.php
+++ b/system/Commands/Generators/EntityGenerator.php
@@ -52,7 +52,7 @@ class EntityGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The entity class name.',
@@ -61,7 +61,7 @@ class EntityGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',

--- a/system/Commands/Generators/FilterGenerator.php
+++ b/system/Commands/Generators/FilterGenerator.php
@@ -52,7 +52,7 @@ class FilterGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The filter class name.',
@@ -61,7 +61,7 @@ class FilterGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',

--- a/system/Commands/Generators/MigrateCreate.php
+++ b/system/Commands/Generators/MigrateCreate.php
@@ -55,7 +55,7 @@ class MigrateCreate extends BaseCommand
     /**
      * The Command's arguments.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The migration file name.',
@@ -64,7 +64,7 @@ class MigrateCreate extends BaseCommand
     /**
      * The Command's options.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Defaults to APP_NAMESPACE',

--- a/system/Commands/Generators/MigrationGenerator.php
+++ b/system/Commands/Generators/MigrationGenerator.php
@@ -56,7 +56,7 @@ class MigrationGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The migration class name.',
@@ -65,7 +65,7 @@ class MigrationGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--session'   => 'Generates the migration file for database sessions.',

--- a/system/Commands/Generators/ModelGenerator.php
+++ b/system/Commands/Generators/ModelGenerator.php
@@ -53,7 +53,7 @@ class ModelGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The model class name.',
@@ -62,7 +62,7 @@ class ModelGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--table'     => 'Supply a table name. Default: "the lowercased plural of the class name".',

--- a/system/Commands/Generators/ScaffoldGenerator.php
+++ b/system/Commands/Generators/ScaffoldGenerator.php
@@ -53,7 +53,7 @@ class ScaffoldGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The class name',
@@ -62,7 +62,7 @@ class ScaffoldGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--bare'      => 'Add the "--bare" option to controller component.',

--- a/system/Commands/Generators/SeederGenerator.php
+++ b/system/Commands/Generators/SeederGenerator.php
@@ -52,7 +52,7 @@ class SeederGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The seeder class name.',
@@ -61,7 +61,7 @@ class SeederGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',

--- a/system/Commands/Generators/SessionMigrationGenerator.php
+++ b/system/Commands/Generators/SessionMigrationGenerator.php
@@ -59,7 +59,7 @@ class SessionMigrationGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '-t' => 'Supply a table name.',

--- a/system/Commands/Generators/ValidationGenerator.php
+++ b/system/Commands/Generators/ValidationGenerator.php
@@ -52,7 +52,7 @@ class ValidationGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The validation class name.',
@@ -61,7 +61,7 @@ class ValidationGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',

--- a/system/Commands/Help.php
+++ b/system/Commands/Help.php
@@ -53,7 +53,7 @@ class Help extends BaseCommand
     /**
      * the Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'command_name' => 'The command name [default: "help"]',
@@ -62,7 +62,7 @@ class Help extends BaseCommand
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [];
 

--- a/system/Commands/Housekeeping/ClearLogs.php
+++ b/system/Commands/Housekeeping/ClearLogs.php
@@ -51,7 +51,7 @@ class ClearLogs extends BaseCommand
     /**
      * The Command's options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--force' => 'Force delete of all logs files without prompting.',

--- a/system/Commands/ListCommands.php
+++ b/system/Commands/ListCommands.php
@@ -54,14 +54,14 @@ class ListCommands extends BaseCommand
     /**
      * the Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [];
 
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--simple' => 'Prints a list of the commands with no other info',

--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -54,7 +54,7 @@ class Serve extends BaseCommand
     /**
      * Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [];
 
@@ -75,7 +75,7 @@ class Serve extends BaseCommand
     /**
      * Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--php'  => 'The PHP Binary [default: "PHP_BINARY"]',

--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -62,7 +62,7 @@ final class Environment extends BaseCommand
     /**
      * The Command's options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [];
 

--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -63,7 +63,7 @@ class FilterCheck extends BaseCommand
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [];
 

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -57,14 +57,14 @@ class Namespaces extends BaseCommand
     /**
      * the Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [];
 
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '-c' => 'Show only CodeIgniter config namespaces.',

--- a/system/Commands/Utilities/Publish.php
+++ b/system/Commands/Utilities/Publish.php
@@ -63,7 +63,7 @@ class Publish extends BaseCommand
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [];
 

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -61,7 +61,7 @@ class Routes extends BaseCommand
     /**
      * the Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [];
 

--- a/tests/_support/Commands/Unsuffixable.php
+++ b/tests/_support/Commands/Unsuffixable.php
@@ -49,7 +49,7 @@ class Unsuffixable extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'Class name',
@@ -58,7 +58,7 @@ class Unsuffixable extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [];
 


### PR DESCRIPTION
**Description**
- make array types more accurate

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
