### PR TITLE
feat: add Model field casting

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -203,6 +203,7 @@ parameters:
       - I18n
     Model:
       - Database
+      - DataConverter
       - Entity
       - I18n
       - Pager

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -177,6 +177,7 @@ parameters:
     DataCaster:
       - I18n
       - URI
+      - Database
     DataConverter:
       - DataCaster
     Email:

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -249,6 +249,8 @@ parameters:
       - CodeIgniter\Entity\Exceptions\CastException
     CodeIgniter\DataCaster\Exceptions\CastException:
       - CodeIgniter\Entity\Exceptions\CastException
+    CodeIgniter\DataConverter\DataConverter:
+      - CodeIgniter\Entity\Entity
     CodeIgniter\Entity\Cast\URICast:
       - CodeIgniter\HTTP\URI
     CodeIgniter\Log\Handlers\ChromeLoggerHandler:

--- a/rector.php
+++ b/rector.php
@@ -116,9 +116,10 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/system/Autoloader/Autoloader.php',
         ],
 
-        // session handlers have the gc() method with underscored parameter `$max_lifetime`
         UnderscoreToCamelCaseVariableNameRector::class => [
+            // session handlers have the gc() method with underscored parameter `$max_lifetime`
             __DIR__ . '/system/Session/Handlers',
+            __DIR__ . '/tests/_support/Entity/CustomUser.php',
         ],
 
         DeclareStrictTypesRector::class => [

--- a/rector.php
+++ b/rector.php
@@ -33,6 +33,7 @@ use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
@@ -94,6 +95,11 @@ return static function (RectorConfig $rectorConfig): void {
 
         JsonThrowOnErrorRector::class,
         YieldDataProviderRector::class,
+
+        RemoveUnusedPromotedPropertyRector::class => [
+            // Bug in rector 1.0.0. See https://github.com/rectorphp/rector-src/pull/5573
+            __DIR__ . '/tests/_support/Entity/CustomUser.php',
+        ],
 
         RemoveUnusedPrivateMethodRector::class => [
             // private method called via getPrivateMethodInvoker

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1815,6 +1815,9 @@ abstract class BaseModel
      * @throws DataException
      * @throws InvalidArgumentException
      * @throws ReflectionException
+     *
+     * @used-by insert()
+     * @used-by update()
      */
     protected function transformDataToArray($row, string $type): array
     {

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -376,7 +376,8 @@ abstract class BaseModel
         if ($this->useCasts()) {
             $this->converter = new DataConverter(
                 $this->casts,
-                $this->castHandlers
+                $this->castHandlers,
+                $this->db
             );
         }
     }

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -366,9 +366,17 @@ abstract class BaseModel
      */
     protected function createDataConverter(): void
     {
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             $this->converter = new DataConverter($this->casts);
         }
+    }
+
+    /**
+     * Are casts used?
+     */
+    protected function useCasts(): bool
+    {
+        return $this->casts !== [];
     }
 
     /**
@@ -1818,7 +1826,7 @@ abstract class BaseModel
             throw DataException::forEmptyDataset($type);
         }
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             if ($row instanceof stdClass) {
                 $row = (array) $row;
             } elseif (is_object($row)) {

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -106,11 +106,18 @@ abstract class BaseModel
     protected $tempReturnType;
 
     /**
-     * Whether we should limit fields in inserts
-     * and updates to those available in $allowedFields or not.
+     * Array of column names and the type of value to cast.
+     *
      * @var array<string, string> [column => type]
      */
-    protected $casts = [];
+    protected array $casts = [];
+
+    /**
+     * Custom convert handlers.
+     *
+     * @var array<string, class-string> [type => classname]
+     */
+    protected array $castHandlers = [];
 
     protected ?DataConverter $converter = null;
 
@@ -367,7 +374,10 @@ abstract class BaseModel
     protected function createDataConverter(): void
     {
         if ($this->useCasts()) {
-            $this->converter = new DataConverter($this->casts, [], 'reconstruct');
+            $this->converter = new DataConverter(
+                $this->casts,
+                $this->castHandlers
+            );
         }
     }
 

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1841,8 +1841,11 @@ abstract class BaseModel
         }
 
         // If it validates with entire rules, all fields are needed.
-        $onlyChanged = ($this->skipValidation === false && $this->cleanValidationRules === false)
-            ? false : ($type === 'update');
+        if ($this->skipValidation === false && $this->cleanValidationRules === false) {
+            $onlyChanged = false;
+        } else {
+            $onlyChanged = ($type === 'update' && $this->updateOnlyChanged);
+        }
 
         if ($this->useCasts()) {
             if (is_array($row)) {
@@ -1862,13 +1865,6 @@ abstract class BaseModel
         // properties representing the collection elements, we need to grab
         // them as an array.
         elseif (is_object($row) && ! $row instanceof stdClass) {
-            // If it validates with entire rules, all fields are needed.
-            if ($this->skipValidation === false && $this->cleanValidationRules === false) {
-                $onlyChanged = false;
-            } else {
-                $onlyChanged = ($type === 'update' && $this->updateOnlyChanged);
-            }
-
             $row = $this->objectToArray($row, $onlyChanged, true);
         }
 

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -367,7 +367,7 @@ abstract class BaseModel
     protected function createDataConverter(): void
     {
         if ($this->useCasts()) {
-            $this->converter = new DataConverter($this->casts);
+            $this->converter = new DataConverter($this->casts, [], 'reconstruct');
         }
     }
 

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -20,7 +20,8 @@ class {class} extends Model
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
 
-    protected $casts = [];
+    protected array $casts = [];
+    protected array $castHandlers = [];
 
     // Dates
     protected $useTimestamps = false;

--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -20,6 +20,8 @@ class {class} extends Model
     protected bool $allowEmptyInserts = false;
     protected bool $updateOnlyChanged = true;
 
+    protected $casts = [];
+
     // Dates
     protected $useTimestamps = false;
     protected $dateFormat    = 'datetime';

--- a/system/DataCaster/Cast/ArrayCast.php
+++ b/system/DataCaster/Cast/ArrayCast.php
@@ -21,8 +21,11 @@ namespace CodeIgniter\DataCaster\Cast;
  */
 class ArrayCast extends BaseCast implements CastInterface
 {
-    public static function get(mixed $value, array $params = []): array
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): array {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }
@@ -34,8 +37,11 @@ class ArrayCast extends BaseCast implements CastInterface
         return (array) $value;
     }
 
-    public static function set(mixed $value, array $params = []): string
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): string {
         return serialize($value);
     }
 }

--- a/system/DataCaster/Cast/BaseCast.php
+++ b/system/DataCaster/Cast/BaseCast.php
@@ -17,13 +17,19 @@ use InvalidArgumentException;
 
 abstract class BaseCast implements CastInterface
 {
-    public static function get(mixed $value, array $params = []): mixed
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): mixed {
         return $value;
     }
 
-    public static function set(mixed $value, array $params = []): mixed
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): mixed {
         return $value;
     }
 

--- a/system/DataCaster/Cast/BaseCast.php
+++ b/system/DataCaster/Cast/BaseCast.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\DataCaster\Cast;
 
-use TypeError;
+use InvalidArgumentException;
 
 abstract class BaseCast implements CastInterface
 {
@@ -34,6 +34,6 @@ abstract class BaseCast implements CastInterface
             $message .= ', and its value: ' . var_export($value, true);
         }
 
-        throw new TypeError($message);
+        throw new InvalidArgumentException($message);
     }
 }

--- a/system/DataCaster/Cast/BooleanCast.php
+++ b/system/DataCaster/Cast/BooleanCast.php
@@ -21,8 +21,11 @@ namespace CodeIgniter\DataCaster\Cast;
  */
 class BooleanCast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): bool
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): bool {
         // For PostgreSQL
         if ($value === 't') {
             return true;

--- a/system/DataCaster/Cast/CSVCast.php
+++ b/system/DataCaster/Cast/CSVCast.php
@@ -21,8 +21,11 @@ namespace CodeIgniter\DataCaster\Cast;
  */
 class CSVCast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): array
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): array {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }
@@ -30,8 +33,11 @@ class CSVCast extends BaseCast
         return explode(',', $value);
     }
 
-    public static function set(mixed $value, array $params = []): string
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): string {
         if (! is_array($value)) {
             self::invalidTypeValueError($value);
         }

--- a/system/DataCaster/Cast/CastInterface.php
+++ b/system/DataCaster/Cast/CastInterface.php
@@ -20,18 +20,28 @@ interface CastInterface
      *
      * @param mixed        $value  Data from database driver
      * @param list<string> $params Additional param
+     * @param object|null  $helper Helper object. E.g., database connection
      *
      * @return mixed PHP native value
      */
-    public static function get(mixed $value, array $params = []): mixed;
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): mixed;
 
     /**
      * Takes a PHP value, returns its value for DataSource.
      *
      * @param mixed        $value  PHP native value
      * @param list<string> $params Additional param
+     * @param object|null  $helper Helper object. E.g., database connection
      *
      * @return mixed Data to pass to database driver
      */
-    public static function set(mixed $value, array $params = []): mixed;
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): mixed;
 }

--- a/system/DataCaster/Cast/FloatCast.php
+++ b/system/DataCaster/Cast/FloatCast.php
@@ -21,8 +21,11 @@ namespace CodeIgniter\DataCaster\Cast;
  */
 class FloatCast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): float
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): float {
         if (! is_float($value) && ! is_string($value)) {
             self::invalidTypeValueError($value);
         }

--- a/system/DataCaster/Cast/IntBoolCast.php
+++ b/system/DataCaster/Cast/IntBoolCast.php
@@ -21,8 +21,11 @@ namespace CodeIgniter\DataCaster\Cast;
  */
 final class IntBoolCast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): bool
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): bool {
         if (! is_int($value) && ! is_string($value)) {
             self::invalidTypeValueError($value);
         }
@@ -30,8 +33,11 @@ final class IntBoolCast extends BaseCast
         return (bool) $value;
     }
 
-    public static function set(mixed $value, array $params = []): int
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): int {
         if (! is_bool($value)) {
             self::invalidTypeValueError($value);
         }

--- a/system/DataCaster/Cast/IntegerCast.php
+++ b/system/DataCaster/Cast/IntegerCast.php
@@ -21,8 +21,11 @@ namespace CodeIgniter\DataCaster\Cast;
  */
 class IntegerCast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): int
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): int {
         if (! is_string($value) && ! is_int($value)) {
             self::invalidTypeValueError($value);
         }

--- a/system/DataCaster/Cast/JsonCast.php
+++ b/system/DataCaster/Cast/JsonCast.php
@@ -25,8 +25,11 @@ use stdClass;
  */
 class JsonCast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): array|stdClass
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): array|stdClass {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }
@@ -44,8 +47,11 @@ class JsonCast extends BaseCast
         return $output;
     }
 
-    public static function set(mixed $value, array $params = []): string
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): string {
         try {
             $output = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {

--- a/system/DataCaster/Cast/TimestampCast.php
+++ b/system/DataCaster/Cast/TimestampCast.php
@@ -23,8 +23,11 @@ use CodeIgniter\I18n\Time;
  */
 class TimestampCast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): Time
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): Time {
         if (! is_int($value) && ! is_string($value)) {
             self::invalidTypeValueError($value);
         }
@@ -32,8 +35,11 @@ class TimestampCast extends BaseCast
         return Time::createFromTimestamp((int) $value);
     }
 
-    public static function set(mixed $value, array $params = []): int
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): int {
         if (! $value instanceof Time) {
             self::invalidTypeValueError($value);
         }

--- a/system/DataCaster/Cast/URICast.php
+++ b/system/DataCaster/Cast/URICast.php
@@ -23,8 +23,11 @@ use CodeIgniter\HTTP\URI;
  */
 class URICast extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): URI
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): URI {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }
@@ -32,8 +35,11 @@ class URICast extends BaseCast
         return new URI($value);
     }
 
-    public static function set(mixed $value, array $params = []): string
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): string {
         if (! $value instanceof URI) {
             self::invalidTypeValueError($value);
         }

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -67,6 +67,8 @@ final class DataCaster
     /**
      * @param array<string, class-string>|null $castHandlers Custom convert handlers
      * @param array<string, string>|null       $types        [field => type]
+     *
+     * @internal
      */
     public function __construct(
         ?array $castHandlers = null,
@@ -101,6 +103,8 @@ final class DataCaster
      * @param array<string, string> $types [field => type]
      *
      * $return $this
+     *
+     * @internal
      */
     public function setTypes(array $types): static
     {
@@ -118,6 +122,8 @@ final class DataCaster
      * @param         string      $field  The field name
      * @param         string      $method Allowed to "get" and "set"
      * @phpstan-param 'get'|'set' $method
+     *
+     * @internal
      */
     public function castAs(mixed $value, string $field, string $method = 'get'): mixed
     {

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -98,9 +98,11 @@ final class DataCaster
     /**
      * This method is only for Entity.
      *
+     * @TODO if Entity::$casts is readonly, we don't need this method.
+     *
      * @param array<string, string> $types [field => type]
      *
-     * $return $this
+     * @return $this
      *
      * @internal
      */

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -66,7 +66,7 @@ final class DataCaster
     /**
      * Helper object.
      */
-    private ?object $helper;
+    private readonly ?object $helper;
 
     /**
      * @param array<string, class-string>|null $castHandlers Custom convert handlers

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -64,15 +64,22 @@ final class DataCaster
     private readonly bool $strict;
 
     /**
+     * Helper object.
+     */
+    private ?object $helper;
+
+    /**
      * @param array<string, class-string>|null $castHandlers Custom convert handlers
      * @param array<string, string>|null       $types        [field => type]
      */
     public function __construct(
         ?array $castHandlers = null,
         ?array $types = null,
+        ?object $helper = null,
         bool $strict = true
     ) {
         $this->castHandlers = array_merge($this->castHandlers, $castHandlers);
+        $this->helper       = $helper;
 
         if ($types !== null) {
             $this->setTypes($types);
@@ -187,6 +194,6 @@ final class DataCaster
             throw CastException::forInvalidInterface($handler);
         }
 
-        return $handler::$method($value, $params);
+        return $handler::$method($value, $params, $this->helper);
     }
 }

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -67,8 +67,6 @@ final class DataCaster
     /**
      * @param array<string, class-string>|null $castHandlers Custom convert handlers
      * @param array<string, string>|null       $types        [field => type]
-     *
-     * @internal
      */
     public function __construct(
         ?array $castHandlers = null,
@@ -122,8 +120,6 @@ final class DataCaster
      * @param         string      $field  The field name
      * @param         string      $method Allowed to "get" and "set"
      * @phpstan-param 'get'|'set' $method
-     *
-     * @internal
      */
     public function castAs(mixed $value, string $field, string $method = 'get'): mixed
     {

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -115,8 +115,8 @@ final class DataCaster
 
     /**
      * Provides the ability to cast an item as a specific data type.
-     * Add ? at the beginning of $type  (i.e. ?string) to get `null`
-     * instead of casting $value if ($value === null).
+     * Add ? at the beginning of the type (i.e. ?string) to get `null`
+     * instead of casting $value when $value is null.
      *
      * @param         mixed       $value  The value to convert
      * @param         string      $field  The field name

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -27,7 +27,6 @@ use CodeIgniter\DataCaster\Cast\URICast;
 use CodeIgniter\Entity\Cast\CastInterface as EntityCastInterface;
 use CodeIgniter\Entity\Exceptions\CastException;
 use InvalidArgumentException;
-use TypeError;
 
 final class DataCaster
 {
@@ -147,7 +146,7 @@ final class DataCaster
             if ($this->strict) {
                 $message = 'Field "' . $field . '" is not nullable, but null was passed.';
 
-                throw new TypeError($message);
+                throw new InvalidArgumentException($message);
             }
         }
 

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -61,7 +61,7 @@ final class DataCaster
     /**
      * Strict mode? Set to false for casts for Entity.
      */
-    private bool $strict;
+    private readonly bool $strict;
 
     /**
      * @param array<string, class-string>|null $castHandlers Custom convert handlers

--- a/system/DataConverter/DataConverter.php
+++ b/system/DataConverter/DataConverter.php
@@ -31,8 +31,10 @@ final class DataConverter
      * @param array<string, string>       $types        [column => type]
      * @param array<string, class-string> $castHandlers Custom convert handlers
      */
-    public function __construct(array $types, array $castHandlers = [])
-    {
+    public function __construct(
+        private array $types,
+        array $castHandlers = []
+    ) {
         $this->dataCaster = new DataCaster($castHandlers, $types);
     }
 

--- a/system/DataConverter/DataConverter.php
+++ b/system/DataConverter/DataConverter.php
@@ -29,7 +29,7 @@ final class DataConverter
     /**
      * The data caster.
      */
-    private DataCaster $dataCaster;
+    private readonly DataCaster $dataCaster;
 
     /**
      * @param array<string, class-string> $castHandlers Custom convert handlers
@@ -42,7 +42,7 @@ final class DataConverter
          *
          * @var array<string, string> [column => type]
          */
-        private array $types,
+        private readonly array $types,
         array $castHandlers = [],
         /**
          * Static reconstruct method name or closure to reconstruct an object.
@@ -50,14 +50,14 @@ final class DataConverter
          *
          * @phpstan-var (Closure(array<string, mixed>): TEntity)|string|null
          */
-        private Closure|string|null $reconstructor = 'reconstruct',
+        private readonly Closure|string|null $reconstructor = 'reconstruct',
         /**
          * Extract method name or closure to extract data from an object.
          * Used by extract().
          *
          * @phpstan-var (Closure(TEntity, bool, bool): array<string, mixed>)|string|null
          */
-        private Closure|string|null $extractor = null,
+        private readonly Closure|string|null $extractor = null,
     ) {
         $this->dataCaster = new DataCaster($castHandlers, $types);
     }

--- a/system/DataConverter/DataConverter.php
+++ b/system/DataConverter/DataConverter.php
@@ -33,6 +33,8 @@ final class DataConverter
 
     /**
      * @param array<string, class-string> $castHandlers Custom convert handlers
+     *
+     * @internal
      */
     public function __construct(
         /**
@@ -64,6 +66,8 @@ final class DataConverter
      * Converts data from DataSource to PHP array with specified type values.
      *
      * @param array<string, mixed> $data DataSource data
+     *
+     * @internal
      */
     public function fromDataSource(array $data): array
     {
@@ -80,6 +84,8 @@ final class DataConverter
      * Converts PHP array to data for DataSource field types.
      *
      * @param array<string, mixed> $phpData PHP data
+     *
+     * @internal
      */
     public function toDataSource(array $phpData): array
     {
@@ -100,6 +106,8 @@ final class DataConverter
      * @param         array<string, mixed>  $row       Raw data from database
      *
      * @phpstan-return TEntity
+     *
+     * @internal
      */
     public function reconstruct(string $classname, array $row): object
     {
@@ -148,6 +156,8 @@ final class DataConverter
      *                          entities will be cast as array as well.
      *
      * @return array<string, mixed>
+     *
+     * @internal
      */
     public function extract(object $object, bool $onlyChanged = false, bool $recursive = false): array
     {

--- a/system/DataConverter/DataConverter.php
+++ b/system/DataConverter/DataConverter.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace CodeIgniter\DataConverter;
 
+use Closure;
 use CodeIgniter\DataCaster\DataCaster;
+use CodeIgniter\Entity\Entity;
 
 /**
  * PHP data <==> DataSource data converter
  *
  * @see \CodeIgniter\DataConverter\DataConverterTest
+ *
+ * @template TEntity of object
  */
 final class DataConverter
 {
@@ -28,12 +32,30 @@ final class DataConverter
     private DataCaster $dataCaster;
 
     /**
-     * @param array<string, string>       $types        [column => type]
      * @param array<string, class-string> $castHandlers Custom convert handlers
      */
     public function __construct(
+        /**
+         * Type definitions.
+         *
+         * @var array<string, string> [column => type]
+         */
         private array $types,
-        array $castHandlers = []
+        array $castHandlers = [],
+        /**
+         * Static reconstruct method name or closure to reconstruct an object.
+         * Used by reconstruct().
+         *
+         * @phpstan-var (Closure(array<string, mixed>): TEntity)|string|null
+         */
+        private Closure|string|null $reconstructor = 'reconstruct',
+        /**
+         * Extract method name or closure to extract data from an object.
+         * Used by extract().
+         *
+         * @phpstan-var (Closure(TEntity, bool, bool): array<string, mixed>)|string|null
+         */
+        private Closure|string|null $extractor = null,
     ) {
         $this->dataCaster = new DataCaster($castHandlers, $types);
     }
@@ -68,5 +90,99 @@ final class DataConverter
         }
 
         return $phpData;
+    }
+
+    /**
+     * Takes database data array and creates a specified type object.
+     *
+     * @param         class-string          $classname
+     * @phpstan-param class-string<TEntity> $classname
+     * @param         array<string, mixed>  $row       Raw data from database
+     *
+     * @phpstan-return TEntity
+     */
+    public function reconstruct(string $classname, array $row): object
+    {
+        $phpData = $this->fromDataSource($row);
+
+        // Use static reconstruct method.
+        if (is_string($this->reconstructor) && method_exists($classname, $this->reconstructor)) {
+            $method = $this->reconstructor;
+
+            return $classname::$method($phpData);
+        }
+
+        // Use closure to reconstruct.
+        if ($this->reconstructor instanceof Closure) {
+            $closure = $this->reconstructor;
+
+            return $closure($phpData);
+        }
+
+        $classObj = new $classname();
+
+        if ($classObj instanceof Entity) {
+            $classObj->injectRawData($phpData);
+            $classObj->syncOriginal();
+
+            return $classObj;
+        }
+
+        $classSet = Closure::bind(function ($key, $value) {
+            $this->{$key} = $value;
+        }, $classObj, $classname);
+
+        foreach ($phpData as $key => $value) {
+            $classSet($key, $value);
+        }
+
+        return $classObj;
+    }
+
+    /**
+     * Takes an object and extract properties as an array.
+     *
+     * @param bool $onlyChanged Only for CodeIgniter's Entity. If true, only returns
+     *                          values that have changed since object creation.
+     * @param bool $recursive   Only for CodeIgniter's Entity. If true, inner
+     *                          entities will be cast as array as well.
+     *
+     * @return array<string, mixed>
+     */
+    public function extract(object $object, bool $onlyChanged = false, bool $recursive = false): array
+    {
+        // Use extractor method.
+        if (is_string($this->extractor) && method_exists($object, $this->extractor)) {
+            $method = $this->extractor;
+            $row    = $object->{$method}($onlyChanged, $recursive);
+
+            return $this->toDataSource($row);
+        }
+
+        // Use closure to extract.
+        if ($this->extractor instanceof Closure) {
+            $closure = $this->extractor;
+            $row     = $closure($object, $onlyChanged, $recursive);
+
+            return $this->toDataSource($row);
+        }
+
+        if ($object instanceof Entity) {
+            $row = $object->toRawArray($onlyChanged, $recursive);
+
+            return $this->toDataSource($row);
+        }
+
+        $array = (array) $object;
+
+        $row = [];
+
+        foreach ($array as $key => $value) {
+            $key = preg_replace('/\000.*\000/', '', $key);
+
+            $row[$key] = $value;
+        }
+
+        return $this->toDataSource($row);
     }
 }

--- a/system/DataConverter/DataConverter.php
+++ b/system/DataConverter/DataConverter.php
@@ -45,13 +45,13 @@ final class DataConverter
      */
     public function fromDataSource(array $data): array
     {
-        $output = [];
-
-        foreach ($data as $field => $value) {
-            $output[$field] = $this->dataCaster->castAs($value, $field, 'get');
+        foreach (array_keys($this->types) as $field) {
+            if (array_key_exists($field, $data)) {
+                $data[$field] = $this->dataCaster->castAs($data[$field], $field, 'get');
+            }
         }
 
-        return $output;
+        return $data;
     }
 
     /**
@@ -61,12 +61,12 @@ final class DataConverter
      */
     public function toDataSource(array $phpData): array
     {
-        $output = [];
-
-        foreach ($phpData as $field => $value) {
-            $output[$field] = $this->dataCaster->castAs($value, $field, 'set');
+        foreach (array_keys($this->types) as $field) {
+            if (array_key_exists($field, $phpData)) {
+                $phpData[$field] = $this->dataCaster->castAs($phpData[$field], $field, 'set');
+            }
         }
 
-        return $output;
+        return $phpData;
     }
 }

--- a/system/DataConverter/DataConverter.php
+++ b/system/DataConverter/DataConverter.php
@@ -45,6 +45,10 @@ final class DataConverter
         private readonly array $types,
         array $castHandlers = [],
         /**
+         * Helper object.
+         */
+        private readonly ?object $helper = null,
+        /**
          * Static reconstruct method name or closure to reconstruct an object.
          * Used by reconstruct().
          *
@@ -59,7 +63,7 @@ final class DataConverter
          */
         private readonly Closure|string|null $extractor = null,
     ) {
-        $this->dataCaster = new DataCaster($castHandlers, $types);
+        $this->dataCaster = new DataCaster($castHandlers, $types, $this->helper);
     }
 
     /**

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -360,8 +360,8 @@ class Entity implements JsonSerializable
 
     /**
      * Provides the ability to cast an item as a specific data type.
-     * Add ? at the beginning of $type  (i.e. ?string) to get NULL
-     * instead of casting $value if $value === null
+     * Add ? at the beginning of the type (i.e. ?string) to get `null`
+     * instead of casting $value when $value is null.
      *
      * @param bool|float|int|string|null $value     Attribute value
      * @param string                     $attribute Attribute name

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -374,6 +374,7 @@ class Entity implements JsonSerializable
     protected function castAs($value, string $attribute, string $method = 'get')
     {
         return $this->dataCaster
+            // @TODO if $casts is readonly, we don't need the setTypes() method.
             ->setTypes($this->casts)
             ->castAs($value, $attribute, $method);
     }

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -137,6 +137,7 @@ class Entity implements JsonSerializable
         $this->dataCaster = new DataCaster(
             array_merge($this->defaultCastHandlers, $this->castHandlers),
             null,
+            null,
             false
         );
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -186,7 +186,7 @@ class Model extends BaseModel
     {
         $builder = $this->builder();
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             $returnType = $this->tempReturnType;
             $this->asArray();
         }
@@ -207,7 +207,7 @@ class Model extends BaseModel
             $row = $builder->get()->getResult($this->tempReturnType);
         }
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             $row = $this->convertToReturnType($row, $returnType);
 
             $this->tempReturnType = $returnType;
@@ -229,7 +229,7 @@ class Model extends BaseModel
     {
         $results = $this->select($columnName)->asArray()->find();
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             foreach ($results as $i => $row) {
                 $results[$i] = $this->converter->fromDataSource($row);
             }
@@ -257,7 +257,7 @@ class Model extends BaseModel
 
         $builder = $this->builder();
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             $returnType = $this->tempReturnType;
             $this->asArray();
         }
@@ -270,7 +270,7 @@ class Model extends BaseModel
             ->get()
             ->getResult($this->tempReturnType);
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             foreach ($results as $i => $row) {
                 $results[$i] = $this->convertToReturnType($row, $returnType);
             }
@@ -293,7 +293,7 @@ class Model extends BaseModel
     {
         $builder = $this->builder();
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             $returnType = $this->tempReturnType;
             $this->asArray();
         }
@@ -312,7 +312,7 @@ class Model extends BaseModel
 
         $row = $builder->limit(1, 0)->get()->getFirstRow($this->tempReturnType);
 
-        if ($this->casts !== []) {
+        if ($this->useCasts()) {
             $row = $this->convertToReturnType($row, $returnType);
 
             $this->tempReturnType = $returnType;

--- a/tests/_support/Entity/CustomUser.php
+++ b/tests/_support/Entity/CustomUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *

--- a/tests/_support/Entity/CustomUser.php
+++ b/tests/_support/Entity/CustomUser.php
@@ -18,6 +18,13 @@ use LogicException;
 
 /**
  * This is a custom Entity class.
+ *
+ * @property string    $country
+ * @property Time|null $created_at
+ * @property array     $email
+ * @property int       $id
+ * @property string    $name
+ * @property Time|null $updated_at
  */
 class CustomUser
 {

--- a/tests/_support/Entity/CustomUser.php
+++ b/tests/_support/Entity/CustomUser.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Entity;
+
+use CodeIgniter\I18n\Time;
+use LogicException;
+
+/**
+ * This is a custom Entity class.
+ */
+class CustomUser
+{
+    private function __construct(
+        private readonly int $id,
+        private string $name,
+        private string $email,
+        private string $country,
+        private readonly ?Time $created_at,
+        private readonly ?Time $updated_at,
+    ) {
+    }
+
+    public static function reconstruct(array $data): static
+    {
+        return new static(
+            $data['id'],
+            $data['name'],
+            $data['email'],
+            $data['country'],
+            $data['created_at'],
+            $data['updated_at'],
+        );
+    }
+
+    public function __isset(string $name)
+    {
+        if (! property_exists($this, $name)) {
+            throw new LogicException('No such property: ' . $name);
+        }
+
+        return isset($this->{$name});
+    }
+
+    public function __get(string $name)
+    {
+        if (! property_exists($this, $name)) {
+            throw new LogicException('No such property: ' . $name);
+        }
+
+        return $this->{$name};
+    }
+}

--- a/tests/_support/Entity/CustomUser.php
+++ b/tests/_support/Entity/CustomUser.php
@@ -22,7 +22,7 @@ class CustomUser
     private function __construct(
         private readonly int $id,
         private string $name,
-        private string $email,
+        private array $email,
         private string $country,
         private readonly ?Time $created_at,
         private readonly ?Time $updated_at,
@@ -39,6 +39,11 @@ class CustomUser
             $data['created_at'],
             $data['updated_at'],
         );
+    }
+
+    public function addEmail(string $email): void
+    {
+        $this->email[] = $email;
     }
 
     public function __isset(string $name)

--- a/tests/_support/Models/UserCastsTimestampModel.php
+++ b/tests/_support/Models/UserCastsTimestampModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *

--- a/tests/_support/Models/UserCastsTimestampModel.php
+++ b/tests/_support/Models/UserCastsTimestampModel.php
@@ -34,7 +34,7 @@ class UserCastsTimestampModel extends Model
     protected $useTimestamps  = true;
     protected $dateFormat     = 'datetime';
 
-    public function initialize()
+    protected function initialize()
     {
         parent::initialize();
 

--- a/tests/_support/Models/UserCastsTimestampModel.php
+++ b/tests/_support/Models/UserCastsTimestampModel.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Models;
+
+use CodeIgniter\Model;
+
+class UserCastsTimestampModel extends Model
+{
+    protected $table         = 'user';
+    protected $allowedFields = [
+        'name',
+        'email',
+        'country',
+    ];
+    protected $casts = [
+        'id'         => 'int',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+    protected $returnType     = 'array';
+    protected $useSoftDeletes = true;
+    protected $useTimestamps  = true;
+    protected $dateFormat     = 'datetime';
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        if ($this->db->DBDriver === 'SQLSRV') {
+            // SQL Server returns a string like `2023-11-27 01:44:04.000`.
+            $this->casts['created_at'] = 'datetime[Y-m-d H:i:s.v]';
+            $this->casts['updated_at'] = 'datetime[Y-m-d H:i:s.v]';
+        }
+    }
+}

--- a/tests/_support/Models/UserCastsTimestampModel.php
+++ b/tests/_support/Models/UserCastsTimestampModel.php
@@ -45,8 +45,8 @@ class UserCastsTimestampModel extends Model
 
         if ($this->db->DBDriver === 'SQLSRV') {
             // SQL Server returns a string like `2023-11-27 01:44:04.000`.
-            $this->casts['created_at'] = 'datetime[Y-m-d H:i:s.v]';
-            $this->casts['updated_at'] = 'datetime[Y-m-d H:i:s.v]';
+            $this->casts['created_at'] = 'datetime[ms]';
+            $this->casts['updated_at'] = 'datetime[ms]';
         }
     }
 }

--- a/tests/_support/Models/UserCastsTimestampModel.php
+++ b/tests/_support/Models/UserCastsTimestampModel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Support\Models;
 
 use CodeIgniter\Model;
+use Tests\Support\Entity\Cast\CastBase64;
 
 class UserCastsTimestampModel extends Model
 {
@@ -23,11 +24,15 @@ class UserCastsTimestampModel extends Model
         'email',
         'country',
     ];
-    protected $casts = [
+    protected array $casts = [
         'id'         => 'int',
+        'name'       => 'base64',
         'email'      => 'json-array',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
+    ];
+    protected array $castHandlers = [
+        'base64' => CastBase64::class,
     ];
     protected $returnType     = 'array';
     protected $useSoftDeletes = true;

--- a/tests/_support/Models/UserCastsTimestampModel.php
+++ b/tests/_support/Models/UserCastsTimestampModel.php
@@ -23,6 +23,7 @@ class UserCastsTimestampModel extends Model
     ];
     protected $casts = [
         'id'         => 'int',
+        'email'      => 'json-array',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -350,18 +350,18 @@ final class DataConverterTest extends CIUnitTestCase
     {
         $types = [
             'id'   => 'int',
-            'date' => 'datetime[j-M-Y]',
+            'date' => 'datetime[us]',
         ];
         $converter = $this->createDataConverter($types, [], db_connect());
 
         $dbData = [
             'id'   => '1',
-            'date' => '15-Feb-2009',
+            'date' => '2009-02-15 00:00:01.123456',
         ];
         $data = $converter->fromDataSource($dbData);
 
         $this->assertInstanceOf(Time::class, $data['date']);
-        $expectedDate = Time::createFromFormat('j-M-Y', '15-Feb-2009');
+        $expectedDate = Time::createFromFormat('Y-m-d H:i:s.u', '2009-02-15 00:00:01.123456');
         $this->assertSame($expectedDate->getTimestamp(), $data['date']->getTimestamp());
     }
 

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -333,7 +333,7 @@ final class DataConverterTest extends CIUnitTestCase
             'id'   => 'int',
             'date' => 'datetime',
         ];
-        $converter = $this->createDataConverter($types);
+        $converter = $this->createDataConverter($types, [], db_connect());
 
         $dbData = [
             'id'   => '1',
@@ -352,7 +352,7 @@ final class DataConverterTest extends CIUnitTestCase
             'id'   => 'int',
             'date' => 'datetime[j-M-Y]',
         ];
-        $converter = $this->createDataConverter($types);
+        $converter = $this->createDataConverter($types, [], db_connect());
 
         $dbData = [
             'id'   => '1',
@@ -531,10 +531,11 @@ final class DataConverterTest extends CIUnitTestCase
     private function createDataConverter(
         array $types,
         array $handlers = [],
+        ?object $helper = null,
         Closure|string|null $reconstructor = 'reconstruct',
         Closure|string|null $extractor = null
     ): DataConverter {
-        return new DataConverter($types, $handlers, $reconstructor, $extractor);
+        return new DataConverter($types, $handlers, $helper, $reconstructor, $extractor);
     }
 
     public function testReconstructObjectWithReconstructMethod()
@@ -545,7 +546,7 @@ final class DataConverterTest extends CIUnitTestCase
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
         ];
-        $converter = $this->createDataConverter($types);
+        $converter = $this->createDataConverter($types, [], db_connect());
 
         $dbData = [
             'id'         => '1',
@@ -578,7 +579,7 @@ final class DataConverterTest extends CIUnitTestCase
 
             return $user;
         };
-        $converter = $this->createDataConverter($types, [], $reconstructor);
+        $converter = $this->createDataConverter($types, [], db_connect(), $reconstructor);
 
         $dbData = [
             'id'         => '1',
@@ -676,7 +677,7 @@ final class DataConverterTest extends CIUnitTestCase
 
             return $array;
         };
-        $converter = $this->createDataConverter($types, [], null, $extractor);
+        $converter = $this->createDataConverter($types, [], db_connect(), null, $extractor);
 
         $phpData = [
             'id'         => 1,

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -555,6 +555,7 @@ final class DataConverterTest extends CIUnitTestCase
             'created_at' => '2023-12-02 07:35:57',
             'updated_at' => '2023-12-02 07:35:57',
         ];
+        /** @var CustomUser $obj */
         $obj = $converter->reconstruct(CustomUser::class, $dbData);
 
         $this->assertIsInt($obj->id);
@@ -587,6 +588,7 @@ final class DataConverterTest extends CIUnitTestCase
             'created_at' => '2023-12-02 07:35:57',
             'updated_at' => '2023-12-02 07:35:57',
         ];
+        /** @var CustomUser $obj */
         $obj = $converter->reconstruct(CustomUser::class, $dbData);
 
         $this->assertIsInt($obj->id);

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -20,7 +20,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use InvalidArgumentException;
 use Tests\Support\Entity\CustomUser;
 use Tests\Support\Entity\User;
-use TypeError;
 
 /**
  * @internal
@@ -473,7 +472,7 @@ final class DataConverterTest extends CIUnitTestCase
 
     public function testInvalidValue(): void
     {
-        $this->expectException(TypeError::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             '[CodeIgniter\DataCaster\Cast\JsonCast] Invalid value type: bool, and its value: true'
         );
@@ -513,7 +512,7 @@ final class DataConverterTest extends CIUnitTestCase
 
     public function testNotNullable(): void
     {
-        $this->expectException(TypeError::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Field "remark" is not nullable, but null was passed.');
 
         $types = [

--- a/tests/system/Models/DataConverterModelTest.php
+++ b/tests/system/Models/DataConverterModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *

--- a/tests/system/Models/DataConverterModelTest.php
+++ b/tests/system/Models/DataConverterModelTest.php
@@ -240,4 +240,53 @@ final class DataConverterModelTest extends LiveModelTestCase
             'private@example.org',
         ], $user->email);
     }
+
+    public function testSaveArray(): void
+    {
+        $id   = $this->prepareOneRecord();
+        $user = $this->model->find($id);
+
+        $user['email'][] = 'private@example.org';
+        $this->model->save($user);
+
+        $user = $this->model->find($id);
+
+        $this->assertSame([
+            'john@example.com',
+            'private@example.org',
+        ], $user['email']);
+    }
+
+    public function testSaveObject(): void
+    {
+        $id   = $this->prepareOneRecord();
+        $user = $this->model->asObject()->find($id);
+
+        $user->email[] = 'private@example.org';
+        $this->model->save($user);
+
+        $user = $this->model->find($id);
+
+        $this->assertSame([
+            'john@example.com',
+            'private@example.org',
+        ], $user['email']);
+    }
+
+    public function testSaveCustomObject(): void
+    {
+        $id = $this->prepareOneRecord();
+        /** @var CustomUser $user */
+        $user = $this->model->asObject(CustomUser::class)->find($id);
+
+        $user->addEmail('private@example.org');
+        $this->model->save($user);
+
+        $user = $this->model->asObject(CustomUser::class)->find($id);
+
+        $this->assertSame([
+            'john@example.com',
+            'private@example.org',
+        ], $user->email);
+    }
 }

--- a/tests/system/Models/DataConverterModelTest.php
+++ b/tests/system/Models/DataConverterModelTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Models;
+
+use CodeIgniter\I18n\Time;
+use Tests\Support\Entity\CustomUser;
+use Tests\Support\Models\UserCastsTimestampModel;
+
+/**
+ * @group DatabaseLive
+ *
+ * @internal
+ */
+final class DataConverterModelTest extends LiveModelTestCase
+{
+    protected $migrate     = true;
+    protected $migrateOnce = true;
+    protected $refresh     = false;
+    protected $seed        = '';
+
+    public function testFindAsArray(): void
+    {
+        $id = $this->prepareOneRecord();
+
+        $user = $this->model->find($id);
+
+        $this->assertIsInt($user['id']);
+        $this->assertInstanceOf(Time::class, $user['created_at']);
+    }
+
+    /**
+     * @return int|string Insert ID
+     */
+    private function prepareOneRecord(): int|string
+    {
+        $this->createModel(UserCastsTimestampModel::class);
+        $this->db->table('user')->truncate();
+
+        $data = [
+            'name'    => 'John Smith',
+            'email'   => 'john@example.com',
+            'country' => 'US',
+        ];
+
+        return $this->model->insert($data, true);
+    }
+
+    public function testFindAsObject(): void
+    {
+        $id = $this->prepareOneRecord();
+
+        $user = $this->model->asObject()->find($id);
+
+        $this->assertIsInt($user->id);
+        $this->assertInstanceOf(Time::class, $user->created_at);
+    }
+
+    public function testFindAsCustomObject(): void
+    {
+        $id = $this->prepareOneRecord();
+
+        $user = $this->model->asObject(CustomUser::class)->find($id);
+
+        $this->assertIsInt($user->id);
+        $this->assertInstanceOf(Time::class, $user->created_at);
+    }
+
+    public function testFindAllAsArray(): void
+    {
+        $this->prepareTwoRecords();
+
+        $users = $this->model->findAll();
+
+        $this->assertIsInt($users[0]['id']);
+        $this->assertInstanceOf(Time::class, $users[0]['created_at']);
+        $this->assertIsInt($users[1]['id']);
+        $this->assertInstanceOf(Time::class, $users[1]['created_at']);
+    }
+
+    private function prepareTwoRecords(): void
+    {
+        $this->prepareOneRecord();
+
+        $data = [
+            'name'    => 'Mike Smith',
+            'email'   => 'mike@example.com',
+            'country' => 'CA',
+        ];
+        $this->model->insert($data);
+    }
+
+    public function testFindAllAsObject(): void
+    {
+        $this->prepareTwoRecords();
+
+        $users = $this->model->asObject()->findAll();
+
+        $this->assertIsInt($users[0]->id);
+        $this->assertInstanceOf(Time::class, $users[0]->created_at);
+        $this->assertIsInt($users[1]->id);
+        $this->assertInstanceOf(Time::class, $users[1]->created_at);
+    }
+
+    public function testFindAllAsCustomObject(): void
+    {
+        $this->prepareTwoRecords();
+
+        $users = $this->model->asObject(CustomUser::class)->findAll();
+
+        $this->assertIsInt($users[0]->id);
+        $this->assertInstanceOf(Time::class, $users[0]->created_at);
+        $this->assertIsInt($users[1]->id);
+        $this->assertInstanceOf(Time::class, $users[1]->created_at);
+    }
+
+    public function testFindColumn(): void
+    {
+        $this->prepareTwoRecords();
+
+        $users = $this->model->findColumn('created_at');
+
+        $this->assertInstanceOf(Time::class, $users[0]);
+        $this->assertInstanceOf(Time::class, $users[1]);
+    }
+
+    public function testFirstAsArray(): void
+    {
+        $this->prepareTwoRecords();
+
+        $user = $this->model->first();
+
+        $this->assertIsInt($user['id']);
+        $this->assertInstanceOf(Time::class, $user['created_at']);
+    }
+
+    public function testFirstAsObject(): void
+    {
+        $this->prepareTwoRecords();
+
+        $user = $this->model->asObject()->first();
+
+        $this->assertIsInt($user->id);
+        $this->assertInstanceOf(Time::class, $user->created_at);
+    }
+
+    public function testFirstAsCustomObject(): void
+    {
+        $this->prepareTwoRecords();
+
+        $user = $this->model->asObject(CustomUser::class)->first();
+
+        $this->assertIsInt($user->id);
+        $this->assertInstanceOf(Time::class, $user->created_at);
+    }
+}

--- a/tests/system/Models/DataConverterModelTest.php
+++ b/tests/system/Models/DataConverterModelTest.php
@@ -38,6 +38,9 @@ final class DataConverterModelTest extends LiveModelTestCase
 
         $this->assertIsInt($user['id']);
         $this->assertInstanceOf(Time::class, $user['created_at']);
+        $this->assertSame('John Smith', $user['name']);
+        // `name` is cast by custom CastBase64 handler.
+        $this->seeInDatabase('user', ['name' => 'Sm9obiBTbWl0aA==']);
     }
 
     /**

--- a/tests/system/Models/DataConverterModelTest.php
+++ b/tests/system/Models/DataConverterModelTest.php
@@ -13,6 +13,7 @@ namespace CodeIgniter\Models;
 
 use CodeIgniter\I18n\Time;
 use Tests\Support\Entity\CustomUser;
+use Tests\Support\Entity\User;
 use Tests\Support\Models\UserCastsTimestampModel;
 
 /**
@@ -74,6 +75,16 @@ final class DataConverterModelTest extends LiveModelTestCase
         $this->assertInstanceOf(Time::class, $user->created_at);
     }
 
+    public function testFindAsEntity(): void
+    {
+        $id = $this->prepareOneRecord();
+
+        $user = $this->model->asObject(User::class)->find($id);
+
+        $this->assertIsInt($user->id);
+        $this->assertInstanceOf(Time::class, $user->created_at);
+    }
+
     public function testFindAllAsArray(): void
     {
         $this->prepareTwoRecords();
@@ -122,6 +133,18 @@ final class DataConverterModelTest extends LiveModelTestCase
         $this->assertInstanceOf(Time::class, $users[1]->created_at);
     }
 
+    public function testFindAllAsEntity(): void
+    {
+        $this->prepareTwoRecords();
+
+        $users = $this->model->asObject(User::class)->findAll();
+
+        $this->assertIsInt($users[0]->id);
+        $this->assertInstanceOf(Time::class, $users[0]->created_at);
+        $this->assertIsInt($users[1]->id);
+        $this->assertInstanceOf(Time::class, $users[1]->created_at);
+    }
+
     public function testFindColumn(): void
     {
         $this->prepareTwoRecords();
@@ -157,6 +180,16 @@ final class DataConverterModelTest extends LiveModelTestCase
         $this->prepareTwoRecords();
 
         $user = $this->model->asObject(CustomUser::class)->first();
+
+        $this->assertIsInt($user->id);
+        $this->assertInstanceOf(Time::class, $user->created_at);
+    }
+
+    public function testFirstAsEntity(): void
+    {
+        $this->prepareTwoRecords();
+
+        $user = $this->model->asObject(User::class)->first();
 
         $this->assertIsInt($user->id);
         $this->assertInstanceOf(Time::class, $user->created_at);
@@ -241,6 +274,25 @@ final class DataConverterModelTest extends LiveModelTestCase
         ], $user->email);
     }
 
+    public function testUpdateEntity(): void
+    {
+        $id = $this->prepareOneRecord();
+        /** @var User $user */
+        $user = $this->model->asObject(User::class)->find($id);
+
+        $email       = $user->email;
+        $email[]     = 'private@example.org';
+        $user->email = $email;
+        $this->model->update($user->id, $user);
+
+        $user = $this->model->asObject(User::class)->find($id);
+
+        $this->assertSame([
+            'john@example.com',
+            'private@example.org',
+        ], $user->email);
+    }
+
     public function testSaveArray(): void
     {
         $id   = $this->prepareOneRecord();
@@ -283,6 +335,25 @@ final class DataConverterModelTest extends LiveModelTestCase
         $this->model->save($user);
 
         $user = $this->model->asObject(CustomUser::class)->find($id);
+
+        $this->assertSame([
+            'john@example.com',
+            'private@example.org',
+        ], $user->email);
+    }
+
+    public function testSaveEntity(): void
+    {
+        $id = $this->prepareOneRecord();
+        /** @var User $user */
+        $user = $this->model->asObject(User::class)->find($id);
+
+        $email       = $user->email;
+        $email[]     = 'private@example.org';
+        $user->email = $email;
+        $this->model->save($user);
+
+        $user = $this->model->asObject(User::class)->find($id);
 
         $this->assertSame([
             'john@example.com',

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -295,6 +295,12 @@ Others
 Model
 =====
 
+Model Field Casting
+-------------------
+
+Added a feature to convert data retrieved from a database into the appropriate
+PHP type. See :ref:`model-field-casting` for details.
+
 .. _v450-model-findall-limit-0-behavior:
 
 findAll(0) Behavior

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -382,7 +382,12 @@ casts try ``array`` or ``json``.
 datetime
 --------
 
-You can set the datetime format like ``datetime[Y-m-d H:i:s.v]``.
+You can pass a parameter like ``datetime[ms]`` for date/time with milliseconds,
+or ``datetime[us]`` for date/time with microseconds.
+
+The datetime format is set in the ``dateFormat`` array of the
+:ref:`database configuration <database-config-explanation-of-values>` in the
+**app/Config/Database.php** file.
 
 Custom Casting
 ==============

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -192,7 +192,6 @@ This allows you to convert data retrieved from a database into the appropriate
 PHP type.
 This option should be an array where the key is the name of the field, and the
 value is the data type. See :ref:`model-field-casting` for details.
->>>>>>> 202e3568ce (docs: add docs)
 
 Dates
 -----

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -183,6 +183,17 @@ with "There is no data to update." will raise.
 Setting this property to ``false`` will ensure that all allowed fields of an Entity
 are submitted to the database and updated at any time.
 
+$casts
+------
+
+.. versionadded:: 4.5.0
+
+This allows you to convert data retrieved from a database into the appropriate
+PHP type.
+This option should be an array where the key is the name of the field, and the
+value is the data type. See :ref:`model-field-casting` for details.
+>>>>>>> 202e3568ce (docs: add docs)
+
 Dates
 -----
 
@@ -293,6 +304,78 @@ $afterUpdateBatch
 
 These arrays allow you to specify callback methods that will be run on the data at the
 time specified in the property name. See :ref:`model-events`.
+
+.. _model-field-casting:
+
+Model Field Casting
+*******************
+
+.. versionadded:: 4.5.0
+
+When retrieving data from a database, data of integer type may be converted to
+string type in PHP. You may also want to convert date/time data into a Time
+object in PHP.
+
+Model Field Casting allows you to convert data retrieved from a database into
+the appropriate PHP type.
+
+.. important::
+    If you use this feature with the :doc:`Entity <./entities>`, do not use
+    :ref:`Entity Property Casting <entities-property-casting>`. Using both casting
+    at the same time does not work.
+
+    Entity Property Casting works at (1)(4), but this casting works at (2)(3)::
+
+        [App Code] --- (1) --> [Entity] --- (2) --> [Database]
+        [App Code] <-- (4) --- [Entity] <-- (3) --- [Database]
+
+    When using this casting, Entity will have correct typed PHP values in the
+    attributes. This behavior is completely different from the previous behavior.
+    Do not expect the attributes hold raw data from database.
+
+Defining Data Types
+===================
+
+The ``$casts`` property sets its definition. This option should be an array
+where the key is the name of the field, and the value is the data type:
+
+.. literalinclude:: model/057.php
+
+Data Types
+==========
+
+The following types are provided by default. Add a question mark at the beginning
+of type to mark the field as nullable, i.e., ``?int``, ``?datetime``.
+
++---------------+----------------+---------------------------+
+| Type          | PHP Value Type | DB Column Type            |
++===============+================+===========================+
+|``int``        | int            | int type                  |
++---------------+----------------+---------------------------+
+|``float``      | float          | float (numeric) type      |
++---------------+----------------+---------------------------+
+|``bool``       | bool           | bool/int/string type      |
++---------------+----------------+---------------------------+
+|``int-bool``   | bool           | int type (1 or 0)         |
++---------------+----------------+---------------------------+
+|``array``      | array          | string type (serialized)  |
++---------------+----------------+---------------------------+
+|``csv``        | array          | string type (CSV)         |
++---------------+----------------+---------------------------+
+|``json``       | stdClass       | json/string type          |
++---------------+----------------+---------------------------+
+|``json-array`` | array          | json/string type          |
++---------------+----------------+---------------------------+
+|``datetime``   | Time           | datetime type             |
++---------------+----------------+---------------------------+
+|``timestamp``  | Time           | int type (UNIX timestamp) |
++---------------+----------------+---------------------------+
+|``uri``        | URI            | string type               |
++---------------+----------------+---------------------------+
+
+.. note:: Casting as ``csv`` uses PHP's internal ``implode()`` and ``explode()``
+    functions and assumes all values are string-safe and free of commas. For more
+    complex data casts try ``array`` or ``json``.
 
 Working with Data
 *****************

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -385,6 +385,47 @@ datetime
 
 You can set the datetime format like ``datetime[Y-m-d H:i:s.v]``.
 
+Custom Casting
+==============
+
+You can define your own conversion types.
+
+Creating Custom Handlers
+------------------------
+
+At first you need to create a handler class for your type.
+Let's say the class will be located in the **app/Models/Cast** directory:
+
+.. literalinclude:: model/058.php
+
+If you don't need to change values when getting or setting a value. Then just
+don't implement the appropriate method:
+
+.. literalinclude:: model/060.php
+
+Registering Custom Handlers
+---------------------------
+
+Now you need to register it:
+
+.. literalinclude:: model/059.php
+
+Parameters
+----------
+
+In some cases, one type is not enough. In this situation, you can use additional
+parameters. Additional parameters are indicated in square brackets and listed
+with a comma like ``type[param1, param2]``.
+
+.. literalinclude:: model/061.php
+
+.. literalinclude:: model/062.php
+
+.. note:: If the casting type is marked as nullable like ``?bool`` and the passed
+    value is not null, then the parameter with the value ``nullable`` will be
+    passed to the casting type handler. If casting type has predefined parameters,
+    then ``nullable`` will be added to the end of the list.
+
 Working with Data
 *****************
 

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -373,9 +373,17 @@ of type to mark the field as nullable, i.e., ``?int``, ``?datetime``.
 |``uri``        | URI            | string type               |
 +---------------+----------------+---------------------------+
 
-.. note:: Casting as ``csv`` uses PHP's internal ``implode()`` and ``explode()``
-    functions and assumes all values are string-safe and free of commas. For more
-    complex data casts try ``array`` or ``json``.
+csv
+---
+
+Casting as ``csv`` uses PHP's internal ``implode()`` and ``explode()`` functions
+and assumes all values are string-safe and free of commas. For more complex data
+casts try ``array`` or ``json``.
+
+datetime
+--------
+
+You can set the datetime format like ``datetime[Y-m-d H:i:s.v]``.
 
 Working with Data
 *****************

--- a/user_guide_src/source/models/model/057.php
+++ b/user_guide_src/source/models/model/057.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class UserModel extends Model
+{
+    // ...
+    protected $casts = [
+        'id'        => 'int',
+        'birthdate' => '?datetime',
+        'hobbies'   => 'json-array',
+        'active'    => 'int-bool',
+    ];
+    // ...
+}

--- a/user_guide_src/source/models/model/058.php
+++ b/user_guide_src/source/models/model/058.php
@@ -8,8 +8,11 @@ use InvalidArgumentException;
 // The class must inherit the CodeIgniter\DataCaster\Cast\BaseCast class
 class CastBase64 extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): string
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): string {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }
@@ -23,8 +26,11 @@ class CastBase64 extends BaseCast
         return $decoded;
     }
 
-    public static function set(mixed $value, array $params = []): string
-    {
+    public static function set(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): string {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }

--- a/user_guide_src/source/models/model/058.php
+++ b/user_guide_src/source/models/model/058.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models\Cast;
+
+use CodeIgniter\DataCaster\Cast\BaseCast;
+use InvalidArgumentException;
+
+// The class must inherit the CodeIgniter\DataCaster\Cast\BaseCast class
+class CastBase64 extends BaseCast
+{
+    public static function get(mixed $value, array $params = []): string
+    {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
+        $decoded = base64_decode($value, true);
+
+        if ($decoded === false) {
+            throw new InvalidArgumentException('Cannot decode: ' . $value);
+        }
+
+        return $decoded;
+    }
+
+    public static function set(mixed $value, array $params = []): string
+    {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
+        return base64_encode($value);
+    }
+}

--- a/user_guide_src/source/models/model/059.php
+++ b/user_guide_src/source/models/model/059.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Cast\CastBase64;
+use CodeIgniter\Model;
+
+class MyModel extends Model
+{
+    // ...
+
+    // Specify the type for the field
+    protected array $casts = [
+        'column1' => 'base64',
+    ];
+
+    // Bind the type to the handler
+    protected array $castHandlers = [
+        'base64' => CastBase64::class,
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/models/model/060.php
+++ b/user_guide_src/source/models/model/060.php
@@ -7,8 +7,11 @@ use InvalidArgumentException;
 
 class CastBase64 extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): string
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): string {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
         }

--- a/user_guide_src/source/models/model/060.php
+++ b/user_guide_src/source/models/model/060.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Cast;
+
+use CodeIgniter\DataCaster\Cast\BaseCast;
+use InvalidArgumentException;
+
+class CastBase64 extends BaseCast
+{
+    public static function get(mixed $value, array $params = []): string
+    {
+        if (! is_string($value)) {
+            self::invalidTypeValueError($value);
+        }
+
+        $decoded = base64_decode($value, true);
+
+        if ($decoded === false) {
+            throw new InvalidArgumentException('Cannot decode: ' . $value);
+        }
+
+        return $decoded;
+    }
+}

--- a/user_guide_src/source/models/model/061.php
+++ b/user_guide_src/source/models/model/061.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Cast\SomeHandler;
+use CodeIgniter\Model;
+
+class MyModel extends Model
+{
+    // ...
+
+    // Define a type with parameters
+    protected array $casts = [
+        'column1' => 'class[App\SomeClass, param2, param3]',
+    ];
+
+    // Bind the type to the handler
+    protected array $castHandlers = [
+        'class' => SomeHandler::class,
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/models/model/062.php
+++ b/user_guide_src/source/models/model/062.php
@@ -6,8 +6,11 @@ use CodeIgniter\DataCaster\Cast\BaseCast;
 
 class SomeHandler extends BaseCast
 {
-    public static function get(mixed $value, array $params = []): mixed
-    {
+    public static function get(
+        mixed $value,
+        array $params = [],
+        ?object $helper = null
+    ): mixed {
         var_dump($params);
         /*
          * Output:

--- a/user_guide_src/source/models/model/062.php
+++ b/user_guide_src/source/models/model/062.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Cast;
+
+use CodeIgniter\DataCaster\Cast\BaseCast;
+
+class SomeHandler extends BaseCast
+{
+    public static function get(mixed $value, array $params = []): mixed
+    {
+        var_dump($params);
+        /*
+         * Output:
+         * array(3) {
+         *   [0]=>
+         *   string(13) "App\SomeClass"
+         *   [1]=>
+         *   string(6) "param2"
+         *   [2]=>
+         *   string(6) "param3"
+         * }
+         */
+    }
+}


### PR DESCRIPTION
~~Needs #8230, #8260, #8539~~

**Description**
[Entity](https://codeigniter4.github.io/CodeIgniter4/models/entities.html) is optional, and some devs do not want to use it.
See https://forum.codeigniter.com/showthread.php?tid=85956
This PR provides field type casting in Model so that all custom entities (or arrays) can use  type casting.
This PR can solve #7177, #5905.

### Model Field Casting

This casting only works when data comes from and goes to database.

```
[Object] --- toDataSource() ---> [DB driver]
[Object] <-- fromDataSource() -- [DB driver]
```

To use this feature, add property `$casts` to a Model.
```php
    protected $casts = [
        'id'         => 'int',
        'email'      => 'json-array',
        'created_at' => 'datetime',
        'updated_at' => 'datetime',
    ];
```

### Entity and this feature
Entity casting works at (1)(4), but this casting works at (2)(3).

```
[App Code] --- (1) --> [Entity] --- (2) --> [Database]
[App Code] <-- (4) --- [Entity] <-- (3) --- [Database]
```

If you use this feature with Entity, do not use casting in Entity.
Using both casting at the same time does not work.

When using casting in Model, Entity has correct typed PHP values in the attributes.
This behavior is completely different from the previous behavior.
Do not expect the attributes hold raw data from database.

**TODO**
- [x] find*()
- [x] insert()
- [x] update()
- [x] save()
- [x] don't break $useTimestamps
- [x] don't break Entity

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
