### PR TITLE
docs: fix incorrect @return type in `ResultInterface-getCustomRowObject()`

### DIFF
--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -292,9 +292,15 @@ abstract class BaseResult implements ResultInterface
     /**
      * Returns a row as a custom class instance.
      *
-     * If row doesn't exists, returns null.
+     * If the row doesn't exist, returns null.
      *
-     * @return array|null
+     * @template T of object
+     *
+     * @param         int             $n         The row number of the results
+     * @phpstan-param class-string<T> $className
+     *
+     * @return         object|null
+     * @phpstan-return T|null
      */
     public function getCustomRowObject(int $n, string $className)
     {

--- a/system/Database/BaseResult.php
+++ b/system/Database/BaseResult.php
@@ -252,14 +252,16 @@ abstract class BaseResult implements ResultInterface
      * Wrapper object to return a row as either an array, an object, or
      * a custom class.
      *
-     * If row doesn't exist, returns null.
+     * If the row doesn't exist, returns null.
      *
-     * @param         int|string                    $n    The index of the results to return, or column name.
-     * @param         string                        $type The type of result object. 'array', 'object' or class name.
-     * @phpstan-param class-string|'array'|'object' $type
+     * @template T of object
+     *
+     * @param         int|string                       $n    The index of the results to return, or column name.
+     * @param         string                           $type The type of result object. 'array', 'object' or class name.
+     * @phpstan-param class-string<T>|'array'|'object' $type
      *
      * @return         array|object|stdClass|null
-     * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : object|null))
+     * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null))
      */
     public function getRow($n = 0, string $type = 'object')
     {
@@ -296,7 +298,7 @@ abstract class BaseResult implements ResultInterface
      *
      * @template T of object
      *
-     * @param         int             $n         The row number of the results
+     * @param         int             $n         The index of the results to return.
      * @phpstan-param class-string<T> $className
      *
      * @return         object|null

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -69,9 +69,15 @@ interface ResultInterface
     /**
      * Returns a row as a custom class instance.
      *
-     * If row doesn't exists, returns null.
+     * If the row doesn't exist, returns null.
      *
-     * @return array|null
+     * @template T of object
+     *
+     * @param         int             $n         The row number of the results
+     * @phpstan-param class-string<T> $className
+     *
+     * @return         object|null
+     * @phpstan-return T|null
      */
     public function getCustomRowObject(int $n, string $className);
 

--- a/system/Database/ResultInterface.php
+++ b/system/Database/ResultInterface.php
@@ -55,14 +55,16 @@ interface ResultInterface
      * Wrapper object to return a row as either an array, an object, or
      * a custom class.
      *
-     * If row doesn't exist, returns null.
+     * If the row doesn't exist, returns null.
      *
-     * @param         int|string                    $n    The index of the results to return, or column name.
-     * @param         string                        $type The type of result object. 'array', 'object' or class name.
-     * @phpstan-param class-string|'array'|'object' $type
+     * @template T of object
+     *
+     * @param         int|string                       $n    The index of the results to return, or column name.
+     * @param         string                           $type The type of result object. 'array', 'object' or class name.
+     * @phpstan-param class-string<T>|'array'|'object' $type
      *
      * @return         array|object|stdClass|null
-     * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : object|null))
+     * @phpstan-return ($type is 'object' ? stdClass|null : ($type is 'array' ? array|null : T|null))
      */
     public function getRow($n = 0, string $type = 'object');
 
@@ -73,7 +75,7 @@ interface ResultInterface
      *
      * @template T of object
      *
-     * @param         int             $n         The row number of the results
+     * @param         int             $n         The index of the results to return.
      * @phpstan-param class-string<T> $className
      *
      * @return         object|null


### PR DESCRIPTION
**Description**
Fixes #8501

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
