### PR TITLE
fix: make:test help and docs

### DIFF
--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -57,7 +57,7 @@ class TestGenerator extends BaseCommand
      * @var array<string, string>
      */
     protected $arguments = [
-        'name' => 'The command class name.',
+        'name' => 'The test class name.',
     ];
 
     /**
@@ -66,7 +66,7 @@ class TestGenerator extends BaseCommand
      * @var array<string, string>
      */
     protected $options = [
-        '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',
+        '--namespace' => 'Set root namespace. Default: "\Tests".',
         '--force'     => 'Force overwrite existing file.',
     ];
 

--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -66,8 +66,7 @@ class TestGenerator extends BaseCommand
      * @var array<string, string>
      */
     protected $options = [
-        '--namespace' => 'Set root namespace. Default: "\Tests".',
-        '--force'     => 'Force overwrite existing file.',
+        '--force' => 'Force overwrite existing file.',
     ];
 
     /**

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -230,6 +230,8 @@ Enhancements
 Commands
 ========
 
+- Added ``spark make:test`` command to generate a skeleton test file. See
+  :ref:`cli-generators-make-test` for the details.
 - Added ``spark config:check`` command to check Config values. See
   :ref:`confirming-config-values` for the details.
 - Added ``spark lang:find`` command to update translations keys. See :ref:`generating-translation-files-via-command` for the details.
@@ -350,6 +352,7 @@ Others
 Message Changes
 ***************
 
+- Added ``CLI.generator.className.test`` message.
 - Added ``Validation.field_exists`` error message.
 
 Changes

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -248,7 +248,6 @@ Argument:
 
 Options:
 ========
-* ``--namespace``: Set the root namespace. Defaults to value of ``\Tests``.
 * ``--force``: Set this flag to overwrite existing files on destination.
 
 make:migration

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -226,6 +226,31 @@ Options:
 * ``--suffix``: Append the component suffix to the generated class name.
 * ``--force``: Set this flag to overwrite existing files on destination.
 
+
+.. _cli-generators-make-test:
+
+make:test
+-----------
+
+.. versionadded:: 4.5.0
+
+Creates a new test file.
+
+Usage:
+======
+::
+
+    make:test <name> [options]
+
+Argument:
+=========
+* ``name``: The name of the test class. **[REQUIRED]**
+
+Options:
+========
+* ``--namespace``: Set the root namespace. Defaults to value of ``\Tests``.
+* ``--force``: Set this flag to overwrite existing files on destination.
+
 make:migration
 --------------
 


### PR DESCRIPTION
**Description**
Follow-up #8333

- add missing docs
- fix help message

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
