### PR TITLE
fix: Handle non-array JSON in validation

### DIFF
--- a/system/HTTP/Exceptions/HTTPException.php
+++ b/system/HTTP/Exceptions/HTTPException.php
@@ -228,4 +228,15 @@ class HTTPException extends FrameworkException
     {
         return new static(lang('Security.invalidSameSiteSetting', [$samesite]));
     }
+
+    /**
+     * Thrown when the JSON format is not supported.
+     * This is specifically for cases where data validation is expected to work with key-value structures.
+     *
+     * @return HTTPException
+     */
+    public static function forUnsupportedJSONFormat()
+    {
+        return new static(lang('HTTP.unsupportedJSONFormat'));
+    }
 }

--- a/system/Language/en/HTTP.php
+++ b/system/Language/en/HTTP.php
@@ -20,6 +20,7 @@ return [
     // IncomingRequest
     'invalidNegotiationType' => '"{0}" is not a valid negotiation type. Must be one of: media, charset, encoding, language.',
     'invalidJSON'            => 'Failed to parse JSON string. Error: {0}',
+    'unsupportedJSONFormat'  => 'The provided JSON format is not supported.',
 
     // Message
     'invalidHTTPProtocol' => 'Invalid HTTP Protocol Version: {0}',

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -12,6 +12,7 @@
 namespace CodeIgniter\Validation;
 
 use Closure;
+use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\Validation\Exceptions\ValidationException;
@@ -495,6 +496,10 @@ class Validation implements ValidationInterface
         /** @var IncomingRequest $request */
         if (strpos($request->getHeaderLine('Content-Type'), 'application/json') !== false) {
             $this->data = $request->getJSON(true);
+
+            if (! is_array($this->data)) {
+                throw HTTPException::forUnsupportedJSONFormat();
+            }
 
             return $this;
         }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -809,6 +809,25 @@ class ValidationTest extends CIUnitTestCase
             ->run();
     }
 
+    public function testJsonInputNotKeyValue(): void
+    {
+        $this->expectException(HTTPException::class);
+        $this->expectExceptionMessage('The provided JSON format is not supported.');
+
+        $config  = new App();
+        $json    = '4';
+        $request = new IncomingRequest($config, new SiteURI($config), $json, new UserAgent());
+        $request->setHeader('Content-Type', 'application/json');
+
+        $rules = [
+            'role' => 'if_exist|max_length[5]',
+        ];
+        $this->validation
+            ->withRequest($request->withMethod('POST'))
+            ->setRules($rules)
+            ->run();
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/6466
      */

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -38,6 +38,7 @@ Message Changes
 ***************
 
 - Added ``HTTP.invalidJSON`` error message.
+- Added ``HTTP.unsupportedJSONFormat`` error message.
 
 *******
 Changes


### PR DESCRIPTION

**Description**
Continue #8176

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
