### PR TITLE
fix: [CURLRequest] skip hostname checks if options 'verify' false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [v4.4.4](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.4) (Unreleased)
-[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.3...v4.4.4)
-
-### Fixed Bugs
-
-* fix: [CURLRequest] skip hostname checks if options 'verify' false by @NicolaeIotu in https://github.com/codeigniter4/CodeIgniter4/pull/8258
-
 ## [v4.4.3](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.3) (2023-10-26)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.2...v4.4.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v4.4.4](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.4) (Unreleased)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.3...v4.4.4)
+
+### Fixed Bugs
+
+* fix: [CURLRequest] skip hostname checks if options 'verify' false by @NicolaeIotu in https://github.com/codeigniter4/CodeIgniter4/pull/8258
+
 ## [v4.4.3](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.3) (2023-10-26)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.2...v4.4.3)
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -548,24 +548,21 @@ class CURLRequest extends OutgoingRequest
 
         // SSL Verification
         if (isset($config['verify'])) {
-            if (is_string($config['verify'])) {
-                $file = realpath($config['ssl_key']) ?: $config['ssl_key'];
+            $configVerify = $config['verify'];
+
+            if (is_string($configVerify)) {
+                $file = realpath($configVerify) ?: $configVerify;
 
                 if (! is_file($file)) {
-                    throw HTTPException::forInvalidSSLKey($config['ssl_key']);
+                    throw HTTPException::forInvalidSSLKey($configVerify);
                 }
 
-                $curlOptions[CURLOPT_CAINFO] = $file;
-                if ($config['verify'] === 'yes') {
-                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = true;
-                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 2;
-                } else {
-                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = false;
-                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 0;
-                }
-            } elseif (is_bool($config['verify'])) {
-                $curlOptions[CURLOPT_SSL_VERIFYPEER] = $config['verify'];
-                $curlOptions[CURLOPT_SSL_VERIFYHOST] = $config['verify'] ? 2 : 0;
+                $curlOptions[CURLOPT_CAINFO]         = $file;
+                $curlOptions[CURLOPT_SSL_VERIFYPEER] = true;
+                $curlOptions[CURLOPT_SSL_VERIFYHOST] = 2;
+            } elseif (is_bool($configVerify)) {
+                $curlOptions[CURLOPT_SSL_VERIFYPEER] = $configVerify;
+                $curlOptions[CURLOPT_SSL_VERIFYHOST] = $configVerify ? 2 : 0;
             }
         }
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -557,10 +557,10 @@ class CURLRequest extends OutgoingRequest
 
                 $curlOptions[CURLOPT_CAINFO] = $file;
                 if ($config['verify'] === 'yes') {
-                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = 1;
+                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = true;
                     $curlOptions[CURLOPT_SSL_VERIFYHOST] = 2;
                 } else {
-                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = 0;
+                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = false;
                     $curlOptions[CURLOPT_SSL_VERIFYHOST] = 0;
                 }
             } elseif (is_bool($config['verify'])) {

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -548,21 +548,19 @@ class CURLRequest extends OutgoingRequest
 
         // SSL Verification
         if (isset($config['verify'])) {
-            $configVerify = $config['verify'];
-
-            if (is_string($configVerify)) {
-                $file = realpath($configVerify) ?: $configVerify;
+            if (is_string($config['verify'])) {
+                $file = realpath($config['verify']) ?: $config['verify'];
 
                 if (! is_file($file)) {
-                    throw HTTPException::forInvalidSSLKey($configVerify);
+                    throw HTTPException::forInvalidSSLKey($config['verify']);
                 }
 
                 $curlOptions[CURLOPT_CAINFO]         = $file;
                 $curlOptions[CURLOPT_SSL_VERIFYPEER] = true;
                 $curlOptions[CURLOPT_SSL_VERIFYHOST] = 2;
-            } elseif (is_bool($configVerify)) {
-                $curlOptions[CURLOPT_SSL_VERIFYPEER] = $configVerify;
-                $curlOptions[CURLOPT_SSL_VERIFYHOST] = $configVerify ? 2 : 0;
+            } elseif (is_bool($config['verify'])) {
+                $curlOptions[CURLOPT_SSL_VERIFYPEER] = $config['verify'];
+                $curlOptions[CURLOPT_SSL_VERIFYHOST] = $config['verify'] ? 2 : 0;
             }
         }
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -559,6 +559,12 @@ class CURLRequest extends OutgoingRequest
                 $curlOptions[CURLOPT_SSL_VERIFYPEER] = 1;
             } elseif (is_bool($config['verify'])) {
                 $curlOptions[CURLOPT_SSL_VERIFYPEER] = $config['verify'];
+
+                if ($config['verify'] === false) {
+                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 0;
+                } else {
+                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 2;
+                }
             }
         }
 

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -555,16 +555,17 @@ class CURLRequest extends OutgoingRequest
                     throw HTTPException::forInvalidSSLKey($config['ssl_key']);
                 }
 
-                $curlOptions[CURLOPT_CAINFO]         = $file;
-                $curlOptions[CURLOPT_SSL_VERIFYPEER] = 1;
+                $curlOptions[CURLOPT_CAINFO] = $file;
+                if ($config['verify'] === 'yes') {
+                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = 1;
+                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 2;
+                } else {
+                    $curlOptions[CURLOPT_SSL_VERIFYPEER] = 0;
+                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 0;
+                }
             } elseif (is_bool($config['verify'])) {
                 $curlOptions[CURLOPT_SSL_VERIFYPEER] = $config['verify'];
-
-                if ($config['verify'] === false) {
-                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 0;
-                } else {
-                    $curlOptions[CURLOPT_SSL_VERIFYHOST] = 2;
-                }
+                $curlOptions[CURLOPT_SSL_VERIFYHOST] = $config['verify'] ? 2 : 0;
             }
         }
 

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -545,7 +545,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
         $this->assertSame($file, $options[CURLOPT_CAINFO]);
 
         $this->assertArrayHasKey(CURLOPT_SSL_VERIFYPEER, $options);
-        $this->assertSame(1, $options[CURLOPT_SSL_VERIFYPEER]);
+        $this->assertTrue($options[CURLOPT_SSL_VERIFYPEER]);
     }
 
     public function testSSLWithBadKey(): void

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -535,8 +535,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
         $file = __FILE__;
 
         $this->request->request('get', 'http://example.com', [
-            'verify'  => 'yes',
-            'ssl_key' => $file,
+            'verify' => $file,
         ]);
 
         $options = $this->request->curl_options;
@@ -546,6 +545,9 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
 
         $this->assertArrayHasKey(CURLOPT_SSL_VERIFYPEER, $options);
         $this->assertTrue($options[CURLOPT_SSL_VERIFYPEER]);
+
+        $this->assertArrayHasKey(CURLOPT_SSL_VERIFYHOST, $options);
+        $this->assertSame(2, $options[CURLOPT_SSL_VERIFYHOST]);
     }
 
     public function testSSLWithBadKey(): void
@@ -554,8 +556,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
         $this->expectException(HTTPException::class);
 
         $this->request->request('get', 'http://example.com', [
-            'verify'  => 'yes',
-            'ssl_key' => $file,
+            'verify' => $file,
         ]);
     }
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -528,10 +528,25 @@ final class CURLRequestTest extends CIUnitTestCase
         $this->assertSame($file, $options[CURLOPT_CAINFO]);
 
         $this->assertArrayHasKey(CURLOPT_SSL_VERIFYPEER, $options);
-        $this->assertSame(1, $options[CURLOPT_SSL_VERIFYPEER]);
+        $this->assertTrue($options[CURLOPT_SSL_VERIFYPEER]);
 
         $this->assertArrayHasKey(CURLOPT_SSL_VERIFYHOST, $options);
         $this->assertSame(2, $options[CURLOPT_SSL_VERIFYHOST]);
+    }
+
+    public function testNoSSL(): void
+    {
+        $this->request->request('get', 'http://example.com', [
+            'verify' => false,
+        ]);
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_SSL_VERIFYPEER, $options);
+        $this->assertFalse($options[CURLOPT_SSL_VERIFYPEER]);
+
+        $this->assertArrayHasKey(CURLOPT_SSL_VERIFYHOST, $options);
+        $this->assertSame(0, $options[CURLOPT_SSL_VERIFYHOST]);
     }
 
     public function testSSLWithBadKey(): void

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -529,6 +529,9 @@ final class CURLRequestTest extends CIUnitTestCase
 
         $this->assertArrayHasKey(CURLOPT_SSL_VERIFYPEER, $options);
         $this->assertSame(1, $options[CURLOPT_SSL_VERIFYPEER]);
+
+        $this->assertArrayHasKey(CURLOPT_SSL_VERIFYHOST, $options);
+        $this->assertSame(2, $options[CURLOPT_SSL_VERIFYHOST]);
     }
 
     public function testSSLWithBadKey(): void

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -518,8 +518,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $file = __FILE__;
 
         $this->request->request('get', 'http://example.com', [
-            'verify'  => 'yes',
-            'ssl_key' => $file,
+            'verify' => $file,
         ]);
 
         $options = $this->request->curl_options;
@@ -555,8 +554,7 @@ final class CURLRequestTest extends CIUnitTestCase
         $this->expectException(HTTPException::class);
 
         $this->request->request('get', 'http://example.com', [
-            'verify'  => 'yes',
-            'ssl_key' => $file,
+            'verify' => $file,
         ]);
     }
 

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -27,11 +27,11 @@ Validation rules matches and differs
 Bugs have been fixed in the case where ``matches`` and ``differs`` in the Strict
 and Traditional rules validate data of non-string types.
 
-CURLRequest option 'ssl_key' eliminated
-=======================================
+The use of the `ssl_key` option in CURLRequest was removed
+==========================================================
 
-CURLRequest option 'ssl_key' was eliminated.
-Please use CURLRequest option 'verify' to indicate the path to a CA bundle.
+Due to a bug, we were using the undocumented `ssl_key` config option to define the CA bundle in CURLRequest.
+This was fixed and is now working according to documentation. You can define your CA bundle via the `verify` option.
 
 ***************
 Message Changes

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -28,7 +28,7 @@ Bugs have been fixed in the case where ``matches`` and ``differs`` in the Strict
 and Traditional rules validate data of non-string types.
 
 CURLRequest option 'ssl_key' eliminated
-====================================
+=======================================
 
 CURLRequest option 'ssl_key' was eliminated.
 Please use CURLRequest option 'verify' to indicate the path to a CA bundle.

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -27,6 +27,12 @@ Validation rules matches and differs
 Bugs have been fixed in the case where ``matches`` and ``differs`` in the Strict
 and Traditional rules validate data of non-string types.
 
+CURLRequest option 'ssl_key' eliminated
+====================================
+
+CURLRequest option 'ssl_key' was eliminated.
+Please use CURLRequest option 'verify' to indicate the path to a CA bundle.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -55,6 +55,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **CURLRequest:** Fixed a bug where the hostname was checked even if options 'verify' was set to *false*.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/installation/upgrade_444.rst
+++ b/user_guide_src/source/installation/upgrade_444.rst
@@ -50,6 +50,15 @@ changed (fixed).
 Note that Traditional Rules should not be used to validate data that is not a
 string.
 
+The use of the `ssl_key` option in CURLRequest was removed
+==========================================================
+
+CURLRequest option `ssl_key` it's not recognized anymore.
+If in use, option `ssl_key` must be replaced with option `verify` in order to define the path
+to a CA bundle for CURLRequest.
+
+CURLRequest option `verify` can also take *boolean* values as usual.
+
 *********************
 Breaking Enhancements
 *********************


### PR DESCRIPTION
Supersedes  #8257

**Description**
When CURLRequest options 'verify' is set to false, some CURLOPT_SSL_... options should be disabled in such a way as to allow requests to pass through in case the destination is for example on private networks.

Avoids SSL errors: SSL: certificate subject name 'CA' does not match target host name 'localhost'

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
