### PR TITLE
feat: add ExceptionHandlingTrait and Exceptions::(un)register

### DIFF
--- a/app/Views/errors/cli/error_404.php
+++ b/app/Views/errors/cli/error_404.php
@@ -1,6 +1,11 @@
 <?php
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Debug\Exceptions;
+
+if (Exceptions::isUsingPhpUnitErrorHandlingInSeparateProcess()) {
+    return;
+}
 
 CLI::error('ERROR: ' . $code);
 CLI::write($message);

--- a/app/Views/errors/cli/error_exception.php
+++ b/app/Views/errors/cli/error_exception.php
@@ -1,6 +1,11 @@
 <?php
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Debug\Exceptions;
+
+if (Exceptions::isUsingPhpUnitErrorHandlingInSeparateProcess()) {
+    return;
+}
 
 // The main Exception
 CLI::write('[' . get_class($exception) . ']', 'light_gray', 'red');

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -190,7 +190,7 @@ class CodeIgniter
         $this->bootstrapEnvironment();
 
         // Setup Exception Handling
-        Services::exceptions()->initialize();
+        Services::exceptions()->register();
 
         // Run this check for manual installations
         if (! is_file(COMPOSER_PATH)) {

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -104,13 +104,33 @@ class Exceptions
      *
      * @codeCoverageIgnore
      *
+     * @deprecated 4.5.0 Use `register()` instead
+     *
      * @return void
      */
     public function initialize()
     {
+        $this->register();
+    }
+
+    /**
+     * Responsible for registering the error handler, exception handler,
+     * and shutdown handler.
+     */
+    public function register(): void
+    {
         set_exception_handler([$this, 'exceptionHandler']);
         set_error_handler([$this, 'errorHandler']);
         register_shutdown_function([$this, 'shutdownHandler']);
+    }
+
+    /**
+     * Unregisters the exception handler and error handler.
+     */
+    public function unregister(): void
+    {
+        restore_exception_handler();
+        restore_error_handler();
     }
 
     /**

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -614,6 +614,27 @@ class Exceptions
         return '<pre><code>' . $out . '</code></pre>';
     }
 
+    /**
+     * When PHPUnit 9.x is running on a separate process, it registers its
+     * simple error handler through the function '__phpunit_error_handler'.
+     *
+     * This checks whether the test is running in a separate process without
+     * creating a direct dependency on PHPUnit.
+     *
+     * @todo Check if the same function is used on PHPUnit 10.x
+     *
+     * @internal
+     */
+    public static function isUsingPhpUnitErrorHandlingInSeparateProcess(): bool
+    {
+        try {
+            // @phpstan-ignore-next-line
+            return set_error_handler(null) === '__phpunit_error_handler';
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     private static function renderBacktrace(array $backtrace): string
     {
         $backtraces = [];

--- a/system/Test/ExceptionHandlingTrait.php
+++ b/system/Test/ExceptionHandlingTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Test;
+
+use Config\Services;
+
+/**
+ * Provides utilities for registering and unregistering
+ * of the exception and error handlers.
+ */
+trait ExceptionHandlingTrait
+{
+    protected function enableExceptionHandling(): void
+    {
+        Services::exceptions()->register();
+    }
+
+    protected function disableExceptionHandling(): void
+    {
+        Services::exceptions()->unregister();
+    }
+}

--- a/tests/_support/Config/Filters.php
+++ b/tests/_support/Config/Filters.php
@@ -13,8 +13,13 @@ declare(strict_types=1);
 
 namespace Tests\Support\Config\Filters;
 
+use CodeIgniter\Debug\Exceptions;
 use Tests\Support\Filters\Customfilter;
 use Tests\Support\Filters\RedirectFilter;
+
+if (Exceptions::isUsingPhpUnitErrorHandlingInSeparateProcess()) {
+    return;
+}
 
 /**
  * @psalm-suppress UndefinedGlobalVariable


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
This PR introduces a way to unregister the error and exception handlers originally registered in `Services::exceptions()->initialize()` by calling the `unregister()` method. Moreover, the `initialize()` method is deprecated in favor of the `register()` method simply for consistency with the unregister method.

**Motivation**
PHPUnit 10 registers its own error handler. This may cause issues if the SUT is registering its own error handler (such as the issues encountered in #8069 ). 

> When PHPUnit’s test runner becomes aware (after it called `set_error_handler()` to register its error handler) that another error handler was registered then it immediately unregisters its error handler so that the previously registered error handler remains active.
https://docs.phpunit.de/en/10.5/error-handling.html

To solve this, we have 2 possible solutions:
1. Use the `#[WithoutErrorHandler]` attribute on each test case. This is problematic as this attribute is on a `TARGET_METHOD` so it needs to be applied to each test method.
2. Let PHPUnit's own error handler do the job and unregister the SUT's own error handling.

This uses the 2nd approach by introducing the `ExceptionHandlingTrait` intended to be used in tests. The trait just provides shortcut access to the register/unregister methods.

This PR is intended to fix the failures in #8069 .

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
