### PR TITLE
feat: 404 controller also can get PageNotFoundException message

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -952,7 +952,10 @@ class CodeIgniter
                 $this->method     = $override[1];
 
                 $controller = $this->createController();
-                $returned   = $this->runController($controller);
+
+                $returned = $controller->{$this->method}($e->getMessage());
+
+                $this->benchmark->stop('controller');
             }
 
             unset($override);

--- a/tests/_support/Errors.php
+++ b/tests/_support/Errors.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support;
+
+use CodeIgniter\Controller;
+
+class Errors extends Controller
+{
+    public function show404(string $message)
+    {
+        return $message;
+    }
+}

--- a/tests/_support/Errors.php
+++ b/tests/_support/Errors.php
@@ -17,7 +17,7 @@ use CodeIgniter\Controller;
 
 class Errors extends Controller
 {
-    public function show404(string $message)
+    public function show404(string $message): string
     {
         return $message;
     }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -122,13 +122,14 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRun404Override(): void
     {
-        $_SERVER['argv'] = ['index.php', '/'];
-        $_SERVER['argc'] = 2;
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI']    = '/pages/about';
+        $_SERVER['SCRIPT_NAME']    = '/index.php';
 
         // Inject mock router.
         $routes = Services::routes();
         $routes->setAutoRoute(false);
-        $routes->set404Override('Tests\Support\Controllers\Hello::index');
+        $routes->set404Override('Tests\Support\Errors::show404');
         $router = Services::router($routes, Services::incomingrequest());
         Services::injectMock('router', $router);
 
@@ -136,7 +137,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->run($routes);
         $output = ob_get_clean();
 
-        $this->assertStringContainsString('Hello', $output);
+        $this->assertStringContainsString("Can't find a route for 'GET: pages/about'.", $output);
     }
 
     public function testRun404OverrideControllerReturnsResponse(): void

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -341,10 +341,13 @@ Others
 - **AutoRouting Improved:** The ``$translateUriToCamelCase`` option has been added
   that allows using CamelCase controller and method names. See
   :ref:`controller-translate-uri-to-camelcase`.
-- **Routing:** Added option ``$multipleSegmentsOneParam``. When this option is
-  enabled, a placeholder that matches multiple segments, such as ``(:any)``, will
-  be passed directly as it is to one parameter, even if it contains multiple segments.
-  See :ref:`multiple-uri-segments-as-one-parameter` for details.
+- **Routing:**
+    - Added option ``$multipleSegmentsOneParam``. When this option is
+      enabled, a placeholder that matches multiple segments, such as ``(:any)``, will
+      be passed directly as it is to one parameter, even if it contains multiple segments.
+      See :ref:`multiple-uri-segments-as-one-parameter` for details.
+    - Now the 404 controller's method that you set in ``$override404`` also receive
+      a ``PageNotFoundException`` message as the first parameter.
 - **Autoloader:**
     - Autoloading performance when using Composer has been improved.
       Adding the ``App`` namespace in the ``autoload.psr4`` setting in **composer.json**


### PR DESCRIPTION
**Description**
Closes #8485

In the current implementation, 404 closure can get the PageNotFoundException message as a parameter,
but 404 controller can't.

This PR enables 404 controller to get the messsage as the first parameter.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
