### PR TITLE
feat: AVIF Supported

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -851,3 +851,23 @@
 .debug-bar-level-6 {
   --level: 6;
 }
+
+.debug-outline #toolbarContainer.dark #debug-bar,
+.debug-outline #toolbarContainer.dark #debug-bar img,
+.debug-outline #toolbarContainer.dark #debug-bar svg,
+.debug-outline #toolbarContainer.dark #debug-bar path,
+.debug-outline #toolbarContainer.light #debug-bar,
+.debug-outline #toolbarContainer.light #debug-bar img,
+.debug-outline #toolbarContainer.light #debug-bar svg,
+.debug-outline #toolbarContainer.light #debug-bar path,
+.debug-outline #debug-bar a,
+.debug-outline #debug-bar h1,
+.debug-outline #debug-bar span,
+.debug-outline #toolbarContainer.light #debug-bar .toolbar,
+.debug-outline #toolbarContainer.dark #debug-bar .toolbar{
+  outline: 0!important;
+}
+
+body.debug-outline *:not(#toolbarContainer) {
+  outline: solid #dd4814 1px;
+}

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -852,6 +852,10 @@
   --level: 6;
 }
 
+.ci-label.active svg{
+  color:#dd4814;
+}
+
 .debug-outline #toolbarContainer.dark #debug-bar,
 .debug-outline #toolbarContainer.dark #debug-bar img,
 .debug-outline #toolbarContainer.dark #debug-bar svg,

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -657,7 +657,7 @@ var ciDebugBar = {
 
     setHotReloadState: function () {
         var btn = document.getElementById("debug-hot-reload").parentNode;
-        var btnImg = btn.getElementsByTagName("img")[0];
+        var btnImg = btn.getElementsByTagName("svg")[0];
         var eventSource;
 
         // If the Hot Reload Collector is inactive stops here

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -19,6 +19,7 @@ var ciDebugBar = {
         ciDebugBar.toggleViewsHints();
         ciDebugBar.routerLink();
         ciDebugBar.setHotReloadState();
+        ciDebugBar.setDebugCss();
 
         document
             .getElementById("debug-bar-link")
@@ -705,6 +706,32 @@ var ciDebugBar = {
         };
 
         return eventSource;
+    },
+
+    setDebugCss: function () {
+
+        var isDebugCssOn = false;
+        
+        var btnCss = document.getElementById("debug-css");
+        if (!btnCss) {
+            return;
+        }
+        
+        btnCss.onclick = function () {
+            toggleDebugClass();
+        }
+
+        function toggleDebugClass() {
+            var body = document.body;
+            if (isDebugCssOn) {
+                btnCss.classList.remove("active");
+                body.classList.remove('debug-outline');
+            } else {
+                btnCss.classList.add("active");
+                body.classList.add('debug-outline');
+            }
+            isDebugCssOn = !isDebugCssOn;
+        }
     },
 
     /**

--- a/system/Debug/Toolbar/Views/toolbar.tpl.php
+++ b/system/Debug/Toolbar/Views/toolbar.tpl.php
@@ -33,16 +33,21 @@
 </div>
 <div id="debug-bar">
     <div class="toolbar">
-        <span id="toolbar-position"><a href="#">&#8597;</a></span>
-        <span id="toolbar-theme"><a href="#">&#128261;</a></span>
+        <span id="toolbar-position"><a href="javascript: void(0)">&#8597;</a></span>
+        <span id="toolbar-theme"><a href="javascript: void(0)">&#128261;</a></span>
         <span id="hot-reload-btn" class="ci-label">
-            <a id="debug-hot-reload" href="#" title="Toggle Hot Reload">
-                <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAABNklEQVR4nN2US04CQRCGv/DaiBxEvYWuBRPDKSCIXsCdcg0ULqTI8xIGN7JwTCU/ScV5tTO64Us6maSq/7+nuqvgkLgHopTl+QAWwBToAg3+wMTzM7YBrihp4jkCToEB8OJyRkCFAB5yDDxVoAd8OpNMOkrcAeMAgz3nzsQ0EqkDayXZqXy5Qugrdy2tGNdKeNWv40xCqGpvJK0YEwXt8ooylMZzUnCh4EkJgzNpmFaMrYLNEgbH0thmGVhSUVrSeE8KLv+7RBMFb0oY3EnDeihGN+WZhmJ7ZlnPtKHB5RvtNwy0d5XWaGgqRmp7a/9QLjRevoDLvOSRM+nnlKumk++0xwZlLhVnEulOhnohTS37vnU1t5M/ho7rPR03/LKW1bxNQep6ETZb5mpGW2/Ak2KpF3oYfAPX9Xpc671kqwAAAABJRU5ErkJggg==" />
+            <a id="debug-hot-reload" href="javascript: void(0)" title="Toggle Hot Reload">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-reload" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M19.933 13.041a8 8 0 1 1 -9.925 -8.788c3.899 -1 7.935 1.007 9.425 4.747" /><path d="M20 4v5h-5" /></svg>
+            </a>
+        </span>
+        <span id="debug-css" class="ci-label">
+            <a href="javascript: void(0)">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-box-margin" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 8h8v8h-8z" /><path d="M4 4v.01" /><path d="M8 4v.01" /><path d="M12 4v.01" /><path d="M16 4v.01" /><path d="M20 4v.01" /><path d="M4 20v.01" /><path d="M8 20v.01" /><path d="M12 20v.01" /><path d="M16 20v.01" /><path d="M20 20v.01" /><path d="M20 16v.01" /><path d="M20 12v.01" /><path d="M20 8v.01" /><path d="M4 16v.01" /><path d="M4 12v.01" /><path d="M4 8v.01" /></svg>
             </a>
         </span>
         <span class="ci-label">
-            <a href="#" data-tab="ci-timeline">
-                <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAD7SURBVEhLY6ArSEtLK09NTbWHcvGC9PR0BaDaQiAdUl9fzwQVxg+AFvwHamqHcnGCpKQkeaDa9yD1UD09UCn8AKaBWJySkmIApFehi0ONwwRQBceBLurAh4FqFoHUAtkrgPgREN+ByYEw1DhMANVEMIhAYQ5U1wtU/wmILwLZRlAp/IBYC8gGw88CaFj3A/FnIL4ETDXGUCnyANSC/UC6HIpnQMXAqQXIvo0khxNDjcMEQEmU9AzDuNI7Lgw1DhOAJIEuhQcRKMcC+e+QNHdDpcgD6BaAANSSQqBcENFlDi6AzQKqgkFlwWhxjVI8o2OgmkFaXI8CTMDAAAAxd1O4FzLMaAAAAABJRU5ErkJggg==">
+            <a href="javascript: void(0)" data-tab="ci-timeline">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-activity" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 12h4l3 8l4 -16l3 8h4" /></svg>
                 <span class="hide-sm"><?= $totalTime ?> ms &nbsp; <?= $totalMemory ?> MB</span>
             </a>
         </span>

--- a/system/Images/Handlers/BaseHandler.php
+++ b/system/Images/Handlers/BaseHandler.php
@@ -113,6 +113,7 @@ abstract class BaseHandler implements ImageHandlerInterface
     protected $supportTransparency = [
         IMAGETYPE_PNG,
         IMAGETYPE_WEBP,
+        IMAGETYPE_AVIF
     ];
 
     /**

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -274,6 +274,16 @@ class GDHandler extends BaseHandler
                     throw ImageException::forSaveFailed();
                 }
                 break;
+            
+            case IMAGETYPE_AVIF:
+                if (! function_exists('imageavif')) {
+                    throw ImageException::forInvalidImageCreate(lang('Images.avifNotSupported'));
+                }
+
+                if (! @imageavif($this->resource, $target, $quality)) {
+                    throw ImageException::forSaveFailed();
+                }
+                break;
 
             default:
                 throw ImageException::forInvalidImageCreate();
@@ -365,6 +375,13 @@ class GDHandler extends BaseHandler
                 }
 
                 return imagecreatefromwebp($path);
+
+             case IMAGETYPE_AVIF:
+                if (! function_exists('imagecreatefromavif')) {
+                    throw ImageException::forInvalidImageCreate(lang('Images.avifNotSupported'));
+                }
+            
+                return imagecreatefromavif($path);
 
             default:
                 throw ImageException::forInvalidImageCreate('Ima');

--- a/system/Images/Image.php
+++ b/system/Images/Image.php
@@ -110,6 +110,7 @@ class Image extends File
             IMAGETYPE_JPEG => 'jpeg',
             IMAGETYPE_PNG  => 'png',
             IMAGETYPE_WEBP => 'webp',
+            IMAGETYPE_AVIF => 'avif',
         ];
 
         $mime = 'image/' . ($types[$vals[2]] ?? 'jpg');

--- a/system/Language/en/Images.php
+++ b/system/Language/en/Images.php
@@ -18,6 +18,7 @@ return [
     'jpgNotSupported'        => 'JPG images are not supported.',
     'pngNotSupported'        => 'PNG images are not supported.',
     'webpNotSupported'       => 'WEBP images are not supported.',
+    'avifNotSupported'       => 'AVIF images are not supported.',
     'fileNotSupported'       => 'The supplied file is not a supported image type.',
     'unsupportedImageCreate' => 'Your server does not support the GD function required to process this type of image.',
     'jpgOrPngRequired'       => 'The image resize protocol specified in your preferences only works with JPEG or PNG image types.',


### PR DESCRIPTION
**Description**
Here is an edition to support the .AVIF format on CodeIgniter 4.5.0, which is the successor to .webp in the years to come. Currently, only three browsers do not yet support AVIF (88.81% of browsers support this version).

https://caniuse.com/avif

The AVIF format is lighter than WEBP.

Here is an example of a comparison from my CodeIgniter CMS, for instance.
![Capture d'écran 2024-02-19 132846](https://github.com/codeigniter4/CodeIgniter4/assets/8069073/f21652be-a62c-427f-b2dd-1c06aa18d1a3)

Warning, changing the format to a larger one than the original image increases its file size.
Exemple of use: 

` $image->withFile($pathfolder.$newName)->convert(IMAGETYPE_AVIF)->save($pathfolderLarge.mb_url_title($newNameC).'.avif');`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
