### PR TITLE
fix: [Auto Routing Improved] `spark routes` shows incorrect routes when translateURIDashes is enabled

### DIFF
--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -11,8 +11,11 @@
 
 namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 
+use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Dash_folder\Dash_controller;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Routing;
 use Tests\Support\Controllers\Newautorouting;
 use Tests\Support\Controllers\Remap;
 
@@ -59,6 +62,43 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
                     'a' => true,
                     'b' => true,
                     'c' => false,
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    public function testReadTranslateURIDashes(): void
+    {
+        $config                     = config(Routing::class);
+        $config->translateURIDashes = true;
+        Factories::injectMock('config', Routing::class, $config);
+
+        $reader = $this->createControllerMethodReader(
+            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers'
+        );
+
+        $routes = $reader->read(Dash_controller::class);
+
+        $expected = [
+            0 => [
+                'method'       => 'get',
+                'route'        => 'dash-folder/dash-controller/somemethod',
+                'route_params' => '[/..]',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Dash_folder\Dash_controller::getSomemethod',
+                'params'       => [
+                    'p1' => false,
+                ],
+            ],
+            [
+                'method'       => 'get',
+                'route'        => 'dash-folder/dash-controller/dash-method',
+                'route_params' => '/..[/..]',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Dash_folder\Dash_controller::getDash_method',
+                'params'       => [
+                    'p1' => true,
+                    'p2' => false,
                 ],
             ],
         ];

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/Dash_folder/Dash_controller.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/Dash_folder/Dash_controller.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Dash_folder;
+
+use CodeIgniter\Controller;
+
+class Dash_controller extends Controller
+{
+    public function getSomemethod($p1 = ''): void
+    {
+    }
+
+    public function getDash_method($p1, $p2 = ''): void
+    {
+    }
+}


### PR DESCRIPTION
**Description**
Follow-up #7422

Before:
```
+-----------+-----------------+------+--------------------------------------+----------------+---------------+
| Method    | Route           | Name | Handler                              | Before Filters | After Filters |
+-----------+-----------------+------+--------------------------------------+----------------+---------------+
| GET(auto) | foo_bar/foo_bar |      | \App\Controllers\Foo_bar::getFoo_bar |                | toolbar       |
+-----------+-----------------+------+--------------------------------------+----------------+---------------+
```

After:
```
+-----------+-----------------+------+--------------------------------------+----------------+---------------+
| Method    | Route           | Name | Handler                              | Before Filters | After Filters |
+-----------+-----------------+------+--------------------------------------+----------------+---------------+
| GET(auto) | foo-bar/foo-bar |      | \App\Controllers\Foo_bar::getFoo_bar |                | toolbar       |
+-----------+-----------------+------+--------------------------------------+----------------+---------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
