### PR TITLE
feat: add event points for spark commands

### DIFF
--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -51,7 +51,7 @@ class Commands
     /**
      * Runs a command given
      *
-     * @return int|void
+     * @return int|void Exit code
      */
     public function run(string $command, array $params)
     {

--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\CLI;
 
 use CodeIgniter\Autoloader\FileLocatorInterface;
+use CodeIgniter\Events\Events;
 use CodeIgniter\Log\Logger;
 use ReflectionClass;
 use ReflectionException;
@@ -64,7 +65,13 @@ class Commands
         $className = $this->commands[$command]['class'];
         $class     = new $className($this->logger, $this);
 
-        return $class->run($params);
+        Events::trigger('pre_command');
+
+        $exit = $class->run($params);
+
+        Events::trigger('post_command');
+
+        return $exit;
     }
 
     /**

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -28,7 +28,7 @@ class Console
     /**
      * Runs the current command discovered on the CLI.
      *
-     * @return int|void
+     * @return int|void Exit code
      *
      * @throws Exception
      */

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\CLI;
 
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\DotEnv;
+use CodeIgniter\Events\Events;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCLIConfig;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
@@ -77,6 +78,38 @@ final class ConsoleTest extends CIUnitTestCase
         // make sure the result looks like a command list
         $this->assertStringContainsString('Lists the available commands.', $this->getStreamFilterBuffer());
         $this->assertStringContainsString('Displays basic usage information.', $this->getStreamFilterBuffer());
+    }
+
+    public function testRunEventsPreCommand(): void
+    {
+        $result = '';
+        Events::on('pre_command', static function () use (&$result): void {
+            $result = 'fired';
+        });
+
+        $this->initCLI();
+
+        $console = new Console();
+        $console->run();
+
+        $this->assertEventTriggered('pre_command');
+        $this->assertSame('fired', $result);
+    }
+
+    public function testRunEventsPostCommand(): void
+    {
+        $result = '';
+        Events::on('post_command', static function () use (&$result): void {
+            $result = 'fired';
+        });
+
+        $this->initCLI();
+
+        $console = new Console();
+        $console->run();
+
+        $this->assertEventTriggered('post_command');
+        $this->assertSame('fired', $result);
     }
 
     public function testBadCommand(): void

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -355,6 +355,8 @@ Others
   usage in your view files, which was supported by CodeIgniter 3.
 - **CSP:** Added ``ContentSecurityPolicy::clearDirective()`` method to clear
   existing CSP directives. See :ref:`csp-clear-directives`.
+- **Events:** Added event points ``pre_command`` and ``post_command`` for Spark
+  commands. See :ref:`Event Points <event-points-for-cli-apps>`.
 - **HTTP:** Added ``Message::addHeader()`` method to add another header with
   the same name. See :php:meth:`CodeIgniter\\HTTP\\Message::addHeader()`.
 - **Web Page Caching:** ``ResponseCache`` has been improved to include the request

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -87,7 +87,11 @@ You can stop simulation by passing false:
 Event Points
 ============
 
-The following is a list of available event points within the CodeIgniter core code:
+For Web Apps
+------------
+
+The following is a list of available event points for web applications that are
+invoked by **public/index.php**:
 
 * **pre_system** Called early during system execution. The URI, Request, and
   Response have been instantiated, but page cache checking, routing, and execution
@@ -95,6 +99,12 @@ The following is a list of available event points within the CodeIgniter core co
 * **post_controller_constructor** Called immediately after your controller is instantiated, but prior to any method calls happening.
 * **post_system** Called right before the final rendered page is sent to the browser,
   at the end of system execution, after the execution of "after" controller filters.
+
+Others
+------
+
+The following is a list of event points available for each of the libraries:
+
 * **email** Called after an email sent successfully from ``CodeIgniter\Email\Email``. Receives an array of the ``Email`` class's properties as a parameter.
 * **DBQuery** Called after a database query whether successful or not. Receives the ``Query`` object.
 * **migrate** Called after a successful migration call to ``latest()`` or ``regress()``. Receives the current properties of ``MigrationRunner`` as well as the name of the method.

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -100,6 +100,8 @@ invoked by **public/index.php**:
 * **post_system** Called right before the final rendered page is sent to the browser,
   at the end of system execution, after the execution of "after" controller filters.
 
+.. _event-points-for-cli-apps:
+
 For CLI Apps
 ------------
 

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -100,6 +100,14 @@ invoked by **public/index.php**:
 * **post_system** Called right before the final rendered page is sent to the browser,
   at the end of system execution, after the execution of "after" controller filters.
 
+For CLI Apps
+------------
+
+The following is a list of available event points for :doc:`../cli/spark_commands`:
+
+* **pre_command** Called right before the command code execution.
+* **post_command** Called right after the command code execution.
+
 Others
 ------
 


### PR DESCRIPTION
**Description**
Closes #8442

- add event points `pre_command` and `post_command`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
