### PR TITLE
[4.5] refactor: use local variables in Model

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -186,7 +186,8 @@ class Model extends BaseModel
     {
         $builder = $this->builder();
 
-        if ($this->useCasts()) {
+        $useCast = $this->useCasts();
+        if ($useCast) {
             $returnType = $this->tempReturnType;
             $this->asArray();
         }
@@ -207,7 +208,7 @@ class Model extends BaseModel
             $row = $builder->get()->getResult($this->tempReturnType);
         }
 
-        if ($this->useCasts()) {
+        if ($useCast) {
             $row = $this->convertToReturnType($row, $returnType);
 
             $this->tempReturnType = $returnType;
@@ -257,7 +258,8 @@ class Model extends BaseModel
 
         $builder = $this->builder();
 
-        if ($this->useCasts()) {
+        $useCast = $this->useCasts();
+        if ($useCast) {
             $returnType = $this->tempReturnType;
             $this->asArray();
         }
@@ -270,7 +272,7 @@ class Model extends BaseModel
             ->get()
             ->getResult($this->tempReturnType);
 
-        if ($this->useCasts()) {
+        if ($useCast) {
             foreach ($results as $i => $row) {
                 $results[$i] = $this->convertToReturnType($row, $returnType);
             }
@@ -293,7 +295,8 @@ class Model extends BaseModel
     {
         $builder = $this->builder();
 
-        if ($this->useCasts()) {
+        $useCast = $this->useCasts();
+        if ($useCast) {
             $returnType = $this->tempReturnType;
             $this->asArray();
         }
@@ -312,7 +315,7 @@ class Model extends BaseModel
 
         $row = $builder->limit(1, 0)->get()->getFirstRow($this->tempReturnType);
 
-        if ($this->useCasts()) {
+        if ($useCast) {
             $row = $this->convertToReturnType($row, $returnType);
 
             $this->tempReturnType = $returnType;


### PR DESCRIPTION
**Description**
To fix PHPStan error. Also, using a local variable is a bit faster than method calling twice.

```
  ------ -------------------------------------------- 
  Line   system/Model.php                            
 ------ -------------------------------------------- 
  211    Variable $returnType might not be defined.  
  213    Variable $returnType might not be defined.  
  275    Variable $returnType might not be defined.  
  278    Variable $returnType might not be defined.  
  316    Variable $returnType might not be defined.  
  318    Variable $returnType might not be defined.  
 ------ -------------------------------------------- 
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/7982852609/job/21797025530

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
