### PR TITLE
feat: Validation::run() accepts DB connection

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -131,7 +131,7 @@ class Validation implements ValidationInterface
      * @TODO Type ?string for $dbGroup should be removed.
      *      See https://github.com/codeigniter4/CodeIgniter4/issues/6723
      */
-    public function run(?array $data = null, ?string $group = null, ?string $dbGroup = null): bool
+    public function run(?array $data = null, ?string $group = null, $dbGroup = null): bool
     {
         if ($data === null) {
             $data = $this->data;


### PR DESCRIPTION
**Description**
See #6723

Remove on run() $dbGroup ?string because it can allow group array connections, not only dgGroup Name.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
