### PR TITLE
fix: Validation rule with `*` gets incorrect values as dot array syntax

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -170,16 +170,9 @@ class Validation implements ValidationInterface
             if (strpos($field, '*') !== false) {
                 $flattenedArray = array_flatten_with_dots($data);
 
-                $pattern = '/\A'
-                    . str_replace(
-                        ['\.\*', '\*\.'],
-                        ['\.[^.]+', '[^.]+\.'],
-                        preg_quote($field, '/')
-                    )
-                    . '\z/';
                 $values = array_filter(
                     $flattenedArray,
-                    static fn ($key) => preg_match($pattern, $key),
+                    static fn ($key) => preg_match(self::getRegex($field), $key),
                     ARRAY_FILTER_USE_KEY
                 );
 
@@ -218,6 +211,20 @@ class Validation implements ValidationInterface
         }
 
         return false;
+    }
+
+    /**
+     * Returns regex pattern for key with dot array syntax.
+     */
+    private static function getRegex(string $field): string
+    {
+        return '/\A'
+            . str_replace(
+                ['\.\*', '\*\.'],
+                ['\.[^.]+', '[^.]+\.'],
+                preg_quote($field, '/')
+            )
+            . '\z/';
     }
 
     /**
@@ -823,15 +830,7 @@ class Validation implements ValidationInterface
      */
     public function hasError(string $field): bool
     {
-        $pattern = '/\A'
-            . str_replace(
-                ['\.\*', '\*\.'],
-                ['\.[^.]+', '[^.]+\.'],
-                preg_quote($field, '/')
-            )
-            . '\z/';
-
-        return (bool) preg_grep($pattern, array_keys($this->getErrors()));
+        return (bool) preg_grep(self::getRegex($field), array_keys($this->getErrors()));
     }
 
     /**
@@ -844,16 +843,9 @@ class Validation implements ValidationInterface
             $field = array_key_first($this->rules);
         }
 
-        $pattern = '/\A'
-            . str_replace(
-                ['\.\*', '\*\.'],
-                ['\.[^.]+', '[^.]+\.'],
-                preg_quote($field, '/')
-            )
-            . '\z/';
         $errors = array_filter(
             $this->getErrors(),
-            static fn ($key) => preg_match($pattern, $key),
+            static fn ($key) => preg_match(self::getRegex($field), $key),
             ARRAY_FILTER_USE_KEY
         );
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1228,17 +1228,17 @@ class ValidationTest extends CIUnitTestCase
     }
 
     /**
-     * @dataProvider provideDotNotationOnIfExistRule
+     * @dataProvider provideIfExistRuleWithAsterisk
      *
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4521
      */
-    public function testDotNotationOnIfExistRule(bool $expected, array $rules, array $data): void
+    public function testIfExistRuleWithAsterisk(bool $expected, array $rules, array $data): void
     {
         $actual = $this->validation->setRules($rules)->run($data);
         $this->assertSame($expected, $actual);
     }
 
-    public static function provideDotNotationOnIfExistRule(): iterable
+    public static function provideIfExistRuleWithAsterisk(): iterable
     {
         yield 'dot-on-end-fail' => [
             false,
@@ -1613,7 +1613,7 @@ class ValidationTest extends CIUnitTestCase
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/5942
      */
-    public function testRequireWithoutWithWildCard(): void
+    public function testRequireWithoutWithAsterisk(): void
     {
         $data = [
             'a' => [

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1111,9 +1111,9 @@ class ValidationTest extends CIUnitTestCase
         $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
 
         $this->validation->setRules([
-            'id_user.*'       => 'numeric',
-            'name_user.*'     => 'alpha',
-            'contacts.*.name' => 'required',
+            'id_user.*'               => 'numeric',
+            'name_user.*'             => 'alpha',
+            'contacts.friends.*.name' => 'required',
         ]);
 
         $this->validation->withRequest($request->withMethod('post'))->run();
@@ -1121,7 +1121,7 @@ class ValidationTest extends CIUnitTestCase
             'id_user.0'               => 'The id_user.* field must contain only numbers.',
             'name_user.0'             => 'The name_user.* field may only contain alphabetical characters.',
             'name_user.2'             => 'The name_user.* field may only contain alphabetical characters.',
-            'contacts.friends.0.name' => 'The contacts.*.name field is required.',
+            'contacts.friends.0.name' => 'The contacts.friends.*.name field is required.',
         ], $this->validation->getErrors());
 
         $this->assertSame(
@@ -1130,8 +1130,8 @@ class ValidationTest extends CIUnitTestCase
             $this->validation->getError('name_user.*')
         );
         $this->assertSame(
-            'The contacts.*.name field is required.',
-            $this->validation->getError('contacts.*.name')
+            'The contacts.friends.*.name field is required.',
+            $this->validation->getError('contacts.friends.*.name')
         );
     }
 

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -14,6 +14,13 @@ Release Date: Unreleased
 BREAKING
 ********
 
+Validation with Dot Array Syntax
+================================
+
+A validation rule with the wildcard ``*`` now validates only data in correct
+dimensions as "dot array syntax".
+See :ref:`Upgrading <upgrade-444-validation-with-dot-array-syntax>` for details.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/installation/upgrade_444.rst
+++ b/user_guide_src/source/installation/upgrade_444.rst
@@ -20,6 +20,25 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+.. _upgrade-444-validation-with-dot-array-syntax:
+
+Validation with Dot Array Syntax
+================================
+
+If you are using :ref:`dot array syntax <validation-dot-array-syntax>` in validation
+rules, a bug where ``*`` would validate data in incorrect dimensions has been fixed.
+
+In previous versions, the rule key ``contacts.*.name`` captured data with any
+level like ``contacts.*.name``, ``contacts.*.*.name``, ``contacts.*.*.*.name``,
+etc., incorrectly.
+
+The following code explains details:
+
+.. literalinclude:: upgrade_444/001.php
+   :lines: 2-
+
+If you have code that depends on the bug, fix the the rule key.
+
 *********************
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/installation/upgrade_444/001.php
+++ b/user_guide_src/source/installation/upgrade_444/001.php
@@ -1,0 +1,38 @@
+<?php
+
+use Config\Services;
+
+$validation = Services::validation();
+
+$data = [
+    'contacts' => [
+        'name' => 'Joe Smith',
+        'just' => [
+            'friends' => [
+                ['name' => 'SATO Taro'],
+                ['name' => 'Li Ming'],
+                ['name' => 'Heinz Müller'],
+            ],
+        ],
+    ],
+];
+
+$validation->setRules(
+    ['contacts.*.name' => 'required|max_length[8]']
+);
+
+$validation->run($data); // false
+
+d($validation->getErrors());
+/*
+ Before: Captured `contacts.*.*.*.name` incorrectly.
+ [
+   contacts.just.friends.0.name => "The contacts.*.name field cannot exceed 8 characters in length.",
+   contacts.just.friends.2.name => "The contacts.*.name field cannot exceed 8 characters in length.",
+ ]
+
+ After: Captures no data for `contacts.*.name`.
+ [
+   contacts.*.name => string (38) "The contacts.*.name field is required.",
+ ]
+*/

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -591,7 +591,7 @@ If you need to retrieve all error messages for failed fields, you can use the ``
 
 If no errors exist, an empty array will be returned.
 
-When using a wildcard, the error will point to a specific field, replacing the asterisk with the appropriate key/keys::
+When using a wildcard (``*``), the error will point to a specific field, replacing the asterisk with the appropriate key/keys::
 
     // for data
     'contacts' => [
@@ -606,10 +606,10 @@ When using a wildcard, the error will point to a specific field, replacing the a
     ]
 
     // rule
-    'contacts.*.name' => 'required'
+    'contacts.friends.*.name' => 'required'
 
     // error will be
-    'contacts.friends.1.name' => 'The contacts.*.name field is required.'
+    'contacts.friends.1.name' => 'The contacts.friends.*.name field is required.'
 
 Getting a Single Error
 ======================

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -314,6 +314,8 @@ To give a labeled error message you can set up as:
 .. note:: ``setRules()`` will overwrite any rules that were set previously. To add more than one
     rule to an existing set of rules, use ``setRule()`` multiple times.
 
+.. _validation-dot-array-syntax:
+
 Setting Rules for Array Data
 ============================
 
@@ -327,6 +329,10 @@ You can use the ``*`` wildcard symbol to match any one level of the array:
 
 .. literalinclude:: validation/010.php
    :lines: 2-
+
+.. note:: Prior to v4.4.4, due to a bug, the wildcard ``*`` validated data in incorrect
+    dimensions. See :ref:`Upgrading <upgrade-444-validation-with-dot-array-syntax>`
+    for details.
 
 "dot array syntax" can also be useful when you have single dimension array data.
 For example, data returned by multi select dropdown:

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -830,7 +830,8 @@ alpha_numeric_punct     No         Fails if field contains anything other than
                                    alphanumeric, space, or this limited set of
                                    punctuation characters: ``~`` (tilde),
                                    ``!`` (exclamation), ``#`` (number),
-                                   ``$`` (dollar), ``% (percent), & (ampersand),
+                                   ``$`` (dollar), ``%`` (percent),
+                                   ``&`` (ampersand),
                                    ``*`` (asterisk), ``-`` (dash),
                                    ``_`` (underscore), ``+`` (plus),
                                    ``=`` (equals), ``|`` (vertical bar),

--- a/user_guide_src/source/libraries/validation/009.php
+++ b/user_guide_src/source/libraries/validation/009.php
@@ -4,7 +4,7 @@
  * The data to test:
  * [
  *     'contacts' => [
- *        'name' => 'Joe Smith',
+ *         'name' => 'Joe Smith',
  *         'friends' => [
  *             [
  *                 'name' => 'Fred Flinstone',
@@ -20,9 +20,4 @@
 // Joe Smith
 $validation->setRules([
     'contacts.name' => 'required|max_length[60]',
-]);
-
-// Fred Flintsone & Wilma
-$validation->setRules([
-    'contacts.friends.name' => 'required|max_length[60]',
 ]);

--- a/user_guide_src/source/libraries/validation/010.php
+++ b/user_guide_src/source/libraries/validation/010.php
@@ -2,5 +2,5 @@
 
 // Fred Flintsone & Wilma
 $validation->setRules([
-    'contacts.*.name' => 'required|max_length[60]',
+    'contacts.friends.*.name' => 'required|max_length[60]',
 ]);


### PR DESCRIPTION
**Description**
Fixes #8128
Superseds #8126

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
