### PR TITLE
docs: fix section title level in v4.4.4.rst

### DIFF
--- a/user_guide_src/source/changelogs/v4.4.4.rst
+++ b/user_guide_src/source/changelogs/v4.4.4.rst
@@ -39,6 +39,7 @@ Filesystem Helper
 :php:func:`get_filenames()` now follows symlink folders, which it previously just returned
 without following.
 
+************
 Enhancements
 ************
 


### PR DESCRIPTION
**Description**
"Enhancements" is located in the wrong place.
![Screenshot 2023-12-29 9 23 53](https://github.com/codeigniter4/CodeIgniter4/assets/87955/58232f44-7cfd-4b02-b745-1e3800ea080d)
https://codeigniter4.github.io/CodeIgniter4/changelogs/v4.4.4.html

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
