### PR TITLE
style: fix incorrect case method name `SplFileInfo-getBaseName()`

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1847,11 +1847,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Exceptions/PageNotFoundException.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to method SplFileInfo\\:\\:getBasename\\(\\) with incorrect case\\: getBaseName$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Files/File.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Files/File.php',

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -140,7 +140,7 @@ class File extends SplFileInfo
     public function move(string $targetPath, ?string $name = null, bool $overwrite = false)
     {
         $targetPath = rtrim($targetPath, '/') . '/';
-        $name ??= $this->getBaseName();
+        $name ??= $this->getBasename();
         $destination = $overwrite ? $targetPath . $name : $this->getDestination($targetPath . $name);
 
         $oldName = $this->getRealPath() ?: $this->__toString();


### PR DESCRIPTION
**Description**
- fix incorrect case

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
