### PR TITLE
docs: restore goals.rst from 3.0 user guide

### DIFF
--- a/user_guide_src/source/concepts/goals.rst
+++ b/user_guide_src/source/concepts/goals.rst
@@ -1,0 +1,32 @@
+##############################
+Design and Architectural Goals
+##############################
+
+Our goal for CodeIgniter is maximum performance, capability, and
+flexibility in the smallest, lightest possible package.
+
+To meet this goal we are committed to benchmarking, re-factoring, and
+simplifying at every step of the development process, rejecting anything
+that doesn't further the stated objective.
+
+From a technical and architectural standpoint, CodeIgniter was created
+with the following objectives:
+
+-  **Dynamic Instantiation.** In CodeIgniter, components are loaded and
+   routines executed only when requested, rather than globally. No
+   assumptions are made by the system regarding what may be needed
+   beyond the minimal core resources, so the system is very light-weight
+   by default. The events, as triggered by the HTTP request, and the
+   controllers and views you design will determine what is invoked.
+-  **Loose Coupling.** Coupling is the degree to which components of a
+   system rely on each other. The less components depend on each other
+   the more reusable and flexible the system becomes. Our goal was a
+   very loosely coupled system.
+-  **Component Singularity.** Singularity is the degree to which
+   components have a narrowly focused purpose. In CodeIgniter, each
+   class and its functions are highly autonomous in order to allow
+   maximum usefulness.
+
+CodeIgniter is a dynamically instantiated, loosely coupled system with
+high component singularity. It strives for simplicity, flexibility, and
+high performance in a small footprint package.

--- a/user_guide_src/source/concepts/index.rst
+++ b/user_guide_src/source/concepts/index.rst
@@ -14,3 +14,4 @@ The following pages describe the architectural concepts behind CodeIgniter4:
     factories
     http
     security
+    goals


### PR DESCRIPTION
**Description**
I don't know why this "Design and Architectural Goals" was removed in 4.0 user guide.
But I would like to restore it.

Basically, this goal is still valid today. If there are any changes that should be made, 
please comment.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
