### PR TITLE
fix: [CURLRequest] Multiple HTTP 100 return by API.

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -389,7 +389,7 @@ class CURLRequest extends OutgoingRequest
         // Set the string we want to break our response from
         $breakString = "\r\n\r\n";
 
-        if (strpos($output, 'HTTP/1.1 100 Continue') === 0) {
+        while (strpos($output, 'HTTP/1.1 100 Continue') === 0) {
             $output = substr($output, strpos($output, $breakString) + 4);
         }
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1110,22 +1110,28 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
         $this->assertSame($agent, $options[CURLOPT_USERAGENT]);
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/8347
+     */
     public function testMultipleHTTP100(): void
     {
-        $output = 'HTTP/1.1 100 Continue
-        Mark bundle as not supporting multiuse
-        HTTP/1.1 100 Continue
-        Mark bundle as not supporting multiuse
-        HTTP/1.1 200 OK
-        Server: Werkzeug/2.2.2 Python/3.7.17
-        Date: Sun, 28 Jan 2024 06:05:36 GMT
-        Content-Type: application/json
-        Content-Length: 33
-        Connection: close';
+        $jsonBody = '{"name":"John Doe","age":30}';
+
+        $output = "HTTP/1.1 100 Continue
+Mark bundle as not supporting multiuse
+HTTP/1.1 100 Continue
+Mark bundle as not supporting multiuse
+HTTP/1.1 200 OK
+Server: Werkzeug/2.2.2 Python/3.7.17
+Date: Sun, 28 Jan 2024 06:05:36 GMT
+Content-Type: application/json
+Content-Length: 33\r\n\r\n" . $jsonBody;
 
         $this->request->setOutput($output);
 
         $response = $this->request->request('get', 'http://example.com');
+
+        $this->assertSame($jsonBody, $response->getBody());
 
         $this->assertSame(200, $response->getStatusCode());
     }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1129,7 +1129,7 @@ Content-Length: 33\r\n\r\n" . $jsonBody;
 
         $this->request->setOutput($output);
 
-        $response = $this->request->request('get', 'http://example.com');
+        $response = $this->request->request('GET', 'http://example.com');
 
         $this->assertSame($jsonBody, $response->getBody());
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1109,4 +1109,24 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
         $this->assertArrayHasKey(CURLOPT_USERAGENT, $options);
         $this->assertSame($agent, $options[CURLOPT_USERAGENT]);
     }
+
+    public function testMultipleHTTP100(): void
+    {
+        $output = 'HTTP/1.1 100 Continue
+        Mark bundle as not supporting multiuse
+        HTTP/1.1 100 Continue
+        Mark bundle as not supporting multiuse
+        HTTP/1.1 200 OK
+        Server: Werkzeug/2.2.2 Python/3.7.17
+        Date: Sun, 28 Jan 2024 06:05:36 GMT
+        Content-Type: application/json
+        Content-Length: 33
+        Connection: close';
+
+        $this->request->setOutput($output);
+
+        $response = $this->request->request('get', 'http://example.com');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
**Description**
Closes #8347 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
