### PR TITLE
fix: PHPDoc types in controller.tpl.php

### DIFF
--- a/system/Commands/Generators/Views/controller.tpl.php
+++ b/system/Commands/Generators/Views/controller.tpl.php
@@ -99,7 +99,7 @@ class {class} extends {extends}
     /**
      * Present a view to present a specific resource object.
      *
-     * @param string $id
+     * @param string|null $id
      *
      * @return ResponseInterface
      */
@@ -132,7 +132,7 @@ class {class} extends {extends}
     /**
      * Present a view to edit the properties of a specific resource object.
      *
-     * @param mixed $id
+     * @param string|null $id
      *
      * @return mixed
      */
@@ -145,7 +145,7 @@ class {class} extends {extends}
      * Process the updating, full or partial, of a specific resource object.
      * This should be a POST.
      *
-     * @param mixed $id
+     * @param string|null $id
      *
      * @return mixed
      */
@@ -157,7 +157,7 @@ class {class} extends {extends}
     /**
      * Present a view to confirm the deletion of a specific resource object.
      *
-     * @param mixed $id
+     * @param string|null $id
      *
      * @return mixed
      */
@@ -169,7 +169,7 @@ class {class} extends {extends}
     /**
      * Process the deletion of a specific resource object.
      *
-     * @param mixed $id
+     * @param string|null $id
      *
      * @return mixed
      */

--- a/system/Commands/Generators/Views/controller.tpl.php
+++ b/system/Commands/Generators/Views/controller.tpl.php
@@ -21,6 +21,8 @@ class {class} extends {extends}
     /**
      * Return the properties of a resource object.
      *
+     * @param string|null $id
+     *
      * @return ResponseInterface
      */
     public function show($id = null)
@@ -51,6 +53,8 @@ class {class} extends {extends}
     /**
      * Return the editable properties of a resource object.
      *
+     * @param string|null $id
+     *
      * @return ResponseInterface
      */
     public function edit($id = null)
@@ -61,6 +65,8 @@ class {class} extends {extends}
     /**
      * Add or update a model resource, from "posted" properties.
      *
+     * @param string|null $id
+     *
      * @return ResponseInterface
      */
     public function update($id = null)
@@ -70,6 +76,8 @@ class {class} extends {extends}
 
     /**
      * Delete the designated resource object from the model.
+     *
+     * @param string|null $id
      *
      * @return ResponseInterface
      */

--- a/system/Commands/Generators/Views/controller.tpl.php
+++ b/system/Commands/Generators/Views/controller.tpl.php
@@ -9,7 +9,7 @@ class {class} extends {extends}
 {
 <?php if ($type === 'controller'): ?>
     /**
-     * Return an array of resource objects, themselves in array format
+     * Return an array of resource objects, themselves in array format.
      *
      * @return ResponseInterface
      */
@@ -19,7 +19,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Return the properties of a resource object
+     * Return the properties of a resource object.
      *
      * @return ResponseInterface
      */
@@ -29,7 +29,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Return a new resource object, with default properties
+     * Return a new resource object, with default properties.
      *
      * @return ResponseInterface
      */
@@ -39,7 +39,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Create a new resource object, from "posted" parameters
+     * Create a new resource object, from "posted" parameters.
      *
      * @return ResponseInterface
      */
@@ -49,7 +49,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Return the editable properties of a resource object
+     * Return the editable properties of a resource object.
      *
      * @return ResponseInterface
      */
@@ -59,7 +59,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Add or update a model resource, from "posted" properties
+     * Add or update a model resource, from "posted" properties.
      *
      * @return ResponseInterface
      */
@@ -69,7 +69,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Delete the designated resource object from the model
+     * Delete the designated resource object from the model.
      *
      * @return ResponseInterface
      */
@@ -79,7 +79,7 @@ class {class} extends {extends}
     }
 <?php elseif ($type === 'presenter'): ?>
     /**
-     * Present a view of resource objects
+     * Present a view of resource objects.
      *
      * @return ResponseInterface
      */
@@ -89,7 +89,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Present a view to present a specific resource object
+     * Present a view to present a specific resource object.
      *
      * @param string $id
      *
@@ -101,7 +101,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Present a view to present a new single resource object
+     * Present a view to present a new single resource object.
      *
      * @return mixed
      */
@@ -122,7 +122,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Present a view to edit the properties of a specific resource object
+     * Present a view to edit the properties of a specific resource object.
      *
      * @param mixed $id
      *
@@ -147,7 +147,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Present a view to confirm the deletion of a specific resource object
+     * Present a view to confirm the deletion of a specific resource object.
      *
      * @param mixed $id
      *
@@ -159,7 +159,7 @@ class {class} extends {extends}
     }
 
     /**
-     * Process the deletion of a specific resource object
+     * Process the deletion of a specific resource object.
      *
      * @param mixed $id
      *

--- a/system/Commands/Generators/Views/controller.tpl.php
+++ b/system/Commands/Generators/Views/controller.tpl.php
@@ -111,7 +111,7 @@ class {class} extends {extends}
     /**
      * Present a view to present a new single resource object.
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function new()
     {
@@ -122,7 +122,7 @@ class {class} extends {extends}
      * Process the creation/insertion of a new resource object.
      * This should be a POST.
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function create()
     {
@@ -134,7 +134,7 @@ class {class} extends {extends}
      *
      * @param string|null $id
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function edit($id = null)
     {
@@ -147,7 +147,7 @@ class {class} extends {extends}
      *
      * @param string|null $id
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function update($id = null)
     {
@@ -159,7 +159,7 @@ class {class} extends {extends}
      *
      * @param string|null $id
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function remove($id = null)
     {
@@ -171,7 +171,7 @@ class {class} extends {extends}
      *
      * @param string|null $id
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function delete($id = null)
     {

--- a/system/Commands/Generators/Views/controller.tpl.php
+++ b/system/Commands/Generators/Views/controller.tpl.php
@@ -21,7 +21,7 @@ class {class} extends {extends}
     /**
      * Return the properties of a resource object.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -53,7 +53,7 @@ class {class} extends {extends}
     /**
      * Return the editable properties of a resource object.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -65,7 +65,7 @@ class {class} extends {extends}
     /**
      * Add or update a model resource, from "posted" properties.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -77,7 +77,7 @@ class {class} extends {extends}
     /**
      * Delete the designated resource object from the model.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -99,7 +99,7 @@ class {class} extends {extends}
     /**
      * Present a view to present a specific resource object.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -132,7 +132,7 @@ class {class} extends {extends}
     /**
      * Present a view to edit the properties of a specific resource object.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -145,7 +145,7 @@ class {class} extends {extends}
      * Process the updating, full or partial, of a specific resource object.
      * This should be a POST.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -157,7 +157,7 @@ class {class} extends {extends}
     /**
      * Present a view to confirm the deletion of a specific resource object.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */
@@ -169,7 +169,7 @@ class {class} extends {extends}
     /**
      * Process the deletion of a specific resource object.
      *
-     * @param string|null $id
+     * @param int|string|null $id
      *
      * @return ResponseInterface
      */


### PR DESCRIPTION
**Description**
See #6310

- fix/add PHPDoc types

Ref #8144

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
