### PR TITLE
fix: [DebugBar] dark mode timeline "Controller"

### DIFF
--- a/admin/css/debug-toolbar/_theme-dark.scss
+++ b/admin/css/debug-toolbar/_theme-dark.scss
@@ -150,10 +150,6 @@
         .timer {
             background-color: $g-orange;
         }
-
-        .timeline-parent-open td {
-            color: $t-dark;
-        }
     }
 }
 

--- a/contributing/css.md
+++ b/contributing/css.md
@@ -9,7 +9,9 @@ the official website: <https://sass-lang.com/install>
 Open your terminal, and navigate to CodeIgniter's root folder. To
 generate the CSS file, use the following command:
 
-`sass --no-source-map admin/css/debug-toolbar/toolbar.scss system/Debug/Toolbar/Views/toolbar.css`
+```console
+sass --no-source-map admin/css/debug-toolbar/toolbar.scss system/Debug/Toolbar/Views/toolbar.css`
+```
 
 Details:
 - `--no-source-map` is an option which prevents sourcemap files from being generated
@@ -18,23 +20,4 @@ Details:
 
 ## Color scheme
 
-**Themes**
-
-Dark: `#252525` / `rgb(37, 37, 37)`
-Light: `#FFFFFF` / `rgb(255, 255, 255)`
-
-**Glossy colors**
-
-Blue: `#5BC0DE` / `rgb(91, 192, 222)`
-Gray: `#434343` / `rgb(67, 67, 67)`
-Green: `#9ACE25` / `rgb(154, 206, 37)`
-Orange: `#DD8615` / `rgb(221, 134, 21)`
-Red: `#DD4814` / `rgb(221, 72, 20)`
-
-**Matt colors**
-
-Blue: `#D8EAF0` / `rgb(216, 234, 240)`
-Gray: `#DFDFDF` / `rgb(223, 223, 223)`
-Green: `#DFF0D8` / `rgb(223, 240, 216)`
-Orange: `#FDC894` / `rgb(253, 200, 148)`
-Red: `#EF9090` / `rgb(239, 144, 144)`
+See [_graphic-charter.scss](../admin/css/debug-toolbar/_graphic-charter.scss).

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -532,9 +532,6 @@
   #debug-bar .timeline .timer {
     background-color: #DD8615;
   }
-  #debug-bar .timeline .timeline-parent-open td {
-    color: #252525;
-  }
   .debug-view.show-view {
     border-color: #DD8615;
   }
@@ -646,9 +643,6 @@
 }
 #toolbarContainer.dark #debug-bar .timeline .timer {
   background-color: #DD8615;
-}
-#toolbarContainer.dark #debug-bar .timeline .timeline-parent-open td {
-  color: #252525;
 }
 #toolbarContainer.dark .debug-view.show-view {
   border-color: #DD8615;


### PR DESCRIPTION
**Description**
Fixes #8064

Before:
<img width="1116" alt="Screenshot 2023-10-30 16 32 03" src="https://github.com/codeigniter4/CodeIgniter4/assets/87955/1a98cb28-171b-40ba-8091-312a02be1356">

After:
<img width="1116" alt="Screenshot 2023-10-30 16 32 14" src="https://github.com/codeigniter4/CodeIgniter4/assets/87955/70b0aa42-eb3e-4d6a-ae53-87885ffa9e8d">

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
