### PR TITLE
docs: use validateData() instead of validate() in Tutorial

### DIFF
--- a/user_guide_src/source/tutorial/create_news_items.rst
+++ b/user_guide_src/source/tutorial/create_news_items.rst
@@ -106,11 +106,22 @@ You're going to do three things here:
 
 The code above adds a lot of functionality.
 
+Retrieve the Data
+^^^^^^^^^^^^^^^^^
+
+First, we use the :doc:`IncomingRequest <../incoming/incomingrequest>`
+object ``$this->request``, which is set in the controller by the framework.
+
+We get the necessary items from the **POST** data by the user and set them in the
+``$data`` variable.
+
 Validate the Data
 ^^^^^^^^^^^^^^^^^
 
-You'll use the Controller-provided helper function :ref:`validate() <controller-validate>` to validate the submitted data.
+Next, you'll use the Controller-provided helper function
+:ref:`validateData() <controller-validatedata>` to validate the submitted data.
 In this case, the title and body fields are required and in the specific length.
+
 CodeIgniter has a powerful validation library as demonstrated
 above. You can read more about the :doc:`Validation library <../libraries/validation>`.
 

--- a/user_guide_src/source/tutorial/create_news_items/005.php
+++ b/user_guide_src/source/tutorial/create_news_items/005.php
@@ -13,8 +13,10 @@ class News extends BaseController
     {
         helper('form');
 
+        $data = $this->request->getPost(['title', 'body']);
+
         // Checks whether the submitted data passed the validation rules.
-        if (! $this->validate([
+        if (! $this->validateData($data, [
             'title' => 'required|max_length[255]|min_length[3]',
             'body'  => 'required|max_length[5000]|min_length[10]',
         ])) {


### PR DESCRIPTION
**Description**
`validate()` is not recommended. See #8157

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
