### PR TITLE
feat: add DB config `dateFormat` to provide default date/time formats

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -43,6 +43,11 @@ class Database extends Config
         'failover'     => [],
         'port'         => 3306,
         'numberNative' => false,
+        'dateFormat'   => [
+            'date'     => 'Y-m-d',
+            'datetime' => 'Y-m-d H:i:s',
+            'time'     => 'H:i:s',
+        ],
     ];
 
     /**
@@ -69,6 +74,11 @@ class Database extends Config
         'port'        => 3306,
         'foreignKeys' => true,
         'busyTimeout' => 1000,
+        'dateFormat'  => [
+            'date'     => 'Y-m-d',
+            'datetime' => 'Y-m-d H:i:s',
+            'time'     => 'H:i:s',
+        ],
     ];
 
     public function __construct()

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -26,6 +26,7 @@ use Throwable;
  * @property-read float      $connectDuration
  * @property-read float      $connectTime
  * @property-read string     $database
+ * @property-read array      $dateFormat
  * @property-read string     $DBCollat
  * @property-read bool       $DBDebug
  * @property-read string     $DBDriver
@@ -348,6 +349,19 @@ abstract class BaseConnection implements ConnectionInterface
     protected $queryClass = Query::class;
 
     /**
+     * Default Date/Time formats
+     *
+     * @var array<string, string>
+     */
+    protected array $dateFormat = [
+        'date'        => 'Y-m-d',
+        'datetime'    => 'Y-m-d H:i:s',
+        'datetime-ms' => 'Y-m-d H:i:s.v',
+        'datetime-us' => 'Y-m-d H:i:s.u',
+        'time'        => 'H:i:s',
+    ];
+
+    /**
      * Saves our connection settings.
      */
     public function __construct(array $params)
@@ -356,6 +370,10 @@ abstract class BaseConnection implements ConnectionInterface
             if (property_exists($this, $key)) {
                 $this->{$key} = $value;
             }
+        }
+
+        if (isset($params['dateFormat'])) {
+            $this->dateFormat = array_merge($this->dateFormat, $params['dateFormat']);
         }
 
         $queryClass = str_replace('Connection', 'Query', static::class);

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -80,6 +80,13 @@ final class BaseConnectionTest extends CIUnitTestCase
         $this->assertFalse($db->compress);
         $this->assertTrue($db->strictOn);
         $this->assertSame([], $db->failover);
+        $this->assertSame([
+            'date'        => 'Y-m-d',
+            'datetime'    => 'Y-m-d H:i:s',
+            'datetime-ms' => 'Y-m-d H:i:s.v',
+            'datetime-us' => 'Y-m-d H:i:s.u',
+            'time'        => 'H:i:s',
+        ], $db->dateFormat);
     }
 
     public function testConnectionThrowExceptionWhenCannotConnect(): void

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -184,7 +184,17 @@ Explanation of Values:
                      To enforce Foreign Key constraint, set this config item to true.
 **busyTimeout**  milliseconds (int) - Sleeps for a specified amount of time when a table is locked (``SQLite3`` only).
 **numberNative** true/false (boolean) - Whether or not to enable MYSQLI_OPT_INT_AND_FLOAT_NATIVE (``MySQLi`` only).
+**dateFormat**   The default date/time formats as PHP's `DateTime format`_.
+                 * ``date``        - date format
+                 * ``datetime``    - date and time format
+                 * ``datetime-ms`` - date and time with millisecond format
+                 * ``datetime-us`` - date and time with microsecond format
+                 * ``time``        - time format
+                 This can be used since v4.5.0, and you can get the value, e.g., ``$db->dateFormat[datetime]``.
+                 Currently, the database drivers do not use these values directly, but just provide the values.
 ================ ===========================================================================================================
+
+.. _DateTime format: https://www.php.net/manual/en/datetime.format.php
 
 .. note:: Depending on what database driver you are using (``MySQLi``, ``Postgre``,
     etc.) not all values will be needed. For example, when using ``SQLite3`` you

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -190,7 +190,7 @@ Explanation of Values:
                  * ``datetime-ms`` - date and time with millisecond format
                  * ``datetime-us`` - date and time with microsecond format
                  * ``time``        - time format
-                 This can be used since v4.5.0, and you can get the value, e.g., ``$db->dateFormat[datetime]``.
+                 This can be used since v4.5.0, and you can get the value, e.g., ``$db->dateFormat['datetime']``.
                  Currently, the database drivers do not use these values directly, but just provide the values.
 ================ ===========================================================================================================
 


### PR DESCRIPTION
**Description**
See #7177

- add DB config `dateFormat`

We should have this config value in the `Connection` class. Because each connection has the datetime format.

The current DB related class layers:
```
Entity
Model
Builder
Connection
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
