### PR TITLE
Fix locale hotreloaded bar

### DIFF
--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -47,7 +47,8 @@ Events::on('pre_system', static function () {
         Services::toolbar()->respond();
         // Hot Reload route - for framework use on the hot reloader.
         if (ENVIRONMENT === 'development') {
-            Services::routes()->get('__hot-reload', static function () {
+            $CiUseLocale = service('request')->getLocale() ? '/' . service('request')->getLocale() : false;
+            Services::routes()->get($CiUseLocal . '/__hot-reload', static function () {
                 (new HotReloader())->run();
             });
         }


### PR DESCRIPTION
The CI use {locale} mode the hot reloadedBar is not working.

follow my other commit toolbar.js
https://github.com/codeigniter4/CodeIgniter4/pull/8390

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
