### PR TITLE
refactor: remove deprecated const SPARKED

### DIFF
--- a/spark
+++ b/spark
@@ -42,13 +42,6 @@ if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
 error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
-/**
- * @var bool
- *
- * @deprecated No longer in use. `CodeIgniter` has `$context` property.
- */
-define('SPARKED', true);
-
 // Path to the front controller
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR);
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -241,6 +241,7 @@ Others
 - **Exceptions:** The deprecated ``CodeIgniter\Exceptions\CastException`` class has been removed.
 - **Entity:** The deprecated ``CodeIgniter\Entity`` class has been removed. Use
   ``CodeIgniter\Entity\Entity`` instead.
+- **spark:** The deprecated constant ``SPARKED`` has been removed.
 
 Enhancements
 ************


### PR DESCRIPTION
**Description**
- remove deprecated const SPARKED

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
