### PR TITLE
fix issue where running FileLocator::getClassname() on a directory would cause a PHP error

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -119,6 +119,10 @@ class FileLocator
      */
     public function getClassname(string $file): string
     {
+        if(is_dir($file)) {
+            return '';
+        }
+
         $php       = file_get_contents($file);
         $tokens    = token_get_all($php);
         $dlm       = false;

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -119,7 +119,7 @@ class FileLocator
      */
     public function getClassname(string $file): string
     {
-        if(is_dir($file)) {
+        if (is_dir($file)) {
             return '';
         }
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -312,4 +312,12 @@ final class FileLocatorTest extends CIUnitTestCase
             $this->locator->getClassname(SYSTEMPATH . 'bootstrap.php')
         );
     }
+
+    public function testGetClassNameFromDirectory(): void
+    {
+        $this->assertSame(
+            '',
+            $this->locator->getClassname(SYSTEMPATH)
+        );
+    }
 }


### PR DESCRIPTION
fix issue where running getClassName on a directory would cause a PHP


**Description**

This issue specifically comes up when you put commands in folders for better organization, the previous setup used `findQualifiedNameFromPath` instead of `getClassname`, `getClassname` has no checking to see if what is passed in is a directory, which could easily happen as `listFiles` can return directories as well as files.

```
An uncaught Exception was encountered

Type:        ErrorException
Message:     file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory
Filename:    vendor/codeigniter4/framework/system/Autoloader/FileLocator.php
Line Number: 122

Backtrace:
-122 - vendor/codeigniter4/framework/system/Autoloader/FileLocator.php::file_get_contents
-104 - vendor/codeigniter4/framework/system/CLI/Commands.php::getClassname
-46 - vendor/codeigniter4/framework/system/CLI/Commands.php::discoverCommands
-174 - vendor/codeigniter4/framework/system/Config/Services.php::__construct
-258 - vendor/codeigniter4/framework/system/Config/BaseService.php::commands
-199 - vendor/codeigniter4/framework/system/Config/BaseService.php::__callStatic
-171 - vendor/codeigniter4/framework/system/Config/Services.php::getSharedInstance
-258 - vendor/codeigniter4/framework/system/Config/BaseService.php::commands
-41 - vendor/codeigniter4/framework/system/CLI/Console.php::__callStatic
-103 - spark::run
```

Potential other solutions to this would be to prevent `listFiles` from returning directories, or filtering the list of files prior to running `getClassname` in `discoverCommands`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
