### PR TITLE
Exclude default extensions for PHP ^8.1

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": "^8.1",
         "ext-intl": "*",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "laminas/laminas-escaper": "^2.13",
         "psr/log": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": "^8.1",
         "ext-intl": "*",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "laminas/laminas-escaper": "^2.13",
         "psr/log": "^2.0"
@@ -38,12 +37,9 @@
     },
     "suggest": {
         "ext-curl": "If you use CURLRequest class",
-        "ext-dom": "If you use TestResponse",
         "ext-exif": "If you run Image class tests",
-        "ext-fileinfo": "Improves mime type detection for files",
         "ext-gd": "If you use Image class GDHandler",
         "ext-imagick": "If you use Image class ImageMagickHandler",
-        "ext-libxml": "If you use TestResponse",
         "ext-memcache": "If you use Cache class MemcachedHandler with Memcache",
         "ext-memcached": "If you use Cache class MemcachedHandler with Memcached",
         "ext-mysqli": "If you use MySQL",
@@ -51,8 +47,6 @@
         "ext-pgsql": "If you use PostgreSQL",
         "ext-readline": "Improves CLI::input() usability",
         "ext-redis": "If you use Cache class RedisHandler",
-        "ext-simplexml": "If you format XML",
-        "ext-sqlite3": "If you use SQLite3",
         "ext-sqlsrv": "If you use SQL Server",
         "ext-xdebug": "If you use CIUnitTestCase::assertHeaderEmitted()"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "^8.1",
         "ext-intl": "*",
+        "ext-json": "*",
         "ext-mbstring": "*",
         "laminas/laminas-escaper": "^2.13",
         "psr/log": "^2.0"
@@ -37,9 +38,12 @@
     },
     "suggest": {
         "ext-curl": "If you use CURLRequest class",
+        "ext-dom": "If you use TestResponse",
         "ext-exif": "If you run Image class tests",
+        "ext-fileinfo": "Improves mime type detection for files",
         "ext-gd": "If you use Image class GDHandler",
         "ext-imagick": "If you use Image class ImageMagickHandler",
+        "ext-libxml": "If you use TestResponse",
         "ext-memcache": "If you use Cache class MemcachedHandler with Memcache",
         "ext-memcached": "If you use Cache class MemcachedHandler with Memcached",
         "ext-mysqli": "If you use MySQL",
@@ -47,6 +51,8 @@
         "ext-pgsql": "If you use PostgreSQL",
         "ext-readline": "Improves CLI::input() usability",
         "ext-redis": "If you use Cache class RedisHandler",
+        "ext-simplexml": "If you format XML",
+        "ext-sqlite3": "If you use SQLite3",
         "ext-sqlsrv": "If you use SQL Server",
         "ext-xdebug": "If you use CIUnitTestCase::assertHeaderEmitted()"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": "^8.1",
         "ext-intl": "*",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "laminas/laminas-escaper": "^2.13",
         "psr/log": "^2.0"


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
Some extensions are included with PHP. It is better to exclude them from requirements as these are most likely unavailable from package managers.

The details of the extensions can be viewed at https://www.php.net/manual/en/extensions.alphabetical.php.
I recommend to open a new tab for each extension of interest and visit section **Installation** which indicates if it is shipped by default or not.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
