### PR TITLE
docs: change phpstan-type names

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10,11 +10,6 @@
       <code>public $plugins = [];</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="system/Cache/FactoriesCache/FileVarExportHandler.php">
-    <UndefinedVariable>
-      <code>$val</code>
-    </UndefinedVariable>
-  </file>
   <file src="system/Cache/Handlers/MemcachedHandler.php">
     <UndefinedClass>
       <code>Memcache</code>
@@ -39,9 +34,9 @@
   </file>
   <file src="system/Config/View.php">
     <UndefinedDocblockClass>
-      <code><![CDATA[array<string, ParserCallableString>]]></code>
-      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
-      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
+      <code><![CDATA[array<string, parser_callable_string>]]></code>
       <code><![CDATA[protected $coreFilters = [
         'abs'            => '\abs',
         'capitalize'     => '\CodeIgniter\View\Filters::capitalize',
@@ -144,8 +139,8 @@
   </file>
   <file src="system/View/Parser.php">
     <UndefinedDocblockClass>
-      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
-      <code><![CDATA[array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>]]></code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
       <code>protected $plugins = [];</code>
       <code>protected $plugins = [];</code>
     </UndefinedDocblockClass>

--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -16,8 +16,8 @@ use CodeIgniter\View\ViewDecoratorInterface;
 /**
  * View configuration
  *
- * @phpstan-type ParserCallable (callable(mixed): mixed)
- * @phpstan-type ParserCallableString (callable(mixed): mixed)&string
+ * @phpstan-type parser_callable (callable(mixed): mixed)
+ * @phpstan-type parser_callable_string (callable(mixed): mixed)&string
  */
 class View extends BaseConfig
 {
@@ -40,7 +40,7 @@ class View extends BaseConfig
      * @psalm-suppress UndefinedDocblockClass
      *
      * @var array<string, string>
-     * @phpstan-var array<string, ParserCallableString>
+     * @phpstan-var array<string, parser_callable_string>
      */
     public $filters = [];
 
@@ -52,7 +52,7 @@ class View extends BaseConfig
      * @psalm-suppress UndefinedDocblockClass
      *
      * @var array<string, array<string>|callable|string>
-     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
+     * @phpstan-var array<string, array<parser_callable_string>|parser_callable_string|parser_callable>
      */
     public $plugins = [];
 
@@ -60,7 +60,7 @@ class View extends BaseConfig
      * Built-in View filters.
      *
      * @var array<string, string>
-     * @phpstan-var array<string, ParserCallableString>
+     * @phpstan-var array<string, parser_callable_string>
      */
     protected $coreFilters = [
         'abs'            => '\abs',
@@ -90,7 +90,7 @@ class View extends BaseConfig
      * Built-in View plugins.
      *
      * @var array<string, array<string>|callable|string>
-     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
+     * @phpstan-var array<string, array<parser_callable_string>|parser_callable_string|parser_callable>
      */
     protected $corePlugins = [
         'csp_script_nonce'  => '\CodeIgniter\View\Plugins::cspScriptNonce',

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -20,8 +20,8 @@ use Psr\Log\LoggerInterface;
 /**
  * Class for parsing pseudo-vars
  *
- * @phpstan-type ParserCallable (callable(mixed): mixed)
- * @phpstan-type ParserCallableString (callable(mixed): mixed)&string
+ * @phpstan-type parser_callable (callable(mixed): mixed)
+ * @phpstan-type parser_callable_string (callable(mixed): mixed)&string
  *
  * @see \CodeIgniter\View\ParserTest
  */
@@ -64,7 +64,7 @@ class Parser extends View
      * Stores any plugins registered at run-time.
      *
      * @var array<string, array<string>|callable|string>
-     * @phpstan-var array<string, array<ParserCallableString>|ParserCallableString|ParserCallable>
+     * @phpstan-var array<string, array<parser_callable_string>|parser_callable_string|parser_callable>
      */
     protected $plugins = [];
 


### PR DESCRIPTION
**Description**
I propose to change the naming convention to `@phpstan-type`.
Using snake_case makes it easy to know it is not a classname.

By the way, I don't know why Psalm does not recognize `@phpstan-type`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
