### PR TITLE
docs: fix incorrect sample code in ajax.rst

### DIFF
--- a/user_guide_src/source/general/ajax.rst
+++ b/user_guide_src/source/general/ajax.rst
@@ -18,7 +18,7 @@ Fetch API
 .. code-block:: javascript
 
     fetch(url, {
-        method: "get",
+        method: "POST",
         headers: {
           "Content-Type": "application/json",
           "X-Requested-With": "XMLHttpRequest"


### PR DESCRIPTION
**Description**
It is not valid that "application/json" and "GET".
The HTTP method names are case-sensitive, and it is not "get" but "GET".
> The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names. By convention, standardized methods are defined in all-uppercase US-ASCII letters.
https://www.rfc-editor.org/rfc/rfc9110#name-overview

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
