### PR TITLE
docs: add missing null to @param to RendererInterface

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -185,8 +185,9 @@ class Parser extends View
      * so that the variable is correctly handled within the
      * parsing itself, and contexts (including raw) are respected.
      *
-     * @param non-empty-string|null $context The context to escape it for: html, css, js, url, raw
-     *                                       If 'raw', no escaping will happen
+     * @param         non-empty-string|null                     $context The context to escape it for.
+     *                                                                   If 'raw', no escaping will happen.
+     * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
      */
     public function setData(array $data = [], ?string $context = null): RendererInterface
     {

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -22,10 +22,10 @@ interface RendererInterface
      * Builds the output based upon a file name and any
      * data that has already been set.
      *
-     * @param array $options  Reserved for 3rd-party uses since
-     *                        it might be needed to pass additional info
-     *                        to other template engines.
-     * @param bool  $saveData Whether to save data for subsequent calls
+     * @param array|null $options  Reserved for 3rd-party uses since
+     *                             it might be needed to pass additional info
+     *                             to other template engines.
+     * @param bool       $saveData Whether to save data for subsequent calls
      */
     public function render(string $view, ?array $options = null, bool $saveData = false): string;
 
@@ -33,20 +33,19 @@ interface RendererInterface
      * Builds the output based upon a string and any
      * data that has already been set.
      *
-     * @param string $view     The view contents
-     * @param array  $options  Reserved for 3rd-party uses since
-     *                         it might be needed to pass additional info
-     *                         to other template engines.
-     * @param bool   $saveData Whether to save data for subsequent calls
+     * @param string     $view     The view contents
+     * @param array|null $options  Reserved for 3rd-party uses since
+     *                             it might be needed to pass additional info
+     *                             to other template engines.
+     * @param bool       $saveData Whether to save data for subsequent calls
      */
     public function renderString(string $view, ?array $options = null, bool $saveData = false): string;
 
     /**
      * Sets several pieces of view data at once.
      *
-     * @param         string                                    $context The context to escape it for: html, css, js, url
-     *                                                                   If 'raw', no escaping will happen
-     * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
+     * @param string|null $context The context to escape it for: html, css, js, url
+     *                             If 'raw', no escaping will happen
      *
      * @return RendererInterface
      */
@@ -55,10 +54,9 @@ interface RendererInterface
     /**
      * Sets a single piece of view data.
      *
-     * @param         mixed                                     $value
-     * @param         string                                    $context The context to escape it for: html, css, js, url
-     *                                                                   If 'raw' no escaping will happen
-     * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
+     * @param mixed       $value
+     * @param string|null $context The context to escape it for: html, css, js, url
+     *                             If 'raw' no escaping will happen
      *
      * @return RendererInterface
      */

--- a/system/View/RendererInterface.php
+++ b/system/View/RendererInterface.php
@@ -44,8 +44,9 @@ interface RendererInterface
     /**
      * Sets several pieces of view data at once.
      *
-     * @param string|null $context The context to escape it for: html, css, js, url
-     *                             If 'raw', no escaping will happen
+     * @param         non-empty-string|null                     $context The context to escape it for.
+     *                                                                   If 'raw', no escaping will happen.
+     * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
      *
      * @return RendererInterface
      */
@@ -54,9 +55,10 @@ interface RendererInterface
     /**
      * Sets a single piece of view data.
      *
-     * @param mixed       $value
-     * @param string|null $context The context to escape it for: html, css, js, url
-     *                             If 'raw' no escaping will happen
+     * @param         mixed                                     $value
+     * @param         non-empty-string|null                     $context The context to escape it for.
+     *                                                                   If 'raw', no escaping will happen.
+     * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
      *
      * @return RendererInterface
      */

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -330,8 +330,8 @@ class View implements RendererInterface
     /**
      * Sets several pieces of view data at once.
      *
-     * @param         string|null                               $context The context to escape it for: html, css, js, url
-     *                                                                   If null, no escaping will happen
+     * @param         non-empty-string|null                     $context The context to escape it for.
+     *                                                                   If 'raw', no escaping will happen.
      * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
      */
     public function setData(array $data = [], ?string $context = null): RendererInterface
@@ -350,8 +350,8 @@ class View implements RendererInterface
      * Sets a single piece of view data.
      *
      * @param         mixed                                     $value
-     * @param         string|null                               $context The context to escape it for: html, css, js, url
-     *                                                                   If null, no escaping will happen
+     * @param         non-empty-string|null                     $context The context to escape it for.
+     *                                                                   If 'raw', no escaping will happen.
      * @phpstan-param null|'html'|'js'|'css'|'url'|'attr'|'raw' $context
      */
     public function setVar(string $name, $value = null, ?string $context = null): RendererInterface


### PR DESCRIPTION
**Description**
- fix `@param`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
