### PR TITLE
fix: [OCI8] getFieldData() returns incorrect `default` value

### DIFF
--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -315,11 +315,7 @@ class Connection extends BaseConnection
 
             $retval[$i]->max_length = $length;
 
-            $default = $query[$i]->DATA_DEFAULT;
-            if ($default === null && $query[$i]->NULLABLE === 'N') {
-                $default = '';
-            }
-            $retval[$i]->default  = $default;
+            $retval[$i]->default  = $query[$i]->DATA_DEFAULT;
             $retval[$i]->nullable = $query[$i]->NULLABLE === 'Y';
         }
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1058,7 +1058,7 @@ final class ForgeTest extends CIUnitTestCase
                     'name'       => 'username',
                     'type'       => 'VARCHAR2',
                     'max_length' => '255',
-                    'default'    => '',
+                    'default'    => null,
                     'nullable'   => false,
                 ],
                 2 => [

--- a/tests/system/Database/Live/OCI8/GetFieldDataTest.php
+++ b/tests/system/Database/Live/OCI8/GetFieldDataTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live\OCI8;
+
+use CodeIgniter\Database\Live\AbstractGetFieldDataTest;
+use Config\Database;
+
+/**
+ * @group DatabaseLive
+ *
+ * @internal
+ */
+final class GetFieldDataTest extends AbstractGetFieldDataTest
+{
+    protected function createForge(): void
+    {
+        if ($this->db->DBDriver !== 'OCI8') {
+            $this->markTestSkipped('This test is only for OCI8.');
+        }
+
+        $this->forge = Database::forge($this->db);
+    }
+
+    public function testGetFieldData(): void
+    {
+        $fields = $this->db->getFieldData('test1');
+
+        $data = [];
+
+        foreach ($fields as $obj) {
+            $data[$obj->name] = $obj;
+        }
+
+        $idDefault = $data['id']->default;
+        $this->assertMatchesRegularExpression('/"ORACLE"."ISEQ\$\$_[0-9]+".nextval/', $idDefault);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                (object) [
+                    'name'       => 'id',
+                    'type'       => 'NUMBER',
+                    'max_length' => '11',
+                    'default'    => $idDefault, // The default value is not defined.
+                    // 'primary_key' => 1,
+                    'nullable' => false,
+                ],
+                (object) [
+                    'name'       => 'text_not_null',
+                    'type'       => 'VARCHAR2',
+                    'max_length' => '64',
+                    'default'    => null, // The default value is not defined.
+                    // 'primary_key' => 0,
+                    'nullable' => false,
+                ],
+                (object) [
+                    'name'       => 'text_null',
+                    'type'       => 'VARCHAR2',
+                    'max_length' => '64',
+                    'default'    => null, // The default value is not defined.
+                    // 'primary_key' => 0,
+                    'nullable' => true,
+                ],
+                (object) [
+                    'name'       => 'int_default_0',
+                    'type'       => 'NUMBER',
+                    'max_length' => '11',
+                    'default'    => '0 ', // int 0
+                    // 'primary_key' => 0,
+                    'nullable' => false,
+                ],
+                (object) [
+                    'name'       => 'text_default_null',
+                    'type'       => 'VARCHAR2',
+                    'max_length' => '64',
+                    'default'    => 'NULL ', // NULL value
+                    // 'primary_key' => 0,
+                    'nullable' => true,
+                ],
+                (object) [
+                    'name'       => 'text_default_text_null',
+                    'type'       => 'VARCHAR2',
+                    'max_length' => '64',
+                    'default'    => "'null' ", // string "null"
+                    // 'primary_key' => 0,
+                    'nullable' => false,
+                ],
+                (object) [
+                    'name'       => 'text_default_abc',
+                    'type'       => 'VARCHAR2',
+                    'max_length' => '64',
+                    'default'    => "'abc' ", // string "abc"
+                    // 'primary_key' => 0,
+                    'nullable' => false,
+                ],
+            ]),
+            json_encode($fields)
+        );
+    }
+}

--- a/tests/system/Database/Live/OCI8/GetFieldDataTest.php
+++ b/tests/system/Database/Live/OCI8/GetFieldDataTest.php
@@ -45,66 +45,71 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
         $idDefault = $data['id']->default;
         $this->assertMatchesRegularExpression('/"ORACLE"."ISEQ\$\$_[0-9]+".nextval/', $idDefault);
 
-        $this->assertJsonStringEqualsJsonString(
-            json_encode([
-                (object) [
-                    'name'       => 'id',
-                    'type'       => 'NUMBER',
-                    'max_length' => '11',
-                    'default'    => $idDefault, // The default value is not defined.
-                    // 'primary_key' => 1,
-                    'nullable' => false,
-                ],
-                (object) [
-                    'name'       => 'text_not_null',
-                    'type'       => 'VARCHAR2',
-                    'max_length' => '64',
-                    'default'    => null, // The default value is not defined.
-                    // 'primary_key' => 0,
-                    'nullable' => false,
-                ],
-                (object) [
-                    'name'       => 'text_null',
-                    'type'       => 'VARCHAR2',
-                    'max_length' => '64',
-                    'default'    => null, // The default value is not defined.
-                    // 'primary_key' => 0,
-                    'nullable' => true,
-                ],
-                (object) [
-                    'name'       => 'int_default_0',
-                    'type'       => 'NUMBER',
-                    'max_length' => '11',
-                    'default'    => '0 ', // int 0
-                    // 'primary_key' => 0,
-                    'nullable' => false,
-                ],
-                (object) [
-                    'name'       => 'text_default_null',
-                    'type'       => 'VARCHAR2',
-                    'max_length' => '64',
-                    'default'    => 'NULL ', // NULL value
-                    // 'primary_key' => 0,
-                    'nullable' => true,
-                ],
-                (object) [
-                    'name'       => 'text_default_text_null',
-                    'type'       => 'VARCHAR2',
-                    'max_length' => '64',
-                    'default'    => "'null' ", // string "null"
-                    // 'primary_key' => 0,
-                    'nullable' => false,
-                ],
-                (object) [
-                    'name'       => 'text_default_abc',
-                    'type'       => 'VARCHAR2',
-                    'max_length' => '64',
-                    'default'    => "'abc' ", // string "abc"
-                    // 'primary_key' => 0,
-                    'nullable' => false,
-                ],
-            ]),
-            json_encode($fields)
-        );
+        $expected = json_decode(json_encode([
+            (object) [
+                'name'       => 'id',
+                'type'       => 'NUMBER',
+                'max_length' => '11',
+                'default'    => $idDefault, // The default value is not defined.
+                // 'primary_key' => 1,
+                'nullable' => false,
+            ],
+            (object) [
+                'name'       => 'text_not_null',
+                'type'       => 'VARCHAR2',
+                'max_length' => '64',
+                'default'    => null, // The default value is not defined.
+                // 'primary_key' => 0,
+                'nullable' => false,
+            ],
+            (object) [
+                'name'       => 'text_null',
+                'type'       => 'VARCHAR2',
+                'max_length' => '64',
+                'default'    => null, // The default value is not defined.
+                // 'primary_key' => 0,
+                'nullable' => true,
+            ],
+            (object) [
+                'name'       => 'int_default_0',
+                'type'       => 'NUMBER',
+                'max_length' => '11',
+                'default'    => '0 ', // int 0
+                // 'primary_key' => 0,
+                'nullable' => false,
+            ],
+            (object) [
+                'name'       => 'text_default_null',
+                'type'       => 'VARCHAR2',
+                'max_length' => '64',
+                'default'    => 'NULL ', // NULL value
+                // 'primary_key' => 0,
+                'nullable' => true,
+            ],
+            (object) [
+                'name'       => 'text_default_text_null',
+                'type'       => 'VARCHAR2',
+                'max_length' => '64',
+                'default'    => "'null' ", // string "null"
+                // 'primary_key' => 0,
+                'nullable' => false,
+            ],
+            (object) [
+                'name'       => 'text_default_abc',
+                'type'       => 'VARCHAR2',
+                'max_length' => '64',
+                'default'    => "'abc' ", // string "abc"
+                // 'primary_key' => 0,
+                'nullable' => false,
+            ],
+        ]), true);
+        $names = array_column($expected, 'name');
+        array_multisort($names, SORT_ASC, $expected);
+
+        $fields = json_decode(json_encode($fields), true);
+        $names  = array_column($fields, 'name');
+        array_multisort($names, SORT_ASC, $fields);
+
+        $this->assertSame($expected, $fields);
     }
 }


### PR DESCRIPTION
**Description**
- fix a bug that returns `''` instead of `null`

Found in #8457 
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7664355802/job/20888609701?pr=8457
```
1) CodeIgniter\Database\Live\ForgeTest::testModifyColumnRename
Failed asserting that '' is null.

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Database/Live/ForgeTest.php:1339
phpvfscomposer:///home/runner/work/CodeIgniter4/CodeIgniter4/vendor/phpunit/phpunit/phpunit:106
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
