### PR TITLE
chore: fix php-cs-fixer version to 3.41.*

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "codeigniter/coding-standard": "^1.5",
         "fakerphp/faker": "^1.9",
-        "friendsofphp/php-cs-fixer": "3.13.0",
+        "friendsofphp/php-cs-fixer": "~3.41.0",
         "kint-php/kint": "^5.0.4",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "codeigniter/phpstan-codeigniter": "^1.4",
         "ergebnis/composer-normalize": "^2.28",
         "fakerphp/faker": "^1.9",
+        "friendsofphp/php-cs-fixer": "~3.41.0",
         "kint-php/kint": "^5.0.4",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",


### PR DESCRIPTION
**Description**
Temporarily fix the version because of conflicts between php-cs-fixer updates and a Rector rule.
See https://github.com/codeigniter4/CodeIgniter4/pull/8367#issuecomment-1868853441

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
