### PR TITLE
docs: update sample code in "Creating Core System Classes"

### DIFF
--- a/user_guide_src/source/extending/core_classes/002.php
+++ b/user_guide_src/source/extending/core_classes/002.php
@@ -12,7 +12,7 @@ class Services extends BaseService
             return static::getSharedInstance('routes');
         }
 
-        return new \App\Libraries\RouteCollection(static::locator(), config('Modules'));
+        return new \App\Libraries\RouteCollection(static::locator(), config(Modules::class), config(Routing::class) );
     }
 
     // ...

--- a/user_guide_src/source/extending/core_classes/002.php
+++ b/user_guide_src/source/extending/core_classes/002.php
@@ -12,7 +12,7 @@ class Services extends BaseService
             return static::getSharedInstance('routes');
         }
 
-        return new \App\Libraries\RouteCollection(static::locator(), config(Modules::class), config(Routing::class) );
+        return new \App\Libraries\RouteCollection(static::locator(), config(Modules::class), config(Routing::class));
     }
 
     // ...


### PR DESCRIPTION
RouteCollection constructor parameters are out of date in the Creating Core System Classes docs. Minor point, but might save someone a few minutes working out what they should be.

Referenced in <#8204>

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
