### PR TITLE
fix: get_filenames() does not follow symlinks

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -209,7 +209,7 @@ if (! function_exists('get_filenames')) {
 
         try {
             foreach (new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS),
+                new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
                 RecursiveIteratorIterator::SELF_FIRST
             ) as $name => $object) {
                 $basename = pathinfo($name, PATHINFO_BASENAME);

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -396,6 +396,35 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $this->assertSame([], get_filenames(SUPPORTPATH . 'Files/shaker/'));
     }
 
+    public function testGetFilenamesWithSymlinks(): void
+    {
+        $targetDir = APPPATH . 'Language';
+        $linkDir   = APPPATH . 'Controllers/Language';
+        if (file_exists($linkDir)) {
+            unlink($linkDir);
+        }
+        symlink($targetDir, $linkDir);
+
+        $targetFile = APPPATH . 'Common.php';
+        $linkFile   = APPPATH . 'Controllers/Common.php';
+        if (file_exists($linkFile)) {
+            unlink($linkFile);
+        }
+        symlink($targetFile, $linkFile);
+
+        $this->assertSame([
+            0 => 'BaseController.php',
+            1 => 'Common.php',
+            2 => 'Home.php',
+            3 => 'Language',
+            4 => 'Validation.php',
+            5 => 'en',
+        ], get_filenames(APPPATH . 'Controllers'));
+
+        unlink($linkDir);
+        unlink($linkFile);
+    }
+
     public function testGetDirFileInfo(): void
     {
         $file = SUPPORTPATH . 'Files/baker/banana.php';

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -33,6 +33,12 @@ The use of the `ssl_key` option in CURLRequest was removed
 Due to a bug, we were using the undocumented `ssl_key` config option to define the CA bundle in CURLRequest.
 This was fixed and is now working according to documentation. You can define your CA bundle via the `verify` option.
 
+Filesystem Helper
+====================================
+
+``get_filenames()`` now follows symlink folders, which it previously just returned
+without following.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -36,7 +36,7 @@ This was fixed and is now working according to documentation. You can define you
 Filesystem Helper
 ====================================
 
-``get_filenames()`` now follows symlink folders, which it previously just returned
+:php:func:`get_filenames()` now follows symlink folders, which it previously just returned
 without following.
 
 ***************

--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -34,7 +34,7 @@ Due to a bug, we were using the undocumented `ssl_key` config option to define t
 This was fixed and is now working according to documentation. You can define your CA bundle via the `verify` option.
 
 Filesystem Helper
-====================================
+=================
 
 :php:func:`get_filenames()` now follows symlink folders, which it previously just returned
 without following.

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -164,6 +164,8 @@ The following functions are available:
     the second parameter to 'relative' for relative paths or any other non-empty value for
     a full file path.
 
+    Prior to v4.4.4, due to a bug, this function did not follow symlink folders.
+
     Example:
 
     .. literalinclude:: filesystem_helper/010.php

--- a/user_guide_src/source/helpers/filesystem_helper.rst
+++ b/user_guide_src/source/helpers/filesystem_helper.rst
@@ -164,7 +164,7 @@ The following functions are available:
     the second parameter to 'relative' for relative paths or any other non-empty value for
     a full file path.
 
-    Prior to v4.4.4, due to a bug, this function did not follow symlink folders.
+    .. note:: Prior to v4.4.4, due to a bug, this function did not follow symlink folders.
 
     Example:
 


### PR DESCRIPTION
**Description**
Supersedes #8225

`get_filenames()` should follow symlinks.
See https://github.com/codeigniter4/CodeIgniter4/pull/8225#issuecomment-1815345901

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
