### PR TITLE
docs: use word "UNIX timestamp" for consistency

### DIFF
--- a/user_guide_src/source/libraries/cookies/004.php
+++ b/user_guide_src/source/libraries/cookies/004.php
@@ -22,7 +22,7 @@ $cookie = new Cookie(
 $cookie->getName();             // 'remember_token'
 $cookie->getPrefix();           // '__Secure-'
 $cookie->getPrefixedName();     // '__Secure-remember_token'
-$cookie->getExpiresTimestamp(); // Unix timestamp
+$cookie->getExpiresTimestamp(); // UNIX timestamp
 $cookie->getExpiresString();    // 'Fri, 14-Feb-2025 00:00:00 GMT'
 $cookie->isExpired();           // false
 $cookie->getMaxAge();           // the difference from time() to expires

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -184,7 +184,7 @@ $dateFormat
 
 This value works with `$useTimestamps`_ and `$useSoftDeletes`_ to ensure that the correct type of
 date value gets inserted into the database. By default, this creates DATETIME values, but
-valid options are: ``'datetime'``, ``'date'``, or ``'int'`` (a PHP timestamp). Using `$useSoftDeletes`_ or
+valid options are: ``'datetime'``, ``'date'``, or ``'int'`` (a UNIX timestamp). Using `$useSoftDeletes`_ or
 `$useTimestamps`_ with an invalid or missing `$dateFormat`_ will cause an exception.
 
 $createdField


### PR DESCRIPTION
**Description**
- use word "UNIX timestamp" for consistency

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
