### PR TITLE
feat: permit __invoke() method as Controller default method

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -879,7 +879,10 @@ class CodeIgniter
         }
 
         // Try to autoload the class
-        if (! class_exists($this->controller, true) || $this->method[0] === '_') {
+        if (
+            ! class_exists($this->controller, true)
+            || ($this->method[0] === '_' && $this->method !== '__invoke')
+        ) {
             throw PageNotFoundException::forControllerNotFound($this->controller, $this->method);
         }
     }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
+use App\Controllers\Home;
 use CodeIgniter\Config\Services;
+use CodeIgniter\Debug\Timer;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Method;
@@ -959,5 +961,18 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->expectException(PageNotFoundException::class);
 
         $this->codeigniter->run($routes);
+    }
+
+    public function testStartControllerPermitsInvoke(): void
+    {
+        $this->setPrivateProperty($this->codeigniter, 'benchmark', new Timer());
+        $this->setPrivateProperty($this->codeigniter, 'controller', '\\' . Home::class);
+        $startController = $this->getPrivateMethodInvoker($this->codeigniter, 'startController');
+
+        $this->setPrivateProperty($this->codeigniter, 'method', '__invoke');
+        $startController();
+
+        // No PageNotFoundException
+        $this->assertTrue(true);
     }
 }

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -374,6 +374,8 @@ Others
       See :ref:`multiple-uri-segments-as-one-parameter` for details.
     - Now the 404 controller's method that you set in ``$override404`` also receive
       a ``PageNotFoundException`` message as the first parameter.
+    - Now you can use the ``__invoke()`` method as the default method. See
+      :ref:`routing-default-method`.
 - **Autoloader:**
     - Autoloading performance when using Composer has been improved.
       Adding the ``App`` namespace in the ``autoload.psr4`` setting in **composer.json**

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -50,7 +50,7 @@ Examples
 Here are a few basic routing examples.
 
 A URL containing the word **journals** in the first segment will be mapped to the ``\App\Controllers\Blogs`` class,
-and the default method, which is usually ``index()``:
+and the :ref:`default method <routing-default-method>`, which is usually ``index()``:
 
 .. literalinclude:: routing/006.php
 
@@ -654,6 +654,32 @@ then you can change this value to save typing:
 
 .. literalinclude:: routing/046.php
 
+.. _routing-default-method:
+
+Default Method
+==============
+
+This setting is used when the route handler only has the controller name and no
+method name listed. The default value is ``index``.
+::
+
+    // In app/Config/Routing.php
+    public string $defaultMethod = 'index';
+
+.. note:: The ``$defaultMethod`` is also common with Auto Routing.
+    See :ref:`Auto Routing (Improved) <routing-auto-routing-improved-default-method>`
+    or :ref:`Auto Routing (Legacy) <routing-auto-routing-legacy-default-method>`.
+
+If you define the following route::
+
+    $routes->get('/', 'Home');
+
+the ``index()`` method of the ``App\Controllers\Home`` controller is executed
+when the route matches.
+
+.. note:: Method names beginning with ``_`` cannot be used as the default method.
+    However, starting with v4.5.0, only ``__invoke`` can be used.
+
 Translate URI Dashes
 ====================
 
@@ -828,6 +854,8 @@ in the controllers directory. For example, if the user visits **example.com/admi
 
 See :ref:`Auto Routing in Controllers <controller-auto-routing-improved>` for more info.
 
+.. _routing-auto-routing-improved-default-method:
+
 Default Method
 --------------
 
@@ -953,6 +981,8 @@ in the controllers directory. For example, if the user visits **example.com/admi
 **app/Controllers/Admin/Home.php**, it would be used.
 
 See :ref:`Auto Routing (Legacy) in Controllers <controller-auto-routing-legacy>` for more info.
+
+.. _routing-auto-routing-legacy-default-method:
 
 Default Method (Legacy)
 -----------------------

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -678,7 +678,7 @@ the ``index()`` method of the ``App\Controllers\Home`` controller is executed
 when the route matches.
 
 .. note:: Method names beginning with ``_`` cannot be used as the default method.
-    However, starting with v4.5.0, only ``__invoke`` can be used.
+    However, starting with v4.5.0, ``__invoke`` method is allowed.
 
 Translate URI Dashes
 ====================


### PR DESCRIPTION
**Description**
- permit `__invoke()` method as Controller default method

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
