### PR TITLE
fix: autoload helpers in test bootstrap

### DIFF
--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -75,6 +75,7 @@ require_once APPPATH . 'Config/Services.php';
 
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
+Services::autoloader()->loadHelpers();
 
 // Now load Composer's if it's available
 if (is_file(COMPOSER_PATH)) {


### PR DESCRIPTION
**Description**
Fixes #8272

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
