### PR TITLE
fix: [SQLite3] getFieldData() returns incorrect `primary_key` values

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -273,7 +273,7 @@ class Connection extends BaseConnection
             $retVal[$i]->type        = $query[$i]->type;
             $retVal[$i]->max_length  = null;
             $retVal[$i]->default     = $query[$i]->dflt_value;
-            $retVal[$i]->primary_key = isset($query[$i]->pk) && (bool) $query[$i]->pk;
+            $retVal[$i]->primary_key = $query[$i]->pk ?? false;
             $retVal[$i]->nullable    = isset($query[$i]->notnull) && ! (bool) $query[$i]->notnull;
         }
 

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -269,11 +269,14 @@ class Connection extends BaseConnection
         for ($i = 0, $c = count($query); $i < $c; $i++) {
             $retVal[$i] = new stdClass();
 
-            $retVal[$i]->name        = $query[$i]->name;
-            $retVal[$i]->type        = $query[$i]->type;
-            $retVal[$i]->max_length  = null;
-            $retVal[$i]->default     = $query[$i]->dflt_value;
-            $retVal[$i]->primary_key = $query[$i]->pk ?? false;
+            $retVal[$i]->name       = $query[$i]->name;
+            $retVal[$i]->type       = $query[$i]->type;
+            $retVal[$i]->max_length = null;
+            $retVal[$i]->default    = $query[$i]->dflt_value;
+            // "pk" (either zero for columns that are not part of the primary key,
+            // or the 1-based index of the column within the primary key).
+            // https://www.sqlite.org/pragma.html#pragma_table_info
+            $retVal[$i]->primary_key = ($query[$i]->pk === 0) ? 0 : 1;
             $retVal[$i]->nullable    = isset($query[$i]->notnull) && ! (bool) $query[$i]->notnull;
         }
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -986,7 +986,7 @@ final class ForgeTest extends CIUnitTestCase
                     'type'        => 'INTEGER',
                     'max_length'  => null,
                     'default'     => null,
-                    'primary_key' => true,
+                    'primary_key' => 1,
                     'nullable'    => true,
                 ],
                 1 => [
@@ -994,7 +994,7 @@ final class ForgeTest extends CIUnitTestCase
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
                     'default'     => null,
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => false,
                 ],
                 2 => [
@@ -1002,7 +1002,7 @@ final class ForgeTest extends CIUnitTestCase
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
                     'default'     => null,
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => true,
                 ],
                 3 => [
@@ -1010,7 +1010,7 @@ final class ForgeTest extends CIUnitTestCase
                     'type'        => 'INTEGER',
                     'max_length'  => null,
                     'default'     => '0',
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => false,
                 ],
             ];

--- a/tests/system/Database/Live/SQLite3/GetFieldDataTest.php
+++ b/tests/system/Database/Live/SQLite3/GetFieldDataTest.php
@@ -102,4 +102,63 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
             json_encode($fields)
         );
     }
+
+    protected function createTableCompositePrimaryKey()
+    {
+        $this->forge->dropTable('test1', true);
+
+        $this->forge->addField([
+            'pk1' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 64,
+            ],
+            'pk2' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 64,
+            ],
+            'text' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 64,
+            ],
+        ]);
+        $this->forge->addPrimaryKey(['pk1', 'pk2']);
+        $this->forge->createTable('test1');
+    }
+
+    public function testGetFieldDataCompositePrimaryKey(): void
+    {
+        $this->createTableCompositePrimaryKey();
+
+        $fields = $this->db->getFieldData('test1');
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                (object) [
+                    'name'        => 'pk1',
+                    'type'        => 'VARCHAR',
+                    'max_length'  => null,
+                    'default'     => null,
+                    'primary_key' => 1,
+                    'nullable'    => false,
+                ],
+                (object) [
+                    'name'        => 'pk2',
+                    'type'        => 'VARCHAR',
+                    'max_length'  => null,
+                    'default'     => null,
+                    'primary_key' => 1,
+                    'nullable'    => false,
+                ],
+                (object) [
+                    'name'        => 'text',
+                    'type'        => 'VARCHAR',
+                    'max_length'  => null,
+                    'default'     => null,
+                    'primary_key' => 0,
+                    'nullable'    => false,
+                ],
+            ]),
+            json_encode($fields)
+        );
+    }
 }

--- a/tests/system/Database/Live/SQLite3/GetFieldDataTest.php
+++ b/tests/system/Database/Live/SQLite3/GetFieldDataTest.php
@@ -47,7 +47,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                     'type'        => 'INTEGER',
                     'max_length'  => null,
                     'default'     => null, // The default value is not defined.
-                    'primary_key' => true,
+                    'primary_key' => 1,
                     'nullable'    => true,
                 ],
                 (object) [
@@ -55,7 +55,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
                     'default'     => null, // The default value is not defined.
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => false,
                 ],
                 (object) [
@@ -63,7 +63,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
                     'default'     => null, // The default value is not defined.
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => true,
                 ],
                 (object) [
@@ -71,7 +71,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                     'type'        => 'INT',
                     'max_length'  => null,
                     'default'     => '0', // int 0
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => false,
                 ],
                 (object) [
@@ -79,7 +79,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
                     'default'     => 'NULL', // NULL value
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => true,
                 ],
                 (object) [
@@ -87,7 +87,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
                     'default'     => "'null'", // string "null"
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => false,
                 ],
                 (object) [
@@ -95,7 +95,7 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
                     'default'     => "'abc'", // string "abc"
-                    'primary_key' => false,
+                    'primary_key' => 0,
                     'nullable'    => false,
                 ],
             ]),

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -105,7 +105,7 @@ database:
 -  name - column name
 -  type - the type of the column
 -  max_length - maximum length of the column
--  primary_key - integer ``1`` if the column is a primary key (all integer ``1``, even if there are multiple primary keys), otherwise integer ``0`` (This field is currently only available for MySQL and SQLite3)
+-  primary_key - integer ``1`` if the column is a primary key (all integer ``1``, even if there are multiple primary keys), otherwise integer ``0`` (This field is currently only available for MySQLi and SQLite3)
 -  nullable - boolean ``true`` if the column is nullable, otherwise boolean ``false``
 -  default - the default value
 

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -102,12 +102,12 @@ supplying the table name:
 The following data is available from this function if supported by your
 database:
 
--  name - column name
--  type - the type of the column
--  max_length - maximum length of the column
--  primary_key - integer ``1`` if the column is a primary key (all integer ``1``, even if there are multiple primary keys), otherwise integer ``0`` (This field is currently only available for MySQLi and SQLite3)
--  nullable - boolean ``true`` if the column is nullable, otherwise boolean ``false``
--  default - the default value
+- ``name`` - column name
+- ``type`` - the type of the column
+- ``max_length`` - maximum length of the column
+- ``primary_key`` - integer ``1`` if the column is a primary key (all integer ``1``, even if there are multiple primary keys), otherwise integer ``0`` (This field is currently only available for ``MySQLi`` and ``SQLite3``)
+- ``nullable`` - boolean ``true`` if the column is nullable, otherwise boolean ``false``
+- ``default`` - the default value
 
 .. note:: Since v4.4.0, SQLSRV supported ``nullable``.
 


### PR DESCRIPTION

**Description**
The return type is integer, not boolean.

> primary_key - integer 1 if the column is a primary key (all integer 1, even if there are multiple primary keys), otherwise integer 0 (This field is currently only available for MySQL and SQLite3)
See https://codeigniter4.github.io/CodeIgniter4/database/metadata.html#retrieve-field-metadata

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
