### PR TITLE
fix: [Validation] DotArrayFilter returns incorrect array when numeric index array is passed

### DIFF
--- a/system/Validation/DotArrayFilter.php
+++ b/system/Validation/DotArrayFilter.php
@@ -44,7 +44,7 @@ final class DotArrayFilter
                 $segments
             );
 
-            $result = array_merge_recursive($result, self::filter($segments, $array));
+            $result = array_replace_recursive($result, self::filter($segments, $array));
         }
 
         return $result;

--- a/tests/system/Validation/DotArrayFilterTest.php
+++ b/tests/system/Validation/DotArrayFilterTest.php
@@ -180,4 +180,19 @@ final class DotArrayFilterTest extends CIUnitTestCase
         ];
         $this->assertSame($expected, $result);
     }
+
+    public function testRunReturnOrderedIndices()
+    {
+        $data = [
+            'foo' => [
+                2 => 'bar',
+                0 => 'baz',
+                1 => 'biz',
+            ],
+        ];
+
+        $result = DotArrayFilter::run(['foo.2', 'foo.0', 'foo.1'], $data);
+
+        $this->assertSame($data, $result);
+    }
 }


### PR DESCRIPTION
**Description**
Supersedes #8414

The use of array_merge_recursive rewrites numerically indexed values when attempting to retrieve validated data. Use of the array_replace_recursive preserves their ordering. [For an in-depth explanation and test harness](https://forum.codeigniter.com/showthread.php?tid=89132&pid=414939). There appears to be a similar issue in [Laravel](https://github.com/laravel/framework/issues/24332).

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
