### PR TITLE
test: fix COMPOSER_PATH may be false

### DIFF
--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -46,7 +46,7 @@ defined('CIPATH')        || define('CIPATH', realpath(SYSTEMPATH . '../') . DIRE
 defined('FCPATH')        || define('FCPATH', realpath(PUBLICPATH) . DIRECTORY_SEPARATOR);
 defined('TESTPATH')      || define('TESTPATH', realpath(HOMEPATH . 'tests/') . DIRECTORY_SEPARATOR);
 defined('SUPPORTPATH')   || define('SUPPORTPATH', realpath(TESTPATH . '_support/') . DIRECTORY_SEPARATOR);
-defined('COMPOSER_PATH') || define('COMPOSER_PATH', realpath(HOMEPATH . 'vendor/autoload.php'));
+defined('COMPOSER_PATH') || define('COMPOSER_PATH', (string) realpath(HOMEPATH . 'vendor/autoload.php'));
 defined('VENDORPATH')    || define('VENDORPATH', realpath(HOMEPATH . 'vendor') . DIRECTORY_SEPARATOR);
 
 // Load Common.php from App then System


### PR DESCRIPTION
**Description**
Supersedes  #8314

`COMPOSER_PATH` may be false.

```
PHP Fatal error:  Uncaught TypeError: is_file(): Argument #1 ($filename) must be of type string, bool given in /home/runner/work/CodeIgniter4/CodeIgniter4/system/Autoloader/Autoloader.php:126
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7148219475/job/19469003051

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
