### PR TITLE
fix: [Commands] `routes` with `{locale}` in route

### DIFF
--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -51,9 +51,12 @@ final class FilterFinder
     {
         $this->filters->reset();
 
-        $isLocaleExist = strpos($uri, '{locale}') !== false;
+        // Fix for the search filters command
+        $isSupportedLocaleOnly = false;
 
-        if ($isLocaleExist) {
+        if (strpos($uri, '{locale}') !== false && Services::routes()->shouldUseSupportedLocalesOnly()) {
+            $isSupportedLocaleOnly = true;
+
             $uri = str_replace('{locale}', config(App::class)->defaultLocale, $uri);
         }
 
@@ -73,7 +76,7 @@ final class FilterFinder
 
             $filters = $this->filters->getFilters();
 
-            if ($isLocaleExist) {
+            if ($isSupportedLocaleOnly) {
                 $filters['before'] = array_map(static fn ($filter) => '!' . $filter, $filters['before']);
                 $filters['after']  = array_map(static fn ($filter) => '!' . $filter, $filters['after']);
             }

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -15,7 +15,6 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\Router\Router;
-use Config\App;
 use Config\Feature;
 use Config\Services;
 
@@ -51,15 +50,6 @@ final class FilterFinder
     {
         $this->filters->reset();
 
-        // Fix for the search filters command
-        $isSupportedLocaleOnly = false;
-
-        if (strpos($uri, '{locale}') !== false && Services::routes()->shouldUseSupportedLocalesOnly()) {
-            $isSupportedLocaleOnly = true;
-
-            $uri = str_replace('{locale}', config(App::class)->defaultLocale, $uri);
-        }
-
         // Add route filters
         try {
             $routeFilters = $this->getRouteFilters($uri);
@@ -74,14 +64,7 @@ final class FilterFinder
 
             $this->filters->initialize($uri);
 
-            $filters = $this->filters->getFilters();
-
-            if ($isSupportedLocaleOnly) {
-                $filters['before'] = array_map(static fn ($filter) => '!' . $filter, $filters['before']);
-                $filters['after']  = array_map(static fn ($filter) => '!' . $filter, $filters['after']);
-            }
-
-            return $filters;
+            return $this->filters->getFilters();
         } catch (RedirectException $e) {
             return [
                 'before' => [],

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -223,4 +223,32 @@ final class RoutesTest extends CIUnitTestCase
             EOL;
         $this->assertStringContainsString($expected, $this->getBuffer());
     }
+
+    public function testRoutesCommandWithAnyLocales(): void
+    {
+        $routes = $this->getCleanRoutes();
+        $routes->useSupportedLocalesOnly(false);
+        $routes->get('{locale}/admin/(:segment)', 'AdminController::index/$1', ['as' => 'admin']);
+
+        command('routes');
+
+        $expected = <<<'EOL'
+            | GET     | {locale}/admin/([^/]+) | admin         | \App\Controllers\AdminController::index/$1 |                | toolbar       |
+            EOL;
+        $this->assertStringContainsString($expected, $this->getBuffer());
+    }
+
+    public function testRoutesCommandWithSupportedLocalesOnly(): void
+    {
+        $routes = $this->getCleanRoutes();
+        $routes->useSupportedLocalesOnly(true);
+        $routes->get('{locale}/admin/(:segment)', 'AdminController::index/$1', ['as' => 'admin']);
+
+        command('routes');
+
+        $expected = <<<'EOL'
+            | GET     | {locale}/admin/([^/]+) | admin         | \App\Controllers\AdminController::index/$1 |                | !toolbar      |
+            EOL;
+        $this->assertStringContainsString($expected, $this->getBuffer());
+    }
 }

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -52,13 +52,6 @@ final class FilterFinderTest extends CIUnitTestCase
         $this->moduleConfig->enabled = false;
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $this->resetServices();
-    }
-
     private function createRouteCollection(array $routes = []): RouteCollection
     {
         $collection = new RouteCollection(Services::locator(), $this->moduleConfig, new Routing());
@@ -318,44 +311,6 @@ final class FilterFinderTest extends CIUnitTestCase
                 'filter1',
                 'filter2',
             ],
-        ];
-        $this->assertSame($expected, $filters);
-    }
-
-    public function testFindFiltersWithAnyLocales(): void
-    {
-        $collection = $this->createRouteCollection();
-        $collection->useSupportedLocalesOnly(false);
-        $collection->get('{locale}/admin/(:segment)', 'AdminController::index/$1');
-        Services::injectMock('routes', $collection);
-        $router  = $this->createRouter($collection);
-        $filters = $this->createFilters();
-        $finder  = new FilterFinder($router, $filters);
-
-        $filters = $finder->find('{locale}/admin/settings');
-
-        $expected = [
-            'before' => ['csrf'],
-            'after'  => ['toolbar'],
-        ];
-        $this->assertSame($expected, $filters);
-    }
-
-    public function testFindFiltersWithSupportedLocalesOnly(): void
-    {
-        $collection = $this->createRouteCollection();
-        $collection->useSupportedLocalesOnly(true);
-        $collection->get('{locale}/admin/(:segment)', 'AdminController::index/$1');
-        Services::injectMock('routes', $collection);
-        $router  = $this->createRouter($collection);
-        $filters = $this->createFilters();
-        $finder  = new FilterFinder($router, $filters);
-
-        $filters = $finder->find('{locale}/admin/settings');
-
-        $expected = [
-            'before' => ['!csrf'],
-            'after'  => ['!toolbar'],
         ];
         $this->assertSame($expected, $filters);
     }

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -923,6 +923,17 @@ The *Route* column shows the route path to match. The route of a defined route i
 
 Since v4.3.0, the *Name* column shows the route name. ``»`` indicates the name is the same as the route path.
 
+Prior to v4.5.0, routes with ``{locale}`` and the enabled parameter ``$routes->shouldUseSupportedLocalesOnly(true)`` in **app/Config/Routes.php** were shown ``<unknown>`` in the *Filters* column. This was due to the fact that it was impossible to resolve filters for all languages.
+Now routes having ``{locale}`` are output as ``!filtername``. This means that filters are set for a group of languages, but there is no guarantee of execution for each language.
+
+.. code-block:: none
+
+    +--------+---------------+------+-----------+----------------+---------------+
+    | Method | Route         | Name | Handler   | Before Filters | After Filters |
+    +--------+---------------+------+-----------+----------------+---------------+
+    | GET    | {locale}/feed | »    | (Closure) |                | !toolbar      |
+    +--------+---------------+------+-----------+----------------+---------------+
+
 .. important:: The system is not perfect. If you use Custom Placeholders, *Filters* might not be correct. If you want to check filters for a route, you can use :ref:`spark filter:check <spark-filter-check>` command.
 
 Auto Routing (Improved)


### PR DESCRIPTION
**Description**
Fix #7997

Previously, the command output `<unknown>` for URLs with `{locale}` instead of possible filters. Since there can be ~10 language options for one route. The commit adds **!filtername** to filters, which means probable application, but not guaranteed.

Set `$routes->useSupportedLocalesOnly(true)` in **app/Config/Routes.php**

Before:
```console
$ ./spark routes

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-05 10:39:57 UTC+00:00

+--------+--------------------------------+------+------------------------------+----------------+---------------+
| Method | Route                          | Name | Handler                      | Before Filters | After Filters |
+--------+--------------------------------+------+------------------------------+----------------+---------------+
| GET    | /                              | »    | \App\Controllers\Home::index | honeypot csrf  | toolbar       |
| GET    | products/all                   | »    | \App\Controllers\Home::index | honeypot csrf  | toolbar       |
| GET    | products/([0-9]+)/([^/]+)/show | »    | \App\Controllers\Home::index | honeypot csrf  | toolbar       |
| GET    | {locale}/products/(.*)         | »    | \App\Controllers\Home::index | <unknown>      | <unknown>     |
| GET    | products/{locale}              | »    | \App\Controllers\Home::index | <unknown>      | <unknown>     |
| GET    | products/{locale}/([0-9]+)     | »    | \App\Controllers\Home::index | <unknown>      | <unknown>     |
| GET    | {locale}                       | »    | \App\Controllers\Home::index | <unknown>      | <unknown>     |
+--------+--------------------------------+------+------------------------------+----------------+---------------+
```
After:
```console
$ ./spark routes

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-05 10:44:13 UTC+00:00

+--------+--------------------------------+------+------------------------------+-----------------+---------------+
| Method | Route                          | Name | Handler                      | Before Filters  | After Filters |
+--------+--------------------------------+------+------------------------------+-----------------+---------------+
| GET    | /                              | »    | \App\Controllers\Home::index | honeypot csrf   | toolbar       |
| GET    | products/all                   | »    | \App\Controllers\Home::index | honeypot csrf   | toolbar       |
| GET    | products/([0-9]+)/([^/]+)/show | »    | \App\Controllers\Home::index | honeypot csrf   | toolbar       |
| GET    | {locale}/products/(.*)         | »    | \App\Controllers\Home::index | !honeypot !csrf | !toolbar      |
| GET    | products/{locale}              | »    | \App\Controllers\Home::index | !honeypot !csrf | !toolbar      |
| GET    | products/{locale}/([0-9]+)     | »    | \App\Controllers\Home::index | !honeypot !csrf | !toolbar      |
| GET    | {locale}                       | »    | \App\Controllers\Home::index | !honeypot !csrf | !toolbar      |
+--------+--------------------------------+------+------------------------------+-----------------+---------------+

```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
