### PR TITLE
feat: `spark routes` shows "Required Filters"

### DIFF
--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -192,5 +192,30 @@ class Routes extends BaseCommand
         }
 
         CLI::table($tbody, $thead);
+
+        $this->showRequiredFilters();
+    }
+
+    private function showRequiredFilters(): void
+    {
+        $filterCollector = new FilterCollector();
+
+        $required = $filterCollector->getRequiredFilters();
+
+        $filters = [];
+
+        foreach ($required['before'] as $filter) {
+            $filters[] = CLI::color($filter, 'yellow');
+        }
+
+        CLI::write('Required Before Filters: ' . implode(', ', $filters));
+
+        $filters = [];
+
+        foreach ($required['after'] as $filter) {
+            $filters[] = CLI::color($filter, 'yellow');
+        }
+
+        CLI::write(' Required After Filters: ' . implode(', ', $filters));
     }
 }

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -76,6 +76,15 @@ final class RoutesTest extends CIUnitTestCase
             +---------+---------+---------------+----------------------------------------+----------------+---------------+
             EOL;
         $this->assertStringContainsString($expected, $this->getBuffer());
+
+        $expected = <<<'EOL'
+            Required Before Filters: forcehttps, pagecache
+             Required After Filters: pagecache, performance, toolbar
+            EOL;
+        $this->assertStringContainsString(
+            $expected,
+            preg_replace('/\033\[.+?m/u', '', $this->getBuffer())
+        );
     }
 
     public function testRoutesCommandSortByHandler(): void


### PR DESCRIPTION
~~Needs #8235, #8236~~

**Description**
Follow-up #8053

```console
$ ./spark routes

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-11-20 07:17:40 UTC+00:00

+--------+-------+------+------------------------------+----------------+---------------+
| Method | Route | Name | Handler                      | Before Filters | After Filters |
+--------+-------+------+------------------------------+----------------+---------------+
| GET    | /     | »    | \App\Controllers\Home::index |                |               |
+--------+-------+------+------------------------------+----------------+---------------+

Required Before Filters: forcehttps, pagecache
 Required After Filters: pagecache, performance, toolbar
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
