### PR TITLE
fix: [Session] Redis session race condition

### DIFF
--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -176,7 +176,7 @@ class RedisHandler extends BaseHandler
             return $data;
         }
 
-        return '';
+        return false;
     }
 
     /**

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -124,12 +124,20 @@ class RedisHandler extends BaseHandler
 
         $redis = new Redis();
 
-        if (! $redis->connect($this->savePath['protocol'] . '://' . $this->savePath['host'], ($this->savePath['host'][0] === '/' ? 0 : $this->savePath['port']), $this->savePath['timeout'])) {
+        if (
+            ! $redis->connect(
+                $this->savePath['protocol'] . '://' . $this->savePath['host'],
+                ($this->savePath['host'][0] === '/' ? 0 : $this->savePath['port']),
+                $this->savePath['timeout']
+            )
+        ) {
             $this->logger->error('Session: Unable to connect to Redis with the configured settings.');
         } elseif (isset($this->savePath['password']) && ! $redis->auth($this->savePath['password'])) {
             $this->logger->error('Session: Unable to authenticate to Redis instance.');
         } elseif (isset($this->savePath['database']) && ! $redis->select($this->savePath['database'])) {
-            $this->logger->error('Session: Unable to select Redis database with index ' . $this->savePath['database']);
+            $this->logger->error(
+                'Session: Unable to select Redis database with index ' . $this->savePath['database']
+            );
         } else {
             $this->redis = $redis;
 
@@ -251,7 +259,9 @@ class RedisHandler extends BaseHandler
     {
         if (isset($this->redis, $this->lockKey)) {
             if (($result = $this->redis->del($this->keyPrefix . $id)) !== 1) {
-                $this->logger->debug('Session: Redis::del() expected to return 1, got ' . var_export($result, true) . ' instead.');
+                $this->logger->debug(
+                    'Session: Redis::del() expected to return 1, got ' . var_export($result, true) . ' instead.'
+                );
             }
 
             return $this->destroyCookie();
@@ -303,7 +313,9 @@ class RedisHandler extends BaseHandler
             }
 
             if (! $this->redis->setex($lockKey, 300, (string) Time::now()->getTimestamp())) {
-                $this->logger->error('Session: Error while trying to obtain lock for ' . $this->keyPrefix . $sessionID);
+                $this->logger->error(
+                    'Session: Error while trying to obtain lock for ' . $this->keyPrefix . $sessionID
+                );
 
                 return false;
             }
@@ -313,13 +325,19 @@ class RedisHandler extends BaseHandler
         } while (++$attempt < 30);
 
         if ($attempt === 30) {
-            log_message('error', 'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.');
+            log_message(
+                'error',
+                'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.'
+            );
 
             return false;
         }
 
         if ($ttl === -1) {
-            log_message('debug', 'Session: Lock for ' . $this->keyPrefix . $sessionID . ' had no TTL, overriding.');
+            log_message(
+                'debug',
+                'Session: Lock for ' . $this->keyPrefix . $sessionID . ' had no TTL, overriding.'
+            );
         }
 
         $this->lock = true;

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -325,8 +325,7 @@ class RedisHandler extends BaseHandler
         } while (++$attempt < 30);
 
         if ($attempt === 30) {
-            log_message(
-                'error',
+            $this->logger->error(
                 'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.'
             );
 
@@ -334,8 +333,7 @@ class RedisHandler extends BaseHandler
         }
 
         if ($ttl === -1) {
-            log_message(
-                'debug',
+            $this->logger->debug(
                 'Session: Lock for ' . $this->keyPrefix . $sessionID . ' had no TTL, overriding.'
             );
         }

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -231,7 +231,9 @@ class RedisHandler extends BaseHandler
 
                 if (($pingReply === true) || ($pingReply === '+PONG')) {
                     if (isset($this->lockKey)) {
-                        $this->releaseLock();
+                        if (! $this->releaseLock()) {
+                            return false;
+                        }
                     }
 
                     if (! $this->redis->close()) {

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -230,10 +230,8 @@ class RedisHandler extends BaseHandler
                 $pingReply = $this->redis->ping();
 
                 if (($pingReply === true) || ($pingReply === '+PONG')) {
-                    if (isset($this->lockKey)) {
-                        if (! $this->releaseLock()) {
-                            return false;
-                        }
+                    if (isset($this->lockKey) && ! $this->releaseLock()) {
+                        return false;
                     }
 
                     if (! $this->redis->close()) {

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -115,6 +115,8 @@ class RedisHandler extends BaseHandler
      *
      * @param string $path The path where to store/retrieve the session
      * @param string $name The session name
+     *
+     * @throws RedisException
      */
     public function open($path, $name): bool
     {
@@ -154,6 +156,8 @@ class RedisHandler extends BaseHandler
      *
      * @return false|string Returns an encoded string of the read data.
      *                      If nothing was read, it must return false.
+     *
+     * @throws RedisException
      */
     #[ReturnTypeWillChange]
     public function read($id)
@@ -184,6 +188,8 @@ class RedisHandler extends BaseHandler
      *
      * @param string $id   The session ID
      * @param string $data The encoded session data
+     *
+     * @throws RedisException
      */
     public function write($id, $data): bool
     {
@@ -254,6 +260,8 @@ class RedisHandler extends BaseHandler
      * Destroys a session
      *
      * @param string $id The session ID being destroyed
+     *
+     * @throws RedisException
      */
     public function destroy($id): bool
     {
@@ -288,6 +296,8 @@ class RedisHandler extends BaseHandler
      * Acquires an emulated lock.
      *
      * @param string $sessionID Session ID
+     *
+     * @throws RedisException
      */
     protected function lockSession(string $sessionID): bool
     {
@@ -338,6 +348,8 @@ class RedisHandler extends BaseHandler
 
     /**
      * Releases a previously acquired lock
+     *
+     * @throws RedisException
      */
     protected function releaseLock(): bool
     {


### PR DESCRIPTION
**Description**
Fixes #4391
Fixes #8567

- fix Redis Session race condition
- fix that `close()` does not return `false` if `releaseLock()` failed
- fix that `read()` does not return `false` if `lockSession()` failed

### Testing

- macOS 12.7.2
- PHP 8.2.16
- symfony CLI version 5.7.4
- Redis 7.2.4

```diff
--- a/app/Config/Session.php
+++ b/app/Config/Session.php
@@ -4,7 +4,6 @@ namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Session\Handlers\BaseHandler;
-use CodeIgniter\Session\Handlers\FileHandler;
 
 class Session extends BaseConfig
 {
@@ -21,7 +20,7 @@ class Session extends BaseConfig
      *
      * @var class-string<BaseHandler>
      */
-    public string $driver = FileHandler::class;
+    public string $driver = 'CodeIgniter\Session\Handlers\RedisHandler';
 
     /**
      * --------------------------------------------------------------------------
@@ -57,7 +56,7 @@ class Session extends BaseConfig
      *
      * IMPORTANT: You are REQUIRED to set a valid save path!
      */
-    public string $savePath = WRITEPATH . 'session';
+    public string $savePath = 'tcp://localhost:6379';
 
     /**
      * --------------------------------------------------------------------------
diff --git a/app/Controllers/Home.php b/app/Controllers/Home.php
index 5934333309..bdf121cce1 100644
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -4,8 +4,16 @@ namespace App\Controllers;
 
 class Home extends BaseController
 {
-    public function index(): string
+    public function index()
     {
-        return view('welcome_message');
+        $session = session();
+
+        var_dump($_SESSION);
+
+        $count = $session->get('count') ?? 0;
+        $count++;
+        $session->set('count', $count);
+
+        var_dump($_SESSION);
     }
 }
```

I have tested by `ab -n 1000 -c 20`.

Results:
```
develop:
Requests per second:    43.53 [#/sec] (mean)
Error while trying to free lock: 2

This PR:
Requests per second:    46.98 [#/sec] (mean)
Error while trying to free lock: 0
```

<details>

develop:
```
$ ab -n 1000 -c 20 -C 'ci_session=j8egao4miu36k4erouc0b0a2s1aagnbr' http://localhost:8000/
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        
Server Hostname:        localhost
Server Port:            8000

Document Path:          /
Document Length:        22431 bytes

Concurrency Level:      20
Time taken for tests:   22.974 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      22709000 bytes
HTML transferred:       22431000 bytes
Requests per second:    43.53 [#/sec] (mean)
Time per request:       459.486 [ms] (mean)
Time per request:       22.974 [ms] (mean, across all concurrent requests)
Transfer rate:          965.29 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.4      0       5
Processing:    52  439 362.5    345    3445
Waiting:       50  438 362.5    345    3445
Total:         52  439 362.5    346    3446

Percentage of the requests served within a certain time (ms)
  50%    346
  66%    362
  75%    377
  80%    403
  90%    478
  95%   1322
  98%   1496
  99%   2353
 100%   3446 (longest request)
```
```
ERROR - 2024-02-22 03:59:55 --> Session: Error while trying to free lock for ci_session:ci_session:j8egao4miu36k4erouc0b0a2s1aagnbr:lock
ERROR - 2024-02-22 03:59:58 --> Session: Error while trying to free lock for ci_session:ci_session:j8egao4miu36k4erouc0b0a2s1aagnbr:lock
```

This PR:
```
$ ab -n 1000 -c 20 -C 'ci_session=j8egao4miu36k4erouc0b0a2s1aagnbr' http://localhost:8000/
This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        
Server Hostname:        localhost
Server Port:            8000

Document Path:          /
Document Length:        22431 bytes

Concurrency Level:      20
Time taken for tests:   21.285 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      22709000 bytes
HTML transferred:       22431000 bytes
Requests per second:    46.98 [#/sec] (mean)
Time per request:       425.692 [ms] (mean)
Time per request:       21.285 [ms] (mean, across all concurrent requests)
Transfer rate:          1041.91 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.4      0       5
Processing:    68  421 155.4    374    1967
Waiting:       66  420 155.4    374    1967
Total:         68  421 155.4    375    1967

Percentage of the requests served within a certain time (ms)
  50%    375
  66%    425
  75%    465
  80%    491
  90%    604
  95%    727
  98%    872
  99%    955
 100%   1967 (longest request)
```
</details>

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
