### PR TITLE
fix: `spark routes` outputs <unknown> only when {locale} with `useSupportedLocalesOnly(true)`

### DIFF
--- a/system/Commands/Utilities/Routes/SampleURIGenerator.php
+++ b/system/Commands/Utilities/Routes/SampleURIGenerator.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Router\RouteCollection;
+use Config\App;
 
 /**
  * Generate a sample URI path from route key regex.
@@ -50,6 +51,14 @@ final class SampleURIGenerator
     public function get(string $routeKey): string
     {
         $sampleUri = $routeKey;
+
+        if (strpos($routeKey, '{locale}') !== false) {
+            $sampleUri = str_replace(
+                '{locale}',
+                config(App::class)->defaultLocale,
+                $routeKey
+            );
+        }
 
         foreach ($this->routes->getPlaceholders() as $placeholder => $regex) {
             $sample = $this->samples[$placeholder] ?? '::unknown::';

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -40,6 +40,8 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
             'placeholder num'     => ['shop/product/([0-9]+)', 'shop/product/123'],
             'placeholder segment' => ['shop/product/([^/]+)', 'shop/product/abc_123'],
             'placeholder any'     => ['shop/product/(.*)', 'shop/product/123/abc'],
+            'locale'              => ['{locale}/home', 'en/home'],
+            'locale segment'      => ['{locale}/product/([^/]+)', 'en/product/abc_123'],
             'auto route'          => ['home/index[/...]', 'home/index/1/2/3/4/5'],
         ];
     }


### PR DESCRIPTION
**Description**
Fixes #7997
See https://github.com/codeigniter4/CodeIgniter4/issues/7997#issuecomment-1798317449

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
