### PR TITLE
docs: add "Error Handling" in "Upgrading from 3.x to 4.x"

### DIFF
--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -171,13 +171,21 @@ Error Handling
 - The behavior in CI4 has been slightly changed.
 
   - In CI3 the behavior was set in the **index.php** file:
-      - errors ignored by ``error_reporting()`` was not logged;
-      - other errors were logged (depending on the settings in ``log_threshold``, they may not have been written to the log file);
-      - errors with an error level of ``E_ERROR | E_PARSE | E_COMPILE_ERROR | E_CORE_ERROR | E_USER_ERROR`` stopped framework processing, regardless of the error level set in ``error_reporting()``;
+
+      - errors with the error level set by ``error_reporting()`` are logged (but
+        depending on the ``log_threshold`` setting, they may not be written to
+        the log file).
+      - errors with an error level of
+        ``E_ERROR | E_PARSE | E_COMPILE_ERROR | E_CORE_ERROR | E_USER_ERROR``
+        stopped framework processing, regardless of the error level set in
+        ``error_reporting()``.
   - In CI4, the behavior is set in the **app/Config/Boot/{environment}.php** file:
-      - errors with the error level set by ``error_reporting()`` are logged (but depending on the
-    ``Config\Logger::$threshold`` setting, they may not be written to the log file);
-      - all errors that are not ignored by ``error_reporting()`` will stop the framework processing;
+
+      - errors with the error level set by ``error_reporting()`` are logged (but
+        depending on the ``Config\Logger::$threshold`` setting, they may not be
+        written to the log file).
+      - all errors that are not ignored by ``error_reporting()`` will stop the
+        framework processing.
 
 Extending the Framework
 =======================

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -170,7 +170,7 @@ Error Handling
 
 - The behavior in CI4 has been slightly changed.
 
-  - In CI3 the behavior was set in the **index.php** file:
+  - In CI3 the behavior is set in the **index.php** file:
 
       - errors with the error level set by ``error_reporting()`` are logged (but
         depending on the ``log_threshold`` setting, they may not be written to

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -165,6 +165,23 @@ Hooks
 - The hook point ``post_system`` has moved just before sending the final rendered
   page.
 
+Error Handling
+==============
+
+- The behavior in CI4 has been slightly changed.
+
+  - In CI3, ignored errors by ``error_reporting()`` in **index.php** are not logged,
+    but other errors are logged (but depending on the ``log_threshold`` setting,
+    they may not be written to the log file). Only errors with the error level
+    ``E_ERROR | E_PARSE | E_COMPILE_ERROR | E_CORE_ERROR | E_USER_ERROR``
+    will stop the framework processing, regardless of the error level set in
+    ``error_reporting()``.
+  - In CI4, only errors with the error level set by ``error_reporting()`` in
+    **app/Config/Boot/{environment}.php** are logged (but depending on the
+    ``Config\Logger::$threshold`` setting, they may not be written to the log file).
+    All errors that are not ignored by ``error_reporting()`` will stop the
+    framework processing.
+
 Extending the Framework
 =======================
 

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -170,17 +170,14 @@ Error Handling
 
 - The behavior in CI4 has been slightly changed.
 
-  - In CI3, ignored errors by ``error_reporting()`` in **index.php** are not logged,
-    but other errors are logged (but depending on the ``log_threshold`` setting,
-    they may not be written to the log file). Only errors with the error level
-    ``E_ERROR | E_PARSE | E_COMPILE_ERROR | E_CORE_ERROR | E_USER_ERROR``
-    will stop the framework processing, regardless of the error level set in
-    ``error_reporting()``.
-  - In CI4, only errors with the error level set by ``error_reporting()`` in
-    **app/Config/Boot/{environment}.php** are logged (but depending on the
-    ``Config\Logger::$threshold`` setting, they may not be written to the log file).
-    All errors that are not ignored by ``error_reporting()`` will stop the
-    framework processing.
+  - In CI3 the behavior was set in the **index.php** file:
+      - errors ignored by ``error_reporting()`` was not logged;
+      - other errors were logged (depending on the settings in ``log_threshold``, they may not have been written to the log file);
+      - errors with an error level of ``E_ERROR | E_PARSE | E_COMPILE_ERROR | E_CORE_ERROR | E_USER_ERROR`` stopped framework processing, regardless of the error level set in ``error_reporting()``;
+  - In CI4, the behavior is set in the **app/Config/Boot/{environment}.php** file:
+      - errors with the error level set by ``error_reporting()`` are logged (but depending on the
+    ``Config\Logger::$threshold`` setting, they may not be written to the log file);
+      - all errors that are not ignored by ``error_reporting()`` will stop the framework processing;
 
 Extending the Framework
 =======================


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=88993

- add "Error Handling" in "Upgrading from 3.x to 4.x"

See
- https://github.com/bcit-ci/CodeIgniter/blob/develop/system/core/Common.php#L600
- https://github.com/codeigniter4/CodeIgniter4/blob/develop/system/Debug/Exceptions.php#L202

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
