### PR TITLE
feat: [Routing] add option to pass multiple URI segments to one Controller parameter

### DIFF
--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -105,6 +105,14 @@ class Routing extends BaseRouting
     public bool $prioritize = false;
 
     /**
+     * For Defined Routes.
+     * If TRUE, matched multiple URI segments will be passed as one parameter.
+     *
+     * Default: false
+     */
+    public bool $multipleSegmentsOneParam = false;
+
+    /**
      * For Auto Routing (Improved).
      * Map of URI segments and namespaces.
      *

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2193,7 +2193,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 3,
+	'count' => 2,
 	'path' => __DIR__ . '/system/Router/Router.php',
 ];
 $ignoreErrors[] = [

--- a/system/Config/Routing.php
+++ b/system/Config/Routing.php
@@ -105,6 +105,14 @@ class Routing extends BaseConfig
     public bool $prioritize = false;
 
     /**
+     * For Defined Routes.
+     * If TRUE, matched multiple URI segments will be passed as one parameter.
+     *
+     * Default: false
+     */
+    public bool $multipleSegmentsOneParam = false;
+
+    /**
      * For Auto Routing (Improved).
      * Map of URI segments and namespaces.
      *

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -387,7 +387,7 @@ class Router implements RouterInterface
         $routes = $this->collection->getRoutes($this->collection->getHTTPVerb());
 
         // Don't waste any time
-        if (empty($routes)) {
+        if ($routes === []) {
             return false;
         }
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -21,6 +21,7 @@ use CodeIgniter\HTTP\Request;
 use CodeIgniter\Router\Exceptions\RouterException;
 use Config\App;
 use Config\Feature;
+use Config\Routing;
 
 /**
  * Request router.
@@ -462,7 +463,12 @@ class Router implements RouterInterface
                     return true;
                 }
 
-                [$controller] = explode('::', $handler);
+                if (str_contains($handler, '::')) {
+                    [$controller, $methodAndParams] = explode('::', $handler);
+                } else {
+                    $controller      = $handler;
+                    $methodAndParams = '';
+                }
 
                 // Checks `/` in controller name
                 if (strpos($controller, '/') !== false) {
@@ -475,11 +481,29 @@ class Router implements RouterInterface
                         throw RouterException::forDynamicController($handler);
                     }
 
-                    // Using back-references
-                    $handler = preg_replace('#^' . $routeKey . '$#u', $handler, $uri);
+                    if (config(Routing::class)->multipleSegmentsOneParam === false) {
+                        // Using back-references
+                        $segments = explode('/', preg_replace('#^' . $routeKey . '$#u', $handler, $uri));
+                    } else {
+                        if (str_contains($methodAndParams, '/')) {
+                            [$method, $handlerParams] = explode('/', $methodAndParams, 2);
+                            $params                   = explode('/', $handlerParams);
+                            $handlerSegments          = array_merge([$controller . '::' . $method], $params);
+                        } else {
+                            $handlerSegments = [$handler];
+                        }
+
+                        $segments = [];
+
+                        foreach ($handlerSegments as $segment) {
+                            $segments[] = $this->replaceBackReferences($segment, $matches);
+                        }
+                    }
+                } else {
+                    $segments = explode('/', $handler);
                 }
 
-                $this->setRequest(explode('/', $handler));
+                $this->setRequest($segments);
 
                 $this->setMatchedRoute($matchedKey, $handler);
 
@@ -488,6 +512,24 @@ class Router implements RouterInterface
         }
 
         return false;
+    }
+
+    /**
+     * Replace string `$n` with `$matches[n]` value.
+     */
+    private function replaceBackReferences(string $input, array $matches): string
+    {
+        $pattern = '/\$([1-' . count($matches) . '])/u';
+
+        return preg_replace_callback(
+            $pattern,
+            static function ($match) use ($matches) {
+                $index = (int) $match[1];
+
+                return $matches[$index] ?? '';
+            },
+            $input
+        );
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -336,6 +336,10 @@ Others
 - **AutoRouting Improved:** The ``$translateUriToCamelCase`` option has been added
   that allows using CamelCase controller and method names. See
   :ref:`controller-translate-uri-to-camelcase`.
+- **Routing:** Added option ``$multipleSegmentsOneParam``. When this option is
+  enabled, a placeholder that matches multiple segments, such as ``(:any)``, will
+  be passed directly as it is to one parameter, even if it contains multiple segments.
+  See :ref:`multiple-uri-segments-as-one-parameter` for details.
 - **Autoloader:**
     - Autoloading performance when using Composer has been improved.
       Adding the ``App`` namespace in the ``autoload.psr4`` setting in **composer.json**

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -200,9 +200,12 @@ For example the route:
 
 will match **product/123**, **product/123/456**, **product/123/456/789** and so on.
 
-In the above example, if the ``$1`` placeholder contains a slash
+By default, in the above example, if the ``$1`` placeholder contains a slash
 (``/``), it will still be split into multiple parameters when passed to
 ``Catalog::productLookup()``.
+
+.. note:: Since v4.5.0, you can change the behavior with the config option.
+    See :ref:`multiple-uri-segments-as-one-parameter` for details.
 
 The implementation in the
 Controller should take into account the maximum parameters:
@@ -257,9 +260,12 @@ redirect them back to the same page after they log in, you may find this example
 
 .. literalinclude:: routing/019.php
 
-In the above example, if the ``$1`` placeholder contains a slash
+By default, in the above example, if the ``$1`` placeholder contains a slash
 (``/``), it will still be split into multiple parameters when passed to
 ``Auth::login()``.
+
+.. note:: Since v4.5.0, you can change the behavior with the config option.
+    See :ref:`multiple-uri-segments-as-one-parameter` for details.
 
 For those of you who don't know regular expressions and want to learn more about them,
 `regular-expressions.info <https://www.regular-expressions.info/>`_ might be a good starting point.
@@ -704,6 +710,27 @@ Disabled by default. This functionality affects all routes.
 For an example use of lowering the priority see :ref:`routing-priority`:
 
 .. literalinclude:: routing/052.php
+
+.. _multiple-uri-segments-as-one-parameter:
+
+Multiple URI Segments as One Parameter
+======================================
+
+.. versionadded:: 4.5.0
+
+When this option is enabled, a placeholder that matches multiple segments, such
+as ``(:any)``, will be passed directly as it is to one parameter, even if it
+contains multiple segments.
+
+.. literalinclude:: routing/069.php
+
+For example the route:
+
+.. literalinclude:: routing/010.php
+
+will match **product/123**, **product/123/456**, **product/123/456/789** and so on.
+And if the URI is **product/123/456**, ``123/456`` will be passed to the first
+parameter of the ``Catalog::productLookup()`` method.
 
 .. _auto-routing-improved:
 

--- a/user_guide_src/source/incoming/routing/069.php
+++ b/user_guide_src/source/incoming/routing/069.php
@@ -1,6 +1,8 @@
 <?php
 
 // In app/Config/Routing.php
+use CodeIgniter\Config\Routing as BaseRouting;
+
 class Routing extends BaseRouting
 {
     // ...

--- a/user_guide_src/source/incoming/routing/069.php
+++ b/user_guide_src/source/incoming/routing/069.php
@@ -1,0 +1,9 @@
+<?php
+
+// In app/Config/Routing.php
+class Routing extends BaseRouting
+{
+    // ...
+    public bool $multipleSegmentsOneParam = true;
+    // ...
+}


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=88954&pid=414392#pid414392

- add an option to pass multiple URI segments to one Controller parameter

The current implementation passes the captured value to the controller after splitting it with `/`.
So if `path/to/image-file.png` is captured, the controller will receive three parameters.
This PR adds an option to pass it to one parameter.

E.g.,
```php
$routes->get('img/(:any)', 'Image::display/$1');
```
```php
<?php

namespace App\Controllers;

use App\Controllers\BaseController;
use CodeIgniter\HTTP\ResponseInterface;

class Image extends BaseController
{
    public function display(...$params)
    {
        dd($params);
    }
}
```
Navigate to `http://localhost:8080/img/path/to/image-file.png`.

The current behavior:
```
$params array (3)
    ⇄0 => string (4) "path"
    ⇄1 => string (2) "to"
    ⇄2 => string (14) "image-file.png"
```
The option is enabled:
```
$params array (1)
    ⇄0 => string (22) "path/to/image-file.png"
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
