### PR TITLE
feat: `spark make:test` creates test files in `/tests/` directory

### DIFF
--- a/app/Config/Autoload.php
+++ b/app/Config/Autoload.php
@@ -40,7 +40,7 @@ class Autoload extends AutoloadConfig
      * @var array<string, list<string>|string>
      */
     public $psr4 = [
-        APP_NAMESPACE => APPPATH,
+        APP_NAMESPACE => [APPPATH, TESTPATH . 'app'],
     ];
 
     /**

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -63,14 +63,14 @@ class Autoloader
     /**
      * Stores namespaces as key, and path as values.
      *
-     * @var array<string, array<string>>
+     * @var array<string, list<string>>
      */
     protected $prefixes = [];
 
     /**
      * Stores class name as key, and path as values.
      *
-     * @var array<string, string>
+     * @var array<class-string, string>
      */
     protected $classmap = [];
 
@@ -215,7 +215,8 @@ class Autoloader
      *
      * If a prefix param is set, returns only paths to the given prefix.
      *
-     * @return array
+     * @return array<string, list<string>>|list<string>
+     * @phpstan-return ($prefix is null ? array<string, list<string>> : list<string>)
      */
     public function getNamespace(?string $prefix = null)
     {

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -175,6 +175,8 @@ class FileLocator implements FileLocatorInterface
      *      'app/Modules/foo/Config/Routes.php',
      *      'app/Modules/bar/Config/Routes.php',
      *  ]
+     *
+     * @return list<string>
      */
     public function search(string $path, string $ext = 'php', bool $prioritizeApp = true): array
     {
@@ -203,7 +205,7 @@ class FileLocator implements FileLocatorInterface
         }
 
         // Remove any duplicates
-        return array_unique($foundPaths);
+        return array_values(array_unique($foundPaths));
     }
 
     /**

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -237,7 +237,7 @@ class FileLocator implements FileLocatorInterface
         foreach ($this->autoloader->getNamespace() as $prefix => $paths) {
             foreach ($paths as $path) {
                 if ($prefix === 'CodeIgniter') {
-                    $system = [
+                    $system[] = [
                         'prefix' => $prefix,
                         'path'   => rtrim($path, '\\/') . DIRECTORY_SEPARATOR,
                     ];
@@ -252,9 +252,7 @@ class FileLocator implements FileLocatorInterface
             }
         }
 
-        $namespaces[] = $system;
-
-        return $namespaces;
+        return array_merge($namespaces, $system);
     }
 
     /**

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -106,7 +106,7 @@ class AutoloadConfig
      * searched for within one or more directories as they would if they
      * were being autoloaded through a namespace.
      *
-     * @var array<string, string>
+     * @var array<class-string, string>
      */
     protected $coreClassmap = [
         AbstractLogger::class                  => SYSTEMPATH . 'ThirdParty/PSR/Log/AbstractLogger.php',

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -91,7 +91,7 @@ class AutoloadConfig
      * @var array<string, string>
      */
     protected $corePsr4 = [
-        'CodeIgniter' => SYSTEMPATH,
+        'CodeIgniter' => [SYSTEMPATH, TESTPATH . 'system'],
         'Config'      => APPPATH . 'Config',
         'Tests'       => ROOTPATH . 'tests',
     ];

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -97,13 +97,13 @@ final class AutoloaderTest extends CIUnitTestCase
         $loader->initialize(new Autoload(), new Modules());
 
         $ns = $loader->getNamespace();
-        $this->assertCount(1, $ns['App']);
+        $this->assertCount(2, $ns['App']);
         $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
 
         $loader->initialize(new Autoload(), new Modules());
 
         $ns = $loader->getNamespace();
-        $this->assertCount(1, $ns['App']);
+        $this->assertCount(2, $ns['App']);
         $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
     }
 

--- a/tests/system/Commands/TestGeneratorTest.php
+++ b/tests/system/Commands/TestGeneratorTest.php
@@ -41,6 +41,6 @@ final class TestGeneratorTest extends CIUnitTestCase
     public function testGenerateTest(): void
     {
         command('make:test Foo/Bar');
-        $this->assertFileExists(ROOTPATH . 'tests/Foo/Bar.php');
+        $this->assertFileExists(ROOTPATH . 'tests/app/Foo/Bar.php');
     }
 }

--- a/user_guide_src/source/cli/cli_generators.rst
+++ b/user_guide_src/source/cli/cli_generators.rst
@@ -248,6 +248,7 @@ Argument:
 
 Options:
 ========
+* ``--namespace``: Set the root namespace. Defaults to value of ``APP_NAMESPACE``.
 * ``--force``: Set this flag to overwrite existing files on destination.
 
 make:migration


### PR DESCRIPTION
**Description**
- add namespace paths for test classes
  - add `tests/app` for namespace `App`
  - add `tests/system` for namespace `CodeIgniter`
- `make:test` creates test files in `/tests/` directory

E.g.,
```console
$ ./spark make:test App\\Controllers\\FooTest 
File created: ROOTPATH/tests/app/Controllers/FooTest.php
```

```console
$ ./spark make:test Controllers\\BarTest
File created: ROOTPATH/tests/app/Controllers/BarTest.php
```

```console
$ ./spark make:test Commands\\FooTest --namespace CodeIgniter
File created: ROOTPATH/tests/system/Commands/FooTest.php
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
