### PR TITLE
fix: [Postgre] QueryBuilder::updateBatch() does not work `<column_name>::<type>`

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1342,11 +1342,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in a negated boolean, array\\<int\\|string, array\\<int, int\\|string\\>\\|string\\> given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Return type \\(CodeIgniter\\\\Database\\\\BaseBuilder\\) of method CodeIgniter\\\\Database\\\\Postgre\\\\Builder\\:\\:join\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\Database\\\\BaseBuilder\\)\\) of method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:join\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Postgre/Builder.php',

--- a/rector.php
+++ b/rector.php
@@ -59,7 +59,7 @@ return static function (RectorConfig $rectorConfig): void {
         PHPUnitSetList::PHPUNIT_100,
     ]);
 
-    $rectorConfig->parallel(120, 8, 15);
+    $rectorConfig->parallel(120, 8, 10);
 
     // paths to refactor; solid alternative to CLI arguments
     $rectorConfig->paths([__DIR__ . '/app', __DIR__ . '/system', __DIR__ . '/tests', __DIR__ . '/utils']);

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1857,11 +1857,7 @@ class BaseBuilder
 
                 $escapedValue = $escape ? $this->db->escape($rowValue) : $rowValue;
 
-                if ($keyType !== null) {
-                    $clean[] = new SqlValue($escapedValue, $keyType);
-                } else {
-                    $clean[] = $escapedValue;
-                }
+                $clean[] = ($keyType !== null) ? new SqlValue($escapedValue, $keyType) : $escapedValue;
             }
 
             $row = $clean;

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -146,7 +146,7 @@ class Builder extends BaseBuilder
             $this->set($set);
         }
 
-        if (! $this->QBSet) {
+        if ($this->QBSet === []) {
             if ($this->db->DBDebug) {
                 throw new DatabaseException('You must use the "set" method to update an entry.');
             }

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Database\Postgre;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\Database\SqlValue;
 use InvalidArgumentException;
 
 /**
@@ -317,9 +318,9 @@ class Builder extends BaseBuilder
      *
      * @used-by batchExecute
      *
-     * @param string                 $table  Protected table name
-     * @param list<string>           $keys   QBKeys
-     * @param list<list<int|string>> $values QBSet
+     * @param string                          $table  Protected table name
+     * @param list<string>                    $keys   QBKeys
+     * @param list<list<int|SqlValue|string>> $values QBSet
      */
     protected function _updateBatch(string $table, array $keys, array $values): string
     {
@@ -393,7 +394,13 @@ class Builder extends BaseBuilder
                 " UNION ALL\n",
                 array_map(
                     static fn ($value) => 'SELECT ' . implode(', ', array_map(
-                        static fn ($key, $index) => $index . ' ' . $key,
+                        static function ($key, $index) {
+                            if ($index instanceof SqlValue) {
+                                return $index->getValue() . '::' . $index->getType() . ' ' . $key;
+                            }
+
+                            return $index . ' ' . $key;
+                        },
                         $keys,
                         $value
                     )),

--- a/system/Database/SqlValue.php
+++ b/system/Database/SqlValue.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+/**
+ * @interal
+ */
+class SqlValue
+{
+    /**
+     * @var string Escaped column value.
+     */
+    private string $value;
+
+    /**
+     * @var string|null Column type.
+     */
+    private ?string $type;
+
+    /**
+     * @param string      $value Escaped column value.
+     * @param string|null $type  Column type.
+     */
+    public function __construct(string $value, ?string $type = null)
+    {
+        $this->value = $value;
+        $this->type  = $type;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -115,24 +115,44 @@ final class UpdateTest extends CIUnitTestCase
     {
         $data = [
             [
-                'name'    => 'Derek Jones',
-                'country' => 'Greece',
+                'name'       => 'Derek Jones',
+                'country'    => 'Greece',
+                'updated_at' => '2023-12-02 18:47:52',
             ],
             [
-                'name'    => 'Ahmadinejad',
-                'country' => 'Greece',
+                'name'       => 'Ahmadinejad',
+                'country'    => 'Greece',
+                'updated_at' => '2023-12-02 18:47:52',
             ],
         ];
+
+        if ($this->db->DBDriver === 'Postgre') {
+            // PostgreSQL needs column type.
+            $data = [
+                [
+                    'name'                  => 'Derek Jones',
+                    'country'               => 'Greece',
+                    'updated_at::TIMESTAMP' => '2023-12-02 18:47:52',
+                ],
+                [
+                    'name'                  => 'Ahmadinejad',
+                    'country'               => 'Greece',
+                    'updated_at::TIMESTAMP' => '2023-12-02 18:47:52',
+                ],
+            ];
+        }
 
         $this->db->table('user')->updateBatch($data, 'name');
 
         $this->seeInDatabase('user', [
-            'name'    => 'Derek Jones',
-            'country' => 'Greece',
+            'name'       => 'Derek Jones',
+            'country'    => 'Greece',
+            'updated_at' => '2023-12-02 18:47:52',
         ]);
         $this->seeInDatabase('user', [
-            'name'    => 'Ahmadinejad',
-            'country' => 'Greece',
+            'name'       => 'Ahmadinejad',
+            'country'    => 'Greece',
+            'updated_at' => '2023-12-02 18:47:52',
         ]);
     }
 

--- a/user_guide_src/source/changelogs/v4.4.5.rst
+++ b/user_guide_src/source/changelogs/v4.4.5.rst
@@ -30,6 +30,9 @@ Deprecations
 Bugs Fixed
 **********
 
+- **QueryBuilder:** Fixed a bug that the ``updateBatch()`` method does not work
+  due to type errors on PostgreSQL. See the note in :ref:`update-from-data`.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1107,6 +1107,8 @@ $builder->updateBatch()
 .. note:: Since v4.3.0, the second parameter ``$index`` of ``updateBatch()`` has
     changed to ``$constraints``. It now accepts types array, string, or ``RawSql``.
 
+.. _update-from-data:
+
 Update from Data
 ^^^^^^^^^^^^^^^^
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1107,18 +1107,20 @@ $builder->updateBatch()
 .. note:: Since v4.3.0, the second parameter ``$index`` of ``updateBatch()`` has
     changed to ``$constraints``. It now accepts types array, string, or ``RawSql``.
 
+Update from Data
+^^^^^^^^^^^^^^^^
+
 Generates an update string based on the data you supply, and runs the query.
 You can either pass an **array** or an **object** to the method.
 Here is an example using an array:
 
 .. literalinclude:: query_builder/092.php
 
+The first parameter is an associative array of values, the second parameter is the where keys.
+
 .. note:: Since v4.3.0, the generated SQL structure has been Improved.
 
-The first parameter is an associative array of values, the second parameter is the where key.
-
-Since v4.3.0, you can also use the ``setQueryAsData()``, ``onConstraint()``, and
-``updateFields()`` methods:
+Since v4.3.0, you can also use the ``onConstraint()`` and ``updateFields()`` methods:
 
 .. literalinclude:: query_builder/120.php
 
@@ -1130,12 +1132,12 @@ Since v4.3.0, you can also use the ``setQueryAsData()``, ``onConstraint()``, and
     due to the very nature of how it works. Instead, ``updateBatch()``
     returns the number of rows affected.
 
-You can also update from a query:
+Update from a Query
+^^^^^^^^^^^^^^^^^^^
+
+Since v4.3.0, you can also update from a query with the ``setQueryAsData()`` method:
 
 .. literalinclude:: query_builder/116.php
-
-.. note:: The ``setQueryAsData()``, ``onConstraint()``, and ``updateFields()``
-    methods can be used since v4.3.0.
 
 .. note:: It is required to alias the columns of the select query to match those of the target table.
 

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1120,6 +1120,13 @@ The first parameter is an associative array of values, the second parameter is t
 
 .. note:: Since v4.3.0, the generated SQL structure has been Improved.
 
+    As a result, PostgreSQL may generate SQL errors if the column type is not
+    specified. In that case, specify the column name and its type as
+    ``<column_name>::<type>`` (e.g., ``updated_at::TIMESTAMP``). This feature
+    can be used since v4.4.5.
+
+    .. literalinclude:: query_builder/123.php
+
 Since v4.3.0, you can also use the ``onConstraint()`` and ``updateFields()`` methods:
 
 .. literalinclude:: query_builder/120.php

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1125,7 +1125,7 @@ The first parameter is an associative array of values, the second parameter is t
     As a result, PostgreSQL may generate SQL errors if the column type is not
     specified. In that case, specify the column name and its type as
     ``<column_name>::<type>`` (e.g., ``updated_at::TIMESTAMP``). This feature
-    can be used since v4.4.5.
+    can be used since v4.4.5 and only for ``updateBatch()`` on PostgreSQL.
 
     .. literalinclude:: query_builder/123.php
 

--- a/user_guide_src/source/database/query_builder/123.php
+++ b/user_guide_src/source/database/query_builder/123.php
@@ -1,0 +1,27 @@
+<?php
+
+$data = [
+    [
+        'name'                  => 'Derek Jones',
+        'country'               => 'Greece',
+        'updated_at::TIMESTAMP' => '2023-12-02 18:47:52',
+    ],
+    [
+        'name'                  => 'Ahmadinejad',
+        'country'               => 'Greece',
+        'updated_at::TIMESTAMP' => '2023-12-02 18:47:52',
+    ],
+];
+$builder->updateBatch($data, 'name');
+/*
+ * Produces:
+ * UPDATE "db_user"
+ * SET
+ * "country" = _u."country",
+ * "updated_at" = _u."updated_at"
+ * FROM (
+ * SELECT 'Greece' "country", 'Derek Jones' "name", '2023-12-02 18:47:52'::TIMESTAMP "updated_at" UNION ALL
+ * SELECT 'Greece' "country", 'Ahmadinejad' "name", '2023-12-02 18:47:52'::TIMESTAMP "updated_at"
+ * ) _u
+ * WHERE "db_user"."name" = _u."name"
+ */


### PR DESCRIPTION
**Description**
Fixes #7387
See https://forum.codeigniter.com/showthread.php?tid=88871

This PR introduces a new syntax to specify column name and its type, `<column_name>::<type>`.
E.g., `updated_at::TIMESTAMP`

```php
$data = [
    [
        'name'                  => 'Derek Jones',
        'country'               => 'Greece',
        'updated_at::TIMESTAMP' => '2023-12-02 18:47:52',
    ],
    [
        'name'                  => 'Ahmadinejad',
        'country'               => 'Greece',
        'updated_at::TIMESTAMP' => '2023-12-02 18:47:52',
    ],
];
$builder->updateBatch($data, 'name');
/*
 * Produces:
 * UPDATE "db_user"
 * SET
 * "country" = _u."country",
 * "updated_at" = _u."updated_at"
 * FROM (
 * SELECT 'Greece' "country", 'Derek Jones' "name", '2023-12-02 18:47:52'::TIMESTAMP "updated_at" UNION ALL
 * SELECT 'Greece' "country", 'Ahmadinejad' "name", '2023-12-02 18:47:52'::TIMESTAMP "updated_at"
 * ) _u
 * WHERE "db_user"."name" = _u."name"
 */
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
