### PR TITLE
[4.5] test: update asssertion for SQLSRV ENUM

### DIFF
--- a/tests/system/Database/Live/SQLSRV/GetFieldDataTest.php
+++ b/tests/system/Database/Live/SQLSRV/GetFieldDataTest.php
@@ -206,8 +206,8 @@ final class GetFieldDataTest extends AbstractGetFieldDataTest
             ],
             14 => (object) [
                 'name'       => 'type_enum',
-                'type'       => 'text',
-                'max_length' => 2_147_483_647,
+                'type'       => 'varchar',
+                'max_length' => 5,
                 'nullable'   => true,
                 'default'    => null,
             ],


### PR DESCRIPTION
**Description**
Follow-up #8478

```diff
1) CodeIgniter\Database\Live\SQLSRV\GetFieldDataTest::testGetFieldDataType
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
     )
     7 => Array &8 (
         'name' => 'type_enum'
-        'type' => 'text'
-        'max_length' => 2147483647
+        'type' => 'varchar'
+        'max_length' => 5
         'nullable' => true
         'default' => null
     )

/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Database/Live/AbstractGetFieldDataTest.php:169
/home/runner/work/CodeIgniter4/CodeIgniter4/tests/system/Database/Live/SQLSRV/GetFieldDataTest.php:229
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7851204632/job/21428585497

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
