### PR TITLE
feat: [Auto Routing Improved] add option to translate uri to camel case

### DIFF
--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -19,6 +19,7 @@ use CodeIgniter\Config\Routing as BaseRouting;
 class Routing extends BaseRouting
 {
     /**
+     * For Defined Routes.
      * An array of files that contain route definitions.
      * Route files are read in order, with the first match
      * found taking precedence.
@@ -30,6 +31,7 @@ class Routing extends BaseRouting
     ];
 
     /**
+     * For Defined Routes and Auto Routing.
      * The default namespace to use for Controllers when no other
      * namespace has been specified.
      *
@@ -38,6 +40,7 @@ class Routing extends BaseRouting
     public string $defaultNamespace = 'App\Controllers';
 
     /**
+     * For Auto Routing.
      * The default controller to use when no other controller has been
      * specified.
      *
@@ -46,6 +49,7 @@ class Routing extends BaseRouting
     public string $defaultController = 'Home';
 
     /**
+     * For Defined Routes and Auto Routing.
      * The default method to call on the controller when no other
      * method has been set in the route.
      *
@@ -54,7 +58,8 @@ class Routing extends BaseRouting
     public string $defaultMethod = 'index';
 
     /**
-     * Whether to translate dashes in URIs to underscores.
+     * For Auto Routing.
+     * Whether to translate dashes in URIs for controller/method to underscores.
      * Primarily useful when using the auto-routing.
      *
      * Default: false
@@ -91,6 +96,7 @@ class Routing extends BaseRouting
     public bool $autoRoute = false;
 
     /**
+     * For Defined Routes.
      * If TRUE, will enable the use of the 'prioritize' option
      * when defining routes.
      *
@@ -99,7 +105,8 @@ class Routing extends BaseRouting
     public bool $prioritize = false;
 
     /**
-     * Map of URI segments and namespaces. For Auto Routing (Improved).
+     * For Auto Routing (Improved).
+     * Map of URI segments and namespaces.
      *
      * The key is the first URI segment. The value is the controller namespace.
      * E.g.,

--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -117,4 +117,13 @@ class Routing extends BaseRouting
      * @var array [ uri_segment => namespace ]
      */
     public array $moduleRoutes = [];
+
+    /**
+     * For Auto Routing (Improved).
+     * Whether to translate dashes in URIs for controller/method to CamelCase.
+     * E.g., blog-controller -> BlogController
+     *
+     * Default: false
+     */
+    public bool $translateUriToCamelCase = false;
 }

--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -123,6 +123,8 @@ class Routing extends BaseRouting
      * Whether to translate dashes in URIs for controller/method to CamelCase.
      * E.g., blog-controller -> BlogController
      *
+     * If you enable this, $translateURIDashes is ignored.
+     *
      * Default: false
      */
     public bool $translateUriToCamelCase = false;

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2607,11 +2607,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Router/AutoRouter.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in &&, Config\\\\Routing given on the right side\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Router/AutoRouterImproved.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^PHPDoc type int of property CodeIgniter\\\\Router\\\\Exceptions\\\\RedirectException\\:\\:\\$code is not the same as PHPDoc type mixed of overridden property Exception\\:\\:\\$code\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Router/Exceptions/RedirectException.php',

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -69,7 +69,7 @@ final class ControllerMethodReader
         $classShortname = $reflection->getShortName();
 
         $output     = [];
-        $classInUri = $this->convertClassnameToUri($classname);
+        $classInUri = $this->convertClassNameToUri($classname);
 
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             $methodName = $method->getName();
@@ -166,7 +166,7 @@ final class ControllerMethodReader
      *
      * @return string URI path part from the folder(s) and controller
      */
-    private function convertClassnameToUri(string $classname): string
+    private function convertClassNameToUri(string $classname): string
     {
         // remove the namespace
         $pattern = '/' . preg_quote($this->namespace, '/') . '/';

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -69,7 +69,7 @@ final class ControllerMethodReader
         $classShortname = $reflection->getShortName();
 
         $output     = [];
-        $classInUri = $this->getUriByClass($classname);
+        $classInUri = $this->convertClassnameToUri($classname);
 
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             $methodName = $method->getName();
@@ -77,7 +77,7 @@ final class ControllerMethodReader
             foreach ($this->httpMethods as $httpVerb) {
                 if (strpos($methodName, strtolower($httpVerb)) === 0) {
                     // Remove HTTP verb prefix.
-                    $methodInUri = $this->getUriByMethod($httpVerb, $methodName);
+                    $methodInUri = $this->convertMethodNameToUri($httpVerb, $methodName);
 
                     // Check if it is the default method.
                     if ($methodInUri === $defaultMethod) {
@@ -166,7 +166,7 @@ final class ControllerMethodReader
      *
      * @return string URI path part from the folder(s) and controller
      */
-    private function getUriByClass(string $classname): string
+    private function convertClassnameToUri(string $classname): string
     {
         // remove the namespace
         $pattern = '/' . preg_quote($this->namespace, '/') . '/';
@@ -189,7 +189,7 @@ final class ControllerMethodReader
     /**
      * @return string URI path part from the method
      */
-    private function getUriByMethod(string $httpVerb, string $methodName): string
+    private function convertMethodNameToUri(string $httpVerb, string $methodName): string
     {
         $methodUri = lcfirst(substr($methodName, strlen($httpVerb)));
 

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -35,6 +35,7 @@ final class ControllerMethodReader
     private array $httpMethods;
 
     private bool $translateURIDashes;
+    private bool $translateUriToCamelCase;
 
     /**
      * @param string $namespace the default namespace
@@ -44,8 +45,9 @@ final class ControllerMethodReader
         $this->namespace   = $namespace;
         $this->httpMethods = $httpMethods;
 
-        $config                   = config(Routing::class);
-        $this->translateURIDashes = $config->translateURIDashes;
+        $config                        = config(Routing::class);
+        $this->translateURIDashes      = $config->translateURIDashes;
+        $this->translateUriToCamelCase = $config->translateUriToCamelCase;
     }
 
     /**
@@ -181,11 +183,7 @@ final class ControllerMethodReader
 
         $classUri = rtrim($classPath, '/');
 
-        if ($this->translateURIDashes) {
-            $classUri = str_replace('_', '-', $classUri);
-        }
-
-        return $classUri;
+        return $this->translateToUri($classUri);
     }
 
     /**
@@ -195,11 +193,23 @@ final class ControllerMethodReader
     {
         $methodUri = lcfirst(substr($methodName, strlen($httpVerb)));
 
-        if ($this->translateURIDashes) {
-            $methodUri = str_replace('_', '-', $methodUri);
+        return $this->translateToUri($methodUri);
+    }
+
+    /**
+     * @param string $string classname or method name
+     */
+    private function translateToUri(string $string): string
+    {
+        if ($this->translateUriToCamelCase) {
+            $string = strtolower(
+                preg_replace('/([a-z\d])([A-Z])/', '$1-$2', $string)
+            );
+        } elseif ($this->translateURIDashes) {
+            $string = str_replace('_', '-', $string);
         }
 
-        return $methodUri;
+        return $string;
     }
 
     /**

--- a/system/Config/Routing.php
+++ b/system/Config/Routing.php
@@ -123,6 +123,8 @@ class Routing extends BaseConfig
      * Whether to translate dashes in URIs for controller/method to CamelCase.
      * E.g., blog-controller -> BlogController
      *
+     * If you enable this, $translateURIDashes is ignored.
+     *
      * Default: false
      */
     public bool $translateUriToCamelCase = false;

--- a/system/Config/Routing.php
+++ b/system/Config/Routing.php
@@ -117,4 +117,13 @@ class Routing extends BaseConfig
      * @var array [ uri_segment => namespace ]
      */
     public array $moduleRoutes = [];
+
+    /**
+     * For Auto Routing (Improved).
+     * Whether to translate dashes in URIs for controller/method to CamelCase.
+     * E.g., blog-controller -> BlogController
+     *
+     * Default: false
+     */
+    public bool $translateUriToCamelCase = false;
 }

--- a/system/Config/Routing.php
+++ b/system/Config/Routing.php
@@ -19,6 +19,7 @@ namespace CodeIgniter\Config;
 class Routing extends BaseConfig
 {
     /**
+     * For Defined Routes.
      * An array of files that contain route definitions.
      * Route files are read in order, with the first match
      * found taking precedence.
@@ -30,6 +31,7 @@ class Routing extends BaseConfig
     ];
 
     /**
+     * For Defined Routes and Auto Routing.
      * The default namespace to use for Controllers when no other
      * namespace has been specified.
      *
@@ -38,6 +40,7 @@ class Routing extends BaseConfig
     public string $defaultNamespace = 'App\Controllers';
 
     /**
+     * For Auto Routing.
      * The default controller to use when no other controller has been
      * specified.
      *
@@ -46,6 +49,7 @@ class Routing extends BaseConfig
     public string $defaultController = 'Home';
 
     /**
+     * For Defined Routes and Auto Routing.
      * The default method to call on the controller when no other
      * method has been set in the route.
      *
@@ -54,7 +58,8 @@ class Routing extends BaseConfig
     public string $defaultMethod = 'index';
 
     /**
-     * Whether to translate dashes in URIs to underscores.
+     * For Auto Routing.
+     * Whether to translate dashes in URIs for controller/method to underscores.
      * Primarily useful when using the auto-routing.
      *
      * Default: false
@@ -91,6 +96,7 @@ class Routing extends BaseConfig
     public bool $autoRoute = false;
 
     /**
+     * For Defined Routes.
      * If TRUE, will enable the use of the 'prioritize' option
      * when defining routes.
      *
@@ -99,7 +105,8 @@ class Routing extends BaseConfig
     public bool $prioritize = false;
 
     /**
-     * Map of URI segments and namespaces. For Auto Routing (Improved).
+     * For Auto Routing (Improved).
+     * Map of URI segments and namespaces.
      *
      * The key is the first URI segment. The value is the controller namespace.
      * E.g.,

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -77,6 +77,19 @@ final class AutoRouterImproved implements AutoRouterInterface
     private string $defaultMethod;
 
     /**
+     * Map of URI segments and namespaces.
+     *
+     * The key is the first URI segment. The value is the controller namespace.
+     * E.g.,
+     *   [
+     *       'blog' => 'Acme\Blog\Controllers',
+     *   ]
+     *
+     * @var array [ uri_segment => namespace ]
+     */
+    private array $moduleRoutes;
+
+    /**
      * The URI segments.
      *
      * @var list<string>
@@ -118,6 +131,8 @@ final class AutoRouterImproved implements AutoRouterInterface
         $this->defaultController    = $defaultController;
         $this->defaultMethod        = $defaultMethod;
 
+        $routingConfig                 = config(Routing::class);
+        $this->moduleRoutes            = $routingConfig->moduleRoutes;
         // Set the default values
         $this->controller = $this->defaultController;
     }
@@ -259,11 +274,10 @@ final class AutoRouterImproved implements AutoRouterInterface
         // Check for Module Routes.
         if (
             $this->segments !== []
-            && ($routingConfig = config(Routing::class))
-            && array_key_exists($this->segments[0], $routingConfig->moduleRoutes)
+            && array_key_exists($this->segments[0], $this->moduleRoutes)
         ) {
             $uriSegment      = array_shift($this->segments);
-            $this->namespace = rtrim($routingConfig->moduleRoutes[$uriSegment], '\\');
+            $this->namespace = rtrim($this->moduleRoutes[$uriSegment], '\\');
         }
 
         if ($this->searchFirstController()) {

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -115,6 +115,11 @@ final class AutoRouterImproved implements AutoRouterInterface
     private ?int $paramPos = null;
 
     /**
+     * The current URI
+     */
+    private ?string $uri = null;
+
+    /**
      * @param class-string[] $protectedControllers
      * @param string         $defaultController    Short classname
      */
@@ -261,7 +266,8 @@ final class AutoRouterImproved implements AutoRouterInterface
      */
     public function getRoute(string $uri, string $httpVerb): array
     {
-        $httpVerb = strtolower($httpVerb);
+        $this->uri = $uri;
+        $httpVerb  = strtolower($httpVerb);
 
         // Reset Controller method params.
         $this->params = [];
@@ -354,11 +360,11 @@ final class AutoRouterImproved implements AutoRouterInterface
 
         // Ensure the URI segments for the controller and method do not contain
         // underscores when $translateURIDashes is true.
-        $this->checkUnderscore($uri);
+        $this->checkUnderscore();
 
         // Check parameter count
         try {
-            $this->checkParameters($uri);
+            $this->checkParameters();
         } catch (MethodNotFoundException $e) {
             throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
         }
@@ -422,7 +428,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         }
     }
 
-    private function checkParameters(string $uri): void
+    private function checkParameters(): void
     {
         try {
             $refClass = new ReflectionClass($this->controller);
@@ -445,7 +451,7 @@ final class AutoRouterImproved implements AutoRouterInterface
             throw new PageNotFoundException(
                 'The param count in the URI are greater than the controller method params.'
                 . ' Handler:' . $this->controller . '::' . $this->method
-                . ', URI:' . $uri
+                . ', URI:' . $this->uri
             );
         }
     }
@@ -465,7 +471,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         }
     }
 
-    private function checkUnderscore(string $uri): void
+    private function checkUnderscore(): void
     {
         if ($this->translateURIDashes === false) {
             return;
@@ -481,7 +487,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                     . ' when $translateURIDashes is enabled.'
                     . ' Please use the dash.'
                     . ' Handler:' . $this->controller . '::' . $this->method
-                    . ', URI:' . $uri
+                    . ', URI:' . $this->uri
                 );
             }
         }

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Dash_folder\Dash_controller;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home;
+use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\SubDir\BlogController;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Routing;
@@ -101,6 +102,41 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
                 'params'       => [
                     'p1' => true,
                     'p2' => false,
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $routes);
+    }
+
+    public function testReadTranslateUriToCamelCase(): void
+    {
+        $config                          = config(Routing::class);
+        $config->translateUriToCamelCase = true;
+        Factories::injectMock('config', Routing::class, $config);
+
+        $reader = $this->createControllerMethodReader(
+            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers'
+        );
+
+        $routes = $reader->read(BlogController::class);
+
+        $expected = [
+            0 => [
+                'method'       => 'get',
+                'route'        => 'sub-dir/blog-controller',
+                'route_params' => '',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\SubDir\BlogController::getIndex',
+                'params'       => [
+                ],
+            ],
+            [
+                'method'       => 'get',
+                'route'        => 'sub-dir/blog-controller/some-method',
+                'route_params' => '[/..]',
+                'handler'      => '\CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\SubDir\BlogController::getSomeMethod',
+                'params'       => [
+                    'first' => false,
                 ],
             ],
         ];

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/SubDir/BlogController.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/Controllers/SubDir/BlogController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\SubDir;
+
+use CodeIgniter\Controller;
+
+class BlogController extends Controller
+{
+    public function getIndex(): void
+    {
+    }
+
+    public function getSomeMethod($first = ''): void
+    {
+    }
+}

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Method;
+use CodeIgniter\Router\Controllers\BlogController;
 use CodeIgniter\Router\Controllers\Dash_folder\Dash_controller;
 use CodeIgniter\Router\Controllers\Dash_folder\Home;
 use CodeIgniter\Router\Controllers\Index;
@@ -455,5 +456,110 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('\\' . Mycontroller::class, $controller);
         $this->assertSame('getSomemethod', $method);
         $this->assertSame(['a-b'], $params);
+    }
+
+    /**
+     * @dataProvider provideTranslateUriToCamelCase
+     */
+    public function testTranslateUriToCamelCase(
+        string $uri,
+        ?string $expDirectory,
+        string $expController,
+        string $expMethod,
+        int $controllerPos,
+        ?int $methodPos,
+        ?int $paramPos
+    ) {
+        $config                          = config(Routing::class);
+        $config->translateUriToCamelCase = true;
+        Factories::injectMock('config', Routing::class, $config);
+
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute($uri, Method::GET);
+
+        $this->assertSame($expDirectory, $directory);
+        $this->assertSame($expController, $controller);
+        $this->assertSame($expMethod, $method);
+        $this->assertSame([], $params);
+        $this->assertSame([
+            'controller' => $controllerPos,
+            'method'     => $methodPos,
+            'params'     => $paramPos,
+        ], $router->getPos());
+    }
+
+    public static function provideTranslateUriToCamelCase(): iterable
+    {
+        yield from [
+            'controller-wz-dash' => [
+                'blog-controller',
+                null,
+                '\\' . BlogController::class,
+                'getIndex',
+                0,
+                null,
+                null,
+            ],
+            'controller-and-method-wz-dash' => [
+                'blog-controller/some-method',
+                null,
+                '\\' . BlogController::class,
+                'getSomeMethod',
+                0,
+                1,
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideRejectTranslateUriToCamelCase
+     */
+    public function testRejectTranslateUriToCamelCase(string $uri, string $expMsg)
+    {
+        $this->expectException(PageNotFoundException::class);
+        $this->expectExceptionMessage(
+            $expMsg
+        );
+
+        $config                          = config(Routing::class);
+        $config->translateUriToCamelCase = true;
+        Factories::injectMock('config', Routing::class, $config);
+
+        $router = $this->createNewAutoRouter();
+
+        $router->getRoute($uri, Method::GET);
+    }
+
+    public static function provideRejectTranslateUriToCamelCase(): iterable
+    {
+        yield from [
+            'controller-wo-dash' => [
+                'blogcontroller',
+                '"\CodeIgniter\Router\Controllers\Blogcontroller" is not found.',
+            ],
+            'controller-wz-double-dash' => [
+                'blog--controller',
+                'AutoRouterImproved prohibits access to the URI containing double dash ("blog--controller") when $translateUriToCamelCase is enabled. Please use the single dash. URI:blog--controller',
+            ],
+            'controller-wz-uppercase' => [
+                'blogController',
+                'AutoRouterImproved prohibits access to the URI containing uppercase letters ("blogController") when $translateUriToCamelCase is enabled. Please use the dash. URI:blogController',
+            ],
+            'method-wo-dash' => [
+                'blog-controller/somemethod',
+                '"\CodeIgniter\Router\Controllers\BlogController::getSomemethod()" is not found.',
+            ],
+            'method-wz-uppercase' => [
+                'blog-controller/someMethod',
+                'AutoRouterImproved prohibits access to the URI containing uppercase letters ("someMethod") when $translateUriToCamelCase is enabled. Please use the dash. URI:blog-controller/someMethod',
+            ],
+            'method-wz-double-dash' => [
+                'blog-controller/some--method',
+                'AutoRouterImproved prohibits access to the URI containing double dash ("some--method") when $translateUriToCamelCase is enabled. Please use the single dash. URI:blog-controller/some--method',
+            ],
+        ];
     }
 }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -511,6 +511,24 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
                 1,
                 null,
             ],
+            'subfolder-controller-and-method-wz-dash' => [
+                'subfolder/sub/blog-controller/some-method',
+                'Subfolder/Sub/',
+                '\CodeIgniter\Router\Controllers\Subfolder\Sub\BlogController',
+                'getSomeMethod',
+                2,
+                3,
+                null,
+            ],
+            'subfolder-wz-dash-controller-and-method-wz-dash' => [
+                'sub-dir/blog-controller/some-method',
+                'SubDir/',
+                '\CodeIgniter\Router\Controllers\SubDir\BlogController',
+                'getSomeMethod',
+                1,
+                2,
+                null,
+            ],
         ];
     }
 

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -514,7 +514,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             'subfolder-controller-and-method-wz-dash' => [
                 'subfolder/sub/blog-controller/some-method',
                 'Subfolder/Sub/',
-                '\CodeIgniter\Router\Controllers\Subfolder\Sub\BlogController',
+                '\\' . \CodeIgniter\Router\Controllers\Subfolder\Sub\BlogController::class,
                 'getSomeMethod',
                 2,
                 3,
@@ -523,7 +523,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             'subfolder-wz-dash-controller-and-method-wz-dash' => [
                 'sub-dir/blog-controller/some-method',
                 'SubDir/',
-                '\CodeIgniter\Router\Controllers\SubDir\BlogController',
+                '\\' . \CodeIgniter\Router\Controllers\SubDir\BlogController::class,
                 'getSomeMethod',
                 1,
                 2,

--- a/tests/system/Router/Controllers/BlogController.php
+++ b/tests/system/Router/Controllers/BlogController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers;
+
+use CodeIgniter\Controller;
+
+class BlogController extends Controller
+{
+    public function getIndex(): void
+    {
+    }
+
+    public function getSomeMethod($first = ''): void
+    {
+    }
+}

--- a/tests/system/Router/Controllers/SubDir/BlogController.php
+++ b/tests/system/Router/Controllers/SubDir/BlogController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers\SubDir;
+
+use CodeIgniter\Controller;
+
+class BlogController extends Controller
+{
+    public function getIndex(): void
+    {
+    }
+
+    public function getSomeMethod($first = ''): void
+    {
+    }
+}

--- a/tests/system/Router/Controllers/Subfolder/Sub/BlogController.php
+++ b/tests/system/Router/Controllers/Subfolder/Sub/BlogController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Router\Controllers\Subfolder\Sub;
+
+use CodeIgniter\Controller;
+
+class BlogController extends Controller
+{
+    public function getIndex(): void
+    {
+    }
+
+    public function getSomeMethod($first = ''): void
+    {
+    }
+}

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -305,6 +305,9 @@ The benchmark points have been changed:
 Others
 ======
 
+- **AutoRouting Improved:** The ``$translateUriToCamelCase`` option has been added
+  that allows using CamelCase controller and method names. See
+  :ref:`controller-translate-uri-to-camelcase`.
 - **Autoloader:**
     - Autoloading performance when using Composer has been improved.
       Adding the ``App`` namespace in the ``autoload.psr4`` setting in **composer.json**

--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -218,6 +218,10 @@ Then save the file to your **app/Controllers** directory.
 
 .. important:: The file must be called **Helloworld.php**, with a capital ``H``. When you use Auto Routing, Controller class names MUST start with an uppercase letter and ONLY the first character can be uppercase.
 
+    Since v4.5.0, if you enable the ``$translateUriToCamelCase`` option, you can
+    use CamelCase classnames. See :ref:`controller-translate-uri-to-camelcase`
+    for details.
+
 .. important:: A controller method that will be executed by Auto Routing (Improved) needs HTTP verb (``get``, ``post``, ``put``, etc.) prefix like ``getIndex()``, ``postCreate()``.
 
 Now visit your site using a URL similar to this::
@@ -239,6 +243,10 @@ This is **not** valid:
 This is **not** valid:
 
 .. literalinclude:: controllers/011.php
+
+.. note:: Since v4.5.0, if you enable the ``$translateUriToCamelCase`` option,
+    you can use CamelCase classnames like above. See
+    :ref:`controller-translate-uri-to-camelcase` for details.
 
 Also, always make sure your controller extends the parent controller
 class so that it can inherit all its methods.
@@ -398,6 +406,10 @@ and place your controller classes within them.
 
 .. important:: Directory names MUST start with an uppercase letter and ONLY the first character can be uppercase.
 
+    Since v4.5.0, if you enable the ``$translateUriToCamelCase`` option, you can
+    use CamelCase directory names. See :ref:`controller-translate-uri-to-camelcase`
+    for details.
+
 When using this feature the first segment of your URI must
 specify the directory. For example, let's say you have a controller located here::
 
@@ -418,6 +430,34 @@ in there that matches the name of your default controller as specified in
 your **app/Config/Routes.php** file.
 
 CodeIgniter also permits you to map your URIs using its :ref:`Defined Route Routing <defined-route-routing>`..
+
+.. _controller-translate-uri-to-camelcase:
+
+Translate URI To CamelCase
+==========================
+
+.. versionadded:: 4.5.0
+
+Since v4.5.0, the ``$translateUriToCamelCase`` option has been implemented,
+which works well with the current CodeIgniter's coding standards.
+
+This option enables you to automatically translate URI with dashes (``-``) to
+CamelCase in the controller and method URI segments.
+
+For example, the URI ``sub-dir/hello-controller/some-method`` will execute the
+``SubDir\HelloController::getSomeMethod()`` method.
+
+.. note:: When this option is enabled, the ``$translateURIDashes`` option is
+    ignored.
+
+Enable Translate URI To CamelCase
+---------------------------------
+
+To enable it, you need to change the setting ``$translateUriToCamelCase`` option
+to ``true`` in **app/Config/Routing.php**::
+
+    public bool $translateUriToCamelCase = true;
+
 
 .. _controller-auto-routing-legacy:
 


### PR DESCRIPTION
**Description**
This PR adds an option to translate URI dashes to CamelCase controller and method names.

For example, the URI `sub-dir/hello-controller/some-method` will execute the `SubDir\HelloController::getSomeMethod()` method.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
