### PR TITLE
test: ensure cleanup of sqlite3 db files after test

### DIFF
--- a/tests/system/Database/Live/SQLite3/GetFieldDataTest.php
+++ b/tests/system/Database/Live/SQLite3/GetFieldDataTest.php
@@ -32,7 +32,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
             'database' => 'database.db',
             'DBDebug'  => true,
         ];
-        $this->db    = db_connect($config);
+        $this->db    = db_connect($config, false);
         $this->forge = Database::forge($config);
     }
 

--- a/tests/system/Database/Live/SQLite3/GetIndexDataTest.php
+++ b/tests/system/Database/Live/SQLite3/GetIndexDataTest.php
@@ -45,7 +45,7 @@ final class GetIndexDataTest extends CIUnitTestCase
             'database' => 'database.db',
             'DBDebug'  => true,
         ];
-        $this->db    = db_connect($config);
+        $this->db    = db_connect($config, false);
         $this->forge = Database::forge($config);
     }
 

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -470,6 +470,10 @@ final class MigrationRunnerTest extends CIUnitTestCase
         $this->assertCount(2, $tables);
         $this->assertSame('migrations', $tables[0]);
         $this->assertSame('foo', $tables[1]);
+
+        if (is_file($config['database'])) {
+            unlink($config['database']);
+        }
     }
 
     protected function resetTables($db = null): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Currently, `writable/` has two leftover DB files from sqlite3: `database.db` and `runner.sqlite`. This PR cleans them.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
