### PR TITLE
docs: update coding style for v3.49.0

### DIFF
--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -37,7 +37,7 @@ class Logger implements LoggerInterface
      * Used by the logThreshold Config setting to define
      * which errors to show.
      *
-     * @var array<string, integer>
+     * @var array<string, int>
      */
     protected $logLevels = [
         'emergency' => 1,


### PR DESCRIPTION
**Description**
Fixed by php-cs-fixer v3.49.0.

```diff
Detected deprecations in use:
- Rule "escape_implicit_backslashes" is deprecated. Use "string_implicit_backslashes" instead.
   1) system/Log/Logger.php (phpdoc_scalar, unary_operator_spaces, not_operator_with_successor_space)
      ---------- begin diff ----------
--- /home/runner/work/CodeIgniter4/CodeIgniter4/system/Log/Logger.php
+++ /home/runner/work/CodeIgniter4/CodeIgniter4/system/Log/Logger.php
@@ -37,7 +37,7 @@
      * Used by the logThreshold Config setting to define
      * which errors to show.
      *
-     * @var array<string, integer>
+     * @var array<string, int>
      */
     protected $logLevels = [
         'emergency' => 1,

      ----------- end diff -----------
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7749714872/job/21134753620?pr=8493

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
