### PR TITLE
fix: Undefined array key error in `spark db:table`

### DIFF
--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -125,7 +125,7 @@ class ShowTableInfo extends BaseCommand
         $limitRows       = (int) ($params['limit-rows'] ?? 10);
         $limitFieldValue = (int) ($params['limit-field-value'] ?? 15);
 
-        if (! in_array($tableName, $tables, true)) {
+        while (! in_array($tableName, $tables, true)) {
             $tableNameNo = CLI::promptByKey(
                 ['Here is the list of your database tables:', 'Which table do you want to see?'],
                 $tables,
@@ -133,7 +133,7 @@ class ShowTableInfo extends BaseCommand
             );
             CLI::newLine();
 
-            $tableName = $tables[$tableNameNo];
+            $tableName = $tables[$tableNameNo] ?? null;
         }
 
         if (array_key_exists('metadata', $params)) {


### PR DESCRIPTION
**Description**

Before:
```console
$ php spark db:table

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-08 04:13:04 UTC+00:00

Here is the list of your database tables:
  [0]  migrations

Which table do you want to see? 0: a


[ErrorException]

Undefined array key "a"

at SYSTEMPATH/Commands/Database/ShowTableInfo.php:136

Backtrace:
  1    SYSTEMPATH/Commands/Database/ShowTableInfo.php:136
       CodeIgniter\Debug\Exceptions()->errorHandler(2, 'Undefined array key "a"', '/.../CodeIgniter4/system/Commands/Database/ShowTableInfo.php', 136)

  2    SYSTEMPATH/CLI/Commands.php:65
       CodeIgniter\Commands\Database\ShowTableInfo()->run([])

  3    SYSTEMPATH/CLI/Console.php:46
       CodeIgniter\CLI\Commands()->run('db:table', [])

  4    ROOTPATH/spark:102
       CodeIgniter\CLI\Console()->run()
```

After:
```console
$ php spark db:table

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-08 04:12:37 UTC+00:00

Here is the list of your database tables:
  [0]  migrations

Which table do you want to see? 0: a

Here is the list of your database tables:
  [0]  migrations

Which table do you want to see? 0: 1

Here is the list of your database tables:
  [0]  migrations

Which table do you want to see? 0: 
```
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
