### PR TITLE
feat: [PagerRenderer] add method to return the number of all items

### DIFF
--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -428,4 +428,12 @@ class PagerRenderer
     {
         return ($this->current === $this->pageCount) ? null : $this->current + 1;
     }
+
+    /**
+     * Returns the number of all items
+     */
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
 }


### PR DESCRIPTION
**Description**
I get this request a lot from users who want to see how many items are
actually in a list.
I think the simplest and most aesthetically pleasing way to do this is to
include it in the Pager itself.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
