### PR TITLE
docs: add note for index.php change

### DIFF
--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -54,8 +54,7 @@ Application Structure
     This means that you should configure your web server to "point" to your project's
     **public** folder, and not to the project root.
 
-    If you would use Shared Hosting and you cannot set it, see
-    `Install CodeIgniter 4 on Shared Hosting (cPanel) <https://forum.codeigniter.com/showthread.php?tid=76779>`_.
+    If you would use Shared Hosting, see :ref:`deployment-to-shared-hosting-services`.
 
 - The **application** folder is renamed as **app** and the framework still has **system** folders,
   with the same interpretation as before.

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -47,6 +47,13 @@ Namespaces
 Application Structure
 =====================
 
+.. important::
+    **index.php** is no longer in the root of the project! It has been moved inside
+    the **public** folder, for better security and separation of components.
+
+    This means that you should configure your web server to "point" to your project's
+    **public** folder, and not to the project root.
+
 - The **application** folder is renamed as **app** and the framework still has **system** folders,
   with the same interpretation as before.
 - The framework now provides for a **public** folder, intended as the document root for your app.

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -54,6 +54,9 @@ Application Structure
     This means that you should configure your web server to "point" to your project's
     **public** folder, and not to the project root.
 
+    If you would use Shared Hosting and you cannot set it, see
+    `Install CodeIgniter 4 on Shared Hosting (cPanel) <https://forum.codeigniter.com/showthread.php?tid=76779>`_.
+
 - The **application** folder is renamed as **app** and the framework still has **system** folders,
   with the same interpretation as before.
 - The framework now provides for a **public** folder, intended as the document root for your app.


### PR DESCRIPTION
**Description**
I saw a YouTube video that a dev had moved index.php to the project root.
Also this description is on the README file, but not in the User Guide upgrading section.

a**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
