### PR TITLE
docs: fix sample code in testing/controllers

### DIFF
--- a/user_guide_src/source/testing/controllers/001.php
+++ b/user_guide_src/source/testing/controllers/001.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace CodeIgniter;
+namespace App\Controllers;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ControllerTestTrait;
 use CodeIgniter\Test\DatabaseTestTrait;
 
-class TestControllerA extends CIUnitTestCase
+class FooControllerTest extends CIUnitTestCase
 {
     use ControllerTestTrait;
     use DatabaseTestTrait;

--- a/user_guide_src/source/testing/controllers/002.php
+++ b/user_guide_src/source/testing/controllers/002.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace CodeIgniter;
+namespace App\Controllers;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ControllerTestTrait;
 use CodeIgniter\Test\DatabaseTestTrait;
 
-class TestControllerA extends CIUnitTestCase
+class FooControllerTest extends CIUnitTestCase
 {
     use ControllerTestTrait;
     use DatabaseTestTrait;
@@ -14,7 +14,7 @@ class TestControllerA extends CIUnitTestCase
     public function testShowCategories()
     {
         $result = $this->withURI('http://example.com/categories')
-            ->controller(\App\Controllers\ForumController::class)
+            ->controller(ForumController::class)
             ->execute('showCategories');
 
         $this->assertTrue($result->isOK());

--- a/user_guide_src/source/testing/controllers/002.php
+++ b/user_guide_src/source/testing/controllers/002.php
@@ -6,7 +6,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ControllerTestTrait;
 use CodeIgniter\Test\DatabaseTestTrait;
 
-class FooControllerTest extends CIUnitTestCase
+class ForumControllerTest extends CIUnitTestCase
 {
     use ControllerTestTrait;
     use DatabaseTestTrait;

--- a/user_guide_src/source/testing/controllers/011.php
+++ b/user_guide_src/source/testing/controllers/011.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace CodeIgniter;
+namespace App\Filters;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\FilterTestTrait;
 
-class FilterTestCase extends CIUnitTestCase
+class FooFilterTest extends CIUnitTestCase
 {
     use FilterTestTrait;
 }

--- a/user_guide_src/source/testing/controllers/012.php
+++ b/user_guide_src/source/testing/controllers/012.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace CodeIgniter;
+namespace App\Filters;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\FilterTestTrait;
 
-final class FilterTestCase extends CIUnitTestCase
+final class FooFilterTest extends CIUnitTestCase
 {
     use FilterTestTrait;
 

--- a/user_guide_src/source/testing/controllers/014.php
+++ b/user_guide_src/source/testing/controllers/014.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace CodeIgniter;
+namespace App\Filters;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\FilterTestTrait;
 
-final class FilterTestCase extends CIUnitTestCase
+final class FooFilterTest extends CIUnitTestCase
 {
     use FilterTestTrait;
 


### PR DESCRIPTION
**Description**
`namespace CodeIgniter` should not be used in app testing.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
