### PR TITLE
refactor: HTTP verbs in Router

### DIFF
--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -51,11 +51,6 @@ final class AutoRouter implements AutoRouterInterface
     private bool $translateURIDashes;
 
     /**
-     * HTTP verb for the request.
-     */
-    private string $httpVerb;
-
-    /**
      * Default namespace for controllers.
      */
     private string $defaultNamespace;
@@ -65,13 +60,11 @@ final class AutoRouter implements AutoRouterInterface
         string $defaultNamespace,
         string $defaultController,
         string $defaultMethod,
-        bool $translateURIDashes,
-        string $httpVerb
+        bool $translateURIDashes
     ) {
         $this->cliRoutes          = $cliRoutes;
         $this->defaultNamespace   = $defaultNamespace;
         $this->translateURIDashes = $translateURIDashes;
-        $this->httpVerb           = $httpVerb;
 
         $this->controller = $defaultController;
         $this->method     = $defaultMethod;

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -124,7 +124,7 @@ final class AutoRouter implements AutoRouterInterface
         }
 
         // Ensure routes registered via $routes->cli() are not accessible via web.
-        if ($this->httpVerb !== 'CLI') {
+        if ($httpVerb !== 'CLI') {
             $controller = '\\' . $this->defaultNamespace;
 
             $controller .= $this->directory ? str_replace('/', '\\', $this->directory) : '';

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -81,6 +81,8 @@ final class AutoRouter implements AutoRouterInterface
      * Attempts to match a URI path against Controllers and directories
      * found in APPPATH/Controllers, to find a matching route.
      *
+     * @param string $httpVerb HTTP verb like `GET`,`POST`
+     *
      * @return array [directory_name, controller_name, controller_method, params]
      */
     public function getRoute(string $uri, string $httpVerb): array

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -243,6 +243,8 @@ final class AutoRouterImproved implements AutoRouterInterface
     /**
      * Finds controller, method and params from the URI.
      *
+     * @param string $httpVerb HTTP verb like `GET`,`POST`
+     *
      * @return array [directory_name, controller_name, controller_method, params]
      */
     public function getRoute(string $uri, string $httpVerb): array

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -104,16 +104,13 @@ final class AutoRouterImproved implements AutoRouterInterface
     /**
      * @param class-string[] $protectedControllers
      * @param string         $defaultController    Short classname
-     *
-     * @deprecated $httpVerb is deprecated. No longer used.
      */
-    public function __construct(// @phpstan-ignore-line
+    public function __construct(
         array $protectedControllers,
         string $namespace,
         string $defaultController,
         string $defaultMethod,
-        bool $translateURIDashes,
-        string $httpVerb
+        bool $translateURIDashes
     ) {
         $this->protectedControllers = $protectedControllers;
         $this->namespace            = rtrim($namespace, '\\');

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -151,8 +151,7 @@ class Router implements RouterInterface
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),
-                    $this->translateURIDashes,
-                    $this->collection->getHTTPVerb()
+                    $this->translateURIDashes
                 );
             } else {
                 $this->autoRouter = new AutoRouter(
@@ -160,8 +159,7 @@ class Router implements RouterInterface
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),
-                    $this->translateURIDashes,
-                    $this->collection->getHTTPVerb()
+                    $this->translateURIDashes
                 );
             }
         }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -42,7 +42,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->collection      = new RouteCollection(Services::locator(), $moduleConfig, new Routing());
     }
 
-    private function createNewAutoRouter(string $httpVerb = 'get', $namespace = 'CodeIgniter\Router\Controllers'): AutoRouterImproved
+    private function createNewAutoRouter(string $httpVerb = 'GET', $namespace = 'CodeIgniter\Router\Controllers'): AutoRouterImproved
     {
         return new AutoRouterImproved(
             [],
@@ -61,7 +61,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('/', 'get');
+            = $router->getRoute('/', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -84,10 +84,10 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $this->collection->setDefaultController('Index');
 
-        $router = $this->createNewAutoRouter('get', 'App/Controllers');
+        $router = $this->createNewAutoRouter('GET', 'App/Controllers');
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('test', 'get');
+            = $router->getRoute('test', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -102,7 +102,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter('post');
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('/', 'post');
+            = $router->getRoute('/', 'POST');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -115,7 +115,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod', 'get');
+            = $router->getRoute('mycontroller/somemethod', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -133,7 +133,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a', 'get');
+            = $router->getRoute('mycontroller/somemethod/a', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -155,7 +155,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('mycontroller/somemethod/a/b', 'get');
+        $router->getRoute('mycontroller/somemethod/a/b', 'GET');
     }
 
     public function testAutoRouteFindsControllerWithFile(): void
@@ -163,7 +163,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller', 'get');
+            = $router->getRoute('mycontroller', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -176,7 +176,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/mycontroller/somemethod', 'get');
+            = $router->getRoute('subfolder/mycontroller/somemethod', 'GET');
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Mycontroller::class, $controller);
@@ -194,7 +194,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/sub/mycontroller/somemethod', 'get');
+            = $router->getRoute('subfolder/sub/mycontroller/somemethod', 'GET');
 
         $this->assertSame('Subfolder/Sub/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Sub\Mycontroller::class, $controller);
@@ -207,7 +207,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder/mycontroller/somemethod', 'get');
+            = $router->getRoute('dash-folder/mycontroller/somemethod', 'GET');
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame(
@@ -223,7 +223,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder/dash-controller/somemethod', 'get');
+            = $router->getRoute('dash-folder/dash-controller/somemethod', 'GET');
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame('\\' . Dash_controller::class, $controller);
@@ -236,7 +236,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder/dash-controller/dash-method', 'get');
+            = $router->getRoute('dash-folder/dash-controller/dash-method', 'GET');
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame('\\' . Dash_controller::class, $controller);
@@ -249,7 +249,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder', 'get');
+            = $router->getRoute('dash-folder', 'GET');
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame('\\' . Home::class, $controller);
@@ -262,7 +262,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('index/15', 'get');
+            = $router->getRoute('index/15', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -280,7 +280,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/15', 'get');
+            = $router->getRoute('subfolder/15', 'GET');
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
@@ -298,7 +298,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/15/20', 'get');
+            = $router->getRoute('subfolder/15/20', 'GET');
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
@@ -316,7 +316,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder', 'get');
+            = $router->getRoute('subfolder', 'GET');
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
@@ -335,7 +335,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('.', 'get');
+        $router->getRoute('.', 'GET');
     }
 
     public function testAutoRouteRejectsDoubleDot(): void
@@ -344,7 +344,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('..', 'get');
+        $router->getRoute('..', 'GET');
     }
 
     public function testAutoRouteRejectsMidDot(): void
@@ -353,7 +353,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('foo.bar', 'get');
+        $router->getRoute('foo.bar', 'GET');
     }
 
     public function testRejectsDefaultControllerPath(): void
@@ -362,7 +362,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('home', 'get');
+        $router->getRoute('home', 'GET');
     }
 
     public function testRejectsDefaultControllerAndDefaultMethodPath(): void
@@ -371,7 +371,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('home/index', 'get');
+        $router->getRoute('home/index', 'GET');
     }
 
     public function testRejectsDefaultMethodPath(): void
@@ -380,7 +380,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('mycontroller/index', 'get');
+        $router->getRoute('mycontroller/index', 'GET');
     }
 
     public function testRejectsControllerWithRemapMethod(): void
@@ -392,7 +392,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('remap/test', 'get');
+        $router->getRoute('remap/test', 'GET');
     }
 
     public function testRejectsURIWithUnderscoreFolder()
@@ -404,7 +404,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash_folder', 'get');
+        $router->getRoute('dash_folder', 'GET');
     }
 
     public function testRejectsURIWithUnderscoreController()
@@ -416,7 +416,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash-folder/dash_controller/dash-method', 'get');
+        $router->getRoute('dash-folder/dash_controller/dash-method', 'GET');
     }
 
     public function testRejectsURIWithUnderscoreMethod()
@@ -428,7 +428,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash-folder/dash-controller/dash_method', 'get');
+        $router->getRoute('dash-folder/dash-controller/dash_method', 'GET');
     }
 
     public function testPermitsURIWithUnderscoreParam()
@@ -436,7 +436,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a_b', 'get');
+            = $router->getRoute('mycontroller/somemethod/a_b', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -449,7 +449,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a-b', 'get');
+            = $router->getRoute('mycontroller/somemethod/a-b', 'GET');
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -42,15 +42,14 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->collection      = new RouteCollection(Services::locator(), $moduleConfig, new Routing());
     }
 
-    private function createNewAutoRouter(string $httpVerb = 'GET', $namespace = 'CodeIgniter\Router\Controllers'): AutoRouterImproved
+    private function createNewAutoRouter($namespace = 'CodeIgniter\Router\Controllers'): AutoRouterImproved
     {
         return new AutoRouterImproved(
             [],
             $namespace,
             $this->collection->getDefaultController(),
             $this->collection->getDefaultMethod(),
-            true,
-            $httpVerb
+            true
         );
     }
 
@@ -84,7 +83,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $this->collection->setDefaultController('Index');
 
-        $router = $this->createNewAutoRouter('GET', 'App/Controllers');
+        $router = $this->createNewAutoRouter('App/Controllers');
 
         [$directory, $controller, $method, $params]
             = $router->getRoute('test', 'GET');
@@ -99,7 +98,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->collection->setDefaultController('Index');
 
-        $router = $this->createNewAutoRouter('post');
+        $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
             = $router->getRoute('/', 'POST');

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Router;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\HTTP\Method;
 use CodeIgniter\Router\Controllers\Dash_folder\Dash_controller;
 use CodeIgniter\Router\Controllers\Dash_folder\Home;
 use CodeIgniter\Router\Controllers\Index;
@@ -60,7 +61,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('/', 'GET');
+            = $router->getRoute('/', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -86,7 +87,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter('App/Controllers');
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('test', 'GET');
+            = $router->getRoute('test', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -101,7 +102,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('/', 'POST');
+            = $router->getRoute('/', Method::POST);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -114,7 +115,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod', 'GET');
+            = $router->getRoute('mycontroller/somemethod', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -132,7 +133,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a', 'GET');
+            = $router->getRoute('mycontroller/somemethod/a', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -154,7 +155,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('mycontroller/somemethod/a/b', 'GET');
+        $router->getRoute('mycontroller/somemethod/a/b', Method::GET);
     }
 
     public function testAutoRouteFindsControllerWithFile(): void
@@ -162,7 +163,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller', 'GET');
+            = $router->getRoute('mycontroller', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -175,7 +176,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/mycontroller/somemethod', 'GET');
+            = $router->getRoute('subfolder/mycontroller/somemethod', Method::GET);
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Mycontroller::class, $controller);
@@ -193,7 +194,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/sub/mycontroller/somemethod', 'GET');
+            = $router->getRoute('subfolder/sub/mycontroller/somemethod', Method::GET);
 
         $this->assertSame('Subfolder/Sub/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Sub\Mycontroller::class, $controller);
@@ -206,7 +207,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder/mycontroller/somemethod', 'GET');
+            = $router->getRoute('dash-folder/mycontroller/somemethod', Method::GET);
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame(
@@ -222,7 +223,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder/dash-controller/somemethod', 'GET');
+            = $router->getRoute('dash-folder/dash-controller/somemethod', Method::GET);
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame('\\' . Dash_controller::class, $controller);
@@ -235,7 +236,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder/dash-controller/dash-method', 'GET');
+            = $router->getRoute('dash-folder/dash-controller/dash-method', Method::GET);
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame('\\' . Dash_controller::class, $controller);
@@ -248,7 +249,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('dash-folder', 'GET');
+            = $router->getRoute('dash-folder', Method::GET);
 
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame('\\' . Home::class, $controller);
@@ -261,7 +262,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('index/15', 'GET');
+            = $router->getRoute('index/15', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Index::class, $controller);
@@ -279,7 +280,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/15', 'GET');
+            = $router->getRoute('subfolder/15', Method::GET);
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
@@ -297,7 +298,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder/15/20', 'GET');
+            = $router->getRoute('subfolder/15/20', Method::GET);
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
@@ -315,7 +316,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('subfolder', 'GET');
+            = $router->getRoute('subfolder', Method::GET);
 
         $this->assertSame('Subfolder/', $directory);
         $this->assertSame('\\' . \CodeIgniter\Router\Controllers\Subfolder\Home::class, $controller);
@@ -334,7 +335,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('.', 'GET');
+        $router->getRoute('.', Method::GET);
     }
 
     public function testAutoRouteRejectsDoubleDot(): void
@@ -343,7 +344,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('..', 'GET');
+        $router->getRoute('..', Method::GET);
     }
 
     public function testAutoRouteRejectsMidDot(): void
@@ -352,7 +353,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('foo.bar', 'GET');
+        $router->getRoute('foo.bar', Method::GET);
     }
 
     public function testRejectsDefaultControllerPath(): void
@@ -361,7 +362,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('home', 'GET');
+        $router->getRoute('home', Method::GET);
     }
 
     public function testRejectsDefaultControllerAndDefaultMethodPath(): void
@@ -370,7 +371,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('home/index', 'GET');
+        $router->getRoute('home/index', Method::GET);
     }
 
     public function testRejectsDefaultMethodPath(): void
@@ -379,7 +380,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('mycontroller/index', 'GET');
+        $router->getRoute('mycontroller/index', Method::GET);
     }
 
     public function testRejectsControllerWithRemapMethod(): void
@@ -391,7 +392,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('remap/test', 'GET');
+        $router->getRoute('remap/test', Method::GET);
     }
 
     public function testRejectsURIWithUnderscoreFolder()
@@ -403,7 +404,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash_folder', 'GET');
+        $router->getRoute('dash_folder', Method::GET);
     }
 
     public function testRejectsURIWithUnderscoreController()
@@ -415,7 +416,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash-folder/dash_controller/dash-method', 'GET');
+        $router->getRoute('dash-folder/dash_controller/dash-method', Method::GET);
     }
 
     public function testRejectsURIWithUnderscoreMethod()
@@ -427,7 +428,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $router = $this->createNewAutoRouter();
 
-        $router->getRoute('dash-folder/dash-controller/dash_method', 'GET');
+        $router->getRoute('dash-folder/dash-controller/dash_method', Method::GET);
     }
 
     public function testPermitsURIWithUnderscoreParam()
@@ -435,7 +436,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a_b', 'GET');
+            = $router->getRoute('mycontroller/somemethod/a_b', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);
@@ -448,7 +449,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router = $this->createNewAutoRouter();
 
         [$directory, $controller, $method, $params]
-            = $router->getRoute('mycontroller/somemethod/a-b', 'GET');
+            = $router->getRoute('mycontroller/somemethod/a-b', Method::GET);
 
         $this->assertNull($directory);
         $this->assertSame('\\' . Mycontroller::class, $controller);


### PR DESCRIPTION
**Description**
Follow-up #8235

- refactor `AutoRouter` and `AutoRouterImproved` (They are final classes, so these changes are not breaking changes.)
- use `HTTP\Method` in tests

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
