### PR TITLE
[4.5] fix: Composer autoload.psr4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,7 @@
     },
     "autoload": {
         "psr-4": {
-            "CodeIgniter\\": "system/",
-            "Config\\": "app/Config/"
+            "CodeIgniter\\": "system/"
         },
         "exclude-from-classmap": [
             "**/Database/Migrations/**"


### PR DESCRIPTION
**Description**
Follow-up #8005

- remove `Config\\` from autoload.psr4

If we use this repository from appstarter, the Config files in `app/Config/` in this repository are loaded first.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
