### PR TITLE
fix: PHP 8.2 - Allow Dynamic Properties in Database Config

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -2,11 +2,13 @@
 
 namespace Config;
 
+use AllowDynamicProperties;
 use CodeIgniter\Database\Config;
 
 /**
  * Database Configuration
  */
+#[AllowDynamicProperties]
 class Database extends Config
 {
     /**


### PR DESCRIPTION
**Description**

Dynamic properties needs to be allowed since PHP8.2 so that additional database conections can be added using registrars.

This is useful in situation where module needs to provide it’s own database connection group.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
