### PR TITLE
docs: add warning on CSRF cookie and redirect()

### DIFF
--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -101,7 +101,9 @@ Token Regeneration
 ------------------
 
 Tokens may be either regenerated on every submission (default) or
-kept the same throughout the life of the CSRF cookie. The default
+kept the same throughout the life of the Session or CSRF cookie.
+
+The default
 regeneration of tokens provides stricter security, but may result
 in usability concerns as other tokens become invalid (back/forward
 navigation, multiple tabs/windows, asynchronous actions, etc). You

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -112,6 +112,10 @@ may alter this behavior by editing the following config parameter value in
 
 .. literalinclude:: security/004.php
 
+.. warning:: If you use Cookie based CSRF protection, and :php:func:`redirect()`
+    after the submission, you must call ``withCookie()`` to send the regenerated
+    CSRF cookie. See :ref:`response-redirect` for details.
+
 .. note:: Since v4.2.3, you can regenerate CSRF token manually with the
     ``Security::generateHash()`` method.
 


### PR DESCRIPTION
**Description**
Fixes #8163

- add warning

Related #8165

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
