### PR TITLE
[4.5] refactor: add `declare(strict_types=1)` to ForgeModifyColumnTest

### DIFF
--- a/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
+++ b/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of CodeIgniter 4 framework.
  *


### PR DESCRIPTION
**Description**
- add missing `declare(strict_types=1)`

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
