### PR TITLE
[4.5] test: fix ShowTableInfoTest::testDbTableShowsDBConfig()

### DIFF
--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -66,7 +66,7 @@ final class ShowTableInfoTest extends CIUnitTestCase
 
     public function testDbTableShowsDBConfig(): void
     {
-        command('db:table');
+        command('db:table --show');
 
         $result = $this->getNormalizedResult();
 


### PR DESCRIPTION
**Description**
- fix test that waits user input forever

```console
$ php spark db:table

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-03 04:34:35 UTC+00:00

+-----------+----------+----------+----------+----------+------+
| hostname  | database | username | DBDriver | DBPrefix | port |
+-----------+----------+----------+----------+----------+------+
| localhost | ci4      | root     | MySQLi   |          | 3306 |
+-----------+----------+----------+----------+----------+------+

Here is the list of your database tables:
  [0]  migrations

Which table do you want to see? 0: 
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
