### PR TITLE
test: fix PHPDoc types in CastBase64

### DIFF
--- a/tests/_support/Entity/Cast/CastBase64.php
+++ b/tests/_support/Entity/Cast/CastBase64.php
@@ -18,10 +18,8 @@ class CastBase64 extends BaseCast
     /**
      * Get
      *
-     * @param mixed $value  Data
-     * @param array $params Additional param
-     *
-     * @return mixed
+     * @param string $value  Data
+     * @param array  $params Additional param
      */
     public static function get($value, array $params = []): string
     {
@@ -31,10 +29,8 @@ class CastBase64 extends BaseCast
     /**
      * Set
      *
-     * @param mixed $value  Data
-     * @param array $params Additional param
-     *
-     * @return mixed
+     * @param string $value  Data
+     * @param array  $params Additional param
      */
     public static function set($value, array $params = []): string
     {


### PR DESCRIPTION
**Description**
```diff
1 file with changes
===================

1) tests/_support/Entity/Cast/CastBase64.php:21

    ---------- begin diff ----------
@@ @@
      *
      * @param mixed $value  Data
      * @param array $params Additional param
-     *
-     * @return mixed
      */
     public static function get($value, array $params = []): string
     {
@@ @@
      *
      * @param mixed $value  Data
      * @param array $params Additional param
-     *
-     * @return mixed
      */
     public static function set($value, array $params = []): string
     {
    ----------- end diff -----------

Applied rules:
 * RemoveUselessReturnTagRector
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7324536612/job/19948207442?pr=8364

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
