### PR TITLE
docs: fix `@var` for $validator in Controller

### DIFF
--- a/system/Controller.php
+++ b/system/Controller.php
@@ -65,7 +65,7 @@ class Controller
     /**
      * Once validation has been run, will hold the Validation instance.
      *
-     * @var ValidationInterface
+     * @var ValidationInterface|null
      */
     protected $validator;
 


### PR DESCRIPTION
**Description**
- fix incorrect `@var`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
