### PR TITLE
docs: add warning to `getVar()`

### DIFF
--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -101,6 +101,11 @@ Getting Data
 
 The ``getVar()`` method will pull from ``$_REQUEST``, so will return any data from ``$_GET``, ``$POST``, or ``$_COOKIE`` (depending on php.ini `request-order <https://www.php.net/manual/en/ini.core.php#ini.request-order>`_).
 
+.. warning:: If you want to validate POST data only, don't use ``getVar()``.
+    Newer values override older values. POST values may be overridden by the
+    cookies if they have the same name, and you set "C" after "P" in
+    `request-order <https://www.php.net/manual/en/ini.core.php#ini.request-order>`_.
+
 .. note:: If the incoming request has a ``Content-Type`` header set to ``application/json``,
     the ``getVar()`` method returns the JSON data instead of ``$_REQUEST`` data.
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -343,6 +343,13 @@ For example, data returned by multi select dropdown:
 withRequest()
 =============
 
+.. warning:: If you want to validate POST data only, don't use ``withRequest()``.
+    This method uses :ref:`$request->getVar() <incomingrequest-getting-data>`
+    which returns ``$_GET``, ``$_POST`` or ``$_COOKIE`` data in that order
+    (depending on php.ini `request-order <https://www.php.net/manual/en/ini.core.php#ini.request-order>`_).
+    Newer values override older values. POST values may be overridden by the
+    cookies if they have the same name.
+
 One of the most common times you will use the validation library is when validating
 data that was input from an HTTP Request. If desired, you can pass an instance of the
 current Request object and it will take all of the input data and set it as the


### PR DESCRIPTION
**Description**
See #8157

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
