### PR TITLE
fix: QueryBuilder limit(0) bug

### DIFF
--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -20,10 +20,10 @@ class Feature extends BaseConfig
     public bool $oldFilterOrder = false;
 
     /**
-     * Keep the behavior of `limit(0)` in Query Builder in 4.4 or before.
+     * The behavior of `limit(0)` in Query Builder.
      *
-     * If true, `limit(0)` returns all records. (the behavior in 4.4 or before)
-     * If false, `limit(0)` returns no records.
+     * If true, `limit(0)` returns all records. (the behavior of 4.4.x or before in version 4.x.)
+     * If false, `limit(0)` returns no records. (the behavior of 3.1.9 or later in version 3.x.)
      */
     public bool $limitZeroAsAll = true;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -18,4 +18,12 @@ class Feature extends BaseConfig
      * Use filter execution order in 4.4 or before.
      */
     public bool $oldFilterOrder = false;
+
+    /**
+     * Keep the behavior of `limit(0)` in Query Builder in 4.4 or before.
+     *
+     * If true, `limit(0)` returns all records. (the behavior in 4.4 or before)
+     * If false, `limit(0)` returns no records.
+     */
+    public bool $limitZeroAsAll = false;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -25,5 +25,5 @@ class Feature extends BaseConfig
      * If true, `limit(0)` returns all records. (the behavior in 4.4 or before)
      * If false, `limit(0)` returns no records.
      */
-    public bool $limitZeroAsAll = false;
+    public bool $limitZeroAsAll = true;
 }

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -833,7 +833,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 40,
+	'count' => 37,
 	'path' => __DIR__ . '/system/Database/BaseBuilder.php',
 ];
 $ignoreErrors[] = [

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -23,6 +23,7 @@ use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Validation\ValidationInterface;
+use Config\Feature;
 use Config\Services;
 use InvalidArgumentException;
 use ReflectionClass;
@@ -602,6 +603,10 @@ abstract class BaseModel
      */
     public function findAll(?int $limit = null, int $offset = 0)
     {
+        if (config(Feature::class)->limitZeroAsAll) {
+            $limit ??= 0;
+        }
+
         if ($this->tempAllowCallbacks) {
             // Call the before event and check for a return
             $eventData = $this->trigger('beforeFind', [

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -384,7 +384,7 @@ abstract class BaseModel
      *
      * @return array
      */
-    abstract protected function doFindAll(int $limit = 0, int $offset = 0);
+    abstract protected function doFindAll(?int $limit = null, int $offset = 0);
 
     /**
      * Returns the first row of the result set.
@@ -600,7 +600,7 @@ abstract class BaseModel
      *
      * @return array
      */
-    public function findAll(int $limit = 0, int $offset = 0)
+    public function findAll(?int $limit = null, int $offset = 0)
     {
         if ($this->tempAllowCallbacks) {
             // Call the before event and check for a return

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -380,8 +380,8 @@ abstract class BaseModel
      * Fetches all results, while optionally limiting them.
      * This method works only with dbCalls.
      *
-     * @param int $limit  Limit
-     * @param int $offset Offset
+     * @param int|null $limit  Limit
+     * @param int      $offset Offset
      *
      * @return array
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2498,7 +2498,7 @@ class BaseBuilder
         return 'UPDATE ' . $this->compileIgnore('update') . $table . ' SET ' . implode(', ', $valStr)
             . $this->compileWhereHaving('QBWhere')
             . $this->compileOrderBy()
-            . ($this->QBLimit ? $this->_limit(' ', true) : '');
+            . ($this->QBLimit !== false ? $this->_limit(' ', true) : '');
     }
 
     /**
@@ -3030,7 +3030,7 @@ class BaseBuilder
             . $this->compileWhereHaving('QBHaving')
             . $this->compileOrderBy();
 
-        if ($this->QBLimit) {
+        if ($this->QBLimit !== false || $this->QBOffset) {
             $sql = $this->_limit($sql . "\n");
         }
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1747,7 +1747,11 @@ class BaseBuilder
             $this->where($where);
         }
 
-        if (! empty($limit)) {
+        if (config(Feature::class)->limitZeroAsAll && $limit === 0) {
+            $limit = null;
+        }
+
+        if ($limit !== null) {
             $this->limit($limit, $offset);
         }
 
@@ -2463,7 +2467,11 @@ class BaseBuilder
             $this->where($where);
         }
 
-        if (! empty($limit)) {
+        if (config(Feature::class)->limitZeroAsAll && $limit === 0) {
+            $limit = null;
+        }
+
+        if ($limit !== null) {
             if (! $this->canLimitWhereUpdates) {
                 throw new DatabaseException('This driver does not allow LIMITs on UPDATE queries using WHERE.');
             }
@@ -2780,7 +2788,11 @@ class BaseBuilder
 
         $sql = $this->_delete($this->removeAlias($table));
 
-        if (! empty($limit)) {
+        if (config(Feature::class)->limitZeroAsAll && $limit === 0) {
+            $limit = null;
+        }
+
+        if ($limit !== null) {
             $this->QBLimit = $limit;
         }
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1489,6 +1489,10 @@ class BaseBuilder
      */
     public function limit(?int $value = null, ?int $offset = 0)
     {
+        if (config(Feature::class)->limitZeroAsAll && $value === 0) {
+            $value = null;
+        }
+
         if ($value !== null) {
             $this->QBLimit = $value;
         }
@@ -1606,8 +1610,8 @@ class BaseBuilder
      */
     public function get(?int $limit = null, int $offset = 0, bool $reset = true)
     {
-        if (config(Feature::class)->limitZeroAsAll) {
-            $limit ??= 0;
+        if (config(Feature::class)->limitZeroAsAll && $limit === 0) {
+            $limit = null;
         }
 
         if ($limit !== null) {

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -618,6 +618,10 @@ class Builder extends BaseBuilder
      */
     public function get(?int $limit = null, int $offset = 0, bool $reset = true)
     {
+        if (config(Feature::class)->limitZeroAsAll && $limit === 0) {
+            $limit = null;
+        }
+
         if ($limit !== null) {
             $this->limit($limit, $offset);
         }

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -18,6 +18,7 @@ use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Database\ResultInterface;
+use Config\Feature;
 
 /**
  * Builder for SQLSRV
@@ -312,7 +313,7 @@ class Builder extends BaseBuilder
         // DatabaseException:
         //   [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The number of
         //   rows provided for a FETCH clause must be greater then zero.
-        if ($this->QBLimit === 0) {
+        if (! config(Feature::class)->limitZeroAsAll && $this->QBLimit === 0) {
             return "SELECT * \nFROM " . $this->_fromTables() . ' WHERE 1=0 ';
         }
 
@@ -598,7 +599,11 @@ class Builder extends BaseBuilder
             . $this->compileOrderBy(); // ORDER BY
 
         // LIMIT
-        if ($this->QBLimit !== false || $this->QBOffset) {
+        if (config(Feature::class)->limitZeroAsAll) {
+            if ($this->QBLimit) {
+                $sql = $this->_limit($sql . "\n");
+            }
+        } elseif ($this->QBLimit !== false || $this->QBOffset) {
             $sql = $this->_limit($sql . "\n");
         }
 

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -308,6 +308,14 @@ class Builder extends BaseBuilder
      */
     protected function _limit(string $sql, bool $offsetIgnore = false): string
     {
+        // SQL Server cannot handle `LIMIT 0`.
+        // DatabaseException:
+        //   [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The number of
+        //   rows provided for a FETCH clause must be greater then zero.
+        if ($this->QBLimit === 0) {
+            return "SELECT * \nFROM " . $this->_fromTables() . ' WHERE 1=0 ';
+        }
+
         if (empty($this->QBOrderBy)) {
             $sql .= ' ORDER BY (SELECT NULL) ';
         }

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -590,7 +590,7 @@ class Builder extends BaseBuilder
             . $this->compileOrderBy(); // ORDER BY
 
         // LIMIT
-        if ($this->QBLimit) {
+        if ($this->QBLimit !== false || $this->QBOffset) {
             $sql = $this->_limit($sql . "\n");
         }
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -224,8 +224,8 @@ class Model extends BaseModel
      * all results, while optionally limiting them.
      * This method works only with dbCalls.
      *
-     * @param int $limit  Limit
-     * @param int $offset Offset
+     * @param int|null $limit  Limit
+     * @param int      $offset Offset
      *
      * @return array
      * @phpstan-return list<row_array|object>

--- a/system/Model.php
+++ b/system/Model.php
@@ -229,7 +229,7 @@ class Model extends BaseModel
      * @return array
      * @phpstan-return list<row_array|object>
      */
-    protected function doFindAll(int $limit = 0, int $offset = 0)
+    protected function doFindAll(?int $limit = null, int $offset = 0)
     {
         $builder = $this->builder();
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -26,6 +26,7 @@ use CodeIgniter\Entity\Entity;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
+use Config\Feature;
 use ReflectionException;
 
 /**
@@ -231,6 +232,10 @@ class Model extends BaseModel
      */
     protected function doFindAll(?int $limit = null, int $offset = 0)
     {
+        if (config(Feature::class)->limitZeroAsAll) {
+            $limit ??= 0;
+        }
+
         $builder = $this->builder();
 
         if ($this->tempUseSoftDeletes) {

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -47,6 +47,9 @@ final class GetTest extends CIUnitTestCase
      */
     public function testGetWithReset(): void
     {
+        $config                 = config(Feature::class);
+        $config->limitZeroAsAll = false;
+
         $builder = $this->db->table('users');
         $builder->testMode()->where('username', 'bogus');
 

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use Config\Feature;
 
 /**
  * @internal
@@ -51,6 +52,22 @@ final class GetTest extends CIUnitTestCase
 
         $expectedSQL           = 'SELECT * FROM "users" WHERE "username" = \'bogus\'  LIMIT 50, 0';
         $expectedSQLafterreset = 'SELECT * FROM "users"  LIMIT 50, 0';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, false)));
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true)));
+        $this->assertSame($expectedSQLafterreset, str_replace("\n", ' ', $builder->get(0, 50, true)));
+    }
+
+    public function testGetWithResetWithLimitZeroAsAll(): void
+    {
+        $config                 = config(Feature::class);
+        $config->limitZeroAsAll = true;
+
+        $builder = $this->db->table('users');
+        $builder->testMode()->where('username', 'bogus');
+
+        $expectedSQL           = 'SELECT * FROM "users" WHERE "username" = \'bogus\'';
+        $expectedSQLafterreset = 'SELECT * FROM "users"';
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, false)));
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true)));

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -49,8 +49,8 @@ final class GetTest extends CIUnitTestCase
         $builder = $this->db->table('users');
         $builder->testMode()->where('username', 'bogus');
 
-        $expectedSQL           = 'SELECT * FROM "users" WHERE "username" = \'bogus\'';
-        $expectedSQLafterreset = 'SELECT * FROM "users"';
+        $expectedSQL           = 'SELECT * FROM "users" WHERE "username" = \'bogus\'  LIMIT 50, 0';
+        $expectedSQLafterreset = 'SELECT * FROM "users"  LIMIT 50, 0';
 
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, false)));
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->get(0, 50, true)));

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\Live;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Feature;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**
@@ -55,6 +56,16 @@ final class GetTest extends CIUnitTestCase
         $jobs = $this->db->table('job')->limit(0)->get()->getResult();
 
         $this->assertCount(0, $jobs);
+    }
+
+    public function testGetWithLimitZeroAsAll(): void
+    {
+        $config                 = config(Feature::class);
+        $config->limitZeroAsAll = true;
+
+        $jobs = $this->db->table('job')->limit(0)->get()->getResult();
+
+        $this->assertCount(4, $jobs);
     }
 
     public function testGetWhereArray(): void

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -50,6 +50,13 @@ final class GetTest extends CIUnitTestCase
         $this->assertSame('Musician', $jobs[1]->name);
     }
 
+    public function testGetWithLimitZero(): void
+    {
+        $jobs = $this->db->table('job')->limit(0)->get()->getResult();
+
+        $this->assertCount(0, $jobs);
+    }
+
     public function testGetWhereArray(): void
     {
         $jobs = $this->db->table('job')

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -53,6 +53,9 @@ final class GetTest extends CIUnitTestCase
 
     public function testGetWithLimitZero(): void
     {
+        $config                 = config(Feature::class);
+        $config->limitZeroAsAll = false;
+
         $jobs = $this->db->table('job')->limit(0)->get()->getResult();
 
         $this->assertCount(0, $jobs);

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -263,7 +263,8 @@ limit(0) Behavior
   generated SQL statement will have no ``LIMIT`` clause and all records will be
   returned.
 - It is recommended that ``$limitZeroAsAll`` in **app/Config/Feature.php** be set
-  to ``false`` as this incorrect behavior will be fixed in a future version.
+  to ``false`` as this incorrect behavior will be fixed in a future version. See
+  also :ref:`v450-model-findall-limit-0-behavior`.
 
 Forge
 -----
@@ -273,6 +274,17 @@ Others
 
 Model
 =====
+
+.. _v450-model-findall-limit-0-behavior:
+
+findAll(0) Behavior
+-------------------
+
+- Added a feature flag ``Feature::$limitZeroAsAll`` to fix the incorrect behavior
+  of ``limit(0)`` for Query Builder. See :ref:`v450-query-builder-limit-0-behavior`
+  for details.
+- If you disable this flag, you need to change code like ``findAll(0, $offset)``
+  to ``findAll(null, $offset)``.
 
 Libraries
 =========

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -251,6 +251,20 @@ Database
 Query Builder
 -------------
 
+.. _v450-query-builder-limit-0-behavior:
+
+limit(0) Behavior
+^^^^^^^^^^^^^^^^^
+
+- Added a feature flag ``Feature::$limitZeroAsAll`` to fix the incorrect behavior
+  of ``limit(0)``.
+- If ``LIMIT 0`` is specified in a SQL statement, 0 records are returned. However,
+  there is a bug in the Query Builder, and if ``limit(0)`` is specified, the
+  generated SQL statement will have no ``LIMIT`` clause and all records will be
+  returned.
+- It is recommended that ``$limitZeroAsAll`` in **app/Config/Feature.php** be set
+  to ``false`` as this incorrect behavior will be fixed in a future version.
+
 Forge
 -----
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -681,6 +681,14 @@ Lets you limit the number of rows you would like returned by the query:
 
 .. literalinclude:: query_builder/070.php
 
+.. note:: If ``LIMIT 0`` is specified in a SQL statement, 0 records are returned.
+  However, there is a bug in the Query Builder, and if ``limit(0)`` is specified,
+  the generated SQL statement will have no ``LIMIT`` clause and all records will
+  be returned. To fix the incorrect behavior, a setting was added in v4.5.0. See
+  :ref:`v450-query-builder-limit-0-behavior` for details. The incorrect behavior
+  will be fixed in a future version, so it is recommended that you change the
+  default setting.
+
 The second parameter lets you set a result offset.
 
 .. literalinclude:: query_builder/071.php

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -262,6 +262,8 @@ Others
     - The default value of ``DBCollat`` in ``$default`` has been change to ``utf8mb4_general_ci``.
     - The default value of ``DBCollat`` in ``$tests`` has been change to ``''``.
 - app/Config/Feature.php
+    - ``Config\Feature::$limitZeroAsAll`` has been added. See
+      :ref:`v450-query-builder-limit-0-behavior`.
     - ``Config\Feature::$multipleFilters`` has been removed, because now
       :ref:`multiple-filters` are always enabled.
 - app/Config/Kint.php

--- a/user_guide_src/source/installation/upgrade_database.rst
+++ b/user_guide_src/source/installation/upgrade_database.rst
@@ -43,6 +43,7 @@ Upgrade Guide
     - ``$this->db->having('user_id',  45);`` to ``$builder->having('user_id',  45);``
 6. CI4 does not provide `Database Caching <https://www.codeigniter.com/userguide3/database/caching.html>`_
    layer known from CI3, so if you need to cache the result, use :doc:`../libraries/caching` instead.
+7. If you use ``limit(0)`` in Query Builder, CI4 returns all records in stead of no records due to a bug. But since v4.5.0, you can change the incorrect behavior with a setting. So change the setting. See :ref:`v450-query-builder-limit-0-behavior` for details.
 
 Code Example
 ============


### PR DESCRIPTION
**Description**
Fixes #8278

- `LIMIT` can be used in MySQL, SQLite3, PostgreSQL, and they return 0 rows when we specify `LIMIT 0`.
- `limit()` is to limit the result rows. So when we specify it, the result should be limited, not be all rows.

> LIMIT 0 quickly returns an empty set. This can be useful for checking the validity of a query.
https://dev.mysql.com/doc/refman/5.7/en/limit-optimization.html

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
