### PR TITLE
docs: fix `@return` in BaseBuilder.php

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2270,7 +2270,7 @@ class BaseBuilder
      *
      * @param array|object|null $set
      *
-     * @return bool|BaseResult|Query
+     * @return BaseResult|bool|Query
      *
      * @throws DatabaseException
      */

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2270,7 +2270,7 @@ class BaseBuilder
      *
      * @param array|object|null $set
      *
-     * @return bool
+     * @return bool|BaseResult|Query
      *
      * @throws DatabaseException
      */


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
The function returns false on failure, but on success it returns the BaseResult unless the pretend flag is set in the query() function. In that case it returns a Query object. Not having this in the PHPdoc is giving PHPStorm fits.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
