### PR TITLE
refactor: move ArrayHelper class

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2293,7 +2293,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 3,
+	'count' => 2,
 	'path' => __DIR__ . '/system/Helpers/array_helper.php',
 ];
 $ignoreErrors[] = [

--- a/system/Commands/Translation/LocalizationFinder.php
+++ b/system/Commands/Translation/LocalizationFinder.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Commands\Translation;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\Commands\Translation\LocalizationFinder\ArrayHelper;
+use CodeIgniter\Helpers\Array\ArrayHelper;
 use Config\App;
 use Locale;
 use RecursiveDirectoryIterator;

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -17,8 +17,10 @@ namespace CodeIgniter\Helpers\Array;
 final class ArrayHelper
 {
     /**
-     * Searches an array through dot syntax. Supports
-     * wildcard searches, like foo.*.bar
+     * Searches an array through dot syntax. Supports wildcard searches,
+     * like `foo.*.bar`.
+     *
+     * @used-by dot_array_search()
      *
      * @return array|bool|int|object|string|null
      */
@@ -38,8 +40,9 @@ final class ArrayHelper
     }
 
     /**
-     * Used by `dotArraySearch()` to recursively search the
-     * array with wildcards.
+     * Recursively search the array with wildcards.
+     *
+     * @used-by dotSearch()
      *
      * @return array|bool|float|int|object|string|null
      */
@@ -101,6 +104,8 @@ final class ArrayHelper
     /**
      * Groups all rows by their index values. Result's depth equals number of indexes
      *
+     * @used-by array_group_by()
+     *
      * @param array $array        Data array (i.e. from query result)
      * @param array $indexes      Indexes to group by. Dot syntax used. Returns $array if empty
      * @param bool  $includeEmpty If true, null and '' are also added as valid keys to group
@@ -123,10 +128,10 @@ final class ArrayHelper
     }
 
     /**
-     * Used by `arrayGroupBy()` to recursively attach $row to the $indexes path of values found by
-     * `dot_array_search()`
+     * Recursively attach $row to the $indexes path of values found by
+     * `dot_array_search()`.
      *
-     * @internal This should not be used on its own
+     * @used-by groupBy()
      */
     private static function arrayAttachIndexedValue(array $result, array $row, array $indexes, bool $includeEmpty): array
     {

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -12,6 +12,11 @@
 namespace CodeIgniter\Helpers\Array;
 
 /**
+ * @interal This is internal implementation for the framework.
+ *
+ * If there are any methods that should be provided, make them
+ * public APIs via helper functions.
+ *
  * @see \CodeIgniter\Helpers\Array\ArrayHelperRecursiveDiffTest
  */
 final class ArrayHelper

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -133,8 +133,12 @@ final class ArrayHelper
      *
      * @used-by groupBy()
      */
-    private static function arrayAttachIndexedValue(array $result, array $row, array $indexes, bool $includeEmpty): array
-    {
+    private static function arrayAttachIndexedValue(
+        array $result,
+        array $row,
+        array $indexes,
+        bool $includeEmpty
+    ): array {
         if (($index = array_shift($indexes)) === null) {
             $result[] = $row;
 

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Helpers\Array;
 /**
  * @see \CodeIgniter\Helpers\Array\ArrayHelperTest
  */
-class ArrayHelper
+final class ArrayHelper
 {
     /**
      * Compare recursively two associative arrays and return difference as new array.

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Helpers\Array;
 
 /**
- * @see \CodeIgniter\Helpers\Array\ArrayHelperTest
+ * @see \CodeIgniter\Helpers\Array\ArrayHelperRecursiveDiffTest
  */
 final class ArrayHelper
 {

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -9,10 +9,10 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Commands\Translation\LocalizationFinder;
+namespace CodeIgniter\Helpers\Array;
 
 /**
- * @see \CodeIgniter\Commands\Translation\LocalizationFinder\ArrayHelperTest
+ * @see \CodeIgniter\Helpers\Array\ArrayHelperTest
  */
 class ArrayHelper
 {

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -22,7 +22,7 @@ final class ArrayHelper
      *
      * @return array|bool|int|object|string|null
      */
-    public static function dotArraySearch(string $index, array $array)
+    public static function dotSearch(string $index, array $array)
     {
         // See https://regex101.com/r/44Ipql/1
         $segments = preg_split(
@@ -107,7 +107,7 @@ final class ArrayHelper
      *
      * @return array Result array where rows are grouped together by indexes values.
      */
-    public static function arrayGroupBy(array $array, array $indexes, bool $includeEmpty = false): array
+    public static function groupBy(array $array, array $indexes, bool $includeEmpty = false): array
     {
         if ($indexes === []) {
             return $array;

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -85,7 +85,7 @@ final class ArrayHelper
 
         // If this is the last index, make sure to return it now,
         // and not try to recurse through things.
-        if (empty($indexes)) {
+        if ($indexes === []) {
             return $array[$currentIndex];
         }
 

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -9,6 +9,8 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+use CodeIgniter\Helpers\Array\ArrayHelper;
+
 // CodeIgniter Array Helpers
 
 if (! function_exists('dot_array_search')) {
@@ -20,82 +22,7 @@ if (! function_exists('dot_array_search')) {
      */
     function dot_array_search(string $index, array $array)
     {
-        // See https://regex101.com/r/44Ipql/1
-        $segments = preg_split(
-            '/(?<!\\\\)\./',
-            rtrim($index, '* '),
-            0,
-            PREG_SPLIT_NO_EMPTY
-        );
-
-        $segments = array_map(static fn ($key) => str_replace('\.', '.', $key), $segments);
-
-        return _array_search_dot($segments, $array);
-    }
-}
-
-if (! function_exists('_array_search_dot')) {
-    /**
-     * Used by `dot_array_search` to recursively search the
-     * array with wildcards.
-     *
-     * @internal This should not be used on its own.
-     *
-     * @return array|bool|float|int|object|string|null
-     */
-    function _array_search_dot(array $indexes, array $array)
-    {
-        // If index is empty, returns null.
-        if ($indexes === []) {
-            return null;
-        }
-
-        // Grab the current index
-        $currentIndex = array_shift($indexes);
-
-        if (! isset($array[$currentIndex]) && $currentIndex !== '*') {
-            return null;
-        }
-
-        // Handle Wildcard (*)
-        if ($currentIndex === '*') {
-            $answer = [];
-
-            foreach ($array as $value) {
-                if (! is_array($value)) {
-                    return null;
-                }
-
-                $answer[] = _array_search_dot($indexes, $value);
-            }
-
-            $answer = array_filter($answer, static fn ($value) => $value !== null);
-
-            if ($answer !== []) {
-                if (count($answer) === 1) {
-                    // If array only has one element, we return that element for BC.
-                    return current($answer);
-                }
-
-                return $answer;
-            }
-
-            return null;
-        }
-
-        // If this is the last index, make sure to return it now,
-        // and not try to recurse through things.
-        if (empty($indexes)) {
-            return $array[$currentIndex];
-        }
-
-        // Do we need to recursively search this value?
-        if (is_array($array[$currentIndex]) && $array[$currentIndex] !== []) {
-            return _array_search_dot($indexes, $array[$currentIndex]);
-        }
-
-        // Otherwise, not found.
-        return null;
+        return ArrayHelper::dotArraySearch($index, $array);
     }
 }
 
@@ -231,55 +158,6 @@ if (! function_exists('array_group_by')) {
      */
     function array_group_by(array $array, array $indexes, bool $includeEmpty = false): array
     {
-        if ($indexes === []) {
-            return $array;
-        }
-
-        $result = [];
-
-        foreach ($array as $row) {
-            $result = _array_attach_indexed_value($result, $row, $indexes, $includeEmpty);
-        }
-
-        return $result;
-    }
-}
-
-if (! function_exists('_array_attach_indexed_value')) {
-    /**
-     * Used by `array_group_by` to recursively attach $row to the $indexes path of values found by
-     * `dot_array_search`
-     *
-     * @internal This should not be used on its own
-     */
-    function _array_attach_indexed_value(array $result, array $row, array $indexes, bool $includeEmpty): array
-    {
-        if (($index = array_shift($indexes)) === null) {
-            $result[] = $row;
-
-            return $result;
-        }
-
-        $value = dot_array_search($index, $row);
-
-        if (! is_scalar($value)) {
-            $value = '';
-        }
-
-        if (is_bool($value)) {
-            $value = (int) $value;
-        }
-
-        if (! $includeEmpty && $value === '') {
-            return $result;
-        }
-
-        if (! array_key_exists($value, $result)) {
-            $result[$value] = [];
-        }
-
-        $result[$value] = _array_attach_indexed_value($result[$value], $row, $indexes, $includeEmpty);
-
-        return $result;
+        return ArrayHelper::arrayGroupBy($array, $indexes, $includeEmpty);
     }
 }

--- a/system/Helpers/array_helper.php
+++ b/system/Helpers/array_helper.php
@@ -22,7 +22,7 @@ if (! function_exists('dot_array_search')) {
      */
     function dot_array_search(string $index, array $array)
     {
-        return ArrayHelper::dotArraySearch($index, $array);
+        return ArrayHelper::dotSearch($index, $array);
     }
 }
 
@@ -158,6 +158,6 @@ if (! function_exists('array_group_by')) {
      */
     function array_group_by(array $array, array $indexes, bool $includeEmpty = false): array
     {
-        return ArrayHelper::arrayGroupBy($array, $indexes, $includeEmpty);
+        return ArrayHelper::groupBy($array, $indexes, $includeEmpty);
     }
 }

--- a/tests/system/Helpers/Array/ArrayHelperRecursiveDiffTest.php
+++ b/tests/system/Helpers/Array/ArrayHelperRecursiveDiffTest.php
@@ -18,7 +18,7 @@ use CodeIgniter\Test\CIUnitTestCase;
  *
  * @internal
  */
-final class ArrayHelperTest extends CIUnitTestCase
+final class ArrayHelperRecursiveDiffTest extends CIUnitTestCase
 {
     private array $compareWith;
 

--- a/tests/system/Helpers/Array/ArrayHelperTest.php
+++ b/tests/system/Helpers/Array/ArrayHelperTest.php
@@ -9,7 +9,7 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace CodeIgniter\Commands\Translation\LocalizationFinder;
+namespace CodeIgniter\Helpers\Array;
 
 use CodeIgniter\Test\CIUnitTestCase;
 


### PR DESCRIPTION
**Description**
- move `ArrayHelper` class to `system/Helpers/Array`
- move code from `array_helper.php` to `ArrayHelper.php`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
