### PR TITLE
fix: OCI8 Forge always sets NOT NULL when BOOLEAN is specified

### DIFF
--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -254,7 +254,6 @@ class Forge extends BaseForge
                 $attributes['TYPE']       = 'NUMBER';
                 $attributes['CONSTRAINT'] = 1;
                 $attributes['UNSIGNED']   = true;
-                $attributes['NULL']       = false;
 
                 return;
 


### PR DESCRIPTION
**Description**
- fix a bug that OCI8 Forge always sets `NOT NULL` when `BOOLEAN` is specified. See https://github.com/codeigniter4/CodeIgniter4/pull/8439#issuecomment-1902546711

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
