### PR TITLE
docs: add note to not recommended Traditional Validation Rules

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -221,6 +221,10 @@ and the new classes (**Strict Rules**) have ``CodeIgniter\Validation\StrictRules
 Traditional Rules
 -----------------
 
+.. important:: Traditional Rules exist only for backward compatibility. Do not
+    use them in new projects. Even if you are already using, we recommend that
+    you switch to Strict Rules.
+
 .. warning:: When validating data that contains non-string values, such as JSON data, it is recommended to use **Strict Rules**.
 
 The **Traditional Rules** implicitly assume that string values are validated,

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -222,8 +222,8 @@ Traditional Rules
 -----------------
 
 .. important:: Traditional Rules exist only for backward compatibility. Do not
-    use them in new projects. Even if you are already using, we recommend that
-    you switch to Strict Rules.
+    use them in new projects. Even if you are already using them, we recommend 
+    switching to Strict Rules.
 
 .. warning:: When validating data that contains non-string values, such as JSON data, it is recommended to use **Strict Rules**.
 


### PR DESCRIPTION
**Description**
They are not recommended.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
