### PR TITLE
docs: add missing `get` in method name in Auto Routing Improved

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -763,7 +763,7 @@ when a controller is found that matches the URI, but no segment exists for the m
 ``index``.
 
 In this example, if the user were to visit **example.com/products**, and a ``Products`` controller existed, the
-``Products::listAll()`` method would be executed:
+``Products::getListAll()`` method would be executed:
 
 .. literalinclude:: routing/048.php
 


### PR DESCRIPTION
**Description**
- fix method name

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
