### PR TITLE
docs: fix incorrect descriptions in Forge::modifyColumn() notes

### DIFF
--- a/user_guide_src/source/dbmgmt/forge.rst
+++ b/user_guide_src/source/dbmgmt/forge.rst
@@ -306,11 +306,11 @@ change the name, you can add a "name" key into the field defining array.
     a table, if ``null`` is not specified, the column will be ``NULL``, not
     ``NOT NULL``.
 
-.. note:: Due to a bug, prior v4.3.3, SQLite3 may not set ``NOT NULL`` even if you
+.. note:: Due to a bug, prior v4.3.4, SQLite3 may not set ``NOT NULL`` even if you
     specify ``'null' => false``.
 
-.. note:: Due to a bug, prior v4.3.3, Postgres and SQLSRV set ``NOT NULL`` even
-    if you specify ``'null' => false``.
+.. note:: Due to a bug, prior v4.3.4, Postgres and SQLSRV set ``NOT NULL`` even
+    if you specify ``'null' => true``.
 
 .. _db-forge-adding-keys-to-a-table:
 


### PR DESCRIPTION
**Description**
Follow-up #7371

This bug was fixed in v4.3.4.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
