### PR TITLE
fix: SQLite3 may not throw DatabaseException

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
-use ErrorException;
 use Exception;
 use SQLite3;
 use SQLite3Result;
@@ -87,9 +86,13 @@ class Connection extends BaseConnection
                 $this->database = WRITEPATH . $this->database;
             }
 
-            return (! $this->password)
+            $sqlite = (! $this->password)
                 ? new SQLite3($this->database)
                 : new SQLite3($this->database, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, $this->password);
+
+            $sqlite->enableExceptions(true);
+
+            return $sqlite;
         } catch (Exception $e) {
             throw new DatabaseException('SQLite3 error: ' . $e->getMessage());
         }
@@ -146,7 +149,7 @@ class Connection extends BaseConnection
             return $this->isWriteType($sql)
                 ? $this->connID->exec($sql)
                 : $this->connID->query($sql);
-        } catch (ErrorException $e) {
+        } catch (Exception $e) {
             log_message('error', (string) $e);
 
             if ($this->DBDebug) {

--- a/system/Database/SQLite3/PreparedQuery.php
+++ b/system/Database/SQLite3/PreparedQuery.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\SQLite3;
 use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use Exception;
 use SQLite3;
 use SQLite3Result;
 use SQLite3Stmt;
@@ -82,7 +83,15 @@ class PreparedQuery extends BasePreparedQuery
             $this->statement->bindValue($key + 1, $item, $bindType);
         }
 
-        $this->result = $this->statement->execute();
+        try {
+            $this->result = $this->statement->execute();
+        } catch (Exception $e) {
+            if ($this->db->DBDebug) {
+                throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+            }
+
+            return false;
+        }
 
         return $this->result !== false;
     }


### PR DESCRIPTION


**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/6913#issuecomment-1912990005

Use enableExceptions().
See https://www.php.net/manual/en/sqlite3.enableexceptions.php

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
