### PR TITLE
feat: `spark filter:check` shows "Required Filters"

### DIFF
--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -106,6 +106,8 @@ class FilterCheck extends BaseCommand
             return EXIT_ERROR;
         }
 
+        $filters = $this->addRequiredFilters($filterCollector, $filters);
+
         $tbody[] = [
             strtoupper($method),
             $route,
@@ -123,5 +125,30 @@ class FilterCheck extends BaseCommand
         CLI::table($tbody, $thead);
 
         return EXIT_SUCCESS;
+    }
+
+    private function addRequiredFilters(FilterCollector $filterCollector, array $filters): array
+    {
+        $output = [];
+
+        $required = $filterCollector->getRequiredFilters();
+
+        $colored = [];
+
+        foreach ($required['before'] as $filter) {
+            $filter    = CLI::color($filter, 'yellow');
+            $colored[] = $filter;
+        }
+        $output['before'] = array_merge($colored, $filters['before']);
+
+        $colored = [];
+
+        foreach ($required['after'] as $filter) {
+            $filter    = CLI::color($filter, 'yellow');
+            $colored[] = $filter;
+        }
+        $output['after'] = array_merge($filters['after'], $colored);
+
+        return $output;
     }
 }

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\Filters;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Router;
 use Config\Filters as FiltersConfig;
@@ -37,6 +38,8 @@ final class FilterCollector
     }
 
     /**
+     * Returns filters for the URI
+     *
      * @param string $method HTTP verb like `GET`,`POST` or `CLI`.
      * @param string $uri    URI path to find filters for
      *
@@ -74,6 +77,24 @@ final class FilterCollector
         $finder = new FilterFinder($router, $filters);
 
         return $finder->find($uri);
+    }
+
+    /**
+     * Returns Required Filters
+     *
+     * @return array{before: list<string>, after: list<string>} array of filter alias or classname
+     */
+    public function getRequiredFilters(): array
+    {
+        $request = Services::incomingrequest(null, false);
+        $request->setMethod(Method::GET);
+
+        $router  = $this->createRouter($request);
+        $filters = $this->createFilters($request);
+
+        $finder = new FilterFinder($router, $filters);
+
+        return $finder->getRequiredFilters();
     }
 
     private function createRouter(Request $request): Router

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -77,4 +77,20 @@ final class FilterFinder
             ];
         }
     }
+
+    /**
+     * Returns Required Filters
+     *
+     * @return array{before: list<string>, after:list<string>}
+     */
+    public function getRequiredFilters(): array
+    {
+        [$requiredBefore] = $this->filters->getRequiredFilters('before');
+        [$requiredAfter]  = $this->filters->getRequiredFilters('after');
+
+        return [
+            'before' => $requiredBefore,
+            'after'  => $requiredAfter,
+        ];
+    }
 }

--- a/tests/system/Commands/FilterCheckTest.php
+++ b/tests/system/Commands/FilterCheckTest.php
@@ -45,8 +45,8 @@ final class FilterCheckTest extends CIUnitTestCase
         command('filter:check GET /');
 
         $this->assertStringContainsString(
-            '|GET|/|||',
-            str_replace(' ', '', $this->getBuffer())
+            '| GET    | /     | forcehttps pagecache | pagecache performance toolbar |',
+            preg_replace('/\033\[.+?m/u', '', $this->getBuffer())
         );
     }
 


### PR DESCRIPTION
~~Needs #8235~~

**Description**
Follow-up #8186

```console
$ ./spark filter:check GET /

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-20 06:15:09 UTC+00:00

+--------+-------+----------------------+-------------------------------+
| Method | Route | Before Filters       | After Filters                 |
+--------+-------+----------------------+-------------------------------+
| GET    | /     | forcehttps pagecache | pagecache performance toolbar |
+--------+-------+----------------------+-------------------------------+
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
