### PR TITLE
docs: fix incorrect sample code in database/results

### DIFF
--- a/user_guide_src/source/database/results/016.php
+++ b/user_guide_src/source/database/results/016.php
@@ -1,3 +1,3 @@
 <?php
 
-$row = $query->getCustomRowObject(0, \App\Entities\User::class);
+$row = $query->getRow(0, \App\Entities\User::class);


### PR DESCRIPTION
**Description**

> You can also use the getRow() method in exactly the same way.
https://codeigniter4.github.io/CodeIgniter4/database/results.html#getcustomrowobject

So it should show a sample code for `getRow()`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
