### PR TITLE
refactor: fix param types

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -256,7 +256,7 @@ class CLI
         static::fwrite(STDOUT, $field . (trim($field) ? ' ' : '') . $extraOutput . ': ');
 
         // Read the input from keyboard.
-        $input = trim(static::$io->input()) ?: $default;
+        $input = trim(static::$io->input()) ?: (string) $default;
 
         if ($validation !== []) {
             while (! static::validate('"' . trim($field) . '"', $input, $validation)) {

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -127,7 +127,7 @@ class MigrateStatus extends BaseCommand
                         continue;
                     }
 
-                    $date  = date('Y-m-d H:i:s', $row->time);
+                    $date  = date('Y-m-d H:i:s', (int) $row->time);
                     $group = $row->group;
                     $batch = $row->batch;
                     // @codeCoverageIgnoreEnd

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -120,7 +120,7 @@ final class InsertModelTest extends LiveModelTestCase
         $this->assertSame(2, $this->model->insertBatch($jobData));
 
         $result = $this->model->where('name', 'Philosopher')->first();
-        $this->assertCloseEnough(time(), $result->created_at);
+        $this->assertCloseEnough(time(), (int) $result->created_at);
     }
 
     public function testInsertBatchSetsDatetimeTimestamps(): void


### PR DESCRIPTION
**Description**
- fix param types for #8072

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
