### PR TITLE
fix: Handle non-array JSON in validation

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -496,10 +496,10 @@ class Validation implements ValidationInterface
         if (strpos($request->getHeaderLine('Content-Type'), 'application/json') !== false) {
             $this->data = $request->getJSON(true);
 
-            if (!is_array($this->data)) {
+            if (! is_array($this->data)) {
                 $this->data = [];
             }
-            
+
             return $this;
         }
 

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -496,6 +496,10 @@ class Validation implements ValidationInterface
         if (strpos($request->getHeaderLine('Content-Type'), 'application/json') !== false) {
             $this->data = $request->getJSON(true);
 
+            if (!is_array($this->data)) {
+                $this->data = [];
+            }
+            
             return $this;
         }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
A check has been added in the JSON validation method to ensure that the data being validated is an array. If the parsed JSON is not an array , it gets defaulted to an empty array to prevent further errors in the validation process.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
