### PR TITLE
docs: fix incomingrequest.rst and note to getVar()

### DIFF
--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -355,10 +355,10 @@ The methods provided by the parent classes that are available are:
     .. php:method:: getVar([$index = null[, $filter = null[, $flags = null]]])
 
         :param  string  $index: The name of the variable/key to look for.
-        :param  int     $filter: The type of filter to apply. A list of filters can be found
-                        `here <https://www.php.net/manual/en/filter.filters.php>`__.
-        :param  int     $flags: Flags to apply. A list of flags can be found
-                        `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
+        :param  int     $filter: The type of filter to apply. A list of filters can be found in
+                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
+        :param  int     $flags: Flags to apply. A list of flags can be found in
+                        `Filter flags <https://www.php.net/manual/en/filter.filters.flags.php>`__.
         :returns:   ``$_REQUEST`` if no parameters supplied, otherwise the REQUEST value if found, or null if not
         :rtype: array|bool|float|int|object|string|null
 
@@ -367,10 +367,10 @@ The methods provided by the parent classes that are available are:
     .. php:method:: getGet([$index = null[, $filter = null[, $flags = null]]])
 
         :param  string  $index: The name of the variable/key to look for.
-        :param  int     $filter: The type of filter to apply. A list of filters can be
-                        found `here <https://www.php.net/manual/en/filter.filters.php>`__.
-        :param  int     $flags: Flags to apply. A list of flags can be found
-                        `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
+        :param  int     $filter: The type of filter to apply. A list of filters can be found in
+                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
+        :param  int     $flags: Flags to apply. A list of flags can be found in
+                        `Filter flags <https://www.php.net/manual/en/filter.filters.flags.php>`__.
         :returns:       ``$_GET`` if no parameters supplied, otherwise the GET value if found, or null if not
         :rtype: array|bool|float|int|object|string|null
 
@@ -418,10 +418,10 @@ The methods provided by the parent classes that are available are:
     .. php:method:: getPostGet([$index = null[, $filter = null[, $flags = null]]])
 
         :param  string  $index: The name of the variable/key to look for.
-        :param  int     $filter: The type of filter to apply. A list of filters can be
-                        found `here <https://www.php.net/manual/en/filter.filters.php>`__.
-        :param  int     $flags: Flags to apply. A list of flags can be found
-                        `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
+        :param  int     $filter: The type of filter to apply. A list of filters can be found in
+                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
+        :param  int     $flags: Flags to apply. A list of flags can be found in
+                        `Filter flags <https://www.php.net/manual/en/filter.filters.flags.php>`__.
         :returns:       ``$_POST`` and ``$_GET`` combined if no parameters specified (prefer POST value on conflict),
                         otherwise looks for POST value, if nothing found looks for GET value, if no value found returns null
         :rtype: array|bool|float|int|object|string|null
@@ -438,10 +438,10 @@ The methods provided by the parent classes that are available are:
     .. php:method:: getGetPost([$index = null[, $filter = null[, $flags = null]]])
 
         :param  string  $index: The name of the variable/key to look for.
-        :param  int     $filter: The type of filter to apply. A list of filters can be
-                        found `here <https://www.php.net/manual/en/filter.filters.php>`__.
-        :param  int     $flags: Flags to apply. A list of flags can be found
-                        `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
+        :param  int     $filter: The type of filter to apply. A list of filters can be found in
+                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
+        :param  int     $flags: Flags to apply. A list of flags can be found in
+                        `Filter flags <https://www.php.net/manual/en/filter.filters.flags.php>`__.
         :returns:       ``$_GET`` and ``$_POST`` combined if no parameters specified (prefer GET value on conflict),
                         otherwise looks for GET value, if nothing found looks for POST value, if no value found returns null
         :rtype: array|bool|float|int|object|string|null
@@ -458,10 +458,10 @@ The methods provided by the parent classes that are available are:
     .. php:method:: getCookie([$index = null[, $filter = null[, $flags = null]]])
 
         :param  array|string|null    $index: COOKIE name
-        :param  int     $filter: The type of filter to apply. A list of filters can be
-                        found `here <https://www.php.net/manual/en/filter.filters.php>`__.
-        :param  int     $flags: Flags to apply. A list of flags can be found
-                        `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
+        :param  int     $filter: The type of filter to apply. A list of filters can be found in
+                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
+        :param  int     $flags: Flags to apply. A list of flags can be found in
+                        `Filter flags <https://www.php.net/manual/en/filter.filters.flags.php>`__.
         :returns:        ``$_COOKIE`` if no parameters supplied, otherwise the COOKIE value if found or null if not
         :rtype: array|bool|float|int|object|string|null
 
@@ -480,10 +480,10 @@ The methods provided by the parent classes that are available are:
     .. php:method:: getServer([$index = null[, $filter = null[, $flags = null]]])
 
         :param  array|string|null    $index: Value name
-        :param  int     $filter: The type of filter to apply. A list of filters can be
-                        found `here <https://www.php.net/manual/en/filter.filters.php>`__.
-        :param  int     $flags: Flags to apply. A list of flags can be found
-                        `here <https://www.php.net/manual/en/filter.filters.flags.php>`__.
+        :param  int     $filter: The type of filter to apply. A list of filters can be found in
+                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
+        :param  int     $flags: Flags to apply. A list of flags can be found in
+                        `Filter flags <https://www.php.net/manual/en/filter.filters.flags.php>`__.
         :returns:        ``$_SERVER`` item value if found, null if not
         :rtype: array|bool|float|int|object|string|null
 
@@ -499,8 +499,8 @@ The methods provided by the parent classes that are available are:
 
     .. php:method:: getUserAgent([$filter = null])
 
-        :param  int $filter: The type of filter to apply. A list of filters can be
-                    found `here <https://www.php.net/manual/en/filter.filters.php>`__.
+        :param  int     $filter: The type of filter to apply. A list of filters can be found in
+                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
         :returns:  The User Agent string, as found in the SERVER data, or null if not found.
         :rtype: CodeIgniter\\HTTP\\UserAgent
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -492,7 +492,7 @@ The methods provided by the parent classes that are available are:
         :rtype: array|bool|float|int|object|string|null
 
         This method is identical to the ``getPost()``, ``getGet()`` and ``getCookie()``
-        methods, only it fetches getServer data (``$_SERVER``):
+        methods, only it fetches Server data (``$_SERVER``):
 
         .. literalinclude:: incomingrequest/036.php
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -182,14 +182,13 @@ The second and third parameters match up to the ``$depth`` and ``$flags`` argume
 Getting Specific Data from JSON
 ===============================
 
-You can get a specific piece of data from a JSON stream by passing a variable name into ``getVar()`` for the
+You can get a specific piece of data from a JSON stream by passing a variable name into ``getJsonVar()`` for the
 data that you want or you can use "dot" notation to dig into the JSON to get data that is not on the root level.
 
 .. literalinclude:: incomingrequest/010.php
 
-If you want the result to be an associative array instead of an object, you can use ``getJsonVar()`` instead and pass
-true in the second parameter. This function can also be used if you can't guarantee that the incoming request will have the
-correct ``Content-Type`` header.
+If you want the result to be an associative array instead of an object, you can
+pass true in the second parameter:
 
 .. literalinclude:: incomingrequest/011.php
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -100,6 +100,54 @@ With CodeIgniter's built-in methods you can simply do this:
 Getting Data
 ============
 
+getGet()
+--------
+
+The ``getGet()`` method will pull from ``$_GET``.
+
+* ``$request->getGet()``
+
+getPost()
+---------
+
+The ``getPost()`` method will pull from ``$_POST``.
+
+* ``$request->getPost()``
+
+getCookie()
+-----------
+
+The ``getCookie()`` method will pull from ``$_COOKIE``.
+
+* ``$request->getCookie()``
+
+getServer()
+-----------
+
+The ``getServer()`` method will pull from ``$_SERVER``.
+
+* ``$request->getServer()``
+
+getEnv()
+--------
+
+The ``getEnv()`` method will pull from ``$_ENV``.
+
+* ``$request->getEnv()``
+
+getPostGet()
+------------
+
+In addition, there are a few utility methods for retrieving information from either ``$_GET`` or ``$_POST``, while
+maintaining the ability to control the order you look for it:
+
+* ``$request->getPostGet()`` - checks ``$_POST`` first, then ``$_GET``
+
+getGetPost()
+------------
+
+* ``$request->getGetPost()`` - checks ``$_GET`` first, then ``$_POST``
+
 getVar()
 --------
 
@@ -112,24 +160,6 @@ The ``getVar()`` method will pull from ``$_REQUEST``, so will return any data fr
 
 .. note:: If the incoming request has a ``Content-Type`` header set to ``application/json``,
     the ``getVar()`` method returns the JSON data instead of ``$_REQUEST`` data.
-
-get*()
-------
-
-While this
-is convenient, you will often need to use a more specific method, like:
-
-* ``$request->getGet()``
-* ``$request->getPost()``
-* ``$request->getCookie()``
-* ``$request->getServer()``
-* ``$request->getEnv()``
-
-In addition, there are a few utility methods for retrieving information from either ``$_GET`` or ``$_POST``, while
-maintaining the ability to control the order you look for it:
-
-* ``$request->getPostGet()`` - checks ``$_POST`` first, then ``$_GET``
-* ``$request->getGetPost()`` - checks ``$_GET`` first, then ``$_POST``
 
 .. _incomingrequest-getting-json-data:
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -508,7 +508,7 @@ The methods provided by the parent classes that are available are:
         :returns:  The User Agent string, as found in the SERVER data, or null if not found.
         :rtype: CodeIgniter\\HTTP\\UserAgent
 
-        This method returns the User Agent string from the SERVER data:
+        This method returns the User Agent instance from the SERVER data:
 
         .. literalinclude:: incomingrequest/038.php
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -177,7 +177,7 @@ By default, this will return any objects in the JSON data as objects. If you wan
 arrays, pass in ``true`` as the first parameter.
 
 The second and third parameters match up to the ``depth`` and ``options`` arguments of the
-`json_decode <https://www.php.net/manual/en/function.json-decode.php>`_ PHP function.
+`json_decode() <https://www.php.net/manual/en/function.json-decode.php>`_ PHP function.
 
 If the incoming request has a ``Content-Type`` header set to ``application/json``, you can also use ``getVar()`` to get
 the JSON stream. Using ``getVar()`` in this way will always return an object.

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -405,7 +405,34 @@ The methods provided by the parent classes that are available are:
         :returns:       ``$_GET`` if no parameters supplied, otherwise the GET value if found, or null if not
         :rtype: array|bool|float|int|object|string|null
 
-        This method is identical to ``getVar()``, only it fetches GET data.
+        The first parameter will contain the name of the GET item you are looking for:
+
+        .. literalinclude:: incomingrequest/041.php
+
+        The method returns null if the item you are attempting to retrieve
+        does not exist.
+
+        The second optional parameter lets you run the data through the PHP's
+        filters. Pass in the desired filter type as the second parameter:
+
+        .. literalinclude:: incomingrequest/042.php
+
+        To return an array of all GET items call without any parameters.
+
+        To return all REQUEST items and pass them through the filter, set the
+        first parameter to null while setting the second parameter to the filter
+        you want to use:
+
+        .. literalinclude:: incomingrequest/043.php
+
+        To return an array of multiple GET parameters, pass all the required keys as an array:
+
+        .. literalinclude:: incomingrequest/044.php
+
+        Same rule applied here, to retrieve the parameters with filtering, set the second parameter to
+        the filter type to apply:
+
+        .. literalinclude:: incomingrequest/045.php
 
     .. php:method:: getPost([$index = null[, $filter = null[, $flags = null]]])
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -396,7 +396,7 @@ The methods provided by the parent classes that are available are:
 
         To return an array of all GET items call without any parameters.
 
-        To return all REQUEST items and pass them through the filter, set the
+        To return all GET items and pass them through the filter, set the
         first parameter to null while setting the second parameter to the filter
         you want to use:
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -179,9 +179,6 @@ arrays, pass in ``true`` as the first parameter.
 The second and third parameters match up to the ``depth`` and ``options`` arguments of the
 `json_decode() <https://www.php.net/manual/en/function.json-decode.php>`_ PHP function.
 
-If the incoming request has a ``Content-Type`` header set to ``application/json``, you can also use ``getVar()`` to get
-the JSON stream. Using ``getVar()`` in this way will always return an object.
-
 Getting Specific Data from JSON
 ===============================
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -417,7 +417,7 @@ The methods provided by the parent classes that are available are:
         :returns:       ``$_POST`` if no parameters supplied, otherwise the POST value if found, or null if not
         :rtype: array|bool|float|int|object|string|null
 
-            This method is identical to ``getVar()``, only it fetches POST data.
+        This method is identical to ``getVar()``, only it fetches POST data.
 
     .. php:method:: getPostGet([$index = null[, $filter = null[, $flags = null]]])
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -151,6 +151,10 @@ getGetPost()
 getVar()
 --------
 
+.. important:: This method exists only for backward compatibility. Do not use it
+    in new projects. Even if you are already using it, we recommend that you use
+    another, more appropriate method.
+
 The ``getVar()`` method will pull from ``$_REQUEST``, so will return any data from ``$_GET``, ``$POST``, or ``$_COOKIE`` (depending on php.ini `request-order <https://www.php.net/manual/en/ini.core.php#ini.request-order>`_).
 
 .. warning:: If you want to validate POST data only, don't use ``getVar()``.
@@ -361,6 +365,10 @@ The methods provided by the parent classes that are available are:
                         `Filter flags <https://www.php.net/manual/en/filter.filters.flags.php>`__.
         :returns:   ``$_REQUEST`` if no parameters supplied, otherwise the REQUEST value if found, or null if not
         :rtype: array|bool|float|int|object|string|null
+
+        .. important:: This method exists only for backward compatibility. Do not use it
+            in new projects. Even if you are already using it, we recommend that you use
+            another, more appropriate method.
 
         This method is identical to ``getGet()``, only it fetches REQUEST data.
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -176,7 +176,7 @@ You can grab the contents of ``php://input`` as a JSON stream with ``getJSON()``
 By default, this will return any objects in the JSON data as objects. If you want that converted to associative
 arrays, pass in ``true`` as the first parameter.
 
-The second and third parameters match up to the ``depth`` and ``options`` arguments of the
+The second and third parameters match up to the ``$depth`` and ``$flags`` arguments of the
 `json_decode() <https://www.php.net/manual/en/function.json-decode.php>`_ PHP function.
 
 Getting Specific Data from JSON

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -366,34 +366,7 @@ The methods provided by the parent classes that are available are:
         :returns:   ``$_REQUEST`` if no parameters supplied, otherwise the REQUEST value if found, or null if not
         :rtype: array|bool|float|int|object|string|null
 
-        The first parameter will contain the name of the REQUEST item you are looking for:
-
-        .. literalinclude:: incomingrequest/027.php
-
-        The method returns null if the item you are attempting to retrieve
-        does not exist.
-
-        The second optional parameter lets you run the data through the PHP's
-        filters. Pass in the desired filter type as the second parameter:
-
-        .. literalinclude:: incomingrequest/028.php
-
-        To return an array of all REQUEST items call without any parameters.
-
-        To return all REQUEST items and pass them through the filter, set the
-        first parameter to null while setting the second parameter to the filter
-        you want to use:
-
-        .. literalinclude:: incomingrequest/029.php
-
-        To return an array of multiple REQUEST parameters, pass all the required keys as an array:
-
-        .. literalinclude:: incomingrequest/030.php
-
-        Same rule applied here, to retrieve the parameters with filtering, set the second parameter to
-        the filter type to apply:
-
-        .. literalinclude:: incomingrequest/031.php
+        This method is identical to ``getGet()``, only it fetches REQUEST data.
 
     .. php:method:: getGet([$index = null[, $filter = null[, $flags = null]]])
 
@@ -444,7 +417,7 @@ The methods provided by the parent classes that are available are:
         :returns:       ``$_POST`` if no parameters supplied, otherwise the POST value if found, or null if not
         :rtype: array|bool|float|int|object|string|null
 
-        This method is identical to ``getVar()``, only it fetches POST data.
+        This method is identical to ``getGet()``, only it fetches POST data.
 
     .. php:method:: getPostGet([$index = null[, $filter = null[, $flags = null]]])
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -378,15 +378,15 @@ The methods provided by the parent classes that are available are:
 
         .. literalinclude:: incomingrequest/028.php
 
-        To return an array of all POST items call without any parameters.
+        To return an array of all REQUEST items call without any parameters.
 
-        To return all POST items and pass them through the filter, set the
+        To return all REQUEST items and pass them through the filter, set the
         first parameter to null while setting the second parameter to the filter
         you want to use:
 
         .. literalinclude:: incomingrequest/029.php
 
-        To return an array of multiple POST parameters, pass all the required keys as an array:
+        To return an array of multiple REQUEST parameters, pass all the required keys as an array:
 
         .. literalinclude:: incomingrequest/030.php
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -76,7 +76,8 @@ You can also check if the request was made through and HTTPS connection with the
 Retrieving Input
 ****************
 
-You can retrieve input from ``$_SERVER``, ``$_GET``, ``$_POST``, and ``$_ENV`` through the Request object.
+You can retrieve input from ``$_GET``, ``$_POST``, ``$_COOKIE``, ``$_SERVER``
+and ``$_ENV`` through the Request object.
 The data is not automatically filtered and returns the raw input data as passed in the request.
 
 .. note:: It is bad practice to use global variables. Basically, it should be avoided

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -497,10 +497,8 @@ The methods provided by the parent classes that are available are:
 
         .. literalinclude:: incomingrequest/037.php
 
-    .. php:method:: getUserAgent([$filter = null])
+    .. php:method:: getUserAgent()
 
-        :param  int     $filter: The type of filter to apply. A list of filters can be found in
-                        `Types of filters <https://www.php.net/manual/en/filter.filters.php>`__.
         :returns:  The User Agent string, as found in the SERVER data, or null if not found.
         :rtype: CodeIgniter\\HTTP\\UserAgent
 

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -99,6 +99,9 @@ With CodeIgniter's built-in methods you can simply do this:
 Getting Data
 ============
 
+getVar()
+--------
+
 The ``getVar()`` method will pull from ``$_REQUEST``, so will return any data from ``$_GET``, ``$POST``, or ``$_COOKIE`` (depending on php.ini `request-order <https://www.php.net/manual/en/ini.core.php#ini.request-order>`_).
 
 .. warning:: If you want to validate POST data only, don't use ``getVar()``.
@@ -108,6 +111,9 @@ The ``getVar()`` method will pull from ``$_REQUEST``, so will return any data fr
 
 .. note:: If the incoming request has a ``Content-Type`` header set to ``application/json``,
     the ``getVar()`` method returns the JSON data instead of ``$_REQUEST`` data.
+
+get*()
+------
 
 While this
 is convenient, you will often need to use a more specific method, like:

--- a/user_guide_src/source/incoming/incomingrequest/008.php
+++ b/user_guide_src/source/incoming/incomingrequest/008.php
@@ -1,3 +1,3 @@
 <?php
 
-$something = $request->getVar('foo');
+$something = $request->getPost('foo');

--- a/user_guide_src/source/incoming/incomingrequest/010.php
+++ b/user_guide_src/source/incoming/incomingrequest/010.php
@@ -10,8 +10,8 @@
  * }
  */
 
-$data = $request->getVar('foo');
+$data = $request->getJsonVar('foo');
 // $data = "bar"
 
-$data = $request->getVar('fizz.buzz');
+$data = $request->getJsonVar('fizz.buzz');
 // $data = "baz"

--- a/user_guide_src/source/incoming/incomingrequest/014.php
+++ b/user_guide_src/source/incoming/incomingrequest/014.php
@@ -1,3 +1,3 @@
 <?php
 
-$email = $request->getVar('email', FILTER_SANITIZE_EMAIL);
+$email = $request->getPost('email', FILTER_SANITIZE_EMAIL);

--- a/user_guide_src/source/incoming/incomingrequest/027.php
+++ b/user_guide_src/source/incoming/incomingrequest/027.php
@@ -1,3 +1,0 @@
-<?php
-
-$request->getVar('some_data');

--- a/user_guide_src/source/incoming/incomingrequest/028.php
+++ b/user_guide_src/source/incoming/incomingrequest/028.php
@@ -1,3 +1,0 @@
-<?php
-
-$request->getVar('some_data', FILTER_SANITIZE_FULL_SPECIAL_CHARS);

--- a/user_guide_src/source/incoming/incomingrequest/029.php
+++ b/user_guide_src/source/incoming/incomingrequest/029.php
@@ -1,4 +1,0 @@
-<?php
-
-$request->getVar(null, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-// returns all REQUEST items with string sanitation

--- a/user_guide_src/source/incoming/incomingrequest/029.php
+++ b/user_guide_src/source/incoming/incomingrequest/029.php
@@ -1,4 +1,4 @@
 <?php
 
 $request->getVar(null, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-// returns all POST items with string sanitation
+// returns all REQUEST items with string sanitation

--- a/user_guide_src/source/incoming/incomingrequest/030.php
+++ b/user_guide_src/source/incoming/incomingrequest/030.php
@@ -1,3 +1,0 @@
-<?php
-
-$request->getVar(['field1', 'field2']);

--- a/user_guide_src/source/incoming/incomingrequest/031.php
+++ b/user_guide_src/source/incoming/incomingrequest/031.php
@@ -1,3 +1,0 @@
-<?php
-
-$request->getVar(['field1', 'field2'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);

--- a/user_guide_src/source/incoming/incomingrequest/041.php
+++ b/user_guide_src/source/incoming/incomingrequest/041.php
@@ -1,0 +1,3 @@
+<?php
+
+$request->getGet('some_data');

--- a/user_guide_src/source/incoming/incomingrequest/042.php
+++ b/user_guide_src/source/incoming/incomingrequest/042.php
@@ -1,0 +1,3 @@
+<?php
+
+$request->getGet('some_data', FILTER_SANITIZE_FULL_SPECIAL_CHARS);

--- a/user_guide_src/source/incoming/incomingrequest/043.php
+++ b/user_guide_src/source/incoming/incomingrequest/043.php
@@ -1,0 +1,4 @@
+<?php
+
+$request->getGet(null, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+// returns all GET items with string sanitation

--- a/user_guide_src/source/incoming/incomingrequest/044.php
+++ b/user_guide_src/source/incoming/incomingrequest/044.php
@@ -1,0 +1,3 @@
+<?php
+
+$request->getGet(['field1', 'field2']);

--- a/user_guide_src/source/incoming/incomingrequest/045.php
+++ b/user_guide_src/source/incoming/incomingrequest/045.php
@@ -1,0 +1,3 @@
+<?php
+
+$request->getGet(['field1', 'field2'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);


### PR DESCRIPTION
**Description**
The `getVar()` method is complicated and difficult to use.
It is not recommended.

- change the descriptions so that `getVar()` can be deprecated.
- fix small errors.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
