### PR TITLE
fix: TypeError in strict mode

### DIFF
--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -306,16 +306,17 @@ final class ArrayHelper
      * Sorts array values in natural order
      * If the value is an array, you need to specify the $sortByIndex of the key to sort
      *
-     * @param int|string|null $sortByIndex
+     * @param list<int|list<int|string>|string> $array
+     * @param int|string|null                   $sortByIndex
      */
     public static function sortValuesByNatural(array &$array, $sortByIndex = null): bool
     {
         return usort($array, static function ($currentValue, $nextValue) use ($sortByIndex) {
             if ($sortByIndex !== null) {
-                return strnatcmp($currentValue[$sortByIndex], $nextValue[$sortByIndex]);
+                return strnatcmp((string) $currentValue[$sortByIndex], (string) $nextValue[$sortByIndex]);
             }
 
-            return strnatcmp($currentValue, $nextValue);
+            return strnatcmp((string) $currentValue, (string) $nextValue);
         });
     }
 }


### PR DESCRIPTION
**Description**
Follow-up #8285

```
1) CodeIgniter\Helpers\Array\ArrayHelperSortValuesByNaturalTest::testSortWithStringValues
TypeError: strnatcmp(): Argument #2 ($string2) must be of type string, int given

/home/runner/work/CodeIgniter4/CodeIgniter4/system/Helpers/Array/ArrayHelper.php:318
/home/runner/work/CodeIgniter4/CodeIgniter4/system/Helpers/Array/ArrayHelper.php:313
/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Helpers/Array/ArrayHelperSortValuesByNaturalTest.php:60

2) CodeIgniter\Helpers\Array\ArrayHelperSortValuesByNaturalTest::testSortWithArrayValues
TypeError: strnatcmp(): Argument #2 ($string2) must be of type string, int given

/home/runner/work/CodeIgniter4/CodeIgniter4/system/Helpers/Array/ArrayHelper.php:315
/home/runner/work/CodeIgniter4/CodeIgniter4/system/Helpers/Array/ArrayHelper.php:313
/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Helpers/Array/ArrayHelperSortValuesByNaturalTest.php:84
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7135744955/job/19433071552?pr=8307

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
