### PR TITLE
config: change the default error reporting level in production

### DIFF
--- a/app/Config/Boot/production.php
+++ b/app/Config/Boot/production.php
@@ -9,8 +9,8 @@
  |
  | If you set 'display_errors' to '1', CI4's detailed error report will show.
  */
+error_reporting(-1);
 ini_set('display_errors', '0');
-error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
 
 /*
  |--------------------------------------------------------------------------

--- a/app/Config/Boot/production.php
+++ b/app/Config/Boot/production.php
@@ -9,8 +9,8 @@
  |
  | If you set 'display_errors' to '1', CI4's detailed error report will show.
  */
-error_reporting(-1);
-// If you want to suppress some types of errors.
+error_reporting(E_ALL & ~E_DEPRECATED);
+// If you want to suppress more types of errors.
 // error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
 ini_set('display_errors', '0');
 

--- a/app/Config/Boot/production.php
+++ b/app/Config/Boot/production.php
@@ -10,6 +10,8 @@
  | If you set 'display_errors' to '1', CI4's detailed error report will show.
  */
 error_reporting(-1);
+// If you want to suppress some types of errors.
+// error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
 ini_set('display_errors', '0');
 
 /*

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -313,6 +313,9 @@ Changes
 - **Config:**
     - ``Config\Feature::$multipleFilters`` has been removed, because now
       :ref:`multiple-filters` are always enabled.
+    - The default error level in the production environment
+      (**app/Config/Boot/production.php**) has been changed to use the same error
+      level in the development environment.
 - **RouteCollection:** The HTTP method keys in the protected property ``$routes``
   has been fixed from lowercase to uppercase.
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -314,8 +314,8 @@ Changes
     - ``Config\Feature::$multipleFilters`` has been removed, because now
       :ref:`multiple-filters` are always enabled.
     - The default error level in the production environment
-      (**app/Config/Boot/production.php**) has been changed to use the same error
-      level in the development environment.
+      (**app/Config/Boot/production.php**) has been changed to ``E_ALL & ~E_DEPRECATED``
+      to match the default **php.ini** for production.
 - **RouteCollection:** The HTTP method keys in the protected property ``$routes``
   has been fixed from lowercase to uppercase.
 

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -255,6 +255,8 @@ The  ``'toolbar'`` in the ``$global['after']`` was removed.
 Others
 ^^^^^^
 
+- app/Config/Boot/production.php
+    - The default error level to ``error_reporting()`` has been changed to ``-1``.
 - app/Config/Database.php
     - The default value of ``charset`` in ``$default`` has been change to ``utf8mb4``.
     - The default value of ``DBCollat`` in ``$default`` has been change to ``utf8mb4_general_ci``.

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -256,7 +256,7 @@ Others
 ^^^^^^
 
 - app/Config/Boot/production.php
-    - The default error level to ``error_reporting()`` has been changed to ``-1``.
+    - The default error level to ``error_reporting()`` has been changed to ``E_ALL & ~E_DEPRECATED``.
 - app/Config/Database.php
     - The default value of ``charset`` in ``$default`` has been change to ``utf8mb4``.
     - The default value of ``DBCollat`` in ``$default`` has been change to ``utf8mb4_general_ci``.


### PR DESCRIPTION
**Description**
There is no reason to change error level only in production.

> In production, you may wish to set this to a less verbose level such as E_ALL & ~E_NOTICE & ~E_DEPRECATED, but in many cases E_ALL is also appropriate, as it may provide early warning of potential issues. 
https://www.php.net/manual/en/language.errors.basics.php#language.errors.basics.handling

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
