### PR TITLE
fix: Time::createFromTimestamp() returns Time with UTC

### DIFF
--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -266,7 +266,8 @@ trait TimeTrait
     public static function createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null)
     {
         $time = new self(gmdate('Y-m-d H:i:s', $timestamp), 'UTC', $locale);
-        $timezone ??= 'UTC';
+
+        $timezone ??= date_default_timezone_get();
 
         return $time->setTimezone($timezone);
     }

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -259,17 +259,21 @@ final class TimeTest extends CIUnitTestCase
 
     public function testCreateFromTimestamp(): void
     {
-        // Set the timezone temporarily to UTC to make sure the test timestamp is correct
+        // Save the current timezone.
         $tz = date_default_timezone_get();
-        date_default_timezone_set('UTC');
+
+        // Change the timezone other than UTC.
+        date_default_timezone_set('Asia/Tokyo'); // +09:00
 
         $timestamp = strtotime('2017-03-18 midnight');
 
-        date_default_timezone_set($tz);
-
         $time = Time::createFromTimestamp($timestamp);
 
-        $this->assertSame(date('2017-03-18 00:00:00'), $time->toDateTimeString());
+        $this->assertSame('Asia/Tokyo', $time->getTimezone()->getName());
+        $this->assertSame('2017-03-18 00:00:00', $time->format('Y-m-d H:i:s'));
+
+        // Restore timezone.
+        date_default_timezone_set($tz);
     }
 
     public function testCreateFromTimestampWithTimezone(): void

--- a/user_guide_src/source/changelogs/v4.4.6.rst
+++ b/user_guide_src/source/changelogs/v4.4.6.rst
@@ -14,6 +14,15 @@ Release Date: Unreleased
 BREAKING
 ********
 
+Time::createFromTimestamp()
+===========================
+
+A bug that caused :ref:`Time::createFromTimestamp() <time-createfromtimestamp>`
+to return a Time instance with a timezone of UTC has been fixed.
+
+Starting with this version, when you do not specify a timezone, a Time instance
+with the app's timezone is returned by default.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/installation/upgrade_446.rst
+++ b/user_guide_src/source/installation/upgrade_446.rst
@@ -20,6 +20,20 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+Time::createFromTimestamp() Timezone Change
+===========================================
+
+When you do not specify a timezone, now
+:ref:`Time::createFromTimestamp() <time-createfromtimestamp>` returns a Time
+instance with the app's timezone is returned.
+
+If you want to keep the timezone UTC, you need to call ``setTimezone('UTC')``::
+
+    use CodeIgniter\I18n\Time;
+
+    $time = Time::createFromTimestamp(1501821586)->setTimezone('UTC');
+
+
 *********************
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -114,12 +114,17 @@ and returns a ``Time`` instance, instead of DateTimeImmutable:
 
 .. literalinclude:: time/011.php
 
+.. _time-createfromtimestamp:
+
 createFromTimestamp()
 =====================
 
 This method takes a UNIX timestamp and, optionally, the timezone and locale, to create a new Time instance:
 
 .. literalinclude:: time/012.php
+
+.. note:: Due to a bug, prior to v4.4.6, this method returned a Time instance
+    in timezone UTC when you do not specify a timezone.
 
 createFromInstance()
 ====================


### PR DESCRIPTION
**Description**
From https://github.com/codeigniter4/shield/pull/1027/files#r1488969384

`Time::createFromTimestamp()` returns Time with the timezone `UTC`.
This behavior is misleading.

```diff
--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -109,7 +109,7 @@ class App extends BaseConfig
      * @see https://www.php.net/manual/en/timezones.php for list of timezones
      *      supported by PHP.
      */
-    public string $appTimezone = 'UTC';
+    public string $appTimezone = 'Asia/Tokyo';
 
     /**
      * --------------------------------------------------------------------------
```

```php
        //        UTC 1999-12-31 15:00:00
        // Asia/Tokyo 2000-01-01 00:00:00
        $timestamp = 946652400;

        $time = DatetimeCast::get($timestamp);

        return $time->format('Y-m-d H:i:s'); // 1999-12-31 15:00:00
```

Carbon sets the current timezone. 
> You can create instances from [unix timestamps](http://en.wikipedia.org/wiki/Unix_time). createFromTimestamp() create a Carbon instance equal to the given timestamp and will set the timezone as well or default it to the current timezone. 
https://carbon.nesbot.com/docs/#api-instantiation

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
