### PR TITLE
chore: [Psalm] workaround for UndefinedClass 

### DIFF
--- a/psalm_autoload.php
+++ b/psalm_autoload.php
@@ -25,6 +25,7 @@ foreach ($helperDirs as $dir) {
 
 $dirs = [
     'tests/_support/Controllers',
+    'tests/_support/_controller',
 ];
 
 foreach ($dirs as $dir) {


### PR DESCRIPTION
**Description**
```
Error: tests/system/Router/RouteCollectionTest.php:1813:34: UndefinedClass: Class, interface or enum named App\Controllers\Product does not exist (see https://psalm.dev/019)
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/6922932775/job/18830239844

Related #8180

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
