### PR TITLE
fix: [Postgre] updateBatch() breaks `char` type data

### DIFF
--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -431,7 +431,16 @@ class Builder extends BaseBuilder
             $this->QBOptions['fieldTypes'][$table] = [];
 
             foreach ($this->db->getFieldData($table) as $field) {
-                $this->QBOptions['fieldTypes'][$table][$field->name] = $field->type;
+                $type = $field->type;
+
+                // If `character` (or `char`) lacks a specifier, it is equivalent
+                // to `character(1)`.
+                // See https://www.postgresql.org/docs/current/datatype-character.html
+                if ($field->type === 'character') {
+                    $type = $field->type . '(' . $field->max_length . ')';
+                }
+
+                $this->QBOptions['fieldTypes'][$table][$field->name] = $type;
             }
         }
 

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -125,7 +125,7 @@ final class UpdateTest extends CIUnitTestCase
         for ($i = 1; $i < 4; $i++) {
             $builder->insert([
                 'type_varchar'  => 'test' . $i,
-                'type_char'     => 'char',
+                'type_char'     => 'char' . $i,
                 'type_text'     => 'text',
                 'type_smallint' => 32767,
                 'type_integer'  => 2_147_483_647,
@@ -159,6 +159,7 @@ final class UpdateTest extends CIUnitTestCase
                 [
                     [
                         'type_varchar'  => 'test1', // Key
+                        'type_char'     => 'updated',
                         'type_text'     => 'updated',
                         'type_smallint' => 9999,
                         'type_integer'  => 9_999_999,
@@ -170,6 +171,7 @@ final class UpdateTest extends CIUnitTestCase
                     ],
                     [
                         'type_varchar'  => 'test2', // Key
+                        'type_char'     => 'updated',
                         'type_text'     => 'updated',
                         'type_smallint' => 9999,
                         'type_integer'  => 9_999_999,
@@ -183,6 +185,7 @@ final class UpdateTest extends CIUnitTestCase
                 [
                     [
                         'type_varchar'  => 'test1',
+                        'type_char'     => 'updated',
                         'type_text'     => 'updated',
                         'type_smallint' => 9999,
                         'type_integer'  => 9_999_999,
@@ -193,6 +196,7 @@ final class UpdateTest extends CIUnitTestCase
                     ],
                     [
                         'type_varchar'  => 'test2',
+                        'type_char'     => 'updated',
                         'type_text'     => 'updated',
                         'type_smallint' => 9999,
                         'type_integer'  => 9_999_999,


### PR DESCRIPTION
**Description**
Follow-up #8439
From https://forum.codeigniter.com/showthread.php?tid=89336

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
