### PR TITLE
fix: error page does not show source files on PHP 8.3

### DIFF
--- a/system/Debug/BaseExceptionHandler.php
+++ b/system/Debug/BaseExceptionHandler.php
@@ -182,8 +182,11 @@ abstract class BaseExceptionHandler
 
         $source = str_replace(["\r\n", "\r"], "\n", $source);
         $source = explode("\n", highlight_string($source, true));
-        $source = str_replace('<br />', "\n", $source[1]);
-        $source = explode("\n", str_replace("\r\n", "\n", $source));
+
+        if (PHP_VERSION_ID < 80300) {
+            $source = str_replace('<br />', "\n", $source[1]);
+            $source = explode("\n", str_replace("\r\n", "\n", $source));
+        }
 
         // Get just the part to show
         $start = max($lineNumber - (int) round($lines / 2), 0);

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -237,4 +237,29 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
         $this->assertSame('/var/www/CodeIgniter4/app/Controllers/Home.php', $newTrace[0]['file']);
     }
+
+    public function testHighlightFile(): void
+    {
+        $highlightFile = $this->getPrivateMethodInvoker($this->handler, 'highlightFile');
+
+        $output = $highlightFile(APPPATH . 'Controllers/Home.php', 9, 3);
+
+        if (PHP_VERSION_ID >= 80300) {
+            $expect = <<< 'HTML'
+                <pre><code><span class="line"><span class="number"> 8</span>     </span><span style="color: #f1ce61;">{
+                <span class='line highlight'><span class='number'> 9</span>         return view('welcome_message');
+                </span></span><span style="color: #c7c7c7"></span><span style="color: #f1ce61;"></span><span style="color: #869d6a"></span><span style="color: #f1ce61;"><span class="line"><span class="number">10</span>     }
+                </span></code></pre>
+                HTML;
+        } else {
+            $expect = <<< 'HTML'
+                <pre><code><span class="line"><span class="number"> 8</span> &nbsp;&nbsp;&nbsp;&nbsp;</span><span style="color: #f1ce61;">{
+                <span class='line highlight'><span class='number'> 9</span> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return&nbsp;view('welcome_message');
+                </span></span><span style="color: #c7c7c7"></span><span style="color: #f1ce61;"></span><span style="color: #869d6a"></span><span style="color: #f1ce61;"><span class="line"><span class="number">10</span> &nbsp;&nbsp;&nbsp;&nbsp;}
+                </span></code></pre>
+                HTML;
+        }
+
+        $this->assertSame($expect, $output);
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #8398

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
