### PR TITLE
feat: add EntityInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@
 * refactor: Table class to fix phpstan errors by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8402
 * fix: typo in pager default_simple by @jasonliang-dev in https://github.com/codeigniter4/CodeIgniter4/pull/8407
 * refactor: improve Forge variable names by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8434
-* refactor: update entity to use interface for better extensibility by @colethorsen in https://github.com/codeigniter4/CodeIgniter4/pull/8325
 
 
 ## [v4.4.4](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.4) (2023-12-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@
 * fix: typo in pager default_simple by @jasonliang-dev in https://github.com/codeigniter4/CodeIgniter4/pull/8407
 * refactor: improve Forge variable names by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8434
 
-
 ## [v4.4.4](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.4) (2023-12-28)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.3...v4.4.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 * refactor: Table class to fix phpstan errors by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8402
 * fix: typo in pager default_simple by @jasonliang-dev in https://github.com/codeigniter4/CodeIgniter4/pull/8407
 * refactor: improve Forge variable names by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8434
+* refactor: update entity to use interface for better extensibility by @colethorsen in https://github.com/codeigniter4/CodeIgniter4/pull/8325
+
 
 ## [v4.4.4](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.4) (2023-12-28)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.3...v4.4.4)

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -20,7 +20,7 @@ use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\Query;
 use CodeIgniter\DataConverter\DataConverter;
-use CodeIgniter\Entity\Entity;
+use CodeIgniter\Entity\EntityInterface;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
@@ -1796,7 +1796,7 @@ abstract class BaseModel
     protected function objectToRawArray($object, bool $onlyChanged = true, bool $recursive = false): array
     {
         // Entity::toRawArray() returns array.
-        if (method_exists($object, 'toRawArray')) {
+        if ($object instanceof EntityInterface) {
             $properties = $object->toRawArray($onlyChanged, $recursive);
         } else {
             $mirror = new ReflectionClass($object);

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use CodeIgniter\Entity\Entity;
+use CodeIgniter\Entity\EntityInterface;
 use stdClass;
 
 /**
@@ -159,7 +159,7 @@ abstract class BaseResult implements ResultInterface
         $this->customResultObject[$className] = [];
 
         while ($row = $this->fetchObject($className)) {
-            if (! is_subclass_of($row, Entity::class) && method_exists($row, 'syncOriginal')) {
+            if (! is_subclass_of($row, EntityInterface::class) && method_exists($row, 'syncOriginal')) {
                 $row->syncOriginal();
             }
 
@@ -240,7 +240,7 @@ abstract class BaseResult implements ResultInterface
         }
 
         while ($row = $this->fetchObject()) {
-            if (! is_subclass_of($row, Entity::class) && method_exists($row, 'syncOriginal')) {
+            if (! is_subclass_of($row, EntityInterface::class) && method_exists($row, 'syncOriginal')) {
                 $row->syncOriginal();
             }
 
@@ -539,7 +539,7 @@ abstract class BaseResult implements ResultInterface
      *
      * Overridden by child classes.
      *
-     * @return Entity|false|object|stdClass
+     * @return EntityInterface|false|object|stdClass
      */
     abstract protected function fetchObject(string $className = 'stdClass');
 }

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseResult;
-use CodeIgniter\Entity\Entity;
+use CodeIgniter\Entity\EntityInterface;
 use mysqli;
 use mysqli_result;
 use stdClass;
@@ -149,7 +149,7 @@ class Result extends BaseResult
      */
     protected function fetchObject(string $className = 'stdClass')
     {
-        if (is_subclass_of($className, Entity::class)) {
+        if (is_subclass_of($className, EntityInterface::class)) {
             return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 

--- a/system/Database/MySQLi/Result.php
+++ b/system/Database/MySQLi/Result.php
@@ -145,7 +145,7 @@ class Result extends BaseResult
      *
      * Overridden by child classes.
      *
-     * @return Entity|false|object|stdClass
+     * @return EntityInterface|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\OCI8;
 
 use CodeIgniter\Database\BaseResult;
-use CodeIgniter\Entity\Entity;
+use CodeIgniter\Entity\EntityInterface;
 use stdClass;
 
 /**
@@ -104,7 +104,7 @@ class Result extends BaseResult
         if ($className === 'stdClass' || ! $row) {
             return $row;
         }
-        if (is_subclass_of($className, Entity::class)) {
+        if (is_subclass_of($className, EntityInterface::class)) {
             return (new $className())->injectRawData((array) $row);
         }
 

--- a/system/Database/OCI8/Result.php
+++ b/system/Database/OCI8/Result.php
@@ -95,7 +95,7 @@ class Result extends BaseResult
      *
      * Overridden by child classes.
      *
-     * @return Entity|false|object|stdClass
+     * @return EntityInterface|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -111,7 +111,7 @@ class Result extends BaseResult
      *
      * Overridden by child classes.
      *
-     * @return Entity|false|object|stdClass
+     * @return EntityInterface|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/Postgre/Result.php
+++ b/system/Database/Postgre/Result.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\Postgre;
 
 use CodeIgniter\Database\BaseResult;
-use CodeIgniter\Entity\Entity;
+use CodeIgniter\Entity\EntityInterface;
 use PgSql\Connection as PgSqlConnection;
 use PgSql\Result as PgSqlResult;
 use stdClass;
@@ -115,7 +115,7 @@ class Result extends BaseResult
      */
     protected function fetchObject(string $className = 'stdClass')
     {
-        if (is_subclass_of($className, Entity::class)) {
+        if (is_subclass_of($className, EntityInterface::class)) {
             return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -151,7 +151,7 @@ class Result extends BaseResult
     /**
      * Returns the result set as an object.
      *
-     * @return Entity|false|object|stdClass
+     * @return EntityInterface|false|object|stdClass
      */
     protected function fetchObject(string $className = 'stdClass')
     {

--- a/system/Database/SQLSRV/Result.php
+++ b/system/Database/SQLSRV/Result.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\SQLSRV;
 
 use CodeIgniter\Database\BaseResult;
-use CodeIgniter\Entity\Entity;
+use CodeIgniter\Entity\EntityInterface;
 use stdClass;
 
 /**
@@ -155,7 +155,7 @@ class Result extends BaseResult
      */
     protected function fetchObject(string $className = 'stdClass')
     {
-        if (is_subclass_of($className, Entity::class)) {
+        if (is_subclass_of($className, EntityInterface::class)) {
             return empty($data = $this->fetchAssoc()) ? false : (new $className())->injectRawData($data);
         }
 

--- a/system/Database/SQLite3/Result.php
+++ b/system/Database/SQLite3/Result.php
@@ -16,7 +16,7 @@ namespace CodeIgniter\Database\SQLite3;
 use Closure;
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use CodeIgniter\Entity\Entity;
+use CodeIgniter\Entity\EntityInterface;
 use SQLite3;
 use SQLite3Result;
 use stdClass;
@@ -143,7 +143,7 @@ class Result extends BaseResult
 
         $classObj = new $className();
 
-        if (is_subclass_of($className, Entity::class)) {
+        if (is_subclass_of($className, EntityInterface::class)) {
             return $classObj->injectRawData($row);
         }
 

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -30,6 +30,7 @@ use CodeIgniter\Entity\Exceptions\CastException;
 use CodeIgniter\I18n\Time;
 use DateTime;
 use Exception;
+use JsonSerializable;
 use ReturnTypeWillChange;
 
 /**
@@ -37,7 +38,7 @@ use ReturnTypeWillChange;
  *
  * @see \CodeIgniter\Entity\EntityTest
  */
-class Entity implements EntityInterface
+class Entity implements EntityInterface, JsonSerializable
 {
     /**
      * Maps names used in sets and gets against unique

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -30,7 +30,6 @@ use CodeIgniter\Entity\Exceptions\CastException;
 use CodeIgniter\I18n\Time;
 use DateTime;
 use Exception;
-use JsonSerializable;
 use ReturnTypeWillChange;
 
 /**
@@ -38,7 +37,7 @@ use ReturnTypeWillChange;
  *
  * @see \CodeIgniter\Entity\EntityTest
  */
-class Entity implements JsonSerializable
+class Entity implements EntityInterface
 {
     /**
      * Maps names used in sets and gets against unique

--- a/system/Entity/EntityInterface.php
+++ b/system/Entity/EntityInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *

--- a/system/Entity/EntityInterface.php
+++ b/system/Entity/EntityInterface.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Entity;
+
+use Exception;
+use JsonSerializable;
+
+/**
+ * Entity encapsulation, for use with CodeIgniter\Model
+ *
+ * @see \CodeIgniter\Entity\EntityTest
+ */
+interface EntityInterface extends JsonSerializable
+{
+    /**
+     * Allows filling in Entity parameters during construction.
+     */
+    public function __construct(?array $data = null);
+
+    /**
+     * Takes an array of key/value pairs and sets them as class
+     * properties, using any `setCamelCasedProperty()` methods
+     * that may or may not exist.
+     *
+     * @param array<string, array|bool|float|int|object|string|null> $data
+     *
+     * @return $this
+     */
+    public function fill(?array $data = null);
+
+    /**
+     * General method that will return all public and protected values
+     * of this entity as an array. All values are accessed through the
+     * __get() magic method so will have any casts, etc applied to them.
+     *
+     * @param bool $onlyChanged If true, only return values that have changed since object creation
+     * @param bool $cast        If true, properties will be cast.
+     * @param bool $recursive   If true, inner entities will be cast as array as well.
+     */
+    public function toArray(bool $onlyChanged = false, bool $cast = true, bool $recursive = false): array;
+
+    /**
+     * Returns the raw values of the current attributes.
+     *
+     * @param bool $onlyChanged If true, only return values that have changed since object creation
+     * @param bool $recursive   If true, inner entities will be cast as array as well.
+     */
+    public function toRawArray(bool $onlyChanged = false, bool $recursive = false): array;
+
+    /**
+     * Ensures our "original" values match the current values.
+     *
+     * @return $this
+     */
+    public function syncOriginal();
+
+    /**
+     * Checks a property to see if it has changed since the entity
+     * was created. Or, without a parameter, checks if any
+     * properties have changed.
+     *
+     * @param string|null $key class property
+     */
+    public function hasChanged(?string $key = null): bool;
+
+    /**
+     * Set raw data array without any mutations
+     *
+     * @return $this
+     */
+    public function injectRawData(array $data);
+
+    /**
+     * Set raw data array without any mutations
+     *
+     * @return $this
+     *
+     * @deprecated Use injectRawData() instead.
+     */
+    public function setAttributes(array $data);
+
+    /**
+     * Change the value of the private $_cast property
+     *
+     * @return bool|Entity
+     */
+    public function cast(?bool $cast = null);
+
+    /**
+     * Magic method to all protected/private class properties to be
+     * easily set, either through a direct access or a
+     * `setCamelCasedProperty()` method.
+     *
+     * Examples:
+     *  $this->my_property = $p;
+     *  $this->setMyProperty() = $p;
+     *
+     * @param array|bool|float|int|object|string|null $value
+     *
+     * @return void
+     *
+     * @throws Exception
+     */
+    public function __set(string $key, $value = null);
+
+    /**
+     * Magic method to allow retrieval of protected and private class properties
+     * either by their name, or through a `getCamelCasedProperty()` method.
+     *
+     * Examples:
+     *  $p = $this->my_property
+     *  $p = $this->getMyProperty()
+     *
+     * @return array|bool|float|int|object|string|null
+     *
+     * @throws Exception
+     *
+     * @params string $key class property
+     */
+    public function __get(string $key);
+
+    /**
+     * Returns true if a property exists names $key, or a getter method
+     * exists named like for __get().
+     */
+    public function __isset(string $key): bool;
+
+    /**
+     * Unsets an attribute property.
+     */
+    public function __unset(string $key): void;
+}

--- a/system/Entity/EntityInterface.php
+++ b/system/Entity/EntityInterface.php
@@ -11,42 +11,17 @@
 
 namespace CodeIgniter\Entity;
 
-use Exception;
-use JsonSerializable;
-
 /**
  * Entity encapsulation, for use with CodeIgniter\Model
  *
  * @see \CodeIgniter\Entity\EntityTest
  */
-interface EntityInterface extends JsonSerializable
+interface EntityInterface
 {
     /**
      * Allows filling in Entity parameters during construction.
      */
     public function __construct(?array $data = null);
-
-    /**
-     * Takes an array of key/value pairs and sets them as class
-     * properties, using any `setCamelCasedProperty()` methods
-     * that may or may not exist.
-     *
-     * @param array<string, array|bool|float|int|object|string|null> $data
-     *
-     * @return $this
-     */
-    public function fill(?array $data = null);
-
-    /**
-     * General method that will return all public and protected values
-     * of this entity as an array. All values are accessed through the
-     * __get() magic method so will have any casts, etc applied to them.
-     *
-     * @param bool $onlyChanged If true, only return values that have changed since object creation
-     * @param bool $cast        If true, properties will be cast.
-     * @param bool $recursive   If true, inner entities will be cast as array as well.
-     */
-    public function toArray(bool $onlyChanged = false, bool $cast = true, bool $recursive = false): array;
 
     /**
      * Returns the raw values of the current attributes.
@@ -57,85 +32,9 @@ interface EntityInterface extends JsonSerializable
     public function toRawArray(bool $onlyChanged = false, bool $recursive = false): array;
 
     /**
-     * Ensures our "original" values match the current values.
-     *
-     * @return $this
-     */
-    public function syncOriginal();
-
-    /**
-     * Checks a property to see if it has changed since the entity
-     * was created. Or, without a parameter, checks if any
-     * properties have changed.
-     *
-     * @param string|null $key class property
-     */
-    public function hasChanged(?string $key = null): bool;
-
-    /**
      * Set raw data array without any mutations
      *
      * @return $this
      */
     public function injectRawData(array $data);
-
-    /**
-     * Set raw data array without any mutations
-     *
-     * @return $this
-     *
-     * @deprecated Use injectRawData() instead.
-     */
-    public function setAttributes(array $data);
-
-    /**
-     * Change the value of the private $_cast property
-     *
-     * @return bool|Entity
-     */
-    public function cast(?bool $cast = null);
-
-    /**
-     * Magic method to all protected/private class properties to be
-     * easily set, either through a direct access or a
-     * `setCamelCasedProperty()` method.
-     *
-     * Examples:
-     *  $this->my_property = $p;
-     *  $this->setMyProperty() = $p;
-     *
-     * @param array|bool|float|int|object|string|null $value
-     *
-     * @return void
-     *
-     * @throws Exception
-     */
-    public function __set(string $key, $value = null);
-
-    /**
-     * Magic method to allow retrieval of protected and private class properties
-     * either by their name, or through a `getCamelCasedProperty()` method.
-     *
-     * Examples:
-     *  $p = $this->my_property
-     *  $p = $this->getMyProperty()
-     *
-     * @return array|bool|float|int|object|string|null
-     *
-     * @throws Exception
-     *
-     * @params string $key class property
-     */
-    public function __get(string $key);
-
-    /**
-     * Returns true if a property exists names $key, or a getter method
-     * exists named like for __get().
-     */
-    public function __isset(string $key): bool;
-
-    /**
-     * Unsets an attribute property.
-     */
-    public function __unset(string $key): void;
 }

--- a/system/Entity/EntityInterface.php
+++ b/system/Entity/EntityInterface.php
@@ -25,11 +25,15 @@ interface EntityInterface
      *
      * @param bool $onlyChanged If true, only return values that have changed since object creation
      * @param bool $recursive   If true, inner entities will be cast as array as well.
+     *
+     * @return array<string, mixed>
      */
     public function toRawArray(bool $onlyChanged = false, bool $recursive = false): array;
 
     /**
      * Set raw data array without any mutations
+     *
+     * @param array<string, mixed> $data
      *
      * @return $this
      */

--- a/system/Entity/EntityInterface.php
+++ b/system/Entity/EntityInterface.php
@@ -19,11 +19,6 @@ namespace CodeIgniter\Entity;
 interface EntityInterface
 {
     /**
-     * Allows filling in Entity parameters during construction.
-     */
-    public function __construct(?array $data = null);
-
-    /**
      * Returns the raw values of the current attributes.
      *
      * @param bool $onlyChanged If true, only return values that have changed since object creation

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -72,6 +72,9 @@ Forge
 Others
 ------
 
+- Update entity to use interface for better extensibility.
+
+
 Model
 =====
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -72,8 +72,10 @@ Forge
 Others
 ------
 
-- Update entity to use interface for better extensibility.
-
+- **Entity:**
+    - Added ``CodeIgniter\Entity\EntityInterface`` for better extensibility.
+    - Now ``Entity`` implements ``EntityInterface``.
+    - Now ``BaseModel`` and ``Result`` classes use ``EntityInterface`` instead of ``Entity``.
 
 Model
 =====


### PR DESCRIPTION
The main CodeIgniter entity couldn't be replaced with a custom one because the database drivers checked to see if entities were extensions of the entity itself and not an interface. Creating an interface allows for a completely new entity to implement the interface instead of having to extend the Entity itself.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
