### PR TITLE
[4.5] fix: DEBUG-VIEW comments are not output

### DIFF
--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -70,6 +70,8 @@ class Filters
      * The processed filters that will
      * be used to check against.
      *
+     * This does not include "Required Filters".
+     *
      * @var array<string, array>
      */
     protected $filters = [
@@ -80,6 +82,8 @@ class Filters
     /**
      * The collection of filters' class names that will
      * be used to execute in each position.
+     *
+     * This does not include "Required Filters".
      *
      * @var array<string, array>
      */
@@ -252,7 +256,7 @@ class Filters
     }
 
     /**
-     * Runs required filters for the specified position.
+     * Runs "Required Filters" for the specified position.
      *
      * @return RequestInterface|ResponseInterface|string|null
      *
@@ -289,7 +293,7 @@ class Filters
     }
 
     /**
-     * Returns required filters for the specified position.
+     * Returns "Required Filters" for the specified position.
      *
      * @phpstan-param 'before'|'after' $position
      *
@@ -423,6 +427,7 @@ class Filters
 
     /**
      * Returns the processed filters array.
+     * This does not include "Required Filters".
      */
     public function getFilters(): array
     {
@@ -431,6 +436,7 @@ class Filters
 
     /**
      * Returns the filtersClass array.
+     * This does not include "Required Filters".
      */
     public function getFiltersClass(): array
     {

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -261,10 +261,19 @@ class View implements RendererInterface
             $this->renderVars['view']
         );
 
-        $afterFilters = service('filters')->getFiltersClass()['after'];
+        // Check if DebugToolbar is enabled.
+        $filters              = Services::filters();
+        $requiredAfterFilters = $filters->getRequiredFilters('after')[0];
+        if (in_array('toolbar', $requiredAfterFilters, true)) {
+            $debugBarEnabled = true;
+        } else {
+            $afterFilters    = $filters->getFiltersClass()['after'];
+            $debugBarEnabled = in_array(DebugToolbar::class, $afterFilters, true);
+        }
+
         if (
-            ($this->debug && (! isset($options['debug']) || $options['debug'] === true))
-            && in_array(DebugToolbar::class, $afterFilters, true)
+            $this->debug && $debugBarEnabled
+            && (! isset($options['debug']) || $options['debug'] === true)
         ) {
             $toolbarCollectors = config(Toolbar::class)->collectors;
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -1022,7 +1022,10 @@ final class FormHelperTest extends CIUnitTestCase
 
         $html = validation_show_error('id');
 
-        $this->assertSame('<span class="help-block">The ID field is required.</span>' . "\n", $html);
+        $this->assertSame('<!-- DEBUG-VIEW START 1 SYSTEMPATH/Validation/Views/single.php -->
+<span class="help-block">The ID field is required.</span>
+
+<!-- DEBUG-VIEW ENDED 1 SYSTEMPATH/Validation/Views/single.php -->' . "\n", $html);
     }
 
     public function testValidationShowErrorForWildcards(): void
@@ -1041,7 +1044,10 @@ final class FormHelperTest extends CIUnitTestCase
 
         $html = validation_show_error('user.*.name');
 
-        $this->assertSame('<span class="help-block">The Name field is required.</span>' . "\n", $html);
+        $this->assertSame('<!-- DEBUG-VIEW START 1 SYSTEMPATH/Validation/Views/single.php -->
+<span class="help-block">The Name field is required.</span>
+
+<!-- DEBUG-VIEW ENDED 1 SYSTEMPATH/Validation/Views/single.php -->' . "\n", $html);
     }
 
     public function testFormParseFormAttributesTrue(): void


### PR DESCRIPTION
**Description**
Follow-up #8053

Fix a bug that `DEBUG-VIEW` comments are not output.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
