### PR TITLE
fix: [OCI8][Postgre][SQLSRV][SQLite3] change order of properties returned by getFieldData()

### DIFF
--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -315,8 +315,8 @@ class Connection extends BaseConnection
 
             $retval[$i]->max_length = $length;
 
-            $retval[$i]->default  = $query[$i]->DATA_DEFAULT;
             $retval[$i]->nullable = $query[$i]->NULLABLE === 'Y';
+            $retval[$i]->default  = $query[$i]->DATA_DEFAULT;
         }
 
         return $retval;

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -318,9 +318,9 @@ class Connection extends BaseConnection
 
             $retVal[$i]->name       = $query[$i]->column_name;
             $retVal[$i]->type       = $query[$i]->data_type;
+            $retVal[$i]->max_length = $query[$i]->character_maximum_length > 0 ? $query[$i]->character_maximum_length : $query[$i]->numeric_precision;
             $retVal[$i]->nullable   = $query[$i]->is_nullable === 'YES';
             $retVal[$i]->default    = $query[$i]->column_default;
-            $retVal[$i]->max_length = $query[$i]->character_maximum_length > 0 ? $query[$i]->character_maximum_length : $query[$i]->numeric_precision;
         }
 
         return $retVal;

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -357,15 +357,15 @@ class Connection extends BaseConnection
         for ($i = 0, $c = count($query); $i < $c; $i++) {
             $retVal[$i] = new stdClass();
 
-            $retVal[$i]->name    = $query[$i]->COLUMN_NAME;
-            $retVal[$i]->type    = $query[$i]->DATA_TYPE;
-            $retVal[$i]->default = $query[$i]->COLUMN_DEFAULT;
+            $retVal[$i]->name = $query[$i]->COLUMN_NAME;
+            $retVal[$i]->type = $query[$i]->DATA_TYPE;
 
             $retVal[$i]->max_length = $query[$i]->CHARACTER_MAXIMUM_LENGTH > 0
                 ? $query[$i]->CHARACTER_MAXIMUM_LENGTH
                 : $query[$i]->NUMERIC_PRECISION;
 
             $retVal[$i]->nullable = $query[$i]->IS_NULLABLE !== 'NO';
+            $retVal[$i]->default  = $query[$i]->COLUMN_DEFAULT;
         }
 
         return $retVal;

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -272,12 +272,12 @@ class Connection extends BaseConnection
             $retVal[$i]->name       = $query[$i]->name;
             $retVal[$i]->type       = $query[$i]->type;
             $retVal[$i]->max_length = null;
+            $retVal[$i]->nullable   = isset($query[$i]->notnull) && ! (bool) $query[$i]->notnull;
             $retVal[$i]->default    = $query[$i]->dflt_value;
             // "pk" (either zero for columns that are not part of the primary key,
             // or the 1-based index of the column within the primary key).
             // https://www.sqlite.org/pragma.html#pragma_table_info
             $retVal[$i]->primary_key = ($query[$i]->pk === 0) ? 0 : 1;
-            $retVal[$i]->nullable    = isset($query[$i]->notnull) && ! (bool) $query[$i]->notnull;
         }
 
         return $retVal;

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -953,30 +953,30 @@ final class ForgeTest extends CIUnitTestCase
                 0 => [
                     'name'       => 'id',
                     'type'       => 'integer',
+                    'max_length' => '32',
                     'nullable'   => false,
                     'default'    => "nextval('db_forge_test_fields_id_seq'::regclass)",
-                    'max_length' => '32',
                 ],
                 1 => [
                     'name'       => 'username',
                     'type'       => 'character varying',
+                    'max_length' => '255',
                     'nullable'   => false,
                     'default'    => null,
-                    'max_length' => '255',
                 ],
                 2 => [
                     'name'       => 'name',
                     'type'       => 'character varying',
+                    'max_length' => '255',
                     'nullable'   => true,
                     'default'    => null,
-                    'max_length' => '255',
                 ],
                 3 => [
                     'name'       => 'active',
                     'type'       => 'integer',
+                    'max_length' => '32',
                     'nullable'   => false,
                     'default'    => '0',
-                    'max_length' => '32',
                 ],
             ];
         } elseif ($this->db->DBDriver === 'SQLite3') {
@@ -985,33 +985,33 @@ final class ForgeTest extends CIUnitTestCase
                     'name'        => 'id',
                     'type'        => 'INTEGER',
                     'max_length'  => null,
+                    'nullable'    => true,
                     'default'     => null,
                     'primary_key' => 1,
-                    'nullable'    => true,
                 ],
                 1 => [
                     'name'        => 'username',
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
+                    'nullable'    => false,
                     'default'     => null,
                     'primary_key' => 0,
-                    'nullable'    => false,
                 ],
                 2 => [
                     'name'        => 'name',
                     'type'        => 'VARCHAR',
                     'max_length'  => null,
+                    'nullable'    => true,
                     'default'     => null,
                     'primary_key' => 0,
-                    'nullable'    => true,
                 ],
                 3 => [
                     'name'        => 'active',
                     'type'        => 'INTEGER',
                     'max_length'  => null,
+                    'nullable'    => false,
                     'default'     => '0',
                     'primary_key' => 0,
-                    'nullable'    => false,
                 ],
             ];
         } elseif ($this->db->DBDriver === 'SQLSRV') {
@@ -1019,30 +1019,30 @@ final class ForgeTest extends CIUnitTestCase
                 0 => [
                     'name'       => 'id',
                     'type'       => 'int',
-                    'default'    => null,
                     'max_length' => 10,
                     'nullable'   => false,
+                    'default'    => null,
                 ],
                 1 => [
                     'name'       => 'username',
                     'type'       => 'varchar',
-                    'default'    => null,
                     'max_length' => 255,
                     'nullable'   => false,
+                    'default'    => null,
                 ],
                 2 => [
                     'name'       => 'name',
                     'type'       => 'varchar',
-                    'default'    => null,
                     'max_length' => 255,
                     'nullable'   => true,
+                    'default'    => null,
                 ],
                 3 => [
                     'name'       => 'active',
                     'type'       => 'int',
-                    'default'    => '((0))', // Why?
                     'max_length' => 10,
                     'nullable'   => false,
+                    'default'    => '((0))', // Why?
                 ],
             ];
         } elseif ($this->db->DBDriver === 'OCI8') {
@@ -1051,29 +1051,29 @@ final class ForgeTest extends CIUnitTestCase
                     'name'       => 'id',
                     'type'       => 'NUMBER',
                     'max_length' => '11',
-                    'default'    => '"ORACLE"."ISEQ$$_80229".nextval', // Sequence id may change
                     'nullable'   => false,
+                    'default'    => '"ORACLE"."ISEQ$$_80229".nextval', // Sequence id may change
                 ],
                 1 => [
                     'name'       => 'username',
                     'type'       => 'VARCHAR2',
                     'max_length' => '255',
-                    'default'    => null,
                     'nullable'   => false,
+                    'default'    => null,
                 ],
                 2 => [
                     'name'       => 'name',
                     'type'       => 'VARCHAR2',
                     'max_length' => '255',
-                    'default'    => null,
                     'nullable'   => true,
+                    'default'    => null,
                 ],
                 3 => [
                     'name'       => 'active',
                     'type'       => 'NUMBER',
                     'max_length' => '11',
-                    'default'    => '0 ', // Why?
                     'nullable'   => false,
+                    'default'    => '0 ', // Why?
                 ],
             ];
 

--- a/tests/system/Database/Live/OCI8/GetFieldDataTest.php
+++ b/tests/system/Database/Live/OCI8/GetFieldDataTest.php
@@ -50,57 +50,57 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
                 'name'       => 'id',
                 'type'       => 'NUMBER',
                 'max_length' => '11',
+                'nullable'   => false,
                 'default'    => $idDefault, // The default value is not defined.
                 // 'primary_key' => 1,
-                'nullable' => false,
             ],
             (object) [
                 'name'       => 'text_not_null',
                 'type'       => 'VARCHAR2',
                 'max_length' => '64',
+                'nullable'   => false,
                 'default'    => null, // The default value is not defined.
                 // 'primary_key' => 0,
-                'nullable' => false,
             ],
             (object) [
                 'name'       => 'text_null',
                 'type'       => 'VARCHAR2',
                 'max_length' => '64',
+                'nullable'   => true,
                 'default'    => null, // The default value is not defined.
                 // 'primary_key' => 0,
-                'nullable' => true,
             ],
             (object) [
                 'name'       => 'int_default_0',
                 'type'       => 'NUMBER',
                 'max_length' => '11',
+                'nullable'   => false,
                 'default'    => '0 ', // int 0
                 // 'primary_key' => 0,
-                'nullable' => false,
             ],
             (object) [
                 'name'       => 'text_default_null',
                 'type'       => 'VARCHAR2',
                 'max_length' => '64',
+                'nullable'   => true,
                 'default'    => 'NULL ', // NULL value
                 // 'primary_key' => 0,
-                'nullable' => true,
             ],
             (object) [
                 'name'       => 'text_default_text_null',
                 'type'       => 'VARCHAR2',
                 'max_length' => '64',
+                'nullable'   => false,
                 'default'    => "'null' ", // string "null"
                 // 'primary_key' => 0,
-                'nullable' => false,
             ],
             (object) [
                 'name'       => 'text_default_abc',
                 'type'       => 'VARCHAR2',
                 'max_length' => '64',
+                'nullable'   => false,
                 'default'    => "'abc' ", // string "abc"
                 // 'primary_key' => 0,
-                'nullable' => false,
             ],
         ]), true);
         $names = array_column($expected, 'name');

--- a/user_guide_src/source/database/metadata.rst
+++ b/user_guide_src/source/database/metadata.rst
@@ -105,9 +105,9 @@ database:
 - ``name`` - column name
 - ``type`` - the type of the column
 - ``max_length`` - maximum length of the column
-- ``primary_key`` - integer ``1`` if the column is a primary key (all integer ``1``, even if there are multiple primary keys), otherwise integer ``0`` (This field is currently only available for ``MySQLi`` and ``SQLite3``)
 - ``nullable`` - boolean ``true`` if the column is nullable, otherwise boolean ``false``
 - ``default`` - the default value
+- ``primary_key`` - integer ``1`` if the column is a primary key (all integer ``1``, even if there are multiple primary keys), otherwise integer ``0`` (This field is currently only available for ``MySQLi`` and ``SQLite3``)
 
 .. note:: Since v4.4.0, SQLSRV supported ``nullable``.
 


### PR DESCRIPTION
**Description**
Change the order of properties in the stdClass object returned by `getFieldData()` to the same for all DB drivers.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
