### PR TITLE
replace -1 with E_ALL in error_reporting calls

### DIFF
--- a/app/Config/Boot/development.php
+++ b/app/Config/Boot/development.php
@@ -10,7 +10,7 @@
  |
  | If you set 'display_errors' to '1', CI4's detailed error report will show.
  */
-error_reporting(-1);
+error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
 /*

--- a/app/Config/Boot/testing.php
+++ b/app/Config/Boot/testing.php
@@ -14,7 +14,7 @@
  | make sure they don't make it to production. And save us hours of
  | painful debugging.
  */
-error_reporting(-1);
+error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
 /*

--- a/spark
+++ b/spark
@@ -39,7 +39,7 @@ if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
 }
 
 // We want errors to be shown when using it from the CLI.
-error_reporting(-1);
+error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
 /**


### PR DESCRIPTION
**Description**
Replaces `error_reporting(-1);` with `error_reporting(E_ALL);` for better readability.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [O] Unit testing, with >80% coverage
- [O] User guide updated
- [O] Conforms to style guide

O = does not apply
