### PR TITLE
docs: fix supported SQL Server version

### DIFF
--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -56,7 +56,7 @@ Currently supported databases are:
   - MySQL via the ``MySQLi`` driver (version 5.1 and above only)
   - PostgreSQL via the ``Postgre`` driver (version 7.4 and above only)
   - SQLite3 via the ``SQLite3`` driver
-  - Microsoft SQL Server via the ``SQLSRV`` driver (version 2005 and above only)
+  - Microsoft SQL Server via the ``SQLSRV`` driver (version 2012 and above only)
   - Oracle Database via the ``OCI8`` driver (version 12.1 and above only)
 
 Not all of the drivers have been converted/rewritten for CodeIgniter4.


### PR DESCRIPTION
**Description**
Closes #5663

We are using `OFFSET`.
SQL Server 2012 also reached the end of life: Jul 12, 2022. 
https://learn.microsoft.com/en-us/lifecycle/products/microsoft-sql-server-2012

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
