### PR TITLE
test: fix path name of composer.json

### DIFF
--- a/tests/system/AutoReview/ComposerJsonTest.php
+++ b/tests/system/AutoReview/ComposerJsonTest.php
@@ -62,7 +62,7 @@ final class ComposerJsonTest extends TestCase
                 $dependency,
                 $expectedVersion,
                 $fwRequireDev[$dependency],
-                clean_path(dirname(__DIR__, 2) . '/admin/framework/composer.json')
+                clean_path(dirname(__DIR__, 3) . '/admin/framework/composer.json')
             ));
         }
     }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Fixes wrong clean path of composer.json in `admin/` folder.
To test, just change any version constraint of a `require-dev` dependency in the root composer.json.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
