### PR TITLE
fix: remove deprecated upper functionality in `Request::getMethod()`

### DIFF
--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -18,17 +18,4 @@ class Feature extends BaseConfig
      * Use filter execution order in 4.4 or before.
      */
     public bool $oldFilterOrder = false;
-
-    /**
-     * Use lowercase HTTP method names like "get", "post" in Config\Filters::$methods.
-     *
-     * But the HTTP method is case-sensitive. So using lowercase is wrong.
-     * We should disable this and use uppercase names like "GET", "POST", etc.
-     *
-     * The method token is case-sensitive because it might be used as a gateway
-     * to object-based systems with case-sensitive method names. By convention,
-     * standardized methods are defined in all-uppercase US-ASCII letters.
-     * https://www.rfc-editor.org/rfc/rfc9110#name-overview
-     */
-    public bool $lowerCaseFilterMethods = true;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -18,4 +18,17 @@ class Feature extends BaseConfig
      * Use filter execution order in 4.4 or before.
      */
     public bool $oldFilterOrder = false;
+
+    /**
+     * Use lowercase HTTP method names like "get", "post" in Config\Filters::$methods.
+     *
+     * But the HTTP method is case-sensitive. So using lowercase is wrong.
+     * We should disable this and use uppercase names like "GET", "POST", etc.
+     *
+     * The method token is case-sensitive because it might be used as a gateway
+     * to object-based systems with case-sensitive method names. By convention,
+     * standardized methods are defined in all-uppercase US-ASCII letters.
+     * https://www.rfc-editor.org/rfc/rfc9110#name-overview
+     */
+    public bool $lowerCaseFilterMethods = true;
 }

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -50,7 +50,7 @@ class Filters extends BaseConfig
      * particular HTTP method (GET, POST, etc.).
      *
      * Example:
-     * 'post' => ['foo', 'bar']
+     * 'POST' => ['foo', 'bar']
      *
      * If you use this, you should disable auto-routing because auto-routing
      * permits any HTTP method to access a controller. Accessing the controller

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -205,7 +205,7 @@ $errorId = uniqid('error', true);
                         </tr>
                         <tr>
                             <td>HTTP Method</td>
-                            <td><?= esc(strtoupper($request->getMethod())) ?></td>
+                            <td><?= esc($request->getMethod()) ?></td>
                         </tr>
                         <tr>
                             <td>IP Address</td>

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1927,11 +1927,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in a negated boolean, array given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -1027,7 +1027,7 @@ class CodeIgniter
     public function spoofRequestMethod()
     {
         // Only works with POSTED forms
-        if (strtolower($this->request->getMethod()) !== 'post') {
+        if ($this->request->getMethod() !== 'POST') {
             return;
         }
 
@@ -1038,7 +1038,7 @@ class CodeIgniter
         }
 
         // Only allows PUT, PATCH, DELETE
-        if (in_array(strtoupper($method), ['PUT', 'PATCH', 'DELETE'], true)) {
+        if (in_array($method, ['PUT', 'PATCH', 'DELETE'], true)) {
             $this->request = $this->request->setMethod($method);
         }
     }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -21,6 +21,7 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\DownloadResponse;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\ResponsableInterface;
@@ -1027,7 +1028,7 @@ class CodeIgniter
     public function spoofRequestMethod()
     {
         // Only works with POSTED forms
-        if ($this->request->getMethod() !== 'POST') {
+        if ($this->request->getMethod() !== Method::POST) {
             return;
         }
 
@@ -1038,7 +1039,7 @@ class CodeIgniter
         }
 
         // Only allows PUT, PATCH, DELETE
-        if (in_array($method, ['PUT', 'PATCH', 'DELETE'], true)) {
+        if (in_array($method, [Method::PUT, Method::PATCH, Method::DELETE], true)) {
             $this->request = $this->request->setMethod($method);
         }
     }

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -128,7 +128,7 @@ class Exceptions
 
         if ($this->config->log === true && ! in_array($statusCode, $this->config->ignoreCodes, true)) {
             $uri       = $this->request->getPath() === '' ? '/' : $this->request->getPath();
-            $routeInfo = '[Method: ' . strtoupper($this->request->getMethod()) . ', Route: ' . $uri . ']';
+            $routeInfo = '[Method: ' . $this->request->getMethod() . ', Route: ' . $uri . ']';
 
             log_message('critical', "{message}\n{routeInfo}\nin {exFile} on line {exLine}.\n{trace}", [
                 'message'   => $exception->getMessage(),

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -79,7 +79,7 @@ class Toolbar
         $data = [];
         // Data items used within the view.
         $data['url']             = current_url();
-        $data['method']          = strtoupper($request->getMethod());
+        $data['method']          = $request->getMethod();
         $data['isAJAX']          = $request->isAJAX();
         $data['startTime']       = $startTime;
         $data['totalTime']       = $totalTime * 1000;

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -494,8 +494,11 @@ class Filters
             return;
         }
 
-        // Request method won't be set for CLI-based requests
-        $method = strtolower($this->request->getMethod()) ?? 'cli';
+        $method = $this->request->getMethod();
+
+        if (config(Feature::class)->lowerCaseFilterMethods) {
+            $method = strtolower($method);
+        }
 
         if (array_key_exists($method, $this->config->methods)) {
             if (config(Feature::class)->oldFilterOrder) {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -502,6 +502,7 @@ class Filters
             $found = true;
         }
         // Checks lowercase HTTP method for backward compatibility.
+        // @deprecated 4.5.0
         // @TODO remove this in the future.
         elseif (array_key_exists(strtolower($method), $this->config->methods)) {
             $found  = true;

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -496,11 +496,19 @@ class Filters
 
         $method = $this->request->getMethod();
 
-        if (config(Feature::class)->lowerCaseFilterMethods) {
+        $found = false;
+
+        if (array_key_exists($method, $this->config->methods)) {
+            $found = true;
+        }
+        // Checks lowercase HTTP method for backward compatibility.
+        // @TODO remove this in the future.
+        elseif (array_key_exists(strtolower($method), $this->config->methods)) {
+            $found  = true;
             $method = strtolower($method);
         }
 
-        if (array_key_exists($method, $this->config->methods)) {
+        if ($found) {
             if (config(Feature::class)->oldFilterOrder) {
                 $this->filters['before'] = array_merge($this->filters['before'], $this->config->methods[$method]);
             } else {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -505,6 +505,12 @@ class Filters
         // @deprecated 4.5.0
         // @TODO remove this in the future.
         elseif (array_key_exists(strtolower($method), $this->config->methods)) {
+            @trigger_error(
+                'Setting lowercase HTTP method key "' . strtolower($method) . '" is deprecated.'
+                . ' Use uppercase HTTP method like "' . strtoupper($method) . '".',
+                E_USER_DEPRECATED
+            );
+
             $found  = true;
             $method = strtolower($method);
         }

--- a/system/HTTP/CLIRequest.php
+++ b/system/HTTP/CLIRequest.php
@@ -56,7 +56,7 @@ class CLIRequest extends Request
      *
      * @var string
      */
-    protected $method = 'cli';
+    protected $method = 'CLI';
 
     /**
      * Constructor

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -130,7 +130,7 @@ class CURLRequest extends OutgoingRequest
      * Sends an HTTP request to the specified $url. If this is a relative
      * URL, it will be merged with $this->baseURI to form a complete URL.
      *
-     * @param string $method
+     * @param string $method HTTP method
      */
     public function request($method, string $url, array $options = []): ResponseInterface
     {
@@ -177,7 +177,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function get(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('get', $url, $options);
+        return $this->request('GET', $url, $options);
     }
 
     /**
@@ -185,7 +185,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function delete(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('delete', $url, $options);
+        return $this->request('DELETE', $url, $options);
     }
 
     /**
@@ -193,7 +193,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function head(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('head', $url, $options);
+        return $this->request('HEAD', $url, $options);
     }
 
     /**
@@ -201,7 +201,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function options(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('options', $url, $options);
+        return $this->request('OPTIONS', $url, $options);
     }
 
     /**
@@ -209,7 +209,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function patch(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('patch', $url, $options);
+        return $this->request('PATCH', $url, $options);
     }
 
     /**
@@ -217,7 +217,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function post(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('post', $url, $options);
+        return $this->request('POST', $url, $options);
     }
 
     /**
@@ -225,7 +225,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function put(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('put', $url, $options);
+        return $this->request('PUT', $url, $options);
     }
 
     /**
@@ -340,17 +340,6 @@ class CURLRequest extends OutgoingRequest
     }
 
     /**
-     * Get the request method. Overrides the Request class' method
-     * since users expect a different answer here.
-     *
-     * @param bool|false $upper Whether to return in upper or lower case.
-     */
-    public function getMethod(bool $upper = false): string
-    {
-        return ($upper) ? strtoupper($this->method) : strtolower($this->method);
-    }
-
-    /**
      * Fires the actual cURL request.
      *
      * @return ResponseInterface
@@ -446,8 +435,6 @@ class CURLRequest extends OutgoingRequest
      */
     protected function applyMethod(string $method, array $curlOptions): array
     {
-        $method = strtoupper($method);
-
         $this->method                       = $method;
         $curlOptions[CURLOPT_CUSTOMREQUEST] = $method;
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -112,7 +112,7 @@ class CURLRequest extends OutgoingRequest
             throw HTTPException::forMissingCurl(); // @codeCoverageIgnore
         }
 
-        parent::__construct('GET', $uri);
+        parent::__construct(Method::GET, $uri);
 
         $this->responseOrig   = $response ?? new Response(config(App::class));
         $this->baseURI        = $uri->useRawQueryString();
@@ -177,7 +177,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function get(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('GET', $url, $options);
+        return $this->request(Method::GET, $url, $options);
     }
 
     /**
@@ -217,7 +217,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function post(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('POST', $url, $options);
+        return $this->request(Method::POST, $url, $options);
     }
 
     /**
@@ -225,7 +225,7 @@ class CURLRequest extends OutgoingRequest
      */
     public function put(string $url, array $options = []): ResponseInterface
     {
-        return $this->request('PUT', $url, $options);
+        return $this->request(Method::PUT, $url, $options);
     }
 
     /**
@@ -445,7 +445,7 @@ class CURLRequest extends OutgoingRequest
             return $this->applyBody($curlOptions);
         }
 
-        if ($method === 'PUT' || $method === 'POST') {
+        if ($method === Method::PUT || $method === Method::POST) {
             // See http://tools.ietf.org/html/rfc7230#section-3.3.2
             if ($this->header('content-length') === null && ! isset($this->config['multipart'])) {
                 $this->setHeader('Content-Length', '0');

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -406,7 +406,7 @@ class IncomingRequest extends Request
         $httpMethods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH', 'OPTIONS'];
 
         if (in_array($valueUpper, $httpMethods, true)) {
-            return strtoupper($this->getMethod()) === $valueUpper;
+            return $this->getMethod() === $valueUpper;
         }
 
         if ($valueUpper === 'JSON') {

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -396,7 +396,8 @@ class IncomingRequest extends Request
     /**
      * Checks this request type.
      *
-     * @param string $type HTTP verb or 'json' or 'ajax'
+     * @param string $type HTTP verb or 'json' or 'ajax'.
+     *                     HTTP verb should be case-sensitive, but this is case-insensitive.
      * @phpstan-param string|'get'|'post'|'put'|'delete'|'head'|'patch'|'options'|'json'|'ajax' $type
      */
     public function is(string $type): bool

--- a/system/HTTP/IncomingRequest.php
+++ b/system/HTTP/IncomingRequest.php
@@ -404,7 +404,7 @@ class IncomingRequest extends Request
     {
         $valueUpper = strtoupper($type);
 
-        $httpMethods = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH', 'OPTIONS'];
+        $httpMethods = Method::all();
 
         if (in_array($valueUpper, $httpMethods, true)) {
             return $this->getMethod() === $valueUpper;

--- a/system/HTTP/Method.php
+++ b/system/HTTP/Method.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\HTTP;
+
+/**
+ * HTTP Method List
+ */
+class Method
+{
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT
+     */
+    public const CONNECT = 'CONNECT';
+
+    /**
+     * Idempotent
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
+     */
+    public const DELETE = 'DELETE';
+
+    /**
+     * Safe, Idempotent, Cacheable
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
+     */
+    public const GET = 'GET';
+
+    /**
+     * Safe, Idempotent, Cacheable
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD
+     */
+    public const HEAD = 'HEAD';
+
+    /**
+     * Safe, Idempotent
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS
+     */
+    public const OPTIONS = 'OPTIONS';
+
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH
+     */
+    public const PATCH = 'PATCH';
+
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
+     */
+    public const POST = 'POST';
+
+    /**
+     * Idempotent
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
+     */
+    public const PUT = 'PUT';
+
+    /**
+     * Safe, Idempotent
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/TRACE
+     */
+    public const TRACE = 'TRACE';
+
+    /**
+     * Returns all HTTP methods.
+     *
+     * @return list<string>
+     */
+    public static function all(): array
+    {
+        return [
+            self::CONNECT,
+            self::DELETE,
+            self::GET,
+            self::HEAD,
+            self::OPTIONS,
+            self::PATCH,
+            self::POST,
+            self::PUT,
+            self::TRACE,
+        ];
+    }
+}

--- a/system/HTTP/OutgoingRequest.php
+++ b/system/HTTP/OutgoingRequest.php
@@ -68,7 +68,7 @@ class OutgoingRequest extends Message implements OutgoingRequestInterface
     /**
      * Retrieves the HTTP method of the request.
      *
-     * @return string Returns the request method.
+     * @return string Returns the request method (always uppercase)
      */
     public function getMethod(): string
     {

--- a/system/HTTP/OutgoingRequest.php
+++ b/system/HTTP/OutgoingRequest.php
@@ -66,15 +66,13 @@ class OutgoingRequest extends Message implements OutgoingRequestInterface
     }
 
     /**
-     * Get the request method.
+     * Retrieves the HTTP method of the request.
      *
-     * @param bool $upper Whether to return in upper or lower case.
-     *
-     * @deprecated The $upper functionality will be removed and this will revert to its PSR-7 equivalent
+     * @return string Returns the request method.
      */
-    public function getMethod(bool $upper = false): string
+    public function getMethod(): string
     {
-        return ($upper) ? strtoupper($this->method) : strtolower($this->method);
+        return $this->method;
     }
 
     /**

--- a/system/HTTP/OutgoingRequestInterface.php
+++ b/system/HTTP/OutgoingRequestInterface.php
@@ -21,14 +21,11 @@ use InvalidArgumentException;
 interface OutgoingRequestInterface extends MessageInterface
 {
     /**
-     * Get the request method.
-     * An extension of PSR-7's getMethod to allow casing.
+     * Retrieves the HTTP method of the request.
      *
-     * @param bool $upper Whether to return in upper or lower case.
-     *
-     * @deprecated The $upper functionality will be removed and this will revert to its PSR-7 equivalent
+     * @return string Returns the request method.
      */
-    public function getMethod(bool $upper = false): string;
+    public function getMethod(): string;
 
     /**
      * Return an instance with the provided HTTP method.

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -41,7 +41,7 @@ class Request extends OutgoingRequest implements RequestInterface
     public function __construct($config = null) // @phpstan-ignore-line
     {
         if (empty($this->method)) {
-            $this->method = $this->getServer('REQUEST_METHOD') ?? 'GET';
+            $this->method = $this->getServer('REQUEST_METHOD') ?? Method::GET;
         }
 
         if (empty($this->uri)) {

--- a/system/HTTP/Request.php
+++ b/system/HTTP/Request.php
@@ -50,20 +50,6 @@ class Request extends OutgoingRequest implements RequestInterface
     }
 
     /**
-     * Get the request method.
-     *
-     * @param bool $upper Whether to return in upper or lower case.
-     *
-     * @deprecated 4.0.5 The $upper functionality will be removed and this will revert to its PSR-7 equivalent
-     *
-     * @codeCoverageIgnore
-     */
-    public function getMethod(bool $upper = false): string
-    {
-        return ($upper) ? strtoupper($this->method) : strtolower($this->method);
-    }
-
-    /**
      * Sets the request method. Used when spoofing the request.
      *
      * @return $this

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -442,9 +442,9 @@ trait ResponseTrait
                 isset($_SERVER['SERVER_PROTOCOL'], $_SERVER['REQUEST_METHOD'])
                 && $this->getProtocolVersion() >= 1.1
             ) {
-                if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+                if ($_SERVER['REQUEST_METHOD'] === Method::GET) {
                     $code = 302;
-                } elseif (in_array($_SERVER['REQUEST_METHOD'], ['POST', 'PUT', 'DELETE'], true)) {
+                } elseif (in_array($_SERVER['REQUEST_METHOD'], [Method::POST, Method::PUT, Method::DELETE], true)) {
                     // reference: https://en.wikipedia.org/wiki/Post/Redirect/Get
                     $code = 303;
                 } else {

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1012,7 +1012,10 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         foreach ($verbs as $verb) {
-            // @TODO We should use correct uppercase verb.
+            /**
+             * @TODO We should use correct uppercase verb.
+             * @deprecated 4.5.0
+             */
             $verb = strtolower($verb);
 
             $this->{$verb}($from, $to, $options);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1001,7 +1001,7 @@ class RouteCollection implements RouteCollectionInterface
      * Specifies a single route to match for multiple HTTP Verbs.
      *
      * Example:
-     *  $route->match( ['get', 'post'], 'users/(:num)', 'users/$1);
+     *  $route->match( ['GET', 'POST'], 'users/(:num)', 'users/$1);
      *
      * @param array|Closure|string $to
      */
@@ -1012,6 +1012,7 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         foreach ($verbs as $verb) {
+            // @TODO We should use correct uppercase verb.
             $verb = strtolower($verb);
 
             $this->{$verb}($from, $to, $options);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1012,6 +1012,14 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         foreach ($verbs as $verb) {
+            if ($verb === strtolower($verb)) {
+                @trigger_error(
+                    'Passing lowercase HTTP method "' . $verb . '" is deprecated.'
+                    . ' Use uppercase HTTP method like "' . strtoupper($verb) . '".',
+                    E_USER_DEPRECATED
+                );
+            }
+
             /**
              * @TODO We should use correct uppercase verb.
              * @deprecated 4.5.0

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -280,7 +280,7 @@ class Security implements SecurityInterface
     public function verify(RequestInterface $request)
     {
         // Protects POST, PUT, DELETE, PATCH
-        $method           = strtoupper($request->getMethod());
+        $method           = $request->getMethod();
         $methodsToProtect = ['POST', 'PUT', 'DELETE', 'PATCH'];
         if (! in_array($method, $methodsToProtect, true)) {
             return $this;

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Security;
 
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\I18n\Time;
@@ -281,7 +282,7 @@ class Security implements SecurityInterface
     {
         // Protects POST, PUT, DELETE, PATCH
         $method           = $request->getMethod();
-        $methodsToProtect = ['POST', 'PUT', 'DELETE', 'PATCH'];
+        $methodsToProtect = [Method::POST, Method::PUT, Method::DELETE, Method::PATCH];
         if (! in_array($method, $methodsToProtect, true)) {
             return $this;
         }

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -51,6 +51,14 @@ trait FeatureTestTrait
             $collection->resetRoutes();
 
             foreach ($routes as $route) {
+                if ($route[0] === strtolower($route[0])) {
+                    @trigger_error(
+                        'Passing lowercase HTTP method "' . $route[0] . '" is deprecated.'
+                        . ' Use uppercase HTTP method like "' . strtoupper($route[0]) . '".',
+                        E_USER_DEPRECATED
+                    );
+                }
+
                 /**
                  * @TODO For backward compatibility. Remove strtolower() in the future.
                  * @deprecated 4.5.0

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -36,7 +36,7 @@ trait FeatureTestTrait
      *
      * Example routes:
      * [
-     *    ['get', 'home', 'Home::index']
+     *    ['GET', 'home', 'Home::index'],
      * ]
      *
      * @param array|null $routes Array to set routes
@@ -51,10 +51,13 @@ trait FeatureTestTrait
             $collection->resetRoutes();
 
             foreach ($routes as $route) {
+                // @TODO For backward compatibility. Remove strtolower() in the future.
+                $method = strtolower($route[0]);
+
                 if (isset($route[3])) {
-                    $collection->{$route[0]}($route[1], $route[2], $route[3]);
+                    $collection->{$method}($route[1], $route[2], $route[3]);
                 } else {
-                    $collection->{$route[0]}($route[1], $route[2]);
+                    $collection->{$method}($route[1], $route[2]);
                 }
             }
         }

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -51,7 +51,10 @@ trait FeatureTestTrait
             $collection->resetRoutes();
 
             foreach ($routes as $route) {
-                // @TODO For backward compatibility. Remove strtolower() in the future.
+                /**
+                 * @TODO For backward compatibility. Remove strtolower() in the future.
+                 * @deprecated 4.5.0
+                 */
                 $method = strtolower($route[0]);
 
                 if (isset($route[3])) {

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Validation;
 
 use Closure;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use CodeIgniter\View\RendererInterface;
@@ -501,7 +502,7 @@ class Validation implements ValidationInterface
             return $this;
         }
 
-        if (in_array($request->getMethod(), ['PUT', 'PATCH', 'DELETE'], true)
+        if (in_array($request->getMethod(), [Method::PUT, Method::PATCH, Method::DELETE], true)
             && strpos($request->getHeaderLine('Content-Type'), 'multipart/form-data') === false
         ) {
             $this->data = $request->getRawInput();

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -501,7 +501,7 @@ class Validation implements ValidationInterface
             return $this;
         }
 
-        if (in_array(strtolower($request->getMethod()), ['put', 'patch', 'delete'], true)
+        if (in_array($request->getMethod(), ['PUT', 'PATCH', 'DELETE'], true)
             && strpos($request->getHeaderLine('Content-Type'), 'multipart/form-data') === false
         ) {
             $this->data = $request->getRawInput();

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -733,7 +733,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->run();
         ob_get_clean();
 
-        $this->assertSame('put', Services::incomingrequest()->getMethod());
+        $this->assertSame('PUT', Services::incomingrequest()->getMethod());
     }
 
     public function testSpoofRequestMethodCannotUseGET(): void
@@ -758,7 +758,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->run();
         ob_get_clean();
 
-        $this->assertSame('post', Services::incomingrequest()->getMethod());
+        $this->assertSame('POST', Services::incomingrequest()->getMethod());
     }
 
     /**

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Router\Exceptions\RedirectException;
 use CodeIgniter\Router\RouteCollection;
@@ -721,7 +722,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['REQUEST_METHOD']  = 'POST';
 
-        $_POST['_method'] = 'PUT';
+        $_POST['_method'] = Method::PUT;
 
         $routes = \Config\Services::routes();
         $routes->setDefaultNamespace('App\Controllers');
@@ -733,7 +734,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->run();
         ob_get_clean();
 
-        $this->assertSame('PUT', Services::incomingrequest()->getMethod());
+        $this->assertSame(Method::PUT, Services::incomingrequest()->getMethod());
     }
 
     public function testSpoofRequestMethodCannotUseGET(): void

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -87,7 +87,7 @@ final class FilterFinderTest extends CIUnitTestCase
                 ],
             ],
             'methods' => [
-                'get' => [],
+                'GET' => [],
             ],
             'filters' => [
                 'honeypot' => ['before' => ['form/*', 'survey/*']],
@@ -215,7 +215,7 @@ final class FilterFinderTest extends CIUnitTestCase
                 ],
             ],
             'methods' => [
-                'get' => ['method1', 'method2'],
+                'GET' => ['method1', 'method2'],
             ],
             'filters' => [
                 'filter1' => ['before' => '*', 'after' => '*'],
@@ -280,7 +280,7 @@ final class FilterFinderTest extends CIUnitTestCase
                 ],
             ],
             'methods' => [
-                'get' => ['method1', 'method2'],
+                'GET' => ['method1', 'method2'],
             ],
             'filters' => [
                 'filter1' => ['before' => '*', 'after' => '*'],

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -89,7 +89,7 @@ final class FiltersTest extends CIUnitTestCase
             'aliases' => ['foo' => ''],
             'globals' => [],
             'methods' => [
-                'cli' => ['foo'],
+                'CLI' => ['foo'],
             ],
         ];
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
@@ -113,7 +113,7 @@ final class FiltersTest extends CIUnitTestCase
             'aliases' => ['foo' => ''],
             'globals' => [],
             'methods' => [
-                'get' => ['foo'],
+                'GET' => ['foo'],
             ],
         ];
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
@@ -137,8 +137,8 @@ final class FiltersTest extends CIUnitTestCase
             ],
             'globals' => [],
             'methods' => [
-                'post' => ['foo'],
-                'get'  => ['bar'],
+                'POST' => ['foo'],
+                'GET'  => ['bar'],
             ],
         ];
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
@@ -162,8 +162,8 @@ final class FiltersTest extends CIUnitTestCase
             ],
             'globals' => [],
             'methods' => [
-                'post' => ['foo'],
-                'get'  => ['bar'],
+                'POST' => ['foo'],
+                'GET'  => ['bar'],
             ],
         ];
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
@@ -348,8 +348,8 @@ final class FiltersTest extends CIUnitTestCase
                 ],
             ],
             'methods' => [
-                'post' => ['foo'],
-                'get'  => ['bar'],
+                'POST' => ['foo'],
+                'GET'  => ['bar'],
             ],
             'filters' => [
                 'foof' => [
@@ -391,7 +391,7 @@ final class FiltersTest extends CIUnitTestCase
                 ],
             ],
             'methods' => [
-                'get' => ['bar'],
+                'GET' => ['bar'],
             ],
             'filters' => [
                 'foof' => [

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -525,8 +525,7 @@ final class CLIRequestTest extends CIUnitTestCase
     public function testMethodReturnsRightStuff(): void
     {
         // Defaults method to CLI now.
-        $this->assertSame('cli', $this->request->getMethod());
-        $this->assertSame('CLI', $this->request->getMethod(true));
+        $this->assertSame('CLI', $this->request->getMethod());
     }
 
     public function testMethodIsCliReturnsAlwaysTrue(): void

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -103,7 +103,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $this->request->get('http://example.com');
 
-        $this->assertSame('get', $this->request->getMethod());
+        $this->assertSame('GET', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -115,7 +115,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $this->request->delete('http://example.com');
 
-        $this->assertSame('delete', $this->request->getMethod());
+        $this->assertSame('DELETE', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -127,7 +127,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $this->request->head('http://example.com');
 
-        $this->assertSame('head', $this->request->getMethod());
+        $this->assertSame('HEAD', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -139,7 +139,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $this->request->options('http://example.com');
 
-        $this->assertSame('options', $this->request->getMethod());
+        $this->assertSame('OPTIONS', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -281,7 +281,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $this->request->patch('http://example.com');
 
-        $this->assertSame('patch', $this->request->getMethod());
+        $this->assertSame('PATCH', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -293,7 +293,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $this->request->post('http://example.com');
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -305,7 +305,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     {
         $this->request->put('http://example.com');
 
-        $this->assertSame('put', $this->request->getMethod());
+        $this->assertSame('PUT', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -322,19 +322,19 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertSame('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('custom', $options[CURLOPT_CUSTOMREQUEST]);
     }
 
     public function testRequestMethodGetsSanitized(): void
     {
         $this->request->request('<script>Custom</script>', 'http://example.com');
 
-        $this->assertSame('custom', $this->request->getMethod());
+        $this->assertSame('Custom', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertSame('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('Custom', $options[CURLOPT_CUSTOMREQUEST]);
     }
 
     public function testRequestSetsBasicCurlOptions(): void
@@ -951,7 +951,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
             'form_params' => $params,
         ]);
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -974,7 +974,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
             'multipart' => $params,
         ]);
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -1022,7 +1022,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
             'json' => $params,
         ]);
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $expected = json_encode($params);
         $this->assertSame(

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -103,7 +103,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $this->request->get('http://example.com');
 
-        $this->assertSame('get', $this->request->getMethod());
+        $this->assertSame('GET', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -115,7 +115,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $this->request->delete('http://example.com');
 
-        $this->assertSame('delete', $this->request->getMethod());
+        $this->assertSame('DELETE', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -127,7 +127,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $this->request->head('http://example.com');
 
-        $this->assertSame('head', $this->request->getMethod());
+        $this->assertSame('HEAD', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -139,7 +139,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $this->request->options('http://example.com');
 
-        $this->assertSame('options', $this->request->getMethod());
+        $this->assertSame('OPTIONS', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -264,7 +264,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $this->request->patch('http://example.com');
 
-        $this->assertSame('patch', $this->request->getMethod());
+        $this->assertSame('PATCH', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -276,7 +276,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $this->request->post('http://example.com');
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -288,7 +288,7 @@ final class CURLRequestTest extends CIUnitTestCase
     {
         $this->request->put('http://example.com');
 
-        $this->assertSame('put', $this->request->getMethod());
+        $this->assertSame('PUT', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -305,19 +305,19 @@ final class CURLRequestTest extends CIUnitTestCase
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertSame('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('custom', $options[CURLOPT_CUSTOMREQUEST]);
     }
 
     public function testRequestMethodGetsSanitized(): void
     {
         $this->request->request('<script>Custom</script>', 'http://example.com');
 
-        $this->assertSame('custom', $this->request->getMethod());
+        $this->assertSame('Custom', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
         $this->assertArrayHasKey(CURLOPT_CUSTOMREQUEST, $options);
-        $this->assertSame('CUSTOM', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame('Custom', $options[CURLOPT_CUSTOMREQUEST]);
     }
 
     public function testRequestSetsBasicCurlOptions(): void
@@ -934,7 +934,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
             'form_params' => $params,
         ]);
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -957,7 +957,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
             'multipart' => $params,
         ]);
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $options = $this->request->curl_options;
 
@@ -1005,7 +1005,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
             'json' => $params,
         ]);
 
-        $this->assertSame('post', $this->request->getMethod());
+        $this->assertSame('POST', $this->request->getMethod());
 
         $expected = json_encode($params);
         $this->assertSame($expected, $this->request->getBody());

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -840,7 +840,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     public function testSpoofing(): void
     {
         $this->request->setMethod('WINK');
-        $this->assertSame('wink', $this->request->getMethod());
+        $this->assertSame('WINK', $this->request->getMethod());
     }
 
     /**

--- a/tests/system/HTTP/OutgoingRequestTest.php
+++ b/tests/system/HTTP/OutgoingRequestTest.php
@@ -44,8 +44,8 @@ final class OutgoingRequestTest extends CIUnitTestCase
 
         $newRequest = $request->withMethod('POST');
 
-        $this->assertSame('GET', strtoupper($request->getMethod()));
-        $this->assertSame('POST', strtoupper($newRequest->getMethod()));
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('POST', $newRequest->getMethod());
     }
 
     public function testWithUri(): void

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -639,7 +639,6 @@ final class RequestTest extends CIUnitTestCase
     public function testMethodReturnsRightStuff(): void
     {
         // Defaults method to GET now.
-        $this->assertSame('get', $this->request->getMethod());
-        $this->assertSame('GET', $this->request->getMethod(true));
+        $this->assertSame('GET', $this->request->getMethod());
     }
 }

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -966,7 +966,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         $routes = Services::routes();
         $routes->group('(:alpha)', static function ($routes): void {
-            $routes->match(['get'], 'login', 'Common\LoginController::loginView', ['as' => 'loginURL']);
+            $routes->match(['GET'], 'login', 'Common\LoginController::loginView', ['as' => 'loginURL']);
         });
 
         url_to('loginURL');

--- a/tests/system/HomeTest.php
+++ b/tests/system/HomeTest.php
@@ -28,7 +28,7 @@ final class HomeTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 '\App\Controllers\Home::index',
             ],

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -148,7 +148,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $this->getCollector();
 
-        $routes->match(['get'], 'home', 'controller');
+        $routes->match(['GET'], 'home', 'controller');
 
         $expects = [
             'home' => '\controller',
@@ -180,7 +180,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $routes = $this->getCollector();
 
-        $routes->match(['put'], 'home', 'controller');
+        $routes->match(['PUT'], 'home', 'controller');
 
         $routes = $routes->getRoutes();
 
@@ -816,12 +816,12 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         $expected = ['here' => '\there'];
 
-        $routes->match(['get', 'post'], 'here', 'there');
+        $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
 
         Services::request()->setMethod('post');
         $routes = $this->getCollector();
-        $routes->match(['get', 'post'], 'here', 'there');
+        $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
     }
 

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -144,7 +144,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testAddWorksWithCurrentHTTPMethods(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -176,7 +176,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testMatchIgnoresInvalidHTTPMethods(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -189,7 +189,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testAddWorksWithArrayOFHTTPMethods(): void
     {
-        Services::request()->setMethod('post');
+        Services::request()->setMethod('POST');
 
         $routes = $this->getCollector();
 
@@ -696,7 +696,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithCustomController(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['controller' => '<script>gallery']);
@@ -713,7 +713,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithCustomPlaceholder(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['placeholder' => ':num']);
@@ -730,7 +730,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithDefaultPlaceholder(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->setDefaultConstraint('num');
@@ -748,7 +748,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithBogusDefaultPlaceholder(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->setDefaultConstraint(':num');
@@ -766,7 +766,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithOnly(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['only' => 'index']);
@@ -780,7 +780,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithExcept(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['except' => 'edit,new']);
@@ -811,7 +811,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testMatchSupportsMultipleMethods(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -819,7 +819,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
 
-        Services::request()->setMethod('post');
+        Services::request()->setMethod('POST');
         $routes = $this->getCollector();
         $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
@@ -827,7 +827,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testGet(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -949,7 +949,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     {
         // ENVIRONMENT should be 'testing'
 
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -1434,7 +1434,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testRouteGroupWithFilterSimple(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->group(
@@ -1453,7 +1453,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testRouteGroupWithFilterWithParams(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->group(
@@ -1471,7 +1471,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideNot(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $this->assertNull($routes->get404Override());
@@ -1479,7 +1479,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideString(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->set404Override('Explode');
@@ -1488,7 +1488,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideCallable(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->set404Override(static function (): void {
@@ -1499,7 +1499,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testOffsetParameters(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
 
         $routes->get('users/(:num)', 'users/show/$1', ['offset' => 1]);
@@ -1515,7 +1515,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1527,7 +1527,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1539,7 +1539,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1551,7 +1551,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1563,7 +1563,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1575,7 +1575,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1587,7 +1587,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1599,7 +1599,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1611,7 +1611,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
 
@@ -1628,7 +1628,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingDifferentSubdomains(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1649,7 +1649,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingTwoRules(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1670,7 +1670,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingTwoRulesLastApplies(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1690,7 +1690,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingMatchingSubdomain(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1710,7 +1710,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingMatchingHost(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1734,7 +1734,7 @@ final class RouteCollectionTest extends CIUnitTestCase
      */
     public function testRouteDefaultNameSpace(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
 
@@ -1748,7 +1748,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testZeroAsURIPath(): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
 
@@ -1796,7 +1796,7 @@ final class RouteCollectionTest extends CIUnitTestCase
      */
     public function testRoutesControllerNameReturnsFQCN($namespace): void
     {
-        Services::request()->setMethod('get');
+        Services::request()->setMethod('GET');
         $routes = $this->getCollector();
         $routes->setAutoRoute(false);
         $routes->setDefaultNamespace($namespace);

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -15,6 +15,7 @@ use App\Controllers\Product;
 use CodeIgniter\Config\Services;
 use CodeIgniter\controller;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Config\Routing;
@@ -144,7 +145,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testAddWorksWithCurrentHTTPMethods(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -176,7 +177,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testMatchIgnoresInvalidHTTPMethods(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -189,7 +190,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testAddWorksWithArrayOFHTTPMethods(): void
     {
-        Services::request()->setMethod('POST');
+        Services::request()->setMethod(Method::POST);
 
         $routes = $this->getCollector();
 
@@ -696,7 +697,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithCustomController(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['controller' => '<script>gallery']);
@@ -713,7 +714,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithCustomPlaceholder(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['placeholder' => ':num']);
@@ -730,7 +731,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithDefaultPlaceholder(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->setDefaultConstraint('num');
@@ -748,7 +749,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithBogusDefaultPlaceholder(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->setDefaultConstraint(':num');
@@ -766,7 +767,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithOnly(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['only' => 'index']);
@@ -780,7 +781,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithExcept(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['except' => 'edit,new']);
@@ -811,7 +812,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testMatchSupportsMultipleMethods(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -819,7 +820,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
 
-        Services::request()->setMethod('POST');
+        Services::request()->setMethod(Method::POST);
         $routes = $this->getCollector();
         $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
@@ -827,7 +828,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testGet(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -949,7 +950,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     {
         // ENVIRONMENT should be 'testing'
 
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -1434,7 +1435,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testRouteGroupWithFilterSimple(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->group(
@@ -1453,7 +1454,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testRouteGroupWithFilterWithParams(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->group(
@@ -1471,7 +1472,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideNot(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $this->assertNull($routes->get404Override());
@@ -1479,7 +1480,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideString(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->set404Override('Explode');
@@ -1488,7 +1489,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideCallable(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->set404Override(static function (): void {
@@ -1499,7 +1500,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testOffsetParameters(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->get('users/(:num)', 'users/show/$1', ['offset' => 1]);
@@ -1515,7 +1516,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1527,7 +1528,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1539,7 +1540,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1551,7 +1552,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1563,7 +1564,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1575,7 +1576,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1587,7 +1588,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1599,7 +1600,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1611,7 +1612,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1628,7 +1629,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingDifferentSubdomains(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1649,7 +1650,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingTwoRules(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1670,7 +1671,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingTwoRulesLastApplies(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1690,7 +1691,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingMatchingSubdomain(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1710,7 +1711,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingMatchingHost(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
 
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
@@ -1734,7 +1735,7 @@ final class RouteCollectionTest extends CIUnitTestCase
      */
     public function testRouteDefaultNameSpace(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
 
@@ -1748,7 +1749,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testZeroAsURIPath(): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
         $router = new Router($routes, Services::request());
 
@@ -1796,7 +1797,7 @@ final class RouteCollectionTest extends CIUnitTestCase
      */
     public function testRoutesControllerNameReturnsFQCN($namespace): void
     {
-        Services::request()->setMethod('GET');
+        Services::request()->setMethod(Method::GET);
         $routes = $this->getCollector();
         $routes->setAutoRoute(false);
         $routes->setDefaultNamespace($namespace);

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -65,7 +65,7 @@ final class RouterTest extends CIUnitTestCase
         $this->collection->map($routes);
 
         $this->request = Services::request();
-        $this->request->setMethod('get');
+        $this->request->setMethod('GET');
     }
 
     public function testEmptyURIMatchesRoot(): void

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -15,6 +15,7 @@ use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\Router\Exceptions\RouterException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
@@ -65,7 +66,7 @@ final class RouterTest extends CIUnitTestCase
         $this->collection->map($routes);
 
         $this->request = Services::request();
-        $this->request->setMethod('GET');
+        $this->request->setMethod(Method::GET);
     }
 
     public function testEmptyURIMatchesRoot(): void

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -150,7 +150,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
             ->execute('popper');
 
         $req = $result->request();
-        $this->assertSame('get', $req->getMethod());
+        $this->assertSame('GET', $req->getMethod());
     }
 
     public function testFailureResponse(): void

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -49,7 +49,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 static fn () => 'Hello World',
             ],
@@ -69,7 +69,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'foo/bar/1/2/3',
                 static fn () => 'Hello World',
             ],
@@ -85,7 +85,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'admin',
                 static fn () => 'Admin Area',
                 ['filter' => 'test-redirectfilter'],
@@ -100,7 +100,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 static function () { echo 'test echo'; },
             ],
@@ -118,7 +118,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'post',
+                'POST',
                 'home',
                 static fn () => 'Hello Mars',
             ],
@@ -132,7 +132,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'post',
+                'POST',
                 'home',
                 static fn () => 'Hello ' . service('request')->getPost('foo') . '!',
             ],
@@ -146,7 +146,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'post',
+                'POST',
                 'section/create',
                 static function () {
                     $validation = Services::validation();
@@ -176,7 +176,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'put',
+                'PUT',
                 'home',
                 static fn () => 'Hello Pluto',
             ],
@@ -190,7 +190,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'patch',
+                'PATCH',
                 'home',
                 static fn () => 'Hello Jupiter',
             ],
@@ -204,7 +204,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'options',
+                'OPTIONS',
                 'home',
                 static fn () => 'Hello George',
             ],
@@ -218,7 +218,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'delete',
+                'DELETE',
                 'home',
                 static fn () => 'Hello Wonka',
             ],
@@ -232,7 +232,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $response = $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 static fn () => 'Home',
             ],
@@ -254,7 +254,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 
         $response = $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 static fn () => 'Home',
             ],
@@ -268,7 +268,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 '\Tests\Support\Controllers\Popcorn::index',
             ],
@@ -281,7 +281,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 '\Tests\Support\Controllers\Popcorn::cat',
             ],
@@ -294,7 +294,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 '\Tests\Support\Controllers\Popcorn::canyon',
             ],
@@ -308,7 +308,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 '\Tests\Support\Controllers\Popcorn::canyon',
             ],
@@ -373,7 +373,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 
         $this->withRoutes([
             [
-                'cli',
+                'CLI',
                 $from,
                 $to,
             ],
@@ -388,7 +388,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 '\Tests\Support\Controllers\Popcorn::goaway',
             ],
@@ -402,7 +402,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 static fn () => json_encode(Services::request()->getGet()),
             ],
@@ -429,7 +429,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'get',
+                'GET',
                 'home',
                 static fn () => json_encode(Services::request()->fetchGlobal('request')),
             ],
@@ -456,7 +456,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'post',
+                'POST',
                 'home',
                 static fn () => json_encode(Services::request()->getPost()),
             ],
@@ -483,7 +483,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'post',
+                'POST',
                 'home',
                 static fn () => json_encode(Services::request()->fetchGlobal('request')),
             ],
@@ -510,7 +510,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'put',
+                'PUT',
                 'home',
                 '\Tests\Support\Controllers\Popcorn::echoJson',
             ],
@@ -534,7 +534,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'put',
+                'PUT',
                 'home',
                 static fn () => json_encode(Services::request()->fetchGlobal('request')),
             ],
@@ -558,7 +558,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
     {
         $this->withRoutes([
             [
-                'post',
+                'POST',
                 'home',
                 '\Tests\Support\Controllers\Popcorn::echoJson',
             ],

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -849,7 +849,7 @@ class ValidationTest extends CIUnitTestCase
         $rules = [
             'role' => 'required|min_length[5]',
         ];
-        $result = $this->validation->withRequest($request->withMethod('patch'))->setRules($rules)->run();
+        $result = $this->validation->withRequest($request->withMethod('PATCH'))->setRules($rules)->run();
 
         $this->assertTrue($result);
         $this->assertSame([], $this->validation->getErrors());
@@ -874,7 +874,7 @@ class ValidationTest extends CIUnitTestCase
             'role' => 'required|min_length[5]',
         ];
         $result = $this->validation
-            ->withRequest($request->withMethod('patch'))
+            ->withRequest($request->withMethod('PATCH'))
             ->setRules($rules)
             ->run();
 
@@ -930,7 +930,7 @@ class ValidationTest extends CIUnitTestCase
             'p' => 'required|array_count[2]',
         ];
         $result = $this->validation
-            ->withRequest($request->withMethod('patch'))
+            ->withRequest($request->withMethod('PATCH'))
             ->setRules($rules)
             ->run();
 
@@ -1113,7 +1113,7 @@ class ValidationTest extends CIUnitTestCase
         $request = new IncomingRequest($config, new SiteURI($config), http_build_query($body), new UserAgent());
 
         $this->validation->setRules($rules);
-        $this->validation->withRequest($request->withMethod('post'))->run($body);
+        $this->validation->withRequest($request->withMethod('POST'))->run($body);
         $this->assertSame($results, $this->validation->getErrors());
     }
 
@@ -1196,7 +1196,7 @@ class ValidationTest extends CIUnitTestCase
             'name_user.*' => 'alpha_numeric',
         ]);
 
-        $this->validation->withRequest($request->withMethod('post'))->run();
+        $this->validation->withRequest($request->withMethod('POST'))->run();
         $this->assertSame([], $this->validation->getErrors());
     }
 
@@ -1231,7 +1231,7 @@ class ValidationTest extends CIUnitTestCase
             'contacts.friends.*.name' => 'required',
         ]);
 
-        $this->validation->withRequest($request->withMethod('post'))->run();
+        $this->validation->withRequest($request->withMethod('POST'))->run();
         $this->assertSame([
             'id_user.0'               => 'The id_user.* field must contain only numbers.',
             'name_user.0'             => 'The name_user.* field may only contain alphabetical characters.',
@@ -1265,7 +1265,7 @@ class ValidationTest extends CIUnitTestCase
             'id_user' => 'numeric',
         ]);
 
-        $this->validation->withRequest($request->withMethod('post'))->run();
+        $this->validation->withRequest($request->withMethod('POST'))->run();
         $this->assertSame([
             'id_user' => 'The id_user field must contain only numbers.',
         ], $this->validation->getErrors());

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -281,6 +281,14 @@ Deprecations
   used.
 - **Response:** The constructor parameter ``$config`` has been deprecated. No
   longer used.
+- **Filters::** The feature that ``Filters`` accept the lowercase HTTP method keys
+  of ``Config\Filters::$methods`` has been deprecated. Use correct uppercase HTTP
+  method keys instead.
+- **RouteCollection:** The feature that the ``match()`` method accepts the lowercase
+  HTTP methods has been deprecated. Use correct uppercase HTTP methods instead.
+- **FeatureTestTrait:** The feature that the ``withRoutes()`` method accepts the
+  lowercase HTTP methods has been deprecated. Use correct uppercase HTTP methods
+  instead.
 
 Bugs Fixed
 **********

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -21,6 +21,23 @@ BREAKING
 Behavior Changes
 ================
 
+Lowercase HTTP Method Name
+--------------------------
+
+For historical reasons, the framework used HTTP method names in lower case like
+"get", "post".
+But the method token is case-sensitive because it might be used as a gateway
+to object-based systems with case-sensitive method names. By convention,
+standardized methods are defined in all-uppercase US-ASCII letters.
+See https://www.rfc-editor.org/rfc/rfc9110#name-overview.
+
+Now the framework uses the correct HTTP method names like "GET", "POST".
+
+- ``Request::getMethod()`` returns uppercase HTTP methods.
+- ``CURLRequest::request()`` does not change the accepted HTTP methods to uppercase.
+
+See :ref:`upgrade-450-lowercase-http-method-name` for details.
+
 Filter Execution Order
 ----------------------
 
@@ -118,6 +135,16 @@ Others
 Removed Deprecated Items
 ========================
 
+Request
+-------
+
+- The ``$upper`` parameter in ``getMethod()`` in ``RequestInterface`` and ``Request``
+  has been removed. See :ref:`upgrade-450-lowercase-http-method-name`.
+- The deprecated ``isValidIP()`` method in ``RequestInterface`` and ``Request``
+  has been removed.
+- The visibility of the deprecated properties ``$uri`` and ``$config`` in
+  ``IncomingRequest`` has been changed to protected.
+
 Filters
 -------
 
@@ -183,10 +210,6 @@ Spark Commands
 Others
 ------
 
-- **IncomingRequest:** The visibility of the deprecated properties ``$uri`` and
-  ``$config`` has been changed to protected.
-- **RequestInterface:** The deprecated ``isValidIP()`` method has been removed.
-- **Request:** The deprecated ``isValidIP()`` method has been removed.
 - **Config:** The deprecated ``CodeIgniter\Config\Config`` class has been removed.
 
 Enhancements

--- a/user_guide_src/source/incoming/filters/008.php
+++ b/user_guide_src/source/incoming/filters/008.php
@@ -9,8 +9,8 @@ class Filters extends BaseConfig
     // ...
 
     public array $methods = [
-        'post' => ['invalidchars', 'csrf'],
-        'get'  => ['csrf'],
+        'POST' => ['invalidchars', 'csrf'],
+        'GET'  => ['csrf'],
     ];
 
     // ...

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -47,7 +47,10 @@ is()
 
 .. versionadded:: 4.3.0
 
-Since v4.3.0, you can use the ``is()`` method. It returns boolean.
+Since v4.3.0, you can use the ``is()`` method. It accepts a HTTP method, ``'ajax'``,
+or ``'json'``, and returns boolean.
+
+.. note:: HTTP method should be case-sensitive, but the parameter is case-insensitive.
 
 .. literalinclude:: incomingrequest/040.php
 
@@ -58,16 +61,16 @@ You can check the HTTP method that this request represents with the ``getMethod(
 
 .. literalinclude:: incomingrequest/005.php
 
-By default, the method is returned as a lower-case string (i.e., ``'get'``, ``'post'``, etc).
+The HTTP method is case-sensitive, and by convention, standardized methods are
+defined in all-uppercase US-ASCII letters.
 
-.. important:: The functionality to convert the return value to lower case is deprecated.
-    It will be removed in the future version, and this method will be PSR-7 equivalent.
+.. note:: Prior to v4.5.0, by default, the method was returned as a lower-case
+    string (i.e., ``'get'``, ``'post'``, etc). But it was a bug.
 
-You can get an
-uppercase version by wrapping the call in ``strtoupper()``::
+You can get an lowercase version by wrapping the call in ``strtolower()``::
 
-    // Returns 'GET'
-    $method = strtoupper($request->getMethod());
+    // Returns 'get'
+    $method = strtolower($request->getMethod());
 
 You can also check if the request was made through and HTTPS connection with the ``isSecure()`` method:
 

--- a/user_guide_src/source/incoming/incomingrequest/005.php
+++ b/user_guide_src/source/incoming/incomingrequest/005.php
@@ -1,4 +1,4 @@
 <?php
 
-// Returns 'post'
+// Returns 'POST'
 $method = $request->getMethod();

--- a/user_guide_src/source/incoming/request.rst
+++ b/user_guide_src/source/incoming/request.rst
@@ -57,16 +57,12 @@ Class Reference
         Accepts an optional second string parameter of ``ipv4`` or ``ipv6`` to specify
         an IP format. The default checks for both formats.
 
-    .. php:method:: getMethod([$upper = false])
+    .. php:method:: getMethod()
 
-        .. important:: Use of the ``$upper`` parameter is deprecated. It will be removed in future releases.
-
-        :param bool $upper: Whether to return the request method name in upper or lower case
         :returns: HTTP request method
         :rtype: string
 
-        Returns the ``$_SERVER['REQUEST_METHOD']``, with the option to set it
-        in uppercase or lowercase.
+        Returns the ``$_SERVER['REQUEST_METHOD']``.
 
         .. literalinclude:: request/003.php
 

--- a/user_guide_src/source/incoming/request/003.php
+++ b/user_guide_src/source/incoming/request/003.php
@@ -1,5 +1,3 @@
 <?php
 
-echo $request->getMethod(true);  // Outputs: POST
-echo $request->getMethod(false); // Outputs: post
-echo $request->getMethod();      // Outputs: post
+echo $request->getMethod(); // Outputs: POST

--- a/user_guide_src/source/incoming/routing/004.php
+++ b/user_guide_src/source/incoming/routing/004.php
@@ -1,3 +1,3 @@
 <?php
 
-$routes->match(['get', 'put'], 'products', 'Product::feature');
+$routes->match(['GET', 'PUT'], 'products', 'Product::feature');

--- a/user_guide_src/source/incoming/routing/033.php
+++ b/user_guide_src/source/incoming/routing/033.php
@@ -8,7 +8,7 @@ $routes->head('from', 'to', $options);
 $routes->options('from', 'to', $options);
 $routes->delete('from', 'to', $options);
 $routes->patch('from', 'to', $options);
-$routes->match(['get', 'put'], 'from', 'to', $options);
+$routes->match(['GET', 'PUT'], 'from', 'to', $options);
 $routes->resource('photos', $options);
 $routes->map($array, $options);
 $routes->group('name', $options, static function () {});

--- a/user_guide_src/source/installation/upgrade_415/001.php
+++ b/user_guide_src/source/installation/upgrade_415/001.php
@@ -9,8 +9,8 @@ class Filters extends BaseConfig
     // ...
 
     public $methods = [
-        'get'  => ['csrf'],
-        'post' => ['csrf'],
+        'GET'  => ['csrf'],
+        'POST' => ['csrf'],
     ];
     // ...
 }

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -18,6 +18,51 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+.. _upgrade-450-lowercase-http-method-name:
+
+Lowercase HTTP Method Name
+==========================
+
+For historical reasons, ``Request::getMethod()`` returned HTTP method names in
+lower case by default.
+
+But the method token is case-sensitive because it might be used as a gateway
+to object-based systems with case-sensitive method names. By convention,
+standardized methods are defined in all-uppercase US-ASCII letters.
+See https://www.rfc-editor.org/rfc/rfc9110#name-overview.
+
+Now the deprecated ``$upper`` parameter in ``Request::getMethod()`` has been
+removed, and the ``getMethod()`` returns the as-is HTTP method name. That is,
+uppercase like "GET", "POST", and so on.
+
+If you want lowercase HTTP method names, use PHP's ``strtolower()`` function::
+
+    strtolower($request->getMethod())
+
+And you should use uppercase HTTP method names in your app code. You should update
+the keys in ``$methods`` in **app/Config/Filters.php**::
+
+    public array $methods = [
+        'POST' => ['invalidchars', 'csrf'],
+        'GET'  => ['csrf'],
+    ];
+
+CURLRequest::request()
+----------------------
+
+In previous versions, you could pass lowercase HTTP methods to the ``request()``
+method. But this bug has been fixed.
+
+Now you must pass the correct HTTP method names like "GET", "POST". Otherwise
+you would get the error response::
+
+    $client   = \Config\Services::curlrequest();
+    $response = $client->request('get', 'https://www.google.com/', [
+        'http_errors' => false,
+    ]);
+    $response->getStatusCode(); // In previous versions: 200
+                                //     In this verrsion: 405
+
 .. _upgrade-450-nested-route-groups-and-options:
 
 Nested Route Groups and Options

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -23,6 +23,9 @@ Breaking Changes
 Lowercase HTTP Method Name
 ==========================
 
+Request::getMethod()
+--------------------
+
 For historical reasons, ``Request::getMethod()`` returned HTTP method names in
 lower case by default.
 
@@ -39,8 +42,12 @@ If you want lowercase HTTP method names, use PHP's ``strtolower()`` function::
 
     strtolower($request->getMethod())
 
-And you should use uppercase HTTP method names in your app code. You should update
-the keys in ``$methods`` in **app/Config/Filters.php**::
+And you should use uppercase HTTP method names in your app code.
+
+app/Config/Filters.php
+----------------------
+
+You should update the keys in ``$methods`` in **app/Config/Filters.php**::
 
     public array $methods = [
         'POST' => ['invalidchars', 'csrf'],

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -95,8 +95,15 @@ Model, View and Controller
 Core Class Changes
 ==================
 
-- CI3's `Input <http://codeigniter.com/userguide3/libraries/input.html>`_ corresponds to CI4's :doc:`IncomingRequest </incoming/incomingrequest>`.
-- CI3's `Output <http://codeigniter.com/userguide3/libraries/output.html>`_ corresponds to CI4's :doc:`Responses </outgoing/response>`.
+- Input
+    - CI3's `Input <http://codeigniter.com/userguide3/libraries/input.html>`_
+      corresponds to CI4's :doc:`IncomingRequest </incoming/incomingrequest>`.
+    - For historical reasons, CI3 and CI4 used incorrect HTTP method names like
+      "get", "post". Since v4.5.0, CI4 uses the correct HTTP method names like
+      "GET", "POST".
+- Output
+    - CI3's `Output <http://codeigniter.com/userguide3/libraries/output.html>`_
+      corresponds to CI4's :doc:`Responses </outgoing/response>`.
 
 Class Loading
 =============

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -92,6 +92,12 @@ Model, View and Controller
     upgrade_views
     upgrade_controllers
 
+Core Class Changes
+==================
+
+- CI3's `Input <http://codeigniter.com/userguide3/libraries/input.html>`_ corresponds to CI4's :doc:`IncomingRequest </incoming/incomingrequest>`.
+- CI3's `Output <http://codeigniter.com/userguide3/libraries/output.html>`_ corresponds to CI4's :doc:`Responses </outgoing/response>`.
+
 Class Loading
 =============
 
@@ -194,8 +200,6 @@ Upgrading Libraries
   `Trackback <http://codeigniter.com/userguide3/libraries/trackback.html>`_,
   `XML-RPC /-Server <http://codeigniter.com/userguide3/libraries/xmlrpc.html>`_,
   and `Zip Encoding <http://codeigniter.com/userguide3/libraries/zip.html>`_.
-- CI3's `Input <http://codeigniter.com/userguide3/libraries/input.html>`_ corresponds to CI4's :doc:`IncomingRequest </incoming/incomingrequest>`.
-- CI3's `Output <http://codeigniter.com/userguide3/libraries/output.html>`_ corresponds to CI4's :doc:`Responses </outgoing/response>`.
 - All the other libraries, which exist in both CodeIgniter versions, can be upgraded with some adjustments.
   The most important and mostly used libraries received an Upgrade Guide, which will help you with simple
   steps and examples to adjust your code.

--- a/user_guide_src/source/libraries/curlrequest/017.php
+++ b/user_guide_src/source/libraries/curlrequest/017.php
@@ -1,3 +1,3 @@
 <?php
 
-$client->setBody($body)->request('put', 'http://example.com');
+$client->setBody($body)->request('PUT', 'http://example.com');

--- a/user_guide_src/source/libraries/curlrequest/018.php
+++ b/user_guide_src/source/libraries/curlrequest/018.php
@@ -1,3 +1,3 @@
 <?php
 
-$client->request('put', 'http://example.com', ['body' => $body]);
+$client->request('PUT', 'http://example.com', ['body' => $body]);

--- a/user_guide_src/source/libraries/curlrequest/019.php
+++ b/user_guide_src/source/libraries/curlrequest/019.php
@@ -1,3 +1,3 @@
 <?php
 
-$client->request('get', '/', ['cert' => ['/path/server.pem', 'password']]);
+$client->request('GET', '/', ['cert' => ['/path/server.pem', 'password']]);

--- a/user_guide_src/source/libraries/curlrequest/025.php
+++ b/user_guide_src/source/libraries/curlrequest/025.php
@@ -1,6 +1,6 @@
 <?php
 
-$client->request('get', '/', [
+$client->request('GET', '/', [
     'headers' => [
         'User-Agent' => 'testing/1.0',
         'Accept'     => 'application/json',

--- a/user_guide_src/source/libraries/security/009.php
+++ b/user_guide_src/source/libraries/security/009.php
@@ -7,8 +7,8 @@ use CodeIgniter\Config\BaseConfig;
 class Filters extends BaseConfig
 {
     public $methods = [
-        'get'  => ['csrf'],
-        'post' => ['csrf'],
+        'GET'  => ['csrf'],
+        'POST' => ['csrf'],
     ];
 
     // ...

--- a/user_guide_src/source/libraries/throttler/004.php
+++ b/user_guide_src/source/libraries/throttler/004.php
@@ -7,7 +7,7 @@ use CodeIgniter\Config\BaseConfig;
 class Filters extends BaseConfig
 {
     public $methods = [
-        'post' => ['throttle'],
+        'POST' => ['throttle'],
     ];
 
     // ...

--- a/user_guide_src/source/testing/feature/002.php
+++ b/user_guide_src/source/testing/feature/002.php
@@ -1,7 +1,7 @@
 <?php
 
 // Get a simple page
-$result = $this->call('get', '/');
+$result = $this->call('GET', '/');
 
 // Submit a form
 $result = $this->call('post', 'contact', [

--- a/user_guide_src/source/testing/feature/004.php
+++ b/user_guide_src/source/testing/feature/004.php
@@ -1,7 +1,7 @@
 <?php
 
 $routes = [
-    ['get', 'users', 'UserController::list'],
+    ['GET', 'users', 'UserController::list'],
 ];
 
 $result = $this->withRoutes($routes)->get('users');

--- a/user_guide_src/source/tutorial/create_news_items/001.php
+++ b/user_guide_src/source/tutorial/create_news_items/001.php
@@ -9,7 +9,7 @@ class Filters extends BaseConfig
     // ...
 
     public $methods = [
-        'post' => ['csrf'],
+        'POST' => ['csrf'],
     ];
 
     // ...


### PR DESCRIPTION
**Description**
The strike line is annoying.
![Screenshot 2023-11-10 13 55 00](https://github.com/codeigniter4/CodeIgniter4/assets/87955/c9c18744-762c-458b-b998-dc0c02a394bf)

- remove deprecated upper functionality in `getMethod()`
- fix HTTP verbs case. E.g., `get` → `GET`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
