### PR TITLE
test: strip colors on `xdebug.cli_color=2`

### DIFF
--- a/tests/system/Commands/Utilities/ConfigCheckTest.php
+++ b/tests/system/Commands/Utilities/ConfigCheckTest.php
@@ -126,6 +126,13 @@ final class ConfigCheckTest extends CIUnitTestCase
                 true
             )
         ) {
+            // Xdebug force adds colors on xdebug.cli_color=2
+            $output = preg_replace(
+                '/(\033\[[0-9;]+m)|(\035\[[0-9;]+m)/u',
+                '',
+                $output
+            );
+
             // Xdebug overloads var_dump().
             $this->assertStringContainsString(
                 'class Config\App#',


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
When `xdebug.cli_color` is set to `2`, Xdebug forces adding colors on overloaded `var_dump()` calls, causing tests to fail.

```
1) CodeIgniter\Commands\Utilities\ConfigCheckTest::testGetVarDump
Failed asserting that 'class Config\App#22494 (12) {\n
  public string $baseURL =>\n
  string(19) "http://example.com/"\n
  public array $allowedHostnames =>\n
  array(0) {\n
  }\n
  public string $indexPage =>\n
  string(9) "index.php"\n
  public string $uriProtocol =>\n
  string(11) "REQUEST_URI"\n
  public string $defaultLocale =>\n
  string(2) "en"\n
  public bool $negotiateLocale =>\n
  bool(false)\n
  public array $supportedLocales =>\n
  array(1) {\n
    [0] =>\n
    string(2) "en"\n
  }\n
  public string $appTimezone =>\n
  string(3) "UTC"\n
  public string $charset =>\n
  string(5) "UTF-8"\n
  public bool $forceGlobalSecureRequests =>\n
  bool(false)\n
  public array $proxyIPs =>\n
  array(0) {\n
  }\n
  public bool $CSPEnabled =>\n
  bool(false)\n
}\n
' contains "class Config\App#".

/Users/paul/Workspace/CodeIgniter4/tests/system/Commands/Utilities/ConfigCheckTest.php:130
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
