### PR TITLE
fix: `@return` in filter.tpl.php

### DIFF
--- a/system/Commands/Generators/Views/filter.tpl.php
+++ b/system/Commands/Generators/Views/filter.tpl.php
@@ -21,7 +21,7 @@ class {class} implements FilterInterface
      * @param RequestInterface $request
      * @param array|null       $arguments
      *
-     * @return mixed
+     * @return RequestInterface|ResponseInterface|string|void
      */
     public function before(RequestInterface $request, $arguments = null)
     {
@@ -38,7 +38,7 @@ class {class} implements FilterInterface
      * @param ResponseInterface $response
      * @param array|null        $arguments
      *
-     * @return mixed
+     * @return ResponseInterface|void
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {


### PR DESCRIPTION
**Description**
See #6310 

- fix `@return` in `filter.tpl.php`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
