### PR TITLE
docs: improve contributing/signing.md

### DIFF
--- a/contributing/signing.md
+++ b/contributing/signing.md
@@ -47,7 +47,19 @@ The basic steps are
 - Provide your GPG key passphrase, as prompted, when you do a commit.
 
 Depending on your IDE, you may have to do your Git commits from your Git
-bash shell to use the **-S** option to force the secure signing.
+bash shell to use the `-S` option to force the secure signing.
+
+## Set Default Signing
+
+We recommend you set git securely sign commits without the `-S` option in
+`git commit`.
+
+You can do it by setting `git config --global commit.gpgsign true` and
+`git config --global user.signingkey 3AC5C34371567BD2` to all local repositories.
+Without the `--global` option, the change is applied to one local repository only.
+
+> [!NOTE]
+> `3AC5C34371567BD2` is your GPG Key ID
 
 ## Commit Messages
 

--- a/contributing/signing.md
+++ b/contributing/signing.md
@@ -29,7 +29,7 @@ Read below to find out how to sign your commits :)
 
 ## Secure Signing
 
-To verify your commits, you will need to setup a GPG key, and attach it
+To verify your commits, you will need to set up a GPG key, and attach it
 to your GitHub account.
 
 See the [git tools](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work) page

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -179,6 +179,10 @@ For instance, to commit your work from a debugging session:
 
 Just make sure that your commits in a feature branch are all related.
 
+> [!NOTE]
+> We recommend to [Set Default Signing](./signing.md#set-default-signing) for
+> secure signing commits without the `-S` option in `git commit`.
+
 ### GPG-Signing Old Commits
 
 Any developer can forget GPG-signing their commits with the option `-S`, like `git commit -S -m 'Signed GPG'`. In such a case, all you need to do is the following:
@@ -197,10 +201,8 @@ All commits:
 > git push --force-with-lease origin your-branch
 ```
 
-As a faster alternative, you can still securely sign commits without the `-S` option in `git commit` by setting `git config --global commit.gpgsign true` and `git config --global user.signingkey 3AC5C34371567BD2` to all local repositories. Without the `--global` option, the change is applied to one local repository only.
-
-> **Note**
-> `3AC5C34371567BD2` is your GPG Key ID
+As a faster alternative, you can still securely sign commits without the `-S`
+option in `git commit`. See [Set Default Signing](./signing.md#set-default-signing).
 
 ### Changing a Commit Message
 


### PR DESCRIPTION
**Description**
- add "Set Default Signing" section and refer it

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
