### PR TITLE
fix: Hot reloading when session is enabled

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -650,7 +650,7 @@ var ciDebugBar = {
     },
 
     hotReloadConnect: function () {
-        const eventSource = new EventSource(ciSiteURL + "/__hot-reload");
+        const eventSource = new EventSource(ciSiteURL + "__hot-reload");
 
         eventSource.addEventListener("reload", function (e) {
             console.log("reload", e);

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -650,7 +650,7 @@ var ciDebugBar = {
     },
 
     hotReloadConnect: function () {
-        const eventSource = new EventSource(ciSiteURL + "__hot-reload");
+        const eventSource = new EventSource(ciSiteURL + "/__hot-reload");
 
         eventSource.addEventListener("reload", function (e) {
             console.log("reload", e);

--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -23,7 +23,7 @@
 </style>
 
 <script id="toolbar_js">
-    var ciSiteURL = "<?= site_url() ?>"
+    var ciSiteURL = "<?= rtrim(site_url(), '/') ?>"
     <?= file_get_contents(__DIR__ . '/toolbar.js') ?>
 </script>
 <div id="debug-icon" class="debug-bar-ndisplay">

--- a/system/HotReloader/HotReloader.php
+++ b/system/HotReloader/HotReloader.php
@@ -18,6 +18,10 @@ final class HotReloader
 {
     public function run(): void
     {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
         ini_set('zlib.output_compression', 'Off');
 
         header('Cache-Control: no-store');


### PR DESCRIPTION
**Description**
When we use the session globally, it can block other requests as they wait for the session to be available for writing. The hot reloader runs in the background as a "long-running process".

This PR may potentially fix: 8093

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
