### PR TITLE
docs: fix incorrect PHPDoc types

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -254,14 +254,16 @@ abstract class BaseResult implements ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param int    $n    The index of the results to return
-     * @param string $type The type of result object. 'array', 'object' or class name.
+     * @param int|string $n    The index of the results to return, or column name.
+     * @param string     $type The type of result object. 'array', 'object' or class name.
+     * @phpstan-param class-string|'array'|'object' $type
      *
      * @return array|object|stdClass|null
      * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : object|null))
      */
     public function getRow($n = 0, string $type = 'object')
     {
+        // $n is a column name.
         if (! is_numeric($n)) {
             // We cache the row data for subsequent uses
             if (! is_array($this->rowData)) {

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -57,8 +57,9 @@ interface ResultInterface
      *
      * If row doesn't exist, returns null.
      *
-     * @param int    $n    The index of the results to return
-     * @param string $type The type of result object. 'array', 'object' or class name.
+     * @param int|string $n    The index of the results to return, or column name.
+     * @param string     $type The type of result object. 'array', 'object' or class name.
+     * @phpstan-param class-string|'array'|'object' $type
      *
      * @return array|object|stdClass|null
      * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : object|null))

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -731,7 +731,7 @@ class Email
     }
 
     /**
-     * @param string $email
+     * @param array|string $email
      *
      * @return array
      */

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -77,7 +77,7 @@ class FileCollection
     /**
      * Verify if a file exist in the collection of uploaded files and is have been uploaded with multiple option.
      *
-     * @return array|null
+     * @return list<UploadedFile>|null
      */
     public function getFileMultiple(string $name)
     {
@@ -245,7 +245,7 @@ class FileCollection
      * @param array $index The index sequence we are navigating down
      * @param array $value The portion of the array to process
      *
-     * @return UploadedFile|null
+     * @return list<UploadedFile>|UploadedFile|null
      */
     protected function getValueDotNotationSyntax(array $index, array $value)
     {


### PR DESCRIPTION
**Description**
- fix PHPDoc type errors found by Psalm

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
