### PR TITLE
feat: 404 Override sets 404 by default

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -938,6 +938,8 @@ class CodeIgniter
      */
     protected function display404errors(PageNotFoundException $e)
     {
+        $this->response->setStatusCode($e->getCode());
+
         // Is there a 404 Override available?
         if ($override = $this->router->get404Override()) {
             $returned = null;
@@ -965,9 +967,6 @@ class CodeIgniter
 
             return $this->response;
         }
-
-        // Display 404 Errors
-        $this->response->setStatusCode($e->getCode());
 
         $this->outputBufferingEnd();
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -138,6 +138,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString("Can't find a route for 'GET: pages/about'.", $output);
+        $this->assertSame(404, response()->getStatusCode());
     }
 
     public function testRun404OverrideControllerReturnsResponse(): void
@@ -194,6 +195,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('404 Override by Closure.', $output);
+        $this->assertSame(404, response()->getStatusCode());
     }
 
     public function testControllersCanReturnString(): void

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -75,6 +75,8 @@ Others
 - **Autoloader:** The prefix ``\`` in the fully qualified classname returned by
   ``FileLocator::findQualifiedNameFromPath()`` has been removed.
 - **BaseModel:** The ``getIdValue()`` method has been changed to ``abstract``.
+- **Routing:** The :ref:`404-override` feature does change the Response status
+  code to 404 by default. See :ref:`Upgrading Guide <upgrade-450-404-override>`.
 
 Interface Changes
 =================

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -686,6 +686,8 @@ to only those defined by you, by setting the ``$autoRoute`` property to false:
 .. warning:: If you use the :doc:`CSRF protection </libraries/security>`, it does not protect **GET**
     requests. If the URI is accessible by the GET method, the CSRF protection will not work.
 
+.. _404-override:
+
 404 Override
 ============
 
@@ -701,10 +703,11 @@ valid class/method pair, or a Closure:
 
 .. literalinclude:: routing/069.php
 
-.. note:: The 404 Override feature does not change the Response status code to ``404``.
-    If you don't set the status code in the controller you set, the default status code ``200``
-    will be returned. See :php:meth:`CodeIgniter\\HTTP\\Response::setStatusCode()` for
-    information on how to set the status code.
+.. note:: Starting with v4.5.0, the 404 Override feature sets the Response status
+    code to ``404`` by default. In previous versions, the code was ``200``.
+    If you want to change the status code in the controller, see
+    :php:meth:`CodeIgniter\\HTTP\\Response::setStatusCode()` for information on
+    how to set the status code.
 
 Route Processing by Priority
 ============================

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -213,10 +213,29 @@ using them, upgrade your code. See :ref:`ChangeLog <v450-removed-deprecated-item
 Breaking Enhancements
 *********************
 
-- The method signatures of ``Validation::run()`` and ``ValidationInterface::run()``
-  have been changed. The ``?string`` typehint on the ``$dbGroup`` parameter was
-  removed. Extending classes should likewise remove the parameter so as not to
-  break LSP.
+.. _upgrade-450-404-override:
+
+404 Override Status Code
+========================
+
+In previous versions, :ref:`404-override` returned responses with the status code
+``200`` by default. Now it returns ``404`` by default.
+
+If you want ``200``, you need to set it in the controller::
+
+    $routes->set404Override(static function () {
+        response()->setStatusCode(200);
+
+        echo view('my_errors/not_found.html');
+    });
+
+Validation::run() Signature
+===========================
+
+The method signatures of ``Validation::run()`` and ``ValidationInterface::run()``
+have been changed. The ``?string`` typehint on the ``$dbGroup`` parameter was
+removed. Extending classes should likewise remove the parameter so as not to
+break LSP.
 
 Project Files
 *************


### PR DESCRIPTION
**Description**
The *404 Override* feature should set 404 by default, because it is for 404 pages.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
