### PR TITLE
chore: update Sphinx version to 5.3

### DIFF
--- a/user_guide_src/requirements.txt
+++ b/user_guide_src/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>=4.5.0,<5
-sphinxcontrib-phpdomain>=0.8.0
-docutils>=0.16
-sphinx-rtd-theme>=0.5.0
-jinja2<3.1
+sphinx>=5.3.0,<6.0.0
+sphinxcontrib-phpdomain>=0.11.0
+docutils>=0.19
+sphinx-rtd-theme>=2.0.0,<3.0.0
+jinja2>=3.1.3,<4.0.0


### PR DESCRIPTION
**Description**
```
Running Sphinx v4.5.0

Sphinx version error:
The sphinxcontrib.devhelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
make: *** [Makefile:20: html] Error 2
Traceback (most recent call last):
  File "/entrypoint.py", line 22, in <module>
    action.build_all_docs(github_env, [os.environ.get("INPUT_DOCS-FOLDER")])
  File "/sphinx_action/action.py", line 167, in build_all_docs
    raise RuntimeError("Build failed")
RuntimeError: Build failed
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7564707135/job/20599261845

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
