### PR TITLE
fix: PHPDoc types in controller.tpl.php

### DIFF
--- a/system/Commands/Generators/Views/controller.tpl.php
+++ b/system/Commands/Generators/Views/controller.tpl.php
@@ -3,6 +3,7 @@
 namespace {namespace};
 
 use {useStatement};
+use CodeIgniter\HTTP\ResponseInterface;
 
 class {class} extends {extends}
 {
@@ -10,7 +11,7 @@ class {class} extends {extends}
     /**
      * Return an array of resource objects, themselves in array format
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function index()
     {
@@ -20,7 +21,7 @@ class {class} extends {extends}
     /**
      * Return the properties of a resource object
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function show($id = null)
     {
@@ -30,7 +31,7 @@ class {class} extends {extends}
     /**
      * Return a new resource object, with default properties
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function new()
     {
@@ -40,7 +41,7 @@ class {class} extends {extends}
     /**
      * Create a new resource object, from "posted" parameters
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function create()
     {
@@ -50,7 +51,7 @@ class {class} extends {extends}
     /**
      * Return the editable properties of a resource object
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function edit($id = null)
     {
@@ -60,7 +61,7 @@ class {class} extends {extends}
     /**
      * Add or update a model resource, from "posted" properties
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function update($id = null)
     {
@@ -70,7 +71,7 @@ class {class} extends {extends}
     /**
      * Delete the designated resource object from the model
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function delete($id = null)
     {
@@ -80,7 +81,7 @@ class {class} extends {extends}
     /**
      * Present a view of resource objects
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function index()
     {
@@ -90,9 +91,9 @@ class {class} extends {extends}
     /**
      * Present a view to present a specific resource object
      *
-     * @param mixed $id
+     * @param string $id
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function show($id = null)
     {


### PR DESCRIPTION
**Description**
See #6310

- fix PHPDoc types in `controller.tpl.php`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
