### PR TITLE
refactor: remove deprecated Controller::loadHelpers()

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -817,11 +817,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Config/Services.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Controller.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in a negated boolean, array given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Controller.php',

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -122,24 +122,6 @@ class Controller
     }
 
     /**
-     * Handles "auto-loading" helper files.
-     *
-     * @deprecated Use `helper` function instead of using this method.
-     *
-     * @codeCoverageIgnore
-     *
-     * @return void
-     */
-    protected function loadHelpers()
-    {
-        if (empty($this->helpers)) {
-            return;
-        }
-
-        helper($this->helpers);
-    }
-
-    /**
      * A shortcut to performing validation on Request data.
      *
      * @param array|string $rules

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -211,6 +211,7 @@ Others
 ------
 
 - **Config:** The deprecated ``CodeIgniter\Config\Config`` class has been removed.
+- **Controller:** The deprecated ``Controller::loadHelpers()`` method has been removed.
 
 Enhancements
 ************


### PR DESCRIPTION
**Description**
- remove deprecated Controller::loadHelpers()

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
