### PR TITLE
docs: use validateData() instead of validate() in uploaded_files

### DIFF
--- a/user_guide_src/source/libraries/uploaded_files/002.php
+++ b/user_guide_src/source/libraries/uploaded_files/002.php
@@ -27,7 +27,7 @@ class Upload extends BaseController
                 ],
             ],
         ];
-        if (! $this->validate($validationRule)) {
+        if (! $this->validateData([], $validationRule)) {
             $data = ['errors' => $this->validator->getErrors()];
 
             return view('upload_form', $data);


### PR DESCRIPTION
**Description**
Closes #8430
Supersedes #8445

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
