### PR TITLE
Fix bug 4.4.4 `spark serve` not working when using Session in Routes.php

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -496,7 +496,7 @@ class Session implements SessionInterface
             return $value;
         }
 
-        if (empty($_SESSION) || $_SESSION === []) {
+        if (! isset($_SESSION) || $_SESSION === []) {
             return $key === null ? [] : null;
         }
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -496,7 +496,7 @@ class Session implements SessionInterface
             return $value;
         }
 
-        if ($_SESSION === []) {
+        if (empty($_SESSION) || $_SESSION === []) {
             return $key === null ? [] : null;
         }
 


### PR DESCRIPTION
After upgrading 4.4.3 to 4.4.4 a bug are coming, spark not launching the CI with cmd. php spark server*

Error log: 
![bugci](https://github.com/codeigniter4/CodeIgniter4/assets/8069073/54f90468-7e02-4930-a6ec-c8da717da063)


Undefined global variable $_SESSION

at SYSTEMPATH\Session\Session.php:499

Backtrace:
  1    SYSTEMPATH\Session\Session.php:499
       CodeIgniter\Debug\Exceptions()->errorHandler(2, 'Undefined global variable $_SESSION', 'C:\\wamp64\\www\\system\\Session\\Session.php', 499)

My fix working with no errors and launching correctly CI.

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
