### PR TITLE
refactor: remove deprecated methods in Security

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -234,46 +234,6 @@ class Security implements SecurityInterface
     /**
      * CSRF Verify
      *
-     * @return $this|false
-     *
-     * @throws SecurityException
-     *
-     * @deprecated Use `CodeIgniter\Security\Security::verify()` instead of using this method.
-     *
-     * @codeCoverageIgnore
-     */
-    public function CSRFVerify(RequestInterface $request)
-    {
-        return $this->verify($request);
-    }
-
-    /**
-     * Returns the CSRF Token.
-     *
-     * @deprecated Use `CodeIgniter\Security\Security::getHash()` instead of using this method.
-     *
-     * @codeCoverageIgnore
-     */
-    public function getCSRFHash(): ?string
-    {
-        return $this->getHash();
-    }
-
-    /**
-     * Returns the CSRF Token Name.
-     *
-     * @deprecated Use `CodeIgniter\Security\Security::getTokenName()` instead of using this method.
-     *
-     * @codeCoverageIgnore
-     */
-    public function getCSRFTokenName(): string
-    {
-        return $this->getTokenName();
-    }
-
-    /**
-     * CSRF Verify
-     *
      * @return $this
      *
      * @throws SecurityException
@@ -445,18 +405,6 @@ class Security implements SecurityInterface
     }
 
     /**
-     * Check if CSRF cookie is expired.
-     *
-     * @deprecated
-     *
-     * @codeCoverageIgnore
-     */
-    public function isExpired(): bool
-    {
-        return $this->cookie->isExpired();
-    }
-
-    /**
      * Check if request should be redirect on failure.
      */
     public function shouldRedirect(): bool
@@ -586,40 +534,6 @@ class Security implements SecurityInterface
 
         $response = Services::response();
         $response->setCookie($this->cookie);
-    }
-
-    /**
-     * CSRF Send Cookie
-     *
-     * @return false|Security
-     *
-     * @deprecated Set cookies to Response object instead.
-     */
-    protected function sendCookie(RequestInterface $request)
-    {
-        assert($request instanceof IncomingRequest);
-
-        if ($this->cookie->isSecure() && ! $request->isSecure()) {
-            return false;
-        }
-
-        $this->doSendCookie();
-        log_message('info', 'CSRF cookie sent.');
-
-        return $this;
-    }
-
-    /**
-     * Actual dispatching of cookies.
-     * Extracted for this to be unit tested.
-     *
-     * @codeCoverageIgnore
-     *
-     * @deprecated Set cookies to Response object instead.
-     */
-    protected function doSendCookie(): void
-    {
-        cookies([$this->cookie], false)->dispatch();
     }
 
     private function saveHashInSession(): void

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -49,13 +49,6 @@ interface SecurityInterface
     public function getCookieName(): string;
 
     /**
-     * Check if CSRF cookie is expired.
-     *
-     * @deprecated
-     */
-    public function isExpired(): bool;
-
-    /**
      * Check if request should be redirect on failure.
      */
     public function shouldRedirect(): bool;

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -184,6 +184,16 @@ Response
     - ``ResponseTrait::$cookieSameSite``
     - ``ResponseTrait::$cookies``
 
+Security
+--------
+
+- ``Security::CSRFVerify()``
+- ``Security::getCSRFHash()``
+- ``Security::getCSRFTokenName()``
+- ``Security::isExpired()``
+- ``Security::sendCookie()``
+- ``Security::doSendCookie()``
+
 CodeIgniter
 -----------
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -187,10 +187,11 @@ Response
 Security
 --------
 
+- ``SecurityInterface::isExpired()``
+- ``Security::isExpired()``
 - ``Security::CSRFVerify()``
 - ``Security::getCSRFHash()``
 - ``Security::getCSRFTokenName()``
-- ``Security::isExpired()``
 - ``Security::sendCookie()``
 - ``Security::doSendCookie()``
 


### PR DESCRIPTION
**Description**
- remove deprecated methods in Security

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
