### PR TITLE
chore: add PhpMetrics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,8 @@
     },
     "scripts": {
         "post-update-cmd": [
-            "CodeIgniter\\ComposerScripts::postUpdate"
+            "CodeIgniter\\ComposerScripts::postUpdate",
+            "composer update --working-dir=tools/phpmetrics"
         ],
         "analyze": [
             "Composer\\Config::disableProcessTimeout",
@@ -111,12 +112,14 @@
         ],
         "sa": "@analyze",
         "style": "@cs-fix",
-        "test": "phpunit"
+        "test": "phpunit",
+        "metrics": "tools/phpmetrics/vendor/bin/phpmetrics --config=phpmetrics.json"
     },
     "scripts-descriptions": {
         "analyze": "Run static analysis",
         "cs": "Check the coding style",
         "cs-fix": "Fix the coding style",
-        "test": "Run unit tests"
+        "test": "Run unit tests",
+        "metrics": "Run PhpMetrics"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -110,16 +110,16 @@
             "php-cs-fixer fix --ansi --verbose --diff --config=.php-cs-fixer.no-header.php",
             "php-cs-fixer fix --ansi --verbose --diff"
         ],
+        "metrics": "tools/phpmetrics/vendor/bin/phpmetrics --config=phpmetrics.json",
         "sa": "@analyze",
         "style": "@cs-fix",
-        "test": "phpunit",
-        "metrics": "tools/phpmetrics/vendor/bin/phpmetrics --config=phpmetrics.json"
+        "test": "phpunit"
     },
     "scripts-descriptions": {
         "analyze": "Run static analysis",
         "cs": "Check the coding style",
         "cs-fix": "Fix the coding style",
-        "test": "Run unit tests",
-        "metrics": "Run PhpMetrics"
+        "metrics": "Run PhpMetrics",
+        "test": "Run unit tests"
     }
 }

--- a/phpmetrics.json
+++ b/phpmetrics.json
@@ -1,0 +1,7 @@
+{
+    "includes": ["system"],
+    "excludes": ["ThirdParty"],
+    "report": {
+        "html": "build/phpmetrics/"
+    }
+}

--- a/tools/phpmetrics/composer.json
+++ b/tools/phpmetrics/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "phpmetrics/phpmetrics": "^3.0rc6"
+    }
+}


### PR DESCRIPTION
**Description**
- add [PhpMetrics](https://phpmetrics.github.io/website/)

How to Use:
```console
$ composer metrics
$ open build/phpmetrics/index.html
```

![Screenshot 2024-02-15 20 07 20](https://github.com/codeigniter4/CodeIgniter4/assets/87955/26eeaca5-3655-4a5d-9aa7-48b92b0bf93b)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
