### PR TITLE
chore: update phpstan-baseline.php

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1262,11 +1262,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/MySQLi/PreparedQuery.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\MySQLi\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\MySQLi\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<mysqli,mysqli_stmt,mysqli_result\\>\\:\\:_prepare\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/MySQLi/PreparedQuery.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Return type \\(mysqli_result\\|false\\) of method CodeIgniter\\\\Database\\\\MySQLi\\\\PreparedQuery\\:\\:_getResult\\(\\) should be covariant with return type \\(object\\|resource\\|null\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<mysqli,mysqli_stmt,mysqli_result\\>\\:\\:_getResult\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/MySQLi/PreparedQuery.php',
@@ -1378,11 +1373,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^PHPDoc type CodeIgniter\\\\Database\\\\OCI8\\\\Connection of property CodeIgniter\\\\Database\\\\OCI8\\\\PreparedQuery\\:\\:\\$db is not the same as PHPDoc type CodeIgniter\\\\Database\\\\BaseConnection\\<resource, resource\\> of overridden property CodeIgniter\\\\Database\\\\BasePreparedQuery\\<resource,resource,resource\\>\\:\\:\\$db\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/OCI8/PreparedQuery.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\OCI8\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\OCI8\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<resource,resource,resource\\>\\:\\:_prepare\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/OCI8/PreparedQuery.php',
 ];
@@ -1510,11 +1500,6 @@ $ignoreErrors[] = [
 	'message' => '#^Return type \\(array\\|bool\\|string\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Forge\\:\\:_alterTable\\(\\) should be covariant with return type \\(array\\<string\\>\\|string\\|false\\) of method CodeIgniter\\\\Database\\\\Forge\\:\\:_alterTable\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Postgre/Forge.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\Postgre\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<PgSql\\\\Connection,PgSql\\\\Result,PgSql\\\\Result\\>\\:\\:_prepare\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/Postgre/PreparedQuery.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
@@ -1652,11 +1637,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/SQLSRV/PreparedQuery.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\SQLSRV\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\SQLSRV\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<resource,resource,resource\\>\\:\\:_prepare\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/SQLSRV/PreparedQuery.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/SQLSRV/Result.php',
@@ -1725,11 +1705,6 @@ $ignoreErrors[] = [
 	'message' => '#^Return type \\(array\\|string\\|null\\) of method CodeIgniter\\\\Database\\\\SQLite3\\\\Forge\\:\\:_alterTable\\(\\) should be covariant with return type \\(array\\<string\\>\\|string\\|false\\) of method CodeIgniter\\\\Database\\\\Forge\\:\\:_alterTable\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/SQLite3/Forge.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\SQLite3\\\\PreparedQuery\\) of method CodeIgniter\\\\Database\\\\SQLite3\\\\PreparedQuery\\:\\:_prepare\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BasePreparedQuery\\<TConnection, TStatement, TResult\\>\\)\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<SQLite3,SQLite3Stmt,SQLite3Result\\>\\:\\:_prepare\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/SQLite3/PreparedQuery.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Return type \\(SQLite3Result\\|false\\) of method CodeIgniter\\\\Database\\\\SQLite3\\\\PreparedQuery\\:\\:_getResult\\(\\) should be covariant with return type \\(object\\|resource\\|null\\) of method CodeIgniter\\\\Database\\\\BasePreparedQuery\\<SQLite3,SQLite3Stmt,SQLite3Result\\>\\:\\:_getResult\\(\\)$#',
@@ -2018,16 +1993,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in an if condition, string given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\DownloadResponse\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:noCache\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\Response\\)\\) of method CodeIgniter\\\\HTTP\\\\Response\\:\\:noCache\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\DownloadResponse\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:noCache\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\ResponseInterface\\)\\) of method CodeIgniter\\\\HTTP\\\\ResponseInterface\\:\\:noCache\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
 ];


### PR DESCRIPTION
**Description**
Because of PHPStan upgrade.

```
Error: Ignored error pattern #^Return type \(CodeIgniter\\Database\\MySQLi\\PreparedQuery\) of method CodeIgniter\\Database\\MySQLi\\PreparedQuery\:\:_prepare\(\) should be covariant with return type \(\$this\(CodeIgniter\\Database\\BasePreparedQuery\<TConnection, TStatement, TResult\>\)\) of method CodeIgniter\\Database\\BasePreparedQuery\<mysqli,mysqli_stmt,mysqli_result\>\:\:_prepare\(\)$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/Database/MySQLi/PreparedQuery.php was not matched in reported errors.
Error: Ignored error pattern #^Return type \(CodeIgniter\\Database\\OCI8\\PreparedQuery\) of method CodeIgniter\\Database\\OCI8\\PreparedQuery\:\:_prepare\(\) should be covariant with return type \(\$this\(CodeIgniter\\Database\\BasePreparedQuery\<TConnection, TStatement, TResult\>\)\) of method CodeIgniter\\Database\\BasePreparedQuery\<resource,resource,resource\>\:\:_prepare\(\)$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/Database/OCI8/PreparedQuery.php was not matched in reported errors.
Error: Ignored error pattern #^Return type \(CodeIgniter\\Database\\Postgre\\PreparedQuery\) of method CodeIgniter\\Database\\Postgre\\PreparedQuery\:\:_prepare\(\) should be covariant with return type \(\$this\(CodeIgniter\\Database\\BasePreparedQuery\<TConnection, TStatement, TResult\>\)\) of method CodeIgniter\\Database\\BasePreparedQuery\<PgSql\\Connection,PgSql\\Result,PgSql\\Result\>\:\:_prepare\(\)$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/Database/Postgre/PreparedQuery.php was not matched in reported errors.
Error: Ignored error pattern #^Return type \(CodeIgniter\\Database\\SQLSRV\\PreparedQuery\) of method CodeIgniter\\Database\\SQLSRV\\PreparedQuery\:\:_prepare\(\) should be covariant with return type \(\$this\(CodeIgniter\\Database\\BasePreparedQuery\<TConnection, TStatement, TResult\>\)\) of method CodeIgniter\\Database\\BasePreparedQuery\<resource,resource,resource\>\:\:_prepare\(\)$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/Database/SQLSRV/PreparedQuery.php was not matched in reported errors.
Error: Ignored error pattern #^Return type \(CodeIgniter\\Database\\SQLite3\\PreparedQuery\) of method CodeIgniter\\Database\\SQLite3\\PreparedQuery\:\:_prepare\(\) should be covariant with return type \(\$this\(CodeIgniter\\Database\\BasePreparedQuery\<TConnection, TStatement, TResult\>\)\) of method CodeIgniter\\Database\\BasePreparedQuery\<SQLite3,SQLite3Stmt,SQLite3Result\>\:\:_prepare\(\)$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/Database/SQLite3/PreparedQuery.php was not matched in reported errors.
Error: Ignored error pattern #^Return type \(CodeIgniter\\HTTP\\DownloadResponse\) of method CodeIgniter\\HTTP\\DownloadResponse\:\:noCache\(\) should be covariant with return type \(\$this\(CodeIgniter\\HTTP\\ResponseInterface\)\) of method CodeIgniter\\HTTP\\ResponseInterface\:\:noCache\(\)$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/HTTP/DownloadResponse.php was not matched in reported errors.
Error: Ignored error pattern #^Return type \(CodeIgniter\\HTTP\\DownloadResponse\) of method CodeIgniter\\HTTP\\DownloadResponse\:\:noCache\(\) should be covariant with return type \(\$this\(CodeIgniter\\HTTP\\Response\)\) of method CodeIgniter\\HTTP\\Response\:\:noCache\(\)$# in path /home/runner/work/CodeIgniter4/CodeIgniter4/system/HTTP/DownloadResponse.php was not matched in reported errors.
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7147604463/job/19467408417?pr=8310

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
