### PR TITLE
feat: [Commands] `lang:find` show bad keys when scanning (v2)

### DIFF
--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -19,7 +19,9 @@ use InvalidArgumentException;
  * If there are any methods that should be provided, make them
  * public APIs via helper functions.
  *
+ * @see \CodeIgniter\Helpers\Array\ArrayHelperDotKeyExistsTest
  * @see \CodeIgniter\Helpers\Array\ArrayHelperRecursiveDiffTest
+ * @see \CodeIgniter\Helpers\Array\ArrayHelperSortValuesByNaturalTest
  */
 final class ArrayHelper
 {
@@ -296,5 +298,22 @@ final class ArrayHelper
         }
 
         return $counter;
+    }
+
+    /**
+     * Sorts array values in natural order
+     * If the value is an array, you need to specify the $sortByIndex of the key to sort
+     *
+     * @param int|string|null $sortByIndex
+     */
+    public static function sortValuesByNatural(array &$array, $sortByIndex = null): bool
+    {
+        return usort($array, static function ($currentValue, $nextValue) use ($sortByIndex) {
+            if ($sortByIndex !== null) {
+                return strnatcmp($currentValue[$sortByIndex], $nextValue[$sortByIndex]);
+            }
+
+            return strnatcmp($currentValue, $nextValue);
+        });
     }
 }

--- a/tests/_support/Services/Translation/TranslationTwo.php
+++ b/tests/_support/Services/Translation/TranslationTwo.php
@@ -26,6 +26,13 @@ class TranslationTwo
         $translationError6 = lang('TranslationTwo...');
         $translationError7 = lang('..invalid_nested_key..');
 
+        $copyTranslationError1 = lang('TranslationTwo');
+        $copyTranslationError2 = lang(' ');
+        $copyTranslationError3 = lang('');
+        $copyTranslationError4 = lang('.invalid_key');
+        $copyTranslationError5 = lang('TranslationTwo.');
+        $copyTranslationError6 = lang('TranslationTwo...');
+        $copyTranslationError7 = lang('..invalid_nested_key..');
         // Empty in comments lang('') lang(' ')
     }
 }

--- a/tests/system/Commands/Translation/LocalizationFinderTest.php
+++ b/tests/system/Commands/Translation/LocalizationFinderTest.php
@@ -103,6 +103,15 @@ final class LocalizationFinderTest extends CIUnitTestCase
         $this->assertStringContainsString($this->getActualTableWithNewKeys(), $this->getStreamFilterBuffer());
     }
 
+    public function testShowBadTranslation(): void
+    {
+        $this->makeLocaleDirectory();
+
+        command('lang:find --dir Translation --verbose');
+
+        $this->assertStringContainsString($this->getActualTableWithBadKeys(), $this->getStreamFilterBuffer());
+    }
+
     private function getActualTranslationOneKeys(): array
     {
         return [
@@ -190,6 +199,21 @@ final class LocalizationFinderTest extends CIUnitTestCase
             | TranslationThree | TranslationThree.formFields.new.name               |
             | TranslationThree | TranslationThree.formFields.new.short_tag          |
             +------------------+----------------------------------------------------+
+            TEXT_WRAP;
+    }
+
+    private function getActualTableWithBadKeys(): string
+    {
+        return <<<'TEXT_WRAP'
+            +---+------------------------+
+            | № | Bad key                |
+            +---+------------------------+
+            | 0 | TranslationTwo         |
+            | 1 | .invalid_key           |
+            | 2 | TranslationTwo.        |
+            | 3 | TranslationTwo...      |
+            | 4 | ..invalid_nested_key.. |
+            +---+------------------------+
             TEXT_WRAP;
     }
 

--- a/tests/system/Commands/Translation/LocalizationFinderTest.php
+++ b/tests/system/Commands/Translation/LocalizationFinderTest.php
@@ -205,15 +205,20 @@ final class LocalizationFinderTest extends CIUnitTestCase
     private function getActualTableWithBadKeys(): string
     {
         return <<<'TEXT_WRAP'
-            +---+------------------------+
-            | № | Bad key                |
-            +---+------------------------+
-            | 0 | TranslationTwo         |
-            | 1 | .invalid_key           |
-            | 2 | TranslationTwo.        |
-            | 3 | TranslationTwo...      |
-            | 4 | ..invalid_nested_key.. |
-            +---+------------------------+
+            +------------------------+--------------------------------------------------------+
+            | Bad Key                | Filepath                                               |
+            +------------------------+--------------------------------------------------------+
+            | ..invalid_nested_key.. | tests/_support/Services/Translation/TranslationTwo.php |
+            | ..invalid_nested_key.. | tests/_support/Services/Translation/TranslationTwo.php |
+            | .invalid_key           | tests/_support/Services/Translation/TranslationTwo.php |
+            | .invalid_key           | tests/_support/Services/Translation/TranslationTwo.php |
+            | TranslationTwo         | tests/_support/Services/Translation/TranslationTwo.php |
+            | TranslationTwo         | tests/_support/Services/Translation/TranslationTwo.php |
+            | TranslationTwo.        | tests/_support/Services/Translation/TranslationTwo.php |
+            | TranslationTwo.        | tests/_support/Services/Translation/TranslationTwo.php |
+            | TranslationTwo...      | tests/_support/Services/Translation/TranslationTwo.php |
+            | TranslationTwo...      | tests/_support/Services/Translation/TranslationTwo.php |
+            +------------------------+--------------------------------------------------------+
             TEXT_WRAP;
     }
 

--- a/tests/system/Helpers/Array/ArrayHelperSortValuesByNaturalTest.php
+++ b/tests/system/Helpers/Array/ArrayHelperSortValuesByNaturalTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Helpers\Array;
+
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @group Others
+ *
+ * @internal
+ */
+final class ArrayHelperSortValuesByNaturalTest extends CIUnitTestCase
+{
+    private array $arrayWithStringValues = [
+        'apple10',
+        'banana',
+        'apple1',
+        'банан',
+        'Banana',
+        'Apple',
+        100000,
+        'яблоко',
+        1200,
+        13000,
+        'Банан',
+        'Яблоко',
+        'apple',
+    ];
+    private array $arrayWithArrayValues = [
+        ['apple', 'Banana'],
+        ['apple10', 'Apple'],
+        ['Яблоко', 1200],
+        [13000, 'Банан'],
+        ['Apple', 'apple1'],
+        ['banana', 'банан'],
+        [100000, 13000],
+        ['Banana', 'Яблоко'],
+        ['Банан', 'banana'],
+        [1200, 'apple'],
+        ['apple1', 'apple10'],
+        ['яблоко', 100000],
+        ['банан', 'яблоко'],
+    ];
+
+    public function testSortWithStringValues(): void
+    {
+        shuffle($this->arrayWithStringValues);
+
+        ArrayHelper::sortValuesByNatural($this->arrayWithStringValues);
+
+        $this->assertSame([
+            1200,
+            13000,
+            100000,
+            'Apple',
+            'Banana',
+            'apple',
+            'apple1',
+            'apple10',
+            'banana',
+            'Банан',
+            'Яблоко',
+            'банан',
+            'яблоко',
+        ], $this->arrayWithStringValues);
+    }
+
+    public function testSortWithArrayValues(): void
+    {
+        shuffle($this->arrayWithArrayValues);
+
+        // For first index
+        ArrayHelper::sortValuesByNatural($this->arrayWithArrayValues, 0);
+
+        $this->assertSame([
+            [1200, 'apple'],
+            [13000, 'Банан'],
+            [100000, 13000],
+            ['Apple', 'apple1'],
+            ['Banana', 'Яблоко'],
+            ['apple', 'Banana'],
+            ['apple1', 'apple10'],
+            ['apple10', 'Apple'],
+            ['banana', 'банан'],
+            ['Банан', 'banana'],
+            ['Яблоко', 1200],
+            ['банан', 'яблоко'],
+            ['яблоко', 100000],
+        ], $this->arrayWithArrayValues);
+
+        shuffle($this->arrayWithArrayValues);
+
+        // For other index
+        ArrayHelper::sortValuesByNatural($this->arrayWithArrayValues, 1);
+
+        $this->assertSame([
+            ['Яблоко', 1200],
+            [100000, 13000],
+            ['яблоко', 100000],
+            ['apple10', 'Apple'],
+            ['apple', 'Banana'],
+            [1200, 'apple'],
+            ['Apple', 'apple1'],
+            ['apple1', 'apple10'],
+            ['Банан', 'banana'],
+            [13000, 'Банан'],
+            ['Banana', 'Яблоко'],
+            ['banana', 'банан'],
+            ['банан', 'яблоко'],
+        ], $this->arrayWithArrayValues);
+    }
+}

--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -284,6 +284,27 @@ Before updating, it is possible to preview the translations found by the command
 
     php spark lang:find --verbose --show-new
 
+The detailed output of ``--verbose`` also shows a list of invalid keys. For example:
+
+.. code-block:: console
+
+    ...
+
+    Files found: 10
+    New translates found: 30
+    Bad translates found: 5
+    +------------------------+---------------------------------+
+    | Bad Key                | Filepath                        |
+    +------------------------+---------------------------------+
+    | ..invalid_nested_key.. | app/Controllers/Translation.php |
+    | .invalid_key           | app/Controllers/Translation.php |
+    | TranslationBad         | app/Controllers/Translation.php |
+    | TranslationBad.        | app/Controllers/Translation.php |
+    | TranslationBad...      | app/Controllers/Translation.php |
+    +------------------------+---------------------------------+
+
+    All operations done!
+
 For a more accurate search, specify the desired locale or directory to scan.
 
 .. code-block:: console


### PR DESCRIPTION
**Description**
Superseds #8149 

- Add filepath in list bad keys
- Add natural sorting output values (bad keys)

```console
$ ./spark lang:find --verbose

...

Files found: 10
New translates found: 30
Bad translates found: 5
+------------------------+---------------------------------+
| Bad Key                | Filepath                        |
+------------------------+---------------------------------+
| ..invalid_nested_key.. | app/Controllers/Translation.php |
| .invalid_key           | app/Controllers/Translation.php |
| TranslationBad         | app/Controllers/Translation.php |
| TranslationBad.        | app/Controllers/Translation.php |
| TranslationBad...      | app/Controllers/Translation.php |
+------------------------+---------------------------------+

All operations done!
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
