### PR TITLE
[Rector] Fix deprecated dynamic pull phpDocInfoFactory from AbstractRector on UnderscoreToCamelCaseVariableNameRector

### DIFF
--- a/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -21,6 +21,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Namespace_;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
 use Rector\Core\Rector\AbstractRector;
@@ -39,12 +40,15 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
     private const PARAM_NAME_REGEX = '#(?<paramPrefix>@param\s.*\s+\$)(?<paramName>%s)#ms';
 
     private ReservedKeywordAnalyzer $reservedKeywordAnalyzer;
+    private PhpDocInfoFactory $phpDocInfoFactory;
     private bool $hasChanged = false;
 
     public function __construct(
-        ReservedKeywordAnalyzer $reservedKeywordAnalyzer
+        ReservedKeywordAnalyzer $reservedKeywordAnalyzer,
+        PhpDocInfoFactory $phpDocInfoFactory
     ) {
         $this->reservedKeywordAnalyzer = $reservedKeywordAnalyzer;
+        $this->phpDocInfoFactory       = $phpDocInfoFactory;
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**

Update left over custom rule: `UnderscoreToCamelCaseVariableNameRector` to inject `phpDocInfoFactory` on `__construct()` instead of from `AbstractRector`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
