### PR TITLE
fix: when request body is `0`, $body will be null

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2148,7 +2148,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 6,
+	'count' => 5,
 	'path' => __DIR__ . '/system/HTTP/IncomingRequest.php',
 ];
 $ignoreErrors[] = [

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -169,9 +169,14 @@ class IncomingRequest extends Request
             $body = file_get_contents('php://input');
         }
 
+        // If file_get_contents() returns false or empty string, set null.
+        if ($body === false || $body === '') {
+            $body = null;
+        }
+
         $this->config       = $config;
         $this->uri          = $uri;
-        $this->body         = ! empty($body) ? $body : null;
+        $this->body         = $body;
         $this->userAgent    = $userAgent;
         $this->validLocales = $config->supportedLocales;
 

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -847,7 +847,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertSame(array_merge($_POST, $_GET), $this->request->getGetPost());
     }
 
-    public function testWithFalseBody(): void
+    public function testGetBodyWithFalseBody(): void
     {
         // Use `false` here to simulate file_get_contents returning a false value
         $request = $this->createRequest(null, false);

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -856,6 +856,13 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertNull($request->getBody());
     }
 
+    public function testGetBodyWithZero(): void
+    {
+        $request = $this->createRequest(null, '0');
+
+        $this->assertSame('0', $request->getBody());
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/3020
      */

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -518,7 +518,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->assertNull($request->getJsonVar('myKey'));
     }
 
-    public function testgetJSONReturnsNullFromNullBody(): void
+    public function testGetJSONReturnsNullFromNullBody(): void
     {
         $config          = new App();
         $config->baseURL = 'http://example.com/';


### PR DESCRIPTION
**Description**
- fix bug that when request body is `0`, $body will be null

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
