### PR TITLE
chore: [Psalm] workaround for UndefinedClass SimpleConfig

### DIFF
--- a/psalm_autoload.php
+++ b/psalm_autoload.php
@@ -25,6 +25,7 @@ foreach ($helperDirs as $dir) {
 
 $dirs = [
     'tests/_support/Controllers',
+    'tests/system/Config/fixtures',
 ];
 
 foreach ($dirs as $dir) {


### PR DESCRIPTION
**Description**
This error does not occur in my environment, so I cannot confirm that it has been resolved.

```
Error: tests/system/Config/BaseConfigTest.php:81:23: UndefinedClass: Class, interface or enum named SimpleConfig does not exist (see https://psalm.dev/019)
Error: Process completed with exit code 2.
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6794733818/job/18471613113?pr=8175

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
