### PR TITLE
docs: fix Database Utility Class `getXMLFromResult()`

### DIFF
--- a/user_guide_src/source/database/utilities.rst
+++ b/user_guide_src/source/database/utilities.rst
@@ -1,6 +1,6 @@
-#########
-Utilities
-#########
+######################
+Database Utility Class
+######################
 
 The Database Utility Class contains methods that help you manage your database.
 
@@ -8,6 +8,27 @@ The Database Utility Class contains methods that help you manage your database.
     :local:
     :depth: 2
 
+******************************
+Initializing the Utility Class
+******************************
+
+Load the Utility Class as follows:
+
+.. literalinclude:: utilities/002.php
+    :lines: 2-
+
+You can also pass another database group to the DB Utility loader, in case
+the database you want to manage isn't the default one:
+
+.. literalinclude:: utilities/003.php
+    :lines: 2-
+
+In the above example, we're passing a database group name as the first
+parameter.
+
+****************************
+Using the Database Utilities
+****************************
 
 Export a Query Result as an XML Document
 ========================================
@@ -30,4 +51,3 @@ and it will get the following xml result when the ``mytable`` has columns ``id``
 .. important:: This method will NOT write the XML file for you. It
     simply creates the XML layout. If you need to write the file
     use the :php:func:`write_file()` helper.
-

--- a/user_guide_src/source/database/utilities.rst
+++ b/user_guide_src/source/database/utilities.rst
@@ -8,18 +8,17 @@ The Database Utility Class contains methods that help you manage your database.
     :local:
     :depth: 2
 
-*******************
-Get XML from Result
-*******************
 
-getXMLFromResult()
-==================
+Export a Query Result as an XML Document
+========================================
 
-This method returns the xml result from database result. You can do like this:
+Permits you to generate an XML file from a query result. The first
+parameter expects a query result object, the second may contain an
+optional array of config parameters. Example:
 
 .. literalinclude:: utilities/001.php
 
-and it will get the following xml result::
+and it will get the following xml result when the ``mytable`` has columns ``id`` and ``name``::
 
     <root>
         <element>
@@ -27,3 +26,8 @@ and it will get the following xml result::
             <name>bar</name>
         </element>
     </root>
+
+.. important:: This method will NOT write the XML file for you. It
+    simply creates the XML layout. If you need to write the file
+    use the :php:func:`write_file()` helper.
+

--- a/user_guide_src/source/database/utilities/001.php
+++ b/user_guide_src/source/database/utilities/001.php
@@ -1,13 +1,15 @@
 <?php
 
-class MyModel extends \CodeIgniter\Model
-{
-    protected $table      = 'foo';
-    protected $primaryKey = 'id';
-}
+$db     = db_connect();
+$dbutil = \CodeIgniter\Database\Config::utils();
 
-$model = new MyModel();
+$query = $db->query('SELECT * FROM mytable');
 
-$util = \CodeIgniter\Database\Config::utils();
+$config = [
+    'root'    => 'root',
+    'element' => 'element',
+    'newline' => "\n",
+    'tab'     => "\t",
+];
 
-echo $util->getXMLFromResult($model->get());
+echo $dbutil->getXMLFromResult($query, $config);

--- a/user_guide_src/source/database/utilities/001.php
+++ b/user_guide_src/source/database/utilities/001.php
@@ -1,7 +1,7 @@
 <?php
 
 $db     = db_connect();
-$dbutil = \CodeIgniter\Database\Config::utils();
+$dbutil = \Config\Database::utils();
 
 $query = $db->query('SELECT * FROM mytable');
 

--- a/user_guide_src/source/database/utilities/002.php
+++ b/user_guide_src/source/database/utilities/002.php
@@ -1,3 +1,3 @@
 <?php
 
-$dbutil = \CodeIgniter\Database\Config::utils();
+$dbutil = \Config\Database::utils();

--- a/user_guide_src/source/database/utilities/002.php
+++ b/user_guide_src/source/database/utilities/002.php
@@ -1,0 +1,3 @@
+<?php
+
+$dbutil = \CodeIgniter\Database\Config::utils();

--- a/user_guide_src/source/database/utilities/003.php
+++ b/user_guide_src/source/database/utilities/003.php
@@ -1,0 +1,3 @@
+<?php
+
+$dbutil = \CodeIgniter\Database\Config::utils('group_name');

--- a/user_guide_src/source/database/utilities/003.php
+++ b/user_guide_src/source/database/utilities/003.php
@@ -1,3 +1,3 @@
 <?php
 
-$dbutil = \CodeIgniter\Database\Config::utils('group_name');
+$dbutil = \Config\Database::utils('group_name');


### PR DESCRIPTION
**Description**
- fix `getXMLFromResult()` description
- add "Initializing the Utility Class"

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
