### PR TITLE
Use hot reloaded bar for locales

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -650,7 +650,9 @@ var ciDebugBar = {
     },
 
     hotReloadConnect: function () {
-        const eventSource = new EventSource(ciSiteURL + "/__hot-reload");
+
+        const ciSiteLocale = `/${window.location.pathname.split('/')[1]}` || false;
+        const eventSource  = new EventSource(ciSiteURL + ciSiteLocale + "/__hot-reload");
 
         eventSource.addEventListener("reload", function (e) {
             console.log("reload", e);


### PR DESCRIPTION
CI locale not working with hot reloaded bar
(please see my other commit following Config/Events.php)
https://github.com/codeigniter4/CodeIgniter4/pull/8391

![Capture d'écran 2023-12-29 195937](https://github.com/codeigniter4/CodeIgniter4/assets/8069073/1368e7bf-b53a-4465-a90f-4d175f206405)

in my option the hotbar is now working ;)
Thanks for suggestion in forums @kenjis 


<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
