### PR TITLE
docs: make note for `spark routes` and filters more accurate

### DIFF
--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -204,7 +204,7 @@ filter:check
 
 .. versionadded:: 4.3.0
 
-Check the filters for the route ``/`` with **GET** method:
+For example, check the filters for the route ``/`` with **GET** method:
 
 .. code-block:: console
 
@@ -220,8 +220,9 @@ The output is like the following:
     | GET    | /     |                | toolbar       |
     +--------+-------+----------------+---------------+
 
-You can also see the routes and filters by the ``spark routes`` command.
-See :ref:`URI Routing <routing-spark-routes>`.
+You can also see the routes and filters by the ``spark routes`` command,
+but it might not show accurate filters when you use regular expressions for routes.
+See :ref:`URI Routing <routing-spark-routes>` for details.
 
 ****************
 Provided Filters

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -907,7 +907,13 @@ The *Route* column shows the route path to match. The route of a defined route i
 
 Since v4.3.0, the *Name* column shows the route name. ``»`` indicates the name is the same as the route path.
 
-.. important:: The system is not perfect. If you use Custom Placeholders, *Filters* might not be correct. If you want to check filters for a route, you can use :ref:`spark filter:check <spark-filter-check>` command.
+.. important:: The system is not perfect.
+    For routes containing regular expression patterns like ``([^/]+)`` or ``{locale}``,
+    the *Filters* displayed might not be correct (if you set complicated URI pattern
+    for the filters in **app/Config/Filters.php**), or it is displayed as ``<unknown>``.
+
+    The :ref:`spark filter:check <spark-filter-check>` command can be used to check
+    for 100% accurate filters.
 
 Auto Routing (Improved)
 -----------------------


### PR DESCRIPTION
**Description**
The current description is inaccurate.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
