### PR TITLE
docs: remove incorrect `@internal` in TestResponse

### DIFF
--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -28,8 +28,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @no-final
  *
- * @internal
- *
  * @mixin DOMParser
  * @see \CodeIgniter\Test\TestResponseTest
  */


### PR DESCRIPTION
**Description**
TestResponse is not internal, but devs use it.
But php-cs-fixer force to add it. How can we remove it?

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
