### PR TITLE
fix: add undocumented Model $allowEmptyInserts

### DIFF
--- a/system/Commands/Generators/Views/model.tpl.php
+++ b/system/Commands/Generators/Views/model.tpl.php
@@ -17,6 +17,8 @@ class {class} extends Model
     protected $protectFields    = true;
     protected $allowedFields    = [];
 
+    protected bool $allowEmptyInserts = false;
+
     // Dates
     protected $useTimestamps = false;
     protected $dateFormat    = 'datetime';

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -157,6 +157,17 @@ potential mass assignment vulnerabilities.
 
 .. note:: The `$primaryKey`_ field should never be an allowed field.
 
+$allowEmptyInserts
+------------------
+
+.. versionadded:: 4.3.0
+
+Whether to allow inserting empty data. The default value is ``false``, meaning
+that if you try to insert empty data, an exception with
+"There is no data to insert." will raise.
+
+You may also change this setting with the :ref:`model-allow-empty-inserts` method.
+
 Dates
 -----
 
@@ -370,6 +381,8 @@ allowEmptyInserts()
 You can use ``allowEmptyInserts()`` method to insert empty data. The Model throws an exception when you try to insert empty data by default. But if you call this method, the check will no longer be performed.
 
 .. literalinclude:: model/056.php
+
+You may also change this setting with the `$allowEmptyInserts`_ property.
 
 You can enable the check again by calling ``allowEmptyInserts(false)``.
 

--- a/user_guide_src/source/models/model/005.php
+++ b/user_guide_src/source/models/model/005.php
@@ -16,6 +16,8 @@ class UserModel extends Model
 
     protected $allowedFields = ['name', 'email'];
 
+    protected bool $allowEmptyInserts = false;
+
     // Dates
     protected $useTimestamps = false;
     protected $dateFormat    = 'datetime';


### PR DESCRIPTION
**Description**
- add missing $allowEmptyInserts to user guide and make:model template

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
