### PR TITLE
docs: replace `$this->validate()` with `validateData()`

### DIFF
--- a/user_guide_src/source/installation/upgrade_file_upload/001.php
+++ b/user_guide_src/source/installation/upgrade_file_upload/001.php
@@ -11,7 +11,7 @@ class Upload extends BaseController
 
     public function do_upload()
     {
-        $this->validate([
+        $this->validateData([], [
             'userfile' => [
                 'uploaded[userfile]',
                 'max_size[userfile,100]',

--- a/user_guide_src/source/installation/upgrade_validations.rst
+++ b/user_guide_src/source/installation/upgrade_validations.rst
@@ -32,9 +32,10 @@ Upgrade Guide
 
 2. Within the controller you have to change the following:
 
-    - ``$this->load->helper(array('form', 'url'));`` to ``helper(['form', 'url']);``
+    - ``$this->load->helper(array('form', 'url'));`` to ``helper('form');``
     - remove the line ``$this->load->library('form_validation');``
-    - ``if ($this->form_validation->run() == FALSE)`` to ``if (! $this->validate([]))``
+    - ``if ($this->form_validation->run() == FALSE)`` to ``if (! $this->validateData($data, $rules))``
+      where ``$data`` is the data to validate, typically, the POST data ``$this->request->getPost()``.
     - ``$this->load->view('myform');`` to ``return view('myform', ['validation' => $this->validator,]);``
 
 3. You have to change the validation rules. The new syntax is to set the rules as array in the controller:

--- a/user_guide_src/source/installation/upgrade_validations/001.php
+++ b/user_guide_src/source/installation/upgrade_validations/001.php
@@ -1,6 +1,6 @@
 <?php
 
-$isValid = $this->validate([
+$isValid = $this->validateData($data, [
     'name'  => 'required|min_length[3]',
     'email' => 'required|valid_email',
     'phone' => 'required|numeric|max_length[10]',

--- a/user_guide_src/source/installation/upgrade_validations/002.php
+++ b/user_guide_src/source/installation/upgrade_validations/002.php
@@ -8,9 +8,11 @@ class Form extends Controller
 {
     public function index()
     {
-        helper(['form', 'url']);
+        helper('form');
 
-        if (! $this->validate([
+        $data = $this->request->getPost();
+
+        if (! $this->validateData($data, [
             // Validation rules
         ])) {
             return view('myform');

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -998,7 +998,7 @@ file upload related rules::
     <input type="file" name="avatar">
 
     // In the controller
-    $this->validate([
+    $this->validateData([], [
         'avatar' => 'uploaded[avatar]|max_size[avatar,1024]',
     ]);
 

--- a/user_guide_src/source/libraries/validation/045.php
+++ b/user_guide_src/source/libraries/validation/045.php
@@ -2,7 +2,7 @@
 
 // In Controller.
 
-if (! $this->validate([
+if (! $this->validateData($data, [
     'username' => 'required',
     'password' => 'required|min_length[10]',
 ])) {


### PR DESCRIPTION

**Description**
`$this->validate()` is not recommended.

Related #8537

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
