### PR TITLE
refactor: remove redundant URL helper loading

### DIFF
--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -88,7 +88,4 @@ require_once SYSTEMPATH . 'Config/DotEnv.php';
 $env = new DotEnv(ROOTPATH);
 $env->load();
 
-// Always load the URL helper, it should be used in most of apps.
-helper('url');
-
 Services::routes()->loadRoutes();


### PR DESCRIPTION
**Description**
- autoloader now loads URL helper

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
