### PR TITLE
fix: DEPRECATED error in Honeypot

### DIFF
--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -78,6 +78,10 @@ class Honeypot
      */
     public function attachHoneypot(ResponseInterface $response)
     {
+        if ($response->getBody() === null) {
+            return;
+        }
+
         if ($response->getCSP()->enabled()) {
             // Add id attribute to the container tag.
             $this->config->container = str_ireplace(

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -67,6 +67,15 @@ final class HoneypotTest extends CIUnitTestCase
         $this->assertStringNotContainsString($this->config->name, $this->response->getBody());
     }
 
+    public function testAttachHoneypotBodyNull(): void
+    {
+        $this->response->setBody(null);
+
+        $this->honeypot->attachHoneypot($this->response);
+
+        $this->assertNull($this->response->getBody());
+    }
+
     public function testAttachHoneypotAndContainer(): void
     {
         $this->response->setBody('<form></form>');


### PR DESCRIPTION
**Description**
Reported in https://forum.codeigniter.com/showthread.php?tid=88952

```
[DEPRECATED] str_ireplace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in SYSTEMPATH\Honeypot\Honeypot.php on line 93.
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
