### PR TITLE
docs: fix section order in testing

### DIFF
--- a/user_guide_src/source/testing/index.rst
+++ b/user_guide_src/source/testing/index.rst
@@ -14,6 +14,6 @@ The following sections should get you quickly testing your applications.
     Controller Testing <controllers>
     HTTP Testing <feature>
     response
+    Mocking <mocking>
     benchmark
     debugging
-    Mocking <mocking>


### PR DESCRIPTION
**Description**
"Mocking" is about PHPUnit testing.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
