### PR TITLE
fix: make Request::getEnv() deprecated

### DIFF
--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -203,9 +203,12 @@ trait RequestTrait
      * @param array|int|null    $flags
      *
      * @return mixed
+     *
+     * @deprecated 4.4.4 This method does not work from the beginning. Use `env()`.
      */
     public function getEnv($index = null, $filter = null, $flags = null)
     {
+        // @phpstan-ignore-next-line
         return $this->fetchGlobal('env', $index, $filter, $flags);
     }
 

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -332,7 +332,7 @@ trait RequestTrait
      * Saves a copy of the current state of one of several PHP globals,
      * so we can retrieve them later.
      *
-     * @param string $name Supergrlobal name (lowercase)
+     * @param string $name Superglobal name (lowercase)
      * @phpstan-param 'get'|'post'|'request'|'cookie'|'server' $name
      *
      * @return void

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -41,6 +41,10 @@ Changes
 Deprecations
 ************
 
+- **Request:** The :php:meth:`CodeIgniter\\HTTP\\Request::getEnv()` method is
+  deprecated. This method does not work from the beginning. Use :php:func:`env()`
+  instead.
+
 **********
 Bugs Fixed
 **********

--- a/user_guide_src/source/incoming/incomingrequest.rst
+++ b/user_guide_src/source/incoming/incomingrequest.rst
@@ -131,6 +131,9 @@ The ``getServer()`` method will pull from ``$_SERVER``.
 getEnv()
 --------
 
+.. deprecated:: 4.4.4 This method does not work from the beginning. Use
+    :php:func:`env()` instead.
+
 The ``getEnv()`` method will pull from ``$_ENV``.
 
 * ``$request->getEnv()``

--- a/user_guide_src/source/incoming/request.rst
+++ b/user_guide_src/source/incoming/request.rst
@@ -107,6 +107,9 @@ Class Reference
 
     .. php:method:: getEnv([$index = null[, $filter = null[, $flags = null]]])
 
+        .. deprecated:: 4.4.4 This method does not work from the beginning. Use
+            :php:func:`env()` instead.
+
         :param    mixed     $index: Value name
         :param    int       $filter: The type of filter to apply. A list of filters can be found in `PHP manual <https://www.php.net/manual/en/filter.filters.php>`__.
         :param    int|array $flags: Flags to apply. A list of flags can be found in `PHP manual <https://www.php.net/manual/en/filter.filters.flags.php>`__.


### PR DESCRIPTION
**Description**
This method does not work from the beginning, and it was intentional.

```php
    public function index(): string
    {
        dd($this->request->getEnv('CI_ENVIRONMENT'));
    }
```
```
$this->request->getEnv(...) null
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
