### PR TITLE
fix: DB Seeder may use wrong DB connection during testing

### DIFF
--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -79,7 +79,7 @@ trait DatabaseTestTrait
             $config          = new Migrations();
             $config->enabled = true;
 
-            $this->migrations = Services::migrations($config, $this->db);
+            $this->migrations = Services::migrations($config, $this->db, false);
             $this->migrations->setSilent(false);
         }
 


### PR DESCRIPTION
**Description**
The shared migration holds an old DB connection.
If SQLite3 `:memory:` is used, a new DB connection is a connection to a new database.

Before:
```console
$ vendor/bin/phpunit tests/system/Database/Live/TransactionDBDebugTrueTest.php 
PHPUnit 9.6.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.15
Configuration: /Users/kenji/work/codeigniter/official/CodeIgniter4/phpunit.xml

.EEEE                                                                5 / 5 (100%)

Time: 00:00.136, Memory: 18.00 MB

There were 4 errors:

1) CodeIgniter\Database\Live\TransactionDBDebugTrueTest::testTransStartTransException
CodeIgniter\Database\Exceptions\DatabaseException: SQLite3::exec(): no such table: db_user
```
After:
```console
$ vendor/bin/phpunit tests/system/Database/Live/TransactionDBDebugTrueTest.php 
PHPUnit 9.6.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.15
Configuration: /Users/kenji/work/codeigniter/official/CodeIgniter4/phpunit.xml

.....                                                                    5 / 5 (100%)

Time: 00:00.296, Memory: 18.00 MB

OK (5 tests, 16 assertions)
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
