### PR TITLE
test: fix failed ValidationTest

### DIFF
--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -797,7 +797,7 @@ class ValidationTest extends CIUnitTestCase
 
         $config  = new App();
         $json    = 'invalid';
-        $request = new IncomingRequest($config, new URI(), $json, new UserAgent());
+        $request = new IncomingRequest($config, new SiteURI($config), $json, new UserAgent());
         $request->setHeader('Content-Type', 'application/json');
 
         $rules = [


### PR DESCRIPTION
**Description**
```
Error: tests/system/Validation/ValidationTest.php:800:53: UndefinedClass: Class, interface or enum named CodeIgniter\Validation\URI does not exist (see https://psalm.dev/019)
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6916967990/job/18817589705
```
1) CodeIgniter\Validation\StrictRules\ValidationTest::testJsonInputInvalid
Failed asserting that exception of type "Error" matches expected exception "CodeIgniter\HTTP\Exceptions\HTTPException". Message was: "Class "CodeIgniter\Validation\URI" not found" at
/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Validation/ValidationTest.php:800
.
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6916968004/job/18817590692
**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
