### PR TITLE
fix: [SQLite3] Forge::modifyColumn() messes up table

### DIFF
--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -131,9 +131,22 @@ class Forge extends BaseForge
                 return ''; // Why empty string?
 
             case 'CHANGE':
+                $fieldsToModify = [];
+
+                foreach ($processedFields as $processedField) {
+                    $name    = $processedField['name'];
+                    $newName = $processedField['new_name'];
+
+                    $field             = $this->fields[$name];
+                    $field['name']     = $name;
+                    $field['new_name'] = $newName;
+
+                    $fieldsToModify[] = $field;
+                }
+
                 (new Table($this->db, $this))
                     ->fromTable($table)
-                    ->modifyColumn($processedFields) // @TODO Bug: should be NOT processed fields
+                    ->modifyColumn($fieldsToModify)
                     ->run();
 
                 return null; // Why null?

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -141,6 +141,12 @@ class Forge extends BaseForge
                     $field['name']     = $name;
                     $field['new_name'] = $newName;
 
+                    // Unlike when creating a table, if `null` is not specified,
+                    // the column will be `NULL`, not `NOT NULL`.
+                    if ($processedField['null'] === '') {
+                        $field['null'] = true;
+                    }
+
                     $fieldsToModify[] = $field;
                 }
 

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -399,7 +399,15 @@ class Table
                 // 'NULL' means that the default value is NULL.
                 $return[$field->name]['default'] = null;
             } else {
-                $return[$field->name]['default'] = trim($field->default, "'");
+                $default = trim($field->default, "'");
+
+                if ($this->isIntegerType($field->type)) {
+                    $default = (int) $default;
+                } elseif ($this->isNumericType($field->type)) {
+                    $default = (float) $default;
+                }
+
+                $return[$field->name]['default'] = $default;
             }
 
             if ($field->primary_key) {
@@ -411,6 +419,30 @@ class Table
         }
 
         return $return;
+    }
+
+    /**
+     * Is INTEGER type?
+     *
+     * @param string $type SQLite data type (case-insensitive)
+     *
+     * @see https://www.sqlite.org/datatype3.html
+     */
+    private function isIntegerType(string $type): bool
+    {
+        return strpos(strtoupper($type), 'INT') !== false;
+    }
+
+    /**
+     * Is NUMERIC type?
+     *
+     * @param string $type SQLite data type (case-insensitive)
+     *
+     * @see https://www.sqlite.org/datatype3.html
+     */
+    private function isNumericType(string $type): bool
+    {
+        return in_array(strtoupper($type), ['NUMERIC', 'DECIMAL'], true);
     }
 
     /**

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -392,6 +392,16 @@ class Table
                 'null'    => $field->nullable,
             ];
 
+            if ($field->default === null) {
+                // `null` means that the default value is not defined.
+                unset($return[$field->name]['default']);
+            } elseif ($field->default === 'NULL') {
+                // 'NULL' means that the default value is NULL.
+                $return[$field->name]['default'] = null;
+            } else {
+                $return[$field->name]['default'] = trim($field->default, "'");
+            }
+
             if ($field->primary_key) {
                 $this->keys['primary'] = [
                     'fields' => [$field->name],

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1289,8 +1289,18 @@ final class ForgeTest extends CIUnitTestCase
                 'unsigned'       => false,
                 'auto_increment' => true,
             ],
+            'int' => [
+                'type'       => 'INT',
+                'constraint' => 10,
+                'null'       => false,
+            ],
+            'varchar' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 7,
+                'null'       => false,
+            ],
             'name' => [
-                'type'       => 'varchar',
+                'type'       => 'VARCHAR',
                 'constraint' => 255,
                 'null'       => true,
             ],
@@ -1304,7 +1314,7 @@ final class ForgeTest extends CIUnitTestCase
         $this->forge->modifyColumn('forge_test_three', [
             'name' => [
                 'name'       => 'altered',
-                'type'       => 'varchar',
+                'type'       => 'VARCHAR',
                 'constraint' => 255,
                 'null'       => true,
             ],
@@ -1312,8 +1322,22 @@ final class ForgeTest extends CIUnitTestCase
 
         $this->db->resetDataCache();
 
+        $fieldData = $this->db->getFieldData('forge_test_three');
+        $fields    = [];
+
+        foreach ($fieldData as $obj) {
+            $fields[$obj->name] = $obj;
+        }
+
         $this->assertFalse($this->db->fieldExists('name', 'forge_test_three'));
         $this->assertTrue($this->db->fieldExists('altered', 'forge_test_three'));
+
+        $this->assertTrue($fields['altered']->nullable);
+        $this->assertFalse($fields['int']->nullable);
+        $this->assertFalse($fields['varchar']->nullable);
+        $this->assertNull($fields['altered']->default);
+        $this->assertNull($fields['int']->default);
+        $this->assertNull($fields['varchar']->default);
 
         $this->forge->dropTable('forge_test_three', true);
     }

--- a/tests/system/Database/Live/SQLite3/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite3/AlterTableTest.php
@@ -89,17 +89,17 @@ final class AlterTableTest extends CIUnitTestCase
 
         $this->assertCount(5, $fields);
         $this->assertArrayHasKey('id', $fields);
-        $this->assertNull($fields['id']['default']);
+        $this->assertArrayNotHasKey('default', $fields['id']);
         $this->assertTrue($fields['id']['null']);
         $this->assertSame('integer', strtolower($fields['id']['type']));
 
         $this->assertArrayHasKey('name', $fields);
-        $this->assertNull($fields['name']['default']);
+        $this->assertArrayNotHasKey('default', $fields['name']);
         $this->assertFalse($fields['name']['null']);
         $this->assertSame('varchar', strtolower($fields['name']['type']));
 
         $this->assertArrayHasKey('email', $fields);
-        $this->assertNull($fields['email']['default']);
+        $this->assertArrayNotHasKey('default', $fields['email']);
         $this->assertTrue($fields['email']['null']);
         $this->assertSame('varchar', strtolower($fields['email']['type']));
 

--- a/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
+++ b/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live\SQLite3;
+
+use CodeIgniter\Database\Forge;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Database;
+
+/**
+ * @group DatabaseLive
+ *
+ * @internal
+ */
+final class ForgeModifyColumnTest extends CIUnitTestCase
+{
+    private Forge $forge;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = Database::connect($this->DBGroup);
+
+        if ($this->db->DBDriver !== 'SQLite3') {
+            $this->markTestSkipped('This test is only for SQLite3.');
+        }
+
+        $this->forge = Database::forge($this->DBGroup);
+    }
+
+    public function testModifyColumnRename(): void
+    {
+        $this->forge->dropTable('forge_test_three', true);
+
+        $this->forge->addField([
+            'id' => [
+                'type'           => 'INTEGER',
+                'constraint'     => 11,
+                'auto_increment' => true,
+            ],
+            'int' => [
+                'type'       => 'INT',
+                'constraint' => 10,
+                'null'       => false,
+                'default'    => 0,
+            ],
+            'varchar' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 7,
+                'null'       => false,
+            ],
+            'decimal' => [
+                'type'       => 'DECIMAL',
+                'constraint' => '10,5',
+                'default'    => 0.1,
+            ],
+            'name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+                'null'       => true,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('forge_test_three');
+
+        $this->assertTrue($this->db->fieldExists('name', 'forge_test_three'));
+
+        $this->forge->modifyColumn('forge_test_three', [
+            'name' => [
+                'name'       => 'altered',
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+                'null'       => true,
+            ],
+        ]);
+
+        $this->db->resetDataCache();
+
+        $fieldData = $this->db->getFieldData('forge_test_three');
+        $fields    = [];
+
+        foreach ($fieldData as $obj) {
+            $fields[$obj->name] = $obj;
+        }
+
+        $this->assertFalse($this->db->fieldExists('name', 'forge_test_three'));
+        $this->assertTrue($this->db->fieldExists('altered', 'forge_test_three'));
+
+        $this->assertFalse($fields['int']->nullable);
+        $this->assertSame('0', $fields['int']->default);
+
+        $this->assertFalse($fields['varchar']->nullable);
+        $this->assertNull($fields['varchar']->default);
+
+        $this->assertFalse($fields['decimal']->nullable);
+        $this->assertSame('0.1', $fields['decimal']->default);
+
+        $this->assertTrue($fields['altered']->nullable);
+        $this->assertNull($fields['altered']->default);
+
+        $this->forge->dropTable('forge_test_three', true);
+    }
+}

--- a/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
+++ b/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
@@ -39,7 +39,9 @@ final class ForgeModifyColumnTest extends CIUnitTestCase
 
     public function testModifyColumnRename(): void
     {
-        $this->forge->dropTable('forge_test_three', true);
+        $table = 'forge_test_three';
+
+        $this->forge->dropTable($table, true);
 
         $this->forge->addField([
             'id' => [
@@ -71,11 +73,11 @@ final class ForgeModifyColumnTest extends CIUnitTestCase
         ]);
 
         $this->forge->addKey('id', true);
-        $this->forge->createTable('forge_test_three');
+        $this->forge->createTable($table);
 
-        $this->assertTrue($this->db->fieldExists('name', 'forge_test_three'));
+        $this->assertTrue($this->db->fieldExists('name', $table));
 
-        $this->forge->modifyColumn('forge_test_three', [
+        $this->forge->modifyColumn($table, [
             'name' => [
                 'name'       => 'altered',
                 'type'       => 'VARCHAR',
@@ -86,15 +88,15 @@ final class ForgeModifyColumnTest extends CIUnitTestCase
 
         $this->db->resetDataCache();
 
-        $fieldData = $this->db->getFieldData('forge_test_three');
+        $fieldData = $this->db->getFieldData($table);
         $fields    = [];
 
         foreach ($fieldData as $obj) {
             $fields[$obj->name] = $obj;
         }
 
-        $this->assertFalse($this->db->fieldExists('name', 'forge_test_three'));
-        $this->assertTrue($this->db->fieldExists('altered', 'forge_test_three'));
+        $this->assertFalse($this->db->fieldExists('name', $table));
+        $this->assertTrue($this->db->fieldExists('altered', $table));
 
         $this->assertFalse($fields['int']->nullable);
         $this->assertSame('0', $fields['int']->default);
@@ -108,6 +110,6 @@ final class ForgeModifyColumnTest extends CIUnitTestCase
         $this->assertTrue($fields['altered']->nullable);
         $this->assertNull($fields['altered']->default);
 
-        $this->forge->dropTable('forge_test_three', true);
+        $this->forge->dropTable($table, true);
     }
 }


### PR DESCRIPTION
**Description**
Fixes #8410

~~OCI8 test failure will be fixed in #8459~~

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
