### PR TITLE
docs: Use validateData() to validate POST data only

### DIFF
--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -112,6 +112,7 @@ rule and message array formats, as well as available rules:
     or :ref:`$request->getRawInput() <incomingrequest-retrieving-raw-data>`
     or :ref:`$request->getVar() <incomingrequest-getting-data>`, and an attacker
     could change what data is validated.
+    Instead of withRequest(), use validateData() to validate POST data only.       withRequest() uses $request->getVar() which returns $_GET, $_POST and $_COOKIE data in that order. Newer values override older values. Post values will be overriden by the cookies if they have the same name.
 
 .. note:: The :ref:`$this->validator->getValidated() <validation-getting-validated-data>`
     method can be used since v4.4.0.


### PR DESCRIPTION
Instead of withRequest(), use validateData() to validate POST data only. withRequest() uses $request->getVar() which returns $_GET, $_POST and $_COOKIE data in that order. Newer values override older values. Post values will be overriden by the cookies if they have the same name.

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
