### PR TITLE
Use validateData() to validate POST data only

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -362,6 +362,7 @@ data to be validated:
     is not HTML form post (``Content-Type: multipart/form-data``),
     or gets data from :ref:`$request->getVar() <incomingrequest-getting-data>`,
     and an attacker could change what data is validated.
+    Instead of withRequest(), use validateData() to validate POST data only. withRequest() uses $request->getVar() which returns $_GET, $_POST and $_COOKIE data in that order. Newer values override older values. Post values will be overriden by the cookies if they have the same name.
 
 .. note:: The :ref:`getValidated() <validation-getting-validated-data>`
     method can be used since v4.4.0.


### PR DESCRIPTION
Instead of withRequest(), use validateData() to validate POST data only. withRequest() uses $request->getVar() which returns $_GET, $_POST and $_COOKIE data in that order. Newer values override older values. Post values will be overriden by the cookies if they have the same name.

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
