### PR TITLE
fix: FilterTestTrait Undefined variable $filterClasses

### DIFF
--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -73,6 +73,14 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $this->assertSame('http://hellowworld.com', $result->getBody());
     }
 
+    public function testCallerSupportClassname(): void
+    {
+        $caller = $this->getFilterCaller(Customfilter::class, 'before');
+        $result = $caller();
+
+        $this->assertSame('http://hellowworld.com', $result->getBody());
+    }
+
     public function testCallerUsesClonedInstance(): void
     {
         $caller = $this->getFilterCaller('test-customfilter', 'before');

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -63,7 +63,7 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $this->getFilterCaller('test-customfilter', 'banana');
     }
 
-    public function testCallerSupportArray(): void
+    public function testCallerSupportsArray(): void
     {
         $this->filtersConfig->aliases['test-customfilter'] = [Customfilter::class];
 
@@ -73,7 +73,7 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $this->assertSame('http://hellowworld.com', $result->getBody());
     }
 
-    public function testCallerSupportClassname(): void
+    public function testCallerSupportsClassname(): void
     {
         $caller = $this->getFilterCaller(Customfilter::class, 'before');
         $result = $caller();

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -81,6 +81,14 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $this->assertSame('http://hellowworld.com', $result->getBody());
     }
 
+    public function testCallerSupportsFilterInstance(): void
+    {
+        $caller = $this->getFilterCaller(new Customfilter(), 'before');
+        $result = $caller();
+
+        $this->assertSame('http://hellowworld.com', $result->getBody());
+    }
+
     public function testCallerUsesClonedInstance(): void
     {
         $caller = $this->getFilterCaller('test-customfilter', 'before');


### PR DESCRIPTION
**Description**
Fixes #8113
Follow-up #8058

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
