### PR TITLE
docs: remove unneeded @deprecated in ResponseInterface::getStatusCode()

### DIFF
--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -110,8 +110,6 @@ interface ResponseInterface extends MessageInterface
      * to understand and satisfy the request.
      *
      * @return int Status code.
-     *
-     * @deprecated To be replaced by the PSR-7 version (compatible)
      */
     public function getStatusCode(): int;
 


### PR DESCRIPTION
**Description**
See 
- https://github.com/php-fig/http-message/blob/2.0/src/ResponseInterface.php#L30
- https://github.com/codeigniter4/CodeIgniter4/pull/3946/files#diff-2cab244a084ce08ac666dff9a88aee13003b4170f6c02a690263e3260dac26d8R32

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
