### PR TITLE
docs: fix return type for lang()

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -755,7 +755,7 @@ if (! function_exists('lang')) {
      * A convenience method to translate a string or array of them and format
      * the result with the intl extension's MessageFormatter.
      *
-     * @return string
+     * @return list<string>|string
      */
     function lang(string $line, array $args = [], ?string $locale = null)
     {

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -88,7 +88,7 @@ class Language
      * Parses the language string for a file, loads the file, if necessary,
      * getting the line.
      *
-     * @return string|string[]
+     * @return list<string>|string
      */
     public function getLine(string $line, array $args = [])
     {


### PR DESCRIPTION
**Description**
- fix `@return`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
