### PR TITLE
fix: DefinedRouteCollector.php to use RouteCollectionInterface

### DIFF
--- a/system/Router/DefinedRouteCollector.php
+++ b/system/Router/DefinedRouteCollector.php
@@ -21,9 +21,9 @@ use Generator;
  */
 final class DefinedRouteCollector
 {
-    private RouteCollection $routeCollection;
+    private RouteCollectionInterface $routeCollection;
 
-    public function __construct(RouteCollection $routes)
+    public function __construct(RouteCollectionInterface $routes)
     {
         $this->routeCollection = $routes;
     }


### PR DESCRIPTION
Use RouteCollectorInterface rather than RouteCollector to allow for people implementing new RouteCollectors by implementing the interface as intended.

Currently this would generate type errors.

Referenced in <#8204>

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
