### PR TITLE
fix: allow get_filenames() to follow symlinks

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -209,7 +209,7 @@ if (! function_exists('get_filenames')) {
 
         try {
             foreach (new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS),
+                new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
                 RecursiveIteratorIterator::SELF_FIRST
             ) as $name => $object) {
                 $basename = pathinfo($name, PATHINFO_BASENAME);

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -27,6 +27,12 @@ Validation rules matches and differs
 Bugs have been fixed in the case where ``matches`` and ``differs`` in the Strict
 and Traditional rules validate data of non-string types.
 
+Filesystem Helper
+====================================
+
+``get_filenames()`` now follows symlink folders, which it previously just returned
+without following.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -30,7 +30,7 @@ and Traditional rules validate data of non-string types.
 Filesystem Helper
 ====================================
 
-``get_filenames()`` now follows symlink folders, which it previously just returned
+:php:func:`get_filenames()` now follows symlink folders, which it previously just returned
 without following.
 
 ***************

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -28,7 +28,7 @@ Bugs have been fixed in the case where ``matches`` and ``differs`` in the Strict
 and Traditional rules validate data of non-string types.
 
 Filesystem Helper
-====================================
+=================
 
 :php:func:`get_filenames()` now follows symlink folders, which it previously just returned
 without following.

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -164,6 +164,8 @@ The following functions are available:
     the second parameter to 'relative' for relative paths or any other non-empty value for
     a full file path.
 
+    Prior to v4.4.4, due to a bug, this function did not follow symlink folders.
+
     Example:
 
     .. literalinclude:: filesystem_helper/010.php

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -164,7 +164,7 @@ The following functions are available:
     the second parameter to 'relative' for relative paths or any other non-empty value for
     a full file path.
 
-    Prior to v4.4.4, due to a bug, this function did not follow symlink folders.
+    .. note:: Prior to v4.4.4, due to a bug, this function did not follow symlink folders.
 
     Example:
 


### PR DESCRIPTION
**Description**

While symlinks that are going directly to a file are followed, the `RecursiveDirectoryIterator` does not follow folder based symlinks without setting the proper flag.

```
new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS),
```

to

```
new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
```

_Originally posted by @colethorsen in https://github.com/codeigniter4/CodeIgniter4/issues/8216#issuecomment-1814755271_
            


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
