### PR TITLE
fix: Validation raises TypeError when invalid JSON comes

### DIFF
--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -73,6 +73,19 @@ class HTTPException extends FrameworkException
     }
 
     /**
+     * Thrown in IncomingRequest when the json_decode() produces
+     *  an error code other than JSON_ERROR_NONE.
+     *
+     * @param string $error The error message
+     *
+     * @return static
+     */
+    public static function forInvalidJSON(?string $error = null)
+    {
+        return new static(lang('HTTP.invalidJSON', [$error]));
+    }
+
+    /**
      * For Message
      *
      * @return HTTPException

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -573,10 +573,18 @@ class IncomingRequest extends Request
      * @see http://php.net/manual/en/function.json-decode.php
      *
      * @return array|bool|float|int|stdClass|null
+     *
+     * @throws HTTPException When the body is invalid as JSON.
      */
     public function getJSON(bool $assoc = false, int $depth = 512, int $options = 0)
     {
-        return json_decode($this->body ?? '', $assoc, $depth, $options);
+        $result = json_decode($this->body ?? '', $assoc, $depth, $options);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw HTTPException::forInvalidJSON(json_last_error_msg());
+        }
+
+        return $result;
     }
 
     /**

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -578,7 +578,11 @@ class IncomingRequest extends Request
      */
     public function getJSON(bool $assoc = false, int $depth = 512, int $options = 0)
     {
-        $result = json_decode($this->body ?? '', $assoc, $depth, $options);
+        if ($this->body === null) {
+            return null;
+        }
+
+        $result = json_decode($this->body, $assoc, $depth, $options);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw HTTPException::forInvalidJSON(json_last_error_msg());

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -19,6 +19,7 @@ return [
 
     // IncomingRequest
     'invalidNegotiationType' => '"{0}" is not a valid negotiation type. Must be one of: media, charset, encoding, language.',
+    'invalidJSON'            => 'Failed to parse JSON string. Error: {0}',
 
     // Message
     'invalidHTTPProtocol' => 'Invalid HTTP Protocol Version: {0}',

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -528,6 +528,19 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertNull($request->getJSON());
     }
 
+    public function testGetJSONWithInvalidJSONString(): void
+    {
+        $this->expectException(HTTPException::class);
+        $this->expectExceptionMessage('Failed to parse JSON string. Error: Syntax error');
+
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+        $json            = 'Invalid JSON string';
+        $request         = $this->createRequest($config, $json);
+
+        $request->getJSON();
+    }
+
     public function testCanGrabGetRawInput(): void
     {
         $rawstring = 'username=admin001&role=administrator&usepass=0';

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -18,6 +18,7 @@ use CodeIgniter\HTTP\Files\UploadedFile;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use InvalidArgumentException;
+use JsonException;
 use TypeError;
 
 /**
@@ -539,6 +540,19 @@ final class IncomingRequestTest extends CIUnitTestCase
         $request         = $this->createRequest($config, $json);
 
         $request->getJSON();
+    }
+
+    public function testGetJSONWithJsonThrowOnErrorAndInvalidJSONString(): void
+    {
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessage('Syntax error');
+
+        $config          = new App();
+        $config->baseURL = 'http://example.com/';
+        $json            = 'Invalid JSON string';
+        $request         = $this->createRequest($config, $json);
+
+        $request->getJSON(false, 512, JSON_THROW_ON_ERROR);
     }
 
     public function testCanGrabGetRawInput(): void

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Validation;
 
+use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
@@ -787,6 +788,25 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame(['role' => 'administrator'], $this->validation->getValidated());
 
         unset($_SERVER['CONTENT_TYPE']);
+    }
+
+    public function testJsonInputInvalid(): void
+    {
+        $this->expectException(HTTPException::class);
+        $this->expectExceptionMessage('Failed to parse JSON string. Error: Syntax error');
+
+        $config  = new App();
+        $json    = 'invalid';
+        $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+        $request->setHeader('Content-Type', 'application/json');
+
+        $rules = [
+            'role' => 'if_exist|max_length[5]',
+        ];
+        $this->validation
+            ->withRequest($request->withMethod('POST'))
+            ->setRules($rules)
+            ->run();
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -31,6 +31,8 @@ and Traditional rules validate data of non-string types.
 Message Changes
 ***************
 
+- Added ``HTTP.invalidJSON`` error message.
+
 *******
 Changes
 *******


### PR DESCRIPTION
~~Needs #8161~~

**Description**
Fixes #8134

- `IncomingRequest` will throw `HTTPException` when the body is invalid as JSON
- add lang key `HTTP.invalidJSON`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
