### PR TITLE
refactor: Use logger in Redis Session Handler

### DIFF
--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -313,13 +313,13 @@ class RedisHandler extends BaseHandler
         } while (++$attempt < 30);
 
         if ($attempt === 30) {
-            log_message('error', 'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.');
+            $this->logger->error('Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.');
 
             return false;
         }
 
         if ($ttl === -1) {
-            log_message('debug', 'Session: Lock for ' . $this->keyPrefix . $sessionID . ' had no TTL, overriding.');
+            $this->logger->debug('Session: Lock for ' . $this->keyPrefix . $sessionID . ' had no TTL, overriding.');
         }
 
         $this->lock = true;


### PR DESCRIPTION
**Description**
log_message was left in some places this changes those instances to use logger object instead.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
