### PR TITLE
feat: add `--dbgroup` option to `spark db:table`

### DIFF
--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -17,6 +17,7 @@ use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Database\BaseConnection;
 use Config\Database;
+use InvalidArgumentException;
 
 /**
  * Get table data if it exists in the database.
@@ -83,6 +84,7 @@ class ShowTableInfo extends BaseCommand
         '--desc'              => 'Sorts the table rows in DESC order.',
         '--limit-rows'        => 'Limits the number of rows. Default: 10.',
         '--limit-field-value' => 'Limits the length of field values. Default: 15.',
+        '--dbgroup'           => 'Database group to show.',
     ];
 
     /**
@@ -90,7 +92,7 @@ class ShowTableInfo extends BaseCommand
      */
     private array $tbody;
 
-    private BaseConnection $db;
+    private ?BaseConnection $db = null;
 
     /**
      * @var bool Sort the table rows in DESC order or not.
@@ -101,7 +103,16 @@ class ShowTableInfo extends BaseCommand
 
     public function run(array $params)
     {
-        $this->db       = Database::connect();
+        $dbGroup = $params['dbgroup'] ?? CLI::getOption('dbgroup');
+
+        try {
+            $this->db = Database::connect($dbGroup);
+        } catch (InvalidArgumentException $e) {
+            CLI::error($e->getMessage());
+
+            return EXIT_ERROR;
+        }
+
         $this->DBPrefix = $this->db->getPrefix();
 
         $this->showDBConfig();

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -127,13 +127,13 @@ class ShowTableInfo extends BaseCommand
             CLI::error('Database has no tables!', 'light_gray', 'red');
             CLI::newLine();
 
-            return;
+            return EXIT_ERROR;
         }
 
         if (array_key_exists('show', $params)) {
             $this->showAllTables($tables);
 
-            return;
+            return EXIT_ERROR;
         }
 
         $tableName       = $params[0] ?? null;
@@ -154,10 +154,12 @@ class ShowTableInfo extends BaseCommand
         if (array_key_exists('metadata', $params)) {
             $this->showFieldMetaData($tableName);
 
-            return;
+            return EXIT_SUCCESS;
         }
 
         $this->showDataOfTable($tableName, $limitRows, $limitFieldValue);
+
+        return EXIT_SUCCESS;
     }
 
     private function showDBConfig(): void

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -69,7 +69,7 @@ class Config extends BaseConfig
             assert(is_string($group));
 
             if (! isset($dbConfig->{$group})) {
-                throw new InvalidArgumentException($group . ' is not a valid database connection group.');
+                throw new InvalidArgumentException('"' . $group . '" is not a valid database connection group.');
             }
 
             $config = $dbConfig->{$group};

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -66,6 +66,16 @@ final class ShowTableInfoTest extends CIUnitTestCase
         $this->assertMatchesRegularExpression($expectedPattern, $result);
     }
 
+    public function testDbTableShowsWithInvalidDBGroup(): void
+    {
+        command('db:table --show --dbgroup invalid');
+
+        $result = $this->getNormalizedResult();
+
+        $expected = '"invalid" is not a valid database connection group.';
+        $this->assertStringContainsString($expected, $result);
+    }
+
     public function testDbTableShowsDBConfig(): void
     {
         command('db:table --show');

--- a/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
+++ b/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
@@ -88,7 +88,7 @@ class DatabaseRelatedRulesTest extends CIUnitTestCase
     public function testIsUniqueWithInvalidDBGroup(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('invalidGroup is not a valid database connection group');
+        $this->expectExceptionMessage('"invalidGroup" is not a valid database connection group');
 
         $this->validation->setRules(['email' => 'is_unique[user.email]']);
         $data = ['email' => 'derek@world.co.uk'];


### PR DESCRIPTION
**Description**
https://forum.codeigniter.com/showthread.php?tid=87978

```console
$ ./spark db:table --show --dbgroup tests

CodeIgniter v4.4.3 Command Line Tool - Server Time: 2023-12-04 22:07:51 UTC+00:00

+-----------+----------+----------+----------+----------+------+
| hostname  | database | username | DBDriver | DBPrefix | port |
+-----------+----------+----------+----------+----------+------+
| 127.0.0.1 | ci4_test | root     | MySQLi   | db_      | 3306 |
+-----------+----------+----------+----------+----------+------+

The following is a list of the names of all database tables:

+----+---------------------------+-------------+---------------+
| ID | Table Name                | Num of Rows | Num of Fields |
+----+---------------------------+-------------+---------------+
| 1  | db_ci_sessions            | 1           | 4             |
| 2  | db_empty                  | 0           | 4             |
| 3  | db_ip_table               | 0           | 2             |
| 4  | db_job                    | 4           | 6             |
| 5  | db_migrations             | 1           | 7             |
| 6  | db_misc                   | 3           | 3             |
| 7  | db_secondary              | 0           | 3             |
| 8  | db_stringifypkey          | 1           | 2             |
| 9  | db_type_test              | 1           | 21            |
| 10 | db_user                   | 4           | 7             |
| 11 | db_uuid                   | 1           | 2             |
| 12 | db_without_auto_increment | 1           | 2             |
+----+---------------------------+-------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
