### PR TITLE
test: update tests to use SiteURI

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -15,7 +15,7 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\Format\JSONFormatter;
 use CodeIgniter\Format\XMLFormatter;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
@@ -42,7 +42,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->formatter = new JSONFormatter();
     }
 
-    protected function makeController(array $userConfig = [], string $uri = 'http://example.com', array $userHeaders = [])
+    protected function makeController(array $userConfig = [], string $routePath = '', array $userHeaders = [])
     {
         $config = new App();
 
@@ -73,7 +73,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         Factories::injectMock('config', 'Cookie', $cookie);
 
         if ($this->request === null) {
-            $this->request  = new MockIncomingRequest($config, new URI($uri), null, new UserAgent());
+            $this->request  = new MockIncomingRequest($config, new SiteURI($config, $routePath), null, new UserAgent());
             $this->response = new MockResponse($config);
         }
 
@@ -115,7 +115,7 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testNoFormatterJSON(): void
     {
         $this->formatter = null;
-        $controller      = $this->makeController([], 'http://codeigniter.com', ['Accept' => 'application/json']);
+        $controller      = $this->makeController([], '', ['Accept' => 'application/json']);
 
         $this->invoke($controller, 'respondCreated', [['id' => 3], 'A Custom Reason']);
 
@@ -133,7 +133,7 @@ final class ResponseTraitTest extends CIUnitTestCase
     public function testNoFormatter(): void
     {
         $this->formatter = null;
-        $controller      = $this->makeController([], 'http://codeigniter.com', ['Accept' => 'application/json']);
+        $controller      = $this->makeController([], '', ['Accept' => 'application/json']);
 
         $this->invoke($controller, 'respondCreated', ['A Custom Reason']);
 
@@ -484,8 +484,9 @@ final class ResponseTraitTest extends CIUnitTestCase
         $original                = $_SERVER;
         $_SERVER['CONTENT_TYPE'] = $mimeType;
 
-        $this->makeController([], 'http://codeigniter.com', ['Accept' => $mimeType]);
+        $this->makeController([], '', ['Accept' => $mimeType]);
         $this->assertSame($mimeType, $this->request->getHeaderLine('Accept'), 'Request header...');
+
         $this->response->setContentType($contentType);
         $this->assertSame($contentType, $this->response->getHeaderLine('Content-Type'), 'Response header pre-response...');
 
@@ -554,7 +555,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         }
         Factories::injectMock('config', 'Cookie', $cookie);
 
-        $request  = new MockIncomingRequest($config, new URI($config->baseURL), null, new UserAgent());
+        $request  = new MockIncomingRequest($config, new SiteURI($config), null, new UserAgent());
         $response = new MockResponse($config);
 
         $controller = new class ($request, $response) {

--- a/tests/system/Cache/ResponseCacheTest.php
+++ b/tests/system/Cache/ResponseCacheTest.php
@@ -15,7 +15,7 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App as AppConfig;
@@ -53,7 +53,7 @@ final class ResponseCacheTest extends CIUnitTestCase
 
         $appConfig ??= $this->appConfig;
 
-        $siteUri = new URI($appConfig->baseURL . $uri);
+        $siteUri = new SiteURI($appConfig, $uri);
         if ($query !== []) {
             $_GET = $_REQUEST = $query;
             $siteUri->setQueryArray($query);

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -18,7 +18,7 @@ use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Session\Handlers\FileHandler;
@@ -411,7 +411,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->routes = $this->createRouteCollection();
         Services::injectMock('routes', $this->routes);
 
-        $this->request = new MockIncomingRequest($this->config, new URI('http://example.com'), null, new UserAgent());
+        $this->request = new MockIncomingRequest($this->config, new SiteURI($this->config), null, new UserAgent());
         Services::injectMock('request', $this->request);
 
         // setup & ask for a redirect...
@@ -446,7 +446,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->routes = $this->createRouteCollection();
         Services::injectMock('routes', $this->routes);
 
-        $this->request = new MockIncomingRequest($this->config, new URI('http://example.com'), null, new UserAgent());
+        $this->request = new MockIncomingRequest($this->config, new SiteURI($this->config), null, new UserAgent());
         Services::injectMock('request', $this->request);
 
         // setup & ask for a redirect...
@@ -481,7 +481,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->routes = $this->createRouteCollection();
         Services::injectMock('routes', $this->routes);
 
-        $this->request = new MockIncomingRequest($this->config, new URI('http://example.com'), null, new UserAgent());
+        $this->request = new MockIncomingRequest($this->config, new SiteURI($this->config), null, new UserAgent());
         Services::injectMock('request', $this->request);
 
         $locations = [

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -16,7 +16,7 @@ use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Exceptions\ValidationException;
@@ -58,7 +58,7 @@ final class ControllerTest extends CIUnitTestCase
         parent::setUp();
 
         $this->config   = new App();
-        $this->request  = new IncomingRequest($this->config, new URI('https://somwhere.com'), null, new UserAgent());
+        $this->request  = new IncomingRequest($this->config, new SiteURI($this->config), null, new UserAgent());
         $this->response = new Response($this->config);
         $this->logger   = Services::logger();
     }

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -13,7 +13,7 @@ namespace CodeIgniter\Filters;
 
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -53,7 +53,7 @@ final class InvalidCharsTest extends CIUnitTestCase
     private function createRequest(): IncomingRequest
     {
         $config    = new MockAppConfig();
-        $uri       = new URI();
+        $uri       = new SiteURI($config);
         $userAgent = new UserAgent();
         $request   = $this->getMockBuilder(IncomingRequest::class)
             ->setConstructorArgs([$config, $uri, null, $userAgent])

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -32,8 +32,7 @@ final class IncomingRequestDetectingTest extends CIUnitTestCase
         $_POST = $_GET = $_SERVER = $_REQUEST = $_ENV = $_COOKIE = $_SESSION = [];
 
         // The URI object is not used in detectPath().
-        $origin        = 'http://www.example.com/index.php/woot?code=good#pos';
-        $this->request = new IncomingRequest(new App(), new URI($origin), null, new UserAgent());
+        $this->request = new IncomingRequest(new App(), new SiteURI(new App(), 'woot?code=good#pos'), null, new UserAgent());
     }
 
     public function testPathDefault(): void

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -223,7 +223,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $config->defaultLocale    = 'es';
         $config->baseURL          = 'http://example.com/';
 
-        $request = new IncomingRequest($config, new URI(), null, new UserAgent());
+        $request = new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
 
         $request->setValidLocales(['ja']);
         $request->setLocale('ja');
@@ -901,7 +901,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $_SERVER['REQUEST_URI'] = $path;
         $_SERVER['SCRIPT_NAME'] = $path;
-        $request                = new IncomingRequest($config, new URI($path), null, new UserAgent());
+        $request                = new IncomingRequest($config, new SiteURI($config, $path), null, new UserAgent());
         $this->assertSame($detectPath, $request->detectPath());
     }
 
@@ -914,7 +914,8 @@ final class IncomingRequestTest extends CIUnitTestCase
 
     public function testSetPath(): void
     {
-        $request = new IncomingRequest(new App(), new URI(), null, new UserAgent());
+        $config  = new App();
+        $request = new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
         $this->assertSame('', $request->getPath());
 
         $request->setPath('foobar');

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -15,7 +15,7 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockResponse;
@@ -49,7 +49,7 @@ final class CookieHelperTest extends CIUnitTestCase
 
         Services::injectMock('response', new MockResponse(new App()));
         $this->response = Services::response();
-        $this->request  = new IncomingRequest(new App(), new URI(), null, new UserAgent());
+        $this->request  = new IncomingRequest(new App(), new SiteURI(new App()), null, new UserAgent());
         Services::injectMock('request', $this->request);
 
         helper('cookie');

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Pager;
 
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Pager\Exceptions\PagerException;
@@ -53,7 +54,7 @@ final class PagerTest extends CIUnitTestCase
 
         $request = new IncomingRequest(
             $config,
-            new URI($config->baseURL . ltrim($requestUri, '/')),
+            new SiteURI($config, ltrim($requestUri, '/')),
             'php://input',
             new UserAgent()
         );
@@ -70,7 +71,7 @@ final class PagerTest extends CIUnitTestCase
 
         $details = $this->pager->getDetails();
 
-        $this->assertSame('foo/bar', $details['uri']->getPath());
+        $this->assertSame('foo/bar', $details['uri']->getRoutePath());
     }
 
     public function testGetDetailsRecognizesPageQueryVar(): void
@@ -474,7 +475,7 @@ final class PagerTest extends CIUnitTestCase
 
         $request = new IncomingRequest(
             $config,
-            new URI(),
+            new SiteURI($config, 'x/y'),
             'php://input',
             new UserAgent()
         );

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -17,7 +17,7 @@ use CodeIgniter\Format\JSONFormatter;
 use CodeIgniter\Format\XMLFormatter;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Model;
 use CodeIgniter\Router\RouteCollection;
@@ -312,7 +312,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $resource = new MockResourceController();
 
         $config = new App();
-        $uri    = new URI();
+        $uri    = new SiteURI($config);
         $agent  = new UserAgent();
 
         $request  = new IncomingRequest($config, $uri, '', $agent);
@@ -340,7 +340,7 @@ final class ResourceControllerTest extends CIUnitTestCase
         $resource = new MockResourceController();
 
         $config = new App();
-        $uri    = new URI();
+        $uri    = new SiteURI($config);
         $agent  = new UserAgent();
 
         $request  = new IncomingRequest($config, $uri, '', $agent);

--- a/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Security;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
@@ -74,7 +74,8 @@ final class SecurityCSRFCookieRandomizeTokenTest extends CIUnitTestCase
         $_POST['foo']              = 'bar';
         $_POST['csrf_test_name']   = $this->randomizedToken;
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $config  = new MockAppConfig();
+        $request = new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
 
         $security = new Security($this->config);
 

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Security;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Session\Handlers\ArrayHandler;
@@ -25,6 +25,7 @@ use CodeIgniter\Test\Mock\MockAppConfig;
 use CodeIgniter\Test\Mock\MockSecurity;
 use CodeIgniter\Test\Mock\MockSession;
 use CodeIgniter\Test\TestLogger;
+use Config\App;
 use Config\Cookie;
 use Config\Logger as LoggerConfig;
 use Config\Security as SecurityConfig;
@@ -136,11 +137,17 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         unset($_POST['csrf_test_name']);
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $security->verify($request);
+    }
+
+    private function createIncomingRequest(?App $config = null): IncomingRequest
+    {
+        $config ??= new MockAppConfig();
+
+        return new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
     }
 
     public function testCSRFVerifyPostThrowsExceptionOnNoMatch(): void
@@ -151,8 +158,7 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST['csrf_test_name']   = '8b9218a55906f9dcc1dc263dce7f005b';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $security->verify($request);
@@ -166,8 +172,7 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST['csrf_test_name']   = '!';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $security->verify($request);
@@ -179,8 +184,7 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $_POST['foo']              = 'bar';
         $_POST['csrf_test_name']   = $this->randomizedToken;
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -192,9 +196,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005b');
-
         $security = $this->createSecurity();
 
         $this->expectException(SecurityException::class);
@@ -208,9 +211,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST['foo']              = 'bar';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', $this->randomizedToken);
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -222,9 +224,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005b');
-
         $security = $this->createSecurity();
 
         $this->expectException(SecurityException::class);
@@ -237,9 +238,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', $this->randomizedToken);
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -250,9 +250,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setBody("csrf_test_name={$this->randomizedToken}&foo=bar");
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -266,9 +265,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setBody('{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005b"}');
-
         $security = $this->createSecurity();
 
         $security->verify($request);
@@ -278,9 +276,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setBody('{"csrf_test_name":"' . $this->randomizedToken . '","foo":"bar"}');
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -298,9 +295,8 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $config->regenerate     = false;
         Factories::injectMock('config', 'Security', $config);
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
-        $security = new MockSecurity($this->config);
+        $request  = $this->createIncomingRequest();
+        $security = new MockSecurity($config);
 
         $oldHash = $security->getHash();
         $security->verify($request);
@@ -319,8 +315,7 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
         $config->regenerate     = true;
         Factories::injectMock('config', 'Security', $config);
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $oldHash = $security->getHash();

--- a/tests/system/Security/SecurityCSRFSessionTest.php
+++ b/tests/system/Security/SecurityCSRFSessionTest.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Security;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Session\Handlers\ArrayHandler;
@@ -24,6 +24,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use CodeIgniter\Test\Mock\MockSession;
 use CodeIgniter\Test\TestLogger;
+use Config\App;
 use Config\Cookie;
 use Config\Logger as LoggerConfig;
 use Config\Security as SecurityConfig;
@@ -125,11 +126,17 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST['csrf_test_name']   = '8b9218a55906f9dcc1dc263dce7f005b';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $security->verify($request);
+    }
+
+    private function createIncomingRequest(?App $config = null): IncomingRequest
+    {
+        $config ??= new MockAppConfig();
+
+        return new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
     }
 
     public function testCSRFVerifyPostReturnsSelfOnMatch(): void
@@ -138,8 +145,7 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         $_POST['foo']              = 'bar';
         $_POST['csrf_test_name']   = '8b9218a55906f9dcc1dc263dce7f005a';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -151,9 +157,8 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005b');
-
         $security = $this->createSecurity();
 
         $this->expectException(SecurityException::class);
@@ -165,9 +170,8 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_POST['foo']              = 'bar';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005a');
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -179,9 +183,8 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005b');
-
         $security = $this->createSecurity();
 
         $this->expectException(SecurityException::class);
@@ -192,9 +195,8 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005a');
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -205,9 +207,8 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setBody('csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a&foo=bar');
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -220,9 +221,8 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setBody('{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005b"}');
-
         $security = $this->createSecurity();
 
         $security->verify($request);
@@ -232,9 +232,8 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
+        $request = $this->createIncomingRequest();
         $request->setBody('{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a","foo":"bar"}');
-
         $security = $this->createSecurity();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -251,8 +250,7 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         $config->regenerate = false;
         Factories::injectMock('config', 'Security', $config);
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $oldHash = $security->getHash();
@@ -271,8 +269,7 @@ final class SecurityCSRFSessionTest extends CIUnitTestCase
         $config->regenerate = true;
         Factories::injectMock('config', 'Security', $config);
 
-        $request = new IncomingRequest(new MockAppConfig(), new URI('http://badurl.com'), null, new UserAgent());
-
+        $request  = $this->createIncomingRequest();
         $security = $this->createSecurity();
 
         $oldHash = $security->getHash();

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -14,7 +14,7 @@ namespace CodeIgniter\Security;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -101,15 +101,22 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005b';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $this->expectException(SecurityException::class);
         $security->verify($request);
+    }
+
+    private function createIncomingRequest(): IncomingRequest
+    {
+        $config = new MockAppConfig();
+
+        return new IncomingRequest(
+            $config,
+            new SiteURI($config),
+            null,
+            new UserAgent()
+        );
     }
 
     public function testCSRFVerifyPostReturnsSelfOnMatch(): void
@@ -120,12 +127,7 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005a';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
         $this->assertLogged('info', 'CSRF token verified.');
@@ -139,12 +141,7 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005b';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005a');
 
@@ -159,12 +156,7 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005a';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $request->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005a');
 
@@ -180,12 +172,7 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005b';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $request->setBody(
             '{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a"}'
@@ -201,12 +188,7 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005a';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $request->setBody(
             '{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a","foo":"bar"}'
@@ -224,12 +206,7 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005b';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $request->setBody(
             'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a'
@@ -245,12 +222,7 @@ final class SecurityTest extends CIUnitTestCase
         $_COOKIE['csrf_cookie_name'] = '8b9218a55906f9dcc1dc263dce7f005a';
 
         $security = $this->createMockSecurity();
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $request->setBody(
             'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a&foo=bar'
@@ -282,12 +254,7 @@ final class SecurityTest extends CIUnitTestCase
         Factories::injectMock('config', 'Security', $config);
 
         $security = new MockSecurity($config);
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $oldHash = $security->getHash();
         $security->verify($request);
@@ -307,12 +274,7 @@ final class SecurityTest extends CIUnitTestCase
         Factories::injectMock('config', 'Security', $config);
 
         $security = $this->createMockSecurity($config);
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $oldHash = $security->getHash();
         $security->verify($request);
@@ -333,12 +295,7 @@ final class SecurityTest extends CIUnitTestCase
         Factories::injectMock('config', 'Security', $config);
 
         $security = $this->createMockSecurity($config);
-        $request  = new IncomingRequest(
-            new MockAppConfig(),
-            new URI('http://badurl.com'),
-            null,
-            new UserAgent()
-        );
+        $request  = $this->createIncomingRequest();
 
         $oldHash = $security->getHash();
         $security->verify($request);

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -12,7 +12,7 @@
 namespace CodeIgniter\Validation;
 
 use CodeIgniter\HTTP\IncomingRequest;
-use CodeIgniter\HTTP\URI;
+use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Exceptions\ValidationException;
@@ -748,7 +748,7 @@ class ValidationTest extends CIUnitTestCase
         $rawstring       = 'username=admin001&role=administrator&usepass=0';
         $config          = new App();
         $config->baseURL = 'http://example.com/';
-        $request         = new IncomingRequest($config, new URI(), $rawstring, new UserAgent());
+        $request         = new IncomingRequest($config, new SiteURI($config), $rawstring, new UserAgent());
 
         $rules = [
             'role' => 'required|min_length[5]',
@@ -772,7 +772,7 @@ class ValidationTest extends CIUnitTestCase
         $json            = json_encode($data);
         $config          = new App();
         $config->baseURL = 'http://example.com/';
-        $request         = new IncomingRequest($config, new URI(), $json, new UserAgent());
+        $request         = new IncomingRequest($config, new SiteURI($config), $json, new UserAgent());
 
         $rules = [
             'role' => 'required|min_length[5]',
@@ -809,7 +809,7 @@ class ValidationTest extends CIUnitTestCase
         $config          = new App();
         $config->baseURL = 'http://example.com/';
 
-        $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+        $request = new IncomingRequest($config, new SiteURI($config), $json, new UserAgent());
 
         $rules = [
             'p' => 'required|array_count[2]',
@@ -995,7 +995,7 @@ class ValidationTest extends CIUnitTestCase
         $config          = new App();
         $config->baseURL = 'http://example.com/';
 
-        $request = new IncomingRequest($config, new URI(), http_build_query($body), new UserAgent());
+        $request = new IncomingRequest($config, new SiteURI($config), http_build_query($body), new UserAgent());
 
         $this->validation->setRules($rules);
         $this->validation->withRequest($request->withMethod('post'))->run($body);
@@ -1074,7 +1074,7 @@ class ValidationTest extends CIUnitTestCase
             ],
         ];
 
-        $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
+        $request = new IncomingRequest($config, new SiteURI($config), 'php://input', new UserAgent());
 
         $this->validation->setRules([
             'id_user.*'   => 'numeric',
@@ -1108,7 +1108,7 @@ class ValidationTest extends CIUnitTestCase
             ],
         ];
 
-        $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
+        $request = new IncomingRequest($config, new SiteURI($config), 'php://input', new UserAgent());
 
         $this->validation->setRules([
             'id_user.*'               => 'numeric',
@@ -1144,7 +1144,7 @@ class ValidationTest extends CIUnitTestCase
             'id_user' => 'gh',
         ];
 
-        $request = new IncomingRequest($config, new URI(), 'php://input', new UserAgent());
+        $request = new IncomingRequest($config, new SiteURI($config), 'php://input', new UserAgent());
 
         $this->validation->setRules([
             'id_user' => 'numeric',


### PR DESCRIPTION
**Description**
`IncomingRequest` is actually already using `SiteURI`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
