### PR TITLE
[4.5] fix: spark does not work with composer install --no-dev

### DIFF
--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -81,6 +81,11 @@ class TestGenerator extends BaseCommand
         $this->template  = 'test.tpl.php';
 
         $this->classNameLang = 'CLI.generator.className.test';
+
+        $autoload = Services::autoloader();
+        $autoload->addNamespace('CodeIgniter', TESTPATH . 'system');
+        $autoload->addNamespace('Tests', ROOTPATH . 'tests');
+
         $this->generateClass($params);
     }
 

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -91,9 +91,8 @@ class AutoloadConfig
      * @var array<string, string>
      */
     protected $corePsr4 = [
-        'CodeIgniter' => [SYSTEMPATH, TESTPATH . 'system'],
+        'CodeIgniter' => SYSTEMPATH,
         'Config'      => APPPATH . 'Config',
-        'Tests'       => ROOTPATH . 'tests',
     ];
 
     /**

--- a/tests/system/Commands/Utilities/NamespacesTest.php
+++ b/tests/system/Commands/Utilities/NamespacesTest.php
@@ -58,9 +58,7 @@ final class NamespacesTest extends CIUnitTestCase
             | Namespace     | Path                    | Found? |
             +---------------+-------------------------+--------+
             | CodeIgniter   | ROOTPATH/system         | Yes    |
-            | CodeIgniter   | ROOTPATH/tests/system   | Yes    |
             | Config        | APPPATH/Config          | Yes    |
-            | Tests         | ROOTPATH/tests          | Yes    |
             | App           | ROOTPATH/app            | Yes    |
             | Tests\Support | ROOTPATH/tests/_support | Yes    |
             +---------------+-------------------------+--------+


### PR DESCRIPTION
**Description**
Follow-up #8388

```console
$ composer install --no-dev
$ ./spark
```
```
[Error]
Class "PHPUnit\Framework\TestCase" not found
at SYSTEMPATH/Test/CIUnitTestCase.php:40

Backtrace:
  1    VENDORPATH/composer/ClassLoader.php:576
       include()

  2    VENDORPATH/composer/ClassLoader.php:427
       Composer\Autoload\{closure}('/Users/kenji/work/codeigniter/official/CodeIgniter4-4.5/vendor/composer/../../system/Test/CIUnitTestCase.php')

  3    ROOTPATH/tests/system/Commands/BaseCommandTest.php:26
       Composer\Autoload\ClassLoader()->loadClass('CodeIgniter\\Test\\CIUnitTestCase')

  4    SYSTEMPATH/Autoloader/Autoloader.php:310
       include_once('/Users/kenji/work/codeigniter/official/CodeIgniter4-4.5/tests/system/Commands/BaseCommandTest.php')

  5    SYSTEMPATH/Autoloader/Autoloader.php:289
       CodeIgniter\Autoloader\Autoloader()->includeFile('/Users/kenji/work/codeigniter/official/CodeIgniter4-4.5/tests/system/Commands/BaseCommandTest.php')

  6    SYSTEMPATH/Autoloader/Autoloader.php:267
       CodeIgniter\Autoloader\Autoloader()->loadInNamespace('Tests\\system\\Commands\\BaseCommandTest')

  7    [internal function]
       CodeIgniter\Autoloader\Autoloader()->loadClass('Tests\\system\\Commands\\BaseCommandTest')

  8    SYSTEMPATH/Autoloader/FileLocator.php:296
       class_exists('Tests\\system\\Commands\\BaseCommandTest')

  9    SYSTEMPATH/CLI/Commands.php:112
       CodeIgniter\Autoloader\FileLocator()->findQualifiedNameFromPath('/Users/kenji/work/codeigniter/official/CodeIgniter4-4.5/tests/system/Commands/BaseCommandTest.php')

 10    SYSTEMPATH/CLI/Commands.php:49
       CodeIgniter\CLI\Commands()->discoverCommands()

 11    SYSTEMPATH/Config/Services.php:176
       CodeIgniter\CLI\Commands()->__construct()

 12    SYSTEMPATH/Config/BaseService.php:261
       CodeIgniter\Config\Services::commands(false)

 13    SYSTEMPATH/Config/BaseService.php:202
       CodeIgniter\Config\BaseService::__callStatic('commands', [...])

 14    SYSTEMPATH/Config/Services.php:173
       CodeIgniter\Config\BaseService::getSharedInstance('commands')

 15    SYSTEMPATH/Config/BaseService.php:261
       CodeIgniter\Config\Services::commands()

 16    SYSTEMPATH/CLI/Console.php:43
       CodeIgniter\Config\BaseService::__callStatic('commands', [])

 17    ROOTPATH/spark:102
       CodeIgniter\CLI\Console()->run()
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
