### PR TITLE
fix: validation rule `matches` and `differs`

### DIFF
--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -24,9 +24,10 @@ class Rules
     /**
      * The value does not match another field in $data.
      *
-     * @param array $data Other field/value pairs
+     * @param string|null $str
+     * @param array       $data Other field/value pairs
      */
-    public function differs(?string $str, string $field, array $data): bool
+    public function differs($str, string $field, array $data): bool
     {
         if (strpos($field, '.') !== false) {
             return $str !== dot_array_search($field, $data);
@@ -177,15 +178,16 @@ class Rules
     /**
      * Matches the value of another field in $data.
      *
-     * @param array $data Other field/value pairs
+     * @param string|null $str
+     * @param array       $data Other field/value pairs
      */
-    public function matches(?string $str, string $field, array $data): bool
+    public function matches($str, string $field, array $data): bool
     {
         if (strpos($field, '.') !== false) {
             return $str === dot_array_search($field, $data);
         }
 
-        return array_key_exists($field, $data) && $str === $data[$field];
+        return isset($data[$field]) ? ($str === $data[$field]) : false;
     }
 
     /**

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -187,7 +187,7 @@ class Rules
             return $str === dot_array_search($field, $data);
         }
 
-        return isset($data[$field]) ? ($str === $data[$field]) : false;
+        return isset($data[$field]) && $str === $data[$field];
     }
 
     /**

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -36,13 +36,26 @@ class Rules
      * @param array|bool|float|int|object|string|null $str
      * @param array                                   $data Other field/value pairs
      */
-    public function differs($str, string $field, array $data): bool
-    {
-        if (! is_string($str)) {
+    public function differs(
+        $str,
+        string $otherField,
+        array $data,
+        ?string $error = null,
+        ?string $field = null
+    ): bool {
+        if (strpos($otherField, '.') !== false) {
+            return $str !== dot_array_search($otherField, $data);
+        }
+
+        if (! array_key_exists($field, $data)) {
             return false;
         }
 
-        return $this->nonStrictRules->differs($str, $field, $data);
+        if (! array_key_exists($otherField, $data)) {
+            return false;
+        }
+
+        return $str !== ($data[$otherField] ?? null);
     }
 
     /**
@@ -254,9 +267,26 @@ class Rules
      * @param array|bool|float|int|object|string|null $str
      * @param array                                   $data Other field/value pairs
      */
-    public function matches($str, string $field, array $data): bool
-    {
-        return $this->nonStrictRules->matches($str, $field, $data);
+    public function matches(
+        $str,
+        string $otherField,
+        array $data,
+        ?string $error = null,
+        ?string $field = null
+    ): bool {
+        if (strpos($otherField, '.') !== false) {
+            return $str === dot_array_search($otherField, $data);
+        }
+
+        if (! array_key_exists($field, $data)) {
+            return false;
+        }
+
+        if (! array_key_exists($otherField, $data)) {
+            return false;
+        }
+
+        return $str === ($data[$otherField] ?? null);
     }
 
     /**

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -303,13 +303,13 @@ class RulesTest extends CIUnitTestCase
         yield from [
             'foo bar not exist'        => [[], false],
             'bar not exist'            => [['foo' => null], false],
-            'foo not exist'            => [['bar' => null], true], // Strict Rule: false
-            'foo bar null'             => [['foo' => null, 'bar' => null], true],
+            'foo not exist'            => [['bar' => null], false],
+            'foo bar null'             => [['foo' => null, 'bar' => null], false], // Strict Rule: true
             'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], true],
             'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], false],
-            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], false], // Strict Rule: true
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], true],
             'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], false],
-            'foo bar bool match'       => [['foo' => true, 'bar' => true], false], // Strict Rule: true
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], true],
         ];
     }
 
@@ -348,9 +348,9 @@ class RulesTest extends CIUnitTestCase
             'foo bar null'             => [['foo' => null, 'bar' => null], false],
             'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], false],
             'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], true],
-            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], true], // Strict Rule: false
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], false],
             'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], true],
-            'foo bar bool match'       => [['foo' => true, 'bar' => true], true], // Strict Rule: false
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], false],
         ];
     }
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -303,13 +303,13 @@ class RulesTest extends CIUnitTestCase
         yield from [
             'foo bar not exist'        => [[], false],
             'bar not exist'            => [['foo' => null], false],
-            'foo not exist'            => [['bar' => null], true], // should be false?
+            'foo not exist'            => [['bar' => null], true], // Strict Rule: false
             'foo bar null'             => [['foo' => null, 'bar' => null], true],
             'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], true],
             'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], false],
-            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], false], // should be true
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], false], // Strict Rule: true
             'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], false],
-            'foo bar bool match'       => [['foo' => true, 'bar' => true], false], // should be true
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], false], // Strict Rule: true
         ];
     }
 
@@ -348,9 +348,9 @@ class RulesTest extends CIUnitTestCase
             'foo bar null'             => [['foo' => null, 'bar' => null], false],
             'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], false],
             'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], true],
-            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], true], // should be false
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], true], // Strict Rule: false
             'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], true],
-            'foo bar bool match'       => [['foo' => true, 'bar' => true], true], // should be false
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], true], // Strict Rule: false
         ];
     }
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -290,7 +290,7 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideMatchesCases
+     * @dataProvider provideMatches
      */
     public function testMatches(array $data, bool $expected): void
     {
@@ -298,12 +298,18 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
-    public static function provideMatchesCases(): iterable
+    public static function provideMatches(): iterable
     {
         yield from [
-            [['foo' => null, 'bar' => null], true],
-            [['foo' => 'match', 'bar' => 'match'], true],
-            [['foo' => 'match', 'bar' => 'nope'], false],
+            'foo bar not exist'        => [[], false],
+            'bar not exist'            => [['foo' => null], false],
+            'foo not exist'            => [['bar' => null], true], // should be false?
+            'foo bar null'             => [['foo' => null, 'bar' => null], true],
+            'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], true],
+            'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], false],
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], false], // should be true
+            'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], false],
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], false], // should be true
         ];
     }
 
@@ -325,12 +331,27 @@ class RulesTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideMatchesCases
+     * @dataProvider provideDiffers
      */
     public function testDiffers(array $data, bool $expected): void
     {
         $this->validation->setRules(['foo' => 'differs[bar]']);
-        $this->assertSame(! $expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public static function provideDiffers(): iterable
+    {
+        yield from [
+            'foo bar not exist'        => [[], false],
+            'bar not exist'            => [['foo' => null], false],
+            'foo not exist'            => [['bar' => null], false],
+            'foo bar null'             => [['foo' => null, 'bar' => null], false],
+            'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], false],
+            'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], true],
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], true], // should be false
+            'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], true],
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], true], // should be false
+        ];
     }
 
     /**

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -213,16 +213,13 @@ final class RulesTest extends TraditionalRulesTest
         yield from [
             'foo bar not exist'        => [[], false],
             'bar not exist'            => [['foo' => null], false],
-            'foo not exist'            => [['bar' => null], true],
+            'foo not exist'            => [['bar' => null], false],
             'foo bar null'             => [['foo' => null, 'bar' => null], true],
             'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], true],
             'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], false],
-            // TypeError: CodeIgniter\Validation\Rules::matches(): Argument #1 ($str) must be of type ?string, float given
-            // 'foo bar float match' => [['foo' => 1.2, 'bar' => 1.2], true],
-            // TypeError: CodeIgniter\Validation\Rules::matches(): Argument #1 ($str) must be of type ?string, float given
-            // 'foo bar float not match' => [['foo' => 1.2, 'bar' => 2.3], false],
-            // TypeError: CodeIgniter\Validation\Rules::matches(): Argument #1 ($str) must be of type ?string, float given
-            // 'foo bar bool match' => [['foo' => true, 'bar' => true], true],
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], true],
+            'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], false],
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], true],
         ];
     }
 
@@ -245,7 +242,7 @@ final class RulesTest extends TraditionalRulesTest
             'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], false],
             'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], true],
             'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], false],
-            'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], false],
+            'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], true],
             'foo bar bool match'       => [['foo' => true, 'bar' => true], false],
         ];
     }

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -198,4 +198,55 @@ final class RulesTest extends TraditionalRulesTest
             [true, '0', false],
         ];
     }
+
+    /**
+     * @dataProvider provideMatches
+     */
+    public function testMatches(array $data, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'matches[bar]']);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public static function provideMatches(): iterable
+    {
+        yield from [
+            'foo bar not exist'        => [[], false],
+            'bar not exist'            => [['foo' => null], false],
+            'foo not exist'            => [['bar' => null], true],
+            'foo bar null'             => [['foo' => null, 'bar' => null], true],
+            'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], true],
+            'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], false],
+            // TypeError: CodeIgniter\Validation\Rules::matches(): Argument #1 ($str) must be of type ?string, float given
+            // 'foo bar float match' => [['foo' => 1.2, 'bar' => 1.2], true],
+            // TypeError: CodeIgniter\Validation\Rules::matches(): Argument #1 ($str) must be of type ?string, float given
+            // 'foo bar float not match' => [['foo' => 1.2, 'bar' => 2.3], false],
+            // TypeError: CodeIgniter\Validation\Rules::matches(): Argument #1 ($str) must be of type ?string, float given
+            // 'foo bar bool match' => [['foo' => true, 'bar' => true], true],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDiffers
+     */
+    public function testDiffers(array $data, bool $expected): void
+    {
+        $this->validation->setRules(['foo' => 'differs[bar]']);
+        $this->assertSame($expected, $this->validation->run($data));
+    }
+
+    public static function provideDiffers(): iterable
+    {
+        yield from [
+            'foo bar not exist'        => [[], false],
+            'bar not exist'            => [['foo' => null], false],
+            'foo not exist'            => [['bar' => null], false],
+            'foo bar null'             => [['foo' => null, 'bar' => null], false],
+            'foo bar string match'     => [['foo' => 'match', 'bar' => 'match'], false],
+            'foo bar string not match' => [['foo' => 'match', 'bar' => 'nope'], true],
+            'foo bar float match'      => [['foo' => 1.2, 'bar' => 1.2], false],
+            'foo bar float not match'  => [['foo' => 1.2, 'bar' => 2.3], false],
+            'foo bar bool match'       => [['foo' => true, 'bar' => true], false],
+        ];
+    }
 }

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -21,6 +21,12 @@ A validation rule with the wildcard ``*`` now validates only data in correct
 dimensions as "dot array syntax".
 See :ref:`Upgrading <upgrade-444-validation-with-dot-array-syntax>` for details.
 
+Validation rules matches and differs
+====================================
+
+Bugs have been fixed in the case where ``matches`` and ``differs`` in the Strict
+and Traditional rules validate data of non-string types.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/installation/upgrade_444.rst
+++ b/user_guide_src/source/installation/upgrade_444.rst
@@ -39,6 +39,17 @@ The following code explains details:
 
 If you have code that depends on the bug, fix the the rule key.
 
+Validation rules matches and differs
+====================================
+
+Because bugs have been fixed in the case where ``matches`` and ``differs`` in
+the Strict and Traditional rules validate data of non-string types, if you are
+using these rules and validate non-string data, the validation results might be
+changed (fixed).
+
+Note that Traditional Rules should not be used to validate data that is not a
+string.
+
 *********************
 Breaking Enhancements
 *********************


### PR DESCRIPTION
**Description**
- fix TypeError in Strict Rules
- fix behaviors
  - Strict Rules: https://github.com/codeigniter4/CodeIgniter4/pull/8122/commits/e89fbd8fbf7454e3c6e8d22f4798e266c8493ba4#diff-7418849ccba3c428c9c850f68e98a540d116ead6b80e37e0963290bc861207fe
  - Traditional Rules are changed to the same as CI3 behavior: https://github.com/codeigniter4/CodeIgniter4/pull/8122/commits/36c0de9d9040372a3d7e73f4ccceede117033805#diff-cf7521c5d54b849f1a6fab1604700fdb41c3319230f71eab68e5922c099531f9

Note: Adding `?string` in CI4 makes the behavior different from that of CI3. There may be similar bugs in other Traditional Rules.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
