### PR TITLE
fix: typo in help message in `spark filter:check`

### DIFF
--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -57,7 +57,7 @@ class FilterCheck extends BaseCommand
      */
     protected $arguments = [
         'method' => 'The HTTP method. get, post, put, etc.',
-        'route'  => 'The route (URI path) to check filtes.',
+        'route'  => 'The route (URI path) to check filters.',
     ];
 
     /**


### PR DESCRIPTION
**Description**
- fix typo

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
