### PR TITLE
fix: [Cache] Double prefix for increment in FileHandler

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -150,8 +150,8 @@ class FileHandler extends BaseHandler
      */
     public function increment(string $key, int $offset = 1)
     {
-        $key = static::validateKey($key, $this->prefix);
-        $tmp = $this->getItem($key);
+        $prefixedKey = static::validateKey($key, $this->prefix);
+        $tmp         = $this->getItem($prefixedKey);
 
         if ($tmp === false) {
             $tmp = ['data' => 0, 'ttl' => 60];

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -67,6 +67,10 @@ final class FileHandlerTest extends AbstractHandlerTest
                     chmod($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $key, 0777);
                     unlink($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $key);
                 }
+                if (is_file($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . $key)) {
+                    chmod($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . $key, 0777);
+                    unlink($this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . $key);
+                }
             }
 
             rmdir($this->config->file['storePath']);
@@ -233,6 +237,22 @@ final class FileHandlerTest extends AbstractHandlerTest
         $this->assertSame(10, $this->handler->increment(self::$key3, 10));
     }
 
+    public function testIncrementWithDefaultPrefix(): void
+    {
+        $this->config->prefix = 'test_';
+        $this->handler        = new FileHandler($this->config);
+        $this->handler->initialize();
+
+        $this->handler->save(self::$key1, 1);
+        $this->handler->save(self::$key2, 'value');
+
+        $this->assertSame(11, $this->handler->increment(self::$key1, 10));
+        $this->assertSame($this->handler->increment(self::$key1, 10), $this->handler->get(self::$key1));
+        $this->assertFalse($this->handler->increment(self::$key2, 10));
+        $this->assertSame(10, $this->handler->increment(self::$key3, 10));
+        $this->assertSame($this->handler->increment(self::$key3, 10), $this->handler->get(self::$key3));
+    }
+
     public function testDecrement(): void
     {
         $this->handler->save(self::$key1, 10);
@@ -244,6 +264,21 @@ final class FileHandlerTest extends AbstractHandlerTest
         $this->assertSame(9, $this->handler->decrement(self::$key1, 1));
         $this->assertFalse($this->handler->decrement(self::$key2, 1));
         $this->assertSame(-1, $this->handler->decrement(self::$key3, 1));
+    }
+
+    public function testDecrementWithDefaultPrefix(): void
+    {
+        $this->handler->save(self::$key1, 10);
+        $this->handler->save(self::$key2, 'value');
+
+        // Line following commented out to force the cache to add a zero entry for key3
+        // $this->fileHandler->save(self::$key3, 0);
+
+        $this->assertSame(9, $this->handler->decrement(self::$key1, 1));
+        $this->assertSame($this->handler->decrement(self::$key1, 1), $this->handler->get(self::$key1));
+        $this->assertFalse($this->handler->decrement(self::$key2, 1));
+        $this->assertSame(-1, $this->handler->decrement(self::$key3, 1));
+        $this->assertSame($this->handler->decrement(self::$key3, 1), $this->handler->get(self::$key3));
     }
 
     public function testClean(): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
When using some default `prefix` in cache config with `FileHandler` being used, the `increment` function would save the updated result with the key having the prefix twice. To fix it, instead of passing the already prefixed key, now it is passing the non-prefixed key to the save function and save function itself appends the prefix when calling `validateKey`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
