### PR TITLE
Improve shouldUpdate method

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -21,6 +21,7 @@ use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Validation\ValidationInterface;
+use CodeIgniter\Validation\StrictRules\Rules;
 use Config\Services;
 use InvalidArgumentException;
 use ReflectionClass;
@@ -725,15 +726,15 @@ abstract class BaseModel
      * It checks if the ID is not empty and does not already exist in the table.
      * If this method returns false, an insert operation will be executed.
      *
-     * @param array|object $data Data
+     * @param array|object $row Data
      * @phpstan-param row_array|object $row
      * @return bool
      */
-    protected function shouldUpdate($data): bool
+    protected function shouldUpdate($row): bool
     {
         $shouldUpdate = false;
     
-        $id = $this->getIdValue($data);
+        $id = $this->getIdValue($row);
         if (!empty($id)) {
             $ci_rules = new Rules;
             if (!$ci_rules->is_unique($id, "`{$this->table}`.`{$this->primaryKey}`", [])) {

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -721,15 +721,27 @@ abstract class BaseModel
     }
 
     /**
-     * This method is called on save to determine if entry have to be updated.
-     * If this method returns false insert operation will be executed
+     * This method is called on save to determine if the entry needs to be updated.
+     * It checks if the ID is not empty and does not already exist in the table.
+     * If this method returns false, an insert operation will be executed.
      *
-     * @param array|object $row Row data
+     * @param array|object $data Data
      * @phpstan-param row_array|object $row
+     * @return bool
      */
-    protected function shouldUpdate($row): bool
+    protected function shouldUpdate($data): bool
     {
-        return ! empty($this->getIdValue($row));
+        $shouldUpdate = false;
+    
+        $id = $this->getIdValue($data);
+        if (!empty($id)) {
+            $ci_rules = new Rules;
+            if (!$ci_rules->is_unique($id, "`{$this->table}`.`{$this->primaryKey}`", [])) {
+                $shouldUpdate = true;
+            }
+        }
+    
+        return $shouldUpdate;
     }
 
     /**


### PR DESCRIPTION
Improve shouldUpdate method

Enhance the shouldUpdate method to ensure it doesn't incorrectly trigger an update operation when a user provides a manually generated ID that does not exist in the system.

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
