### PR TITLE
refactor: RedisHandler ttl() calls

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -3037,11 +3037,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Session/Handlers/RedisHandler.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in a negated boolean, int given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Session/Handlers/RedisHandler.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Accessing offset \'HTTP_X_REQUESTED_WITH\' directly on \\$_SERVER is discouraged\\.$#',
 	'count' => 2,
 	'path' => __DIR__ . '/system/Session/Session.php',

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -245,6 +245,7 @@ class RedisHandler extends BaseHandler
         if ($value !== null) {
             $time = Time::now()->getTimestamp();
             $ttl  = $this->redis->ttl(static::validateKey($key, $this->prefix));
+            assert(is_int($ttl));
 
             return [
                 'expire' => $ttl > 0 ? $time + $ttl : null,

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -293,7 +293,10 @@ class RedisHandler extends BaseHandler
         $attempt = 0;
 
         do {
-            if (($ttl = $this->redis->ttl($lockKey)) > 0) {
+            $ttl = $this->redis->ttl($lockKey);
+            assert(is_int($ttl));
+
+            if ($ttl > 0) {
                 sleep(1);
 
                 continue;


### PR DESCRIPTION
**Description**
- fix PHPStan 1.10.41 errors
  - https://github.com/phpstan/phpstan/releases/tag/1.10.41

```
Error: Comparison operation ">" between (int|Redis|false) and 0 results in an error.
Error: Ignored error pattern #^Only booleans are allowed in a negated boolean, int given\.$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/Session/Handlers/RedisHandler.php was not matched in reported errors.
Error: Comparison operation ">" between (int|Redis|false) and 0 results in an error.
 ------ --------------------------------------------------------------------- 
  Line   system/Cache/Handlers/RedisHandler.php                               
 ------ --------------------------------------------------------------------- 
  250    Comparison operation ">" between (int|Redis|false) and 0 results in  
         an error.                                                            
 ------ --------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------- 
  Line   system/Session/Handlers/RedisHandler.php                                              
 ------ -------------------------------------------------------------------------------------- 
         Ignored error pattern #^Only booleans are allowed in a negated                        
         boolean, int given\.$# in path                                                        
         /home/runner/work/CodeIgniter4/CodeIgniter4/system/Session/Handlers/RedisHandler.php  
         was not matched in reported errors.                                                   
  296    Comparison operation ">" between (int|Redis|false) and 0 results in                   
         an error.                                                                             
 ------ -------------------------------------------------------------------------------------- 
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6763592529/job/18380895677

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
