### PR TITLE
feat: [Commands] `lang:find` show bad keys when scanning

### DIFF
--- a/tests/system/Commands/Translation/LocalizationFinderTest.php
+++ b/tests/system/Commands/Translation/LocalizationFinderTest.php
@@ -103,6 +103,15 @@ final class LocalizationFinderTest extends CIUnitTestCase
         $this->assertStringContainsString($this->getActualTableWithNewKeys(), $this->getStreamFilterBuffer());
     }
 
+    public function testShowBadTranslation(): void
+    {
+        $this->makeLocaleDirectory();
+
+        command('lang:find --dir Translation --verbose');
+
+        $this->assertStringContainsString($this->getActualTableWithBadKeys(), $this->getStreamFilterBuffer());
+    }
+
     private function getActualTranslationOneKeys(): array
     {
         return [
@@ -190,6 +199,21 @@ final class LocalizationFinderTest extends CIUnitTestCase
             | TranslationThree | TranslationThree.formFields.new.name               |
             | TranslationThree | TranslationThree.formFields.new.short_tag          |
             +------------------+----------------------------------------------------+
+            TEXT_WRAP;
+    }
+
+    private function getActualTableWithBadKeys(): string
+    {
+        return <<<'TEXT_WRAP'
+            +---+------------------------+
+            | № | Bad key                |
+            +---+------------------------+
+            | 0 | TranslationTwo         |
+            | 1 | .invalid_key           |
+            | 2 | TranslationTwo.        |
+            | 3 | TranslationTwo...      |
+            | 4 | ..invalid_nested_key.. |
+            +---+------------------------+
             TEXT_WRAP;
     }
 


### PR DESCRIPTION
**Description**
I tried to add a list of bad keys when scanning.
Now this is not exactly what @kenjis was talking about, but it's still better than nothing
Example:

```console
$ ./spark lang:find --dir Controllers/Translation --verbose

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-04 08:23:17 UTC+00:00

File found: Controllers/Translation/TranslationNested/TranslationFour.php
File found: Controllers/Translation/TranslationOne.php
File found: Controllers/Translation/TranslationThree.php
File found: Controllers/Translation/TranslationTwo.php
Files found: 4
New translates found: 0
Bad translates found: 5
+---+------------------------+
| № | Bad key                |
+---+------------------------+
| 0 | TranslationTwo         |
| 1 | .invalid_key           |
| 2 | TranslationTwo.        |
| 3 | TranslationTwo...      |
| 4 | ..invalid_nested_key.. |
+---+------------------------+

All operations done!
```

---

_Originally posted by @kenjis in https://github.com/codeigniter4/CodeIgniter4/issues/7896#issuecomment-1714606747_
> I say on removing `lang()` from the code, or changing the argument.
> E.g. `lang('Cache.unabelToWrite')` → `lang('Cache.unableToWrite')`
> `Cache.unabelToWrite` is gone (but not deleted in the lang file), and `Cache.unableToWrite` is added.
> 
> I want to say, if there are items in the lang files that are not used by `lang()`,
> it seems better to have a way to know them.


            
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
