### PR TITLE
fix: [Postgre] QueryBuilder::deleteBatch() does not work

### DIFF
--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -579,11 +579,7 @@ class Builder extends BaseBuilder
                                 );
                         }
 
-                        return $table . '.' . $value . ' = '
-                            . $that->cast(
-                                $alias . '.' . $value,
-                                $that->getFieldType($table, $key)
-                            );
+                        return $table . '.' . $value . ' = ' . $alias . '.' . $value;
                     },
                     array_keys($constraints),
                     $constraints

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -566,15 +566,25 @@ class Builder extends BaseBuilder
             $sql .= 'WHERE ' . implode(
                 ' AND ',
                 array_map(
-                    static fn ($key, $value) => (
-                        $value instanceof RawSql ?
-                        $value :
-                        (
-                            is_string($key) ?
-                            $table . '.' . $key . ' = ' . $that->cast($alias . '.' . $value, $that->getFieldType($table, $key)) :
-                            $table . '.' . $value . ' = ' . $that->cast($alias . '.' . $value, $that->getFieldType($table, $key))
-                        )
-                    ),
+                    static function ($key, $value) use ($table, $alias, $that) {
+                        if ($value instanceof RawSql) {
+                            return $value;
+                        }
+
+                        if (is_string($key)) {
+                            return $table . '.' . $key . ' = '
+                                . $that->cast(
+                                    $alias . '.' . $value,
+                                    $that->getFieldType($table, $key)
+                                );
+                        }
+
+                        return $table . '.' . $value . ' = '
+                            . $that->cast(
+                                $alias . '.' . $value,
+                                $that->getFieldType($table, $key)
+                            );
+                    },
                     array_keys($constraints),
                     $constraints
                 )

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -562,6 +562,7 @@ class Builder extends BaseBuilder
 
             $sql .= ') ' . $alias . "\n";
 
+            $that = $this;
             $sql .= 'WHERE ' . implode(
                 ' AND ',
                 array_map(
@@ -570,8 +571,8 @@ class Builder extends BaseBuilder
                         $value :
                         (
                             is_string($key) ?
-                            $table . '.' . $key . ' = ' . $alias . '.' . $value :
-                            $table . '.' . $value . ' = ' . $alias . '.' . $value
+                            $table . '.' . $key . ' = ' . $that->cast($alias . '.' . $value, $that->getFieldType($table, $key)) :
+                            $table . '.' . $value . ' = ' . $that->cast($alias . '.' . $value, $that->getFieldType($table, $key))
                         )
                     ),
                     array_keys($constraints),

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -98,6 +98,52 @@ final class DeleteTest extends CIUnitTestCase
         $this->dontSeeInDatabase('user', ['email' => 'ahmadinejad@world.com', 'name' => 'Ahmadinejad']);
     }
 
+    public function testDeleteBatchConstraintsDate(): void
+    {
+        $table = 'type_test';
+
+        // Prepares test data.
+        $builder = $this->db->table($table);
+        $builder->truncate();
+
+        for ($i = 1; $i < 4; $i++) {
+            $builder->insert([
+                'type_varchar'  => 'test' . $i,
+                'type_char'     => 'char',
+                'type_text'     => 'text',
+                'type_smallint' => 32767,
+                'type_integer'  => 2_147_483_647,
+                'type_bigint'   => 9_223_372_036_854_775_807,
+                'type_float'    => 10.1,
+                'type_numeric'  => 123.23,
+                'type_date'     => '2023-12-0' . $i,
+                'type_datetime' => '2023-12-21 12:00:00',
+            ]);
+        }
+
+        $data = [
+            ['date' => '2023-12-01', 'unused' => 'You can have fields you dont use'],
+            ['date' => '2023-12-02', 'unused' => 'You can have fields you dont use'],
+        ];
+        $builder = $this->db->table($table)
+            ->setData($data, null, 'data')
+            ->onConstraint(['type_date' => 'date']);
+        $builder->deleteBatch();
+
+        $this->dontSeeInDatabase(
+            $table,
+            ['type_date' => '2023-12-01', 'type_varchar' => 'test1']
+        );
+        $this->dontSeeInDatabase(
+            $table,
+            ['type_date' => '2023-12-02', 'type_varchar' => 'test2']
+        );
+        $this->seeInDatabase(
+            $table,
+            ['type_date' => '2023-12-03', 'type_varchar' => 'test3']
+        );
+    }
+
     public function testDeleteBatchWithQuery(): void
     {
         $this->forge = Database::forge($this->DBGroup);


### PR DESCRIPTION
**Description**
- fix type error in `deleteBatch()` on PostgreSQL

Ref #8439

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
