### PR TITLE
docs: [Validation] Add explanation where to place custom validation rules error messages

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -760,9 +760,12 @@ a boolean true or false value signifying true if it passed the test or false if 
 
 .. literalinclude:: validation/034.php
 
-By default, the system will look within **system/Language/en/Validation.php** for the language strings used
-within errors. In custom rules, you may provide error messages by accepting a ``&$error`` variable by reference in the
-second parameter:
+By default, the system will look within **system/Language/en/Validation.php** for the language strings used within
+errors. To provide default error messages for your custom rules, you may place them in **app/Language/en/Validation.php**
+(and/or corresponding folder of locale you use in place of ``en``). Also, in case you want to use some other language
+string file in place of the default **Validation.php**, you may provide error messages by accepting an ``&$error``
+variable by reference in the second (or, in case your rule needs to work with parameters, as cescribed below – the
+fourth) parameter:
 
 .. literalinclude:: validation/035.php
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -764,7 +764,7 @@ By default, the system will look within **system/Language/en/Validation.php** fo
 errors. To provide default error messages for your custom rules, you may place them in **app/Language/en/Validation.php**
 (and/or corresponding folder of locale you use in place of ``en``). Also, in case you want to use some other language
 string file in place of the default **Validation.php**, you may provide error messages by accepting an ``&$error``
-variable by reference in the second (or, in case your rule needs to work with parameters, as cescribed below – the
+variable by reference in the second (or, in case your rule needs to work with parameters, as described below – the
 fourth) parameter:
 
 .. literalinclude:: validation/035.php


### PR DESCRIPTION
**Description**
Modified explanation where to place default error messages for custom validation rules, since current explanation was somewhat incomplete and misleading.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
