### PR TITLE
docs: fix Parser filter `default` explanation

### DIFF
--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -109,15 +109,20 @@ final class ParserFilterTest extends CIUnitTestCase
         $parser = new Parser($this->config, $this->viewsDir, $this->loader);
 
         $data = [
-            'value1' => null,
-            'value2' => 0,
-            'value3' => 'test',
+            'value1' => '',
+            'value2' => null,
+            'value3' => 0,
+            'value4' => 'test',
         ];
 
-        $template = '{ value1|default(foo) } { value2|default(bar) } { value3|default(baz) }';
+        $template = '{ value1|default(foo) } { value2|default(bar) } { value3|default(baz) }'
+                    . ' { value4|default(boo) } { undef|default(far) }';
 
         $parser->setData($data);
-        $this->assertSame('foo bar test', $parser->renderString($template));
+        $this->assertSame(
+            'foo bar baz test { undef|default(far) }',
+            $parser->renderString($template)
+        );
     }
 
     public function testEsc(): void

--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -371,8 +371,7 @@ date              format (Y-m-d)   A PHP **date**-compatible formatting string. 
 date_modify       value to add     A **strtotime** compatible string to modify the date,       { v|date_modify(+1 day) }
                   / subtract       like ``+5 day`` or ``-1 week``.
 
-default           default value    Displays the default value if the variable is empty or      { v|default(just in case) }
-                                   undefined.
+default           default value    Displays the default value if the variable is `empty()`_.   { v|default(just in case) }
 
 esc               html, attr,      Specifies the context to escape the data.                   { v|esc(attr) }
                   css, js
@@ -418,6 +417,8 @@ title                              Displays a "title case" version of the string
 
 upper                              Displays the string in all uppercase.                       { v|upper }
 ================ ================= =========================================================== ======================================
+
+.. _empty(): https://www.php.net/manual/en/function.empty.php
 
 See `PHP's NumberFormatter <https://www.php.net/manual/en/numberformatter.create.php>`_ for details relevant to the
 "local_number" filter.


### PR DESCRIPTION
**Description**
- fix docs
- add test cases

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
