### PR TITLE
fix: DOMParser cannot see element with `id="0"`

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -3172,11 +3172,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/DOMParser.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 6,
-	'path' => __DIR__ . '/system/Test/DOMParser.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Access to an undefined property object\\:\\:\\$createdField\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Test/Fabricator.php',

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -189,23 +189,23 @@ class DOMParser
         $path = '';
 
         // By ID
-        if (! empty($selector['id'])) {
-            $path = empty($selector['tag'])
+        if (isset($selector['id'])) {
+            $path = ($selector['tag'] === '')
                 ? "id(\"{$selector['id']}\")"
                 : "//{$selector['tag']}[@id=\"{$selector['id']}\"]";
         }
         // By Class
-        elseif (! empty($selector['class'])) {
-            $path = empty($selector['tag'])
+        elseif (isset($selector['class'])) {
+            $path = ($selector['tag'] === '')
                 ? "//*[@class=\"{$selector['class']}\"]"
                 : "//{$selector['tag']}[@class=\"{$selector['class']}\"]";
         }
         // By tag only
-        elseif (! empty($selector['tag'])) {
+        elseif ($selector['tag'] !== '') {
             $path = "//{$selector['tag']}";
         }
 
-        if (! empty($selector['attr'])) {
+        if (isset($selector['attr'])) {
             foreach ($selector['attr'] as $key => $value) {
                 $path .= "[@{$key}=\"{$value}\"]";
             }

--- a/system/Test/DOMParser.php
+++ b/system/Test/DOMParser.php
@@ -231,7 +231,7 @@ class DOMParser
     /**
      * Look for the a selector  in the passed text.
      *
-     * @return array
+     * @return array{tag: string, id: string|null, class: string|null, attr: array<string, string>|null}
      */
     public function parseSelector(string $selector)
     {

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -91,7 +91,7 @@ final class DOMParserTest extends CIUnitTestCase
     /**
      * @dataProvider provideText
      *
-     * @param mixed $text
+     * @param string $text
      */
     public function testSeeText($text): void
     {
@@ -139,7 +139,7 @@ final class DOMParserTest extends CIUnitTestCase
     /**
      * @dataProvider provideText
      *
-     * @param mixed $text
+     * @param string $text
      */
     public function testSeeElement($text): void
     {

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -171,6 +171,16 @@ final class DOMParserTest extends CIUnitTestCase
         $this->assertTrue($dom->see('Hello World', '#heading'));
     }
 
+    public function testSeeElementIDZero(): void
+    {
+        $dom = new DOMParser();
+
+        $html = '<html><body><h1 id="0">Hello World Wide Web</h1></body></html>';
+        $dom->withString($html);
+
+        $this->assertTrue($dom->see('Hello World', '#0'));
+    }
+
     public function testSeeElementIDFails(): void
     {
         $dom = new DOMParser();


### PR DESCRIPTION
**Description**
- fix bug with `empty()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
