### PR TITLE
test: ensure no .env when EncryptionTest is run

### DIFF
--- a/tests/system/Encryption/EncryptionTest.php
+++ b/tests/system/Encryption/EncryptionTest.php
@@ -25,19 +25,40 @@ final class EncryptionTest extends CIUnitTestCase
 {
     private Encryption $encryption;
 
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (is_file(ROOTPATH . '.env')) {
+            rename(ROOTPATH . '.env', ROOTPATH . '.env.bak');
+
+            putenv('encryption.key');
+            unset($_ENV['encryption.key'], $_SERVER['encryption.key']);
+        }
+    }
+
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->encryption = new Encryption();
     }
 
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        if (is_file(ROOTPATH . '.env.bak')) {
+            rename(ROOTPATH . '.env.bak', ROOTPATH . '.env');
+        }
+    }
+
     /**
-     * __construct test
-     *
      * Covers behavior with config encryption key set or not
      */
     public function testConstructor(): void
     {
-        // Assume no configuration from set_up()
+        // Assume no configuration from setUp()
         $this->assertEmpty($this->encryption->key);
 
         // Try with an empty value


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
For contributors, when running `EncryptionTest` and there is a `.env` file in the root, tests will fail because of a set encryption key.
```
There were 2 failures:

1) CodeIgniter\Encryption\EncryptionTest::testConstructor
Failed asserting that a string is empty.

/Users/paul/Workspace/CodeIgniter4/tests/system/Encryption/EncryptionTest.php:61

2) CodeIgniter\Encryption\EncryptionTest::testServiceWithoutKey
Failed asserting that exception of type "CodeIgniter\Encryption\Exceptions\EncryptionException" is thrown.
```

This PR will backup the `.env` and unset any environment variables already set by the file.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
