### PR TITLE
feat: add spark command to check php.ini

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -256,6 +256,8 @@ parameters:
       - CodeIgniter\HTTP\URI
     CodeIgniter\Log\Handlers\ChromeLoggerHandler:
       - CodeIgniter\HTTP\ResponseInterface
+    CodeIgniter\Security\CheckPhpIni:
+      - CodeIgniter\View\Table
     CodeIgniter\View\Table:
       - CodeIgniter\Database\BaseResult
     CodeIgniter\View\Plugins:

--- a/system/Commands/Utilities/PhpIniCheck.php
+++ b/system/Commands/Utilities/PhpIniCheck.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands\Utilities;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\Security\CheckPhpIni;
+
+/**
+ * Check php.ini values.
+ */
+final class PhpIniCheck extends BaseCommand
+{
+    /**
+     * The group the command is lumped under
+     * when listing commands.
+     *
+     * @var string
+     */
+    protected $group = 'CodeIgniter';
+
+    /**
+     * The Command's name
+     *
+     * @var string
+     */
+    protected $name = 'phpini:check';
+
+    /**
+     * The Command's short description
+     *
+     * @var string
+     */
+    protected $description = 'Check your php.ini values.';
+
+    /**
+     * The Command's usage
+     *
+     * @var string
+     */
+    protected $usage = 'phpini:check';
+
+    /**
+     * The Command's arguments
+     *
+     * @var array<string, string>
+     */
+    protected $arguments = [
+    ];
+
+    /**
+     * The Command's options
+     *
+     * @var array<string, string>
+     */
+    protected $options = [];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function run(array $params)
+    {
+        CheckPhpIni::run();
+
+        return EXIT_SUCCESS;
+    }
+}

--- a/system/Security/CheckPhpIni.php
+++ b/system/Security/CheckPhpIni.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Security;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\View\Table;
+
+/**
+ * Checks php.ini settings
+ *
+ * @used-by \CodeIgniter\Commands\Utilities\PhpIniCheck
+ * @see \CodeIgniter\Security\CheckPhpIniTest
+ */
+class CheckPhpIni
+{
+    /**
+     * @param bool $isCli Set false if you run via Web
+     *
+     * @return string|void HTML string or void in CLI
+     */
+    public static function run(bool $isCli = true)
+    {
+        $output = static::checkIni();
+
+        $thead = ['Directive', 'Global', 'Current', 'Recommended', 'Remark'];
+        $tbody = [];
+
+        // CLI
+        if ($isCli) {
+            self::outputForCli($output, $thead, $tbody);
+
+            return;
+        }
+
+        // Web
+        return self::outputForWeb($output, $thead, $tbody);
+    }
+
+    private static function outputForCli(array $output, array $thead, array $tbody): void
+    {
+        foreach ($output as $directive => $values) {
+            $current        = $values['current'];
+            $notRecommended = false;
+
+            if ($values['recommended'] !== '') {
+                if ($values['recommended'] !== $values['current']) {
+                    $notRecommended = true;
+                }
+
+                $current = $notRecommended
+                    ? CLI::color($values['current'] === '' ? 'n/a' : $values['current'], 'red')
+                    : $values['current'];
+            }
+
+            $directive = $notRecommended ? CLI::color($directive, 'red') : $directive;
+            $tbody[]   = [
+                $directive, $values['global'], $current, $values['recommended'], $values['remark'],
+            ];
+        }
+
+        CLI::table($tbody, $thead);
+    }
+
+    private static function outputForWeb(array $output, array $thead, array $tbody): string
+    {
+        foreach ($output as $directive => $values) {
+            $current        = $values['current'];
+            $notRecommended = false;
+
+            if ($values['recommended'] !== '') {
+                if ($values['recommended'] !== $values['current']) {
+                    $notRecommended = true;
+                }
+
+                if ($values['current'] === '') {
+                    $current = 'n/a';
+                }
+
+                $current = $notRecommended
+                    ? '<span style="color: red">' . $current . '</span>'
+                    : $current;
+            }
+
+            $directive = $notRecommended
+                ? '<span style="color: red">' . $directive . '</span>'
+                : $directive;
+            $tbody[] = [
+                $directive, $values['global'], $current, $values['recommended'], $values['remark'],
+            ];
+        }
+
+        $table    = new Table();
+        $template = [
+            'table_open' => '<table border="1" cellpadding="4" cellspacing="0">',
+        ];
+        $table->setTemplate($template);
+
+        $table->setHeading($thead);
+
+        return '<pre>' . $table->generate($tbody) . '</pre>';
+    }
+
+    /**
+     * @internal Used for testing purposes only.
+     * @testTag
+     */
+    public static function checkIni(): array
+    {
+        $items = [
+            'error_reporting'        => ['recommended' => '5111'],
+            'display_errors'         => ['recommended' => '0'],
+            'display_startup_errors' => ['recommended' => '0'],
+            'log_errors'             => [],
+            'error_log'              => [],
+            'default_charset'        => ['recommended' => 'UTF-8'],
+            'memory_limit'           => ['remark' => '> post_max_size'],
+            'post_max_size'          => ['remark' => '> upload_max_filesize'],
+            'upload_max_filesize'    => ['remark' => '< post_max_size'],
+            'request_order'          => ['recommended' => 'GP'],
+            'variables_order'        => ['recommended' => 'GPCS'],
+            'date.timezone'          => ['recommended' => 'UTC'],
+            'mbstring.language'      => ['recommended' => 'neutral'],
+        ];
+
+        $output = [];
+        $ini    = ini_get_all();
+
+        foreach ($items as $key => $values) {
+            $output[$key] = [
+                'global'      => $ini[$key]['global_value'],
+                'current'     => $ini[$key]['local_value'],
+                'recommended' => $values['recommended'] ?? '',
+                'remark'      => $values['remark'] ?? '',
+            ];
+        }
+
+        // [directive => [current_value, recommended_value]]
+        return $output;
+    }
+}

--- a/system/Security/CheckPhpIni.php
+++ b/system/Security/CheckPhpIni.php
@@ -118,19 +118,23 @@ class CheckPhpIni
     public static function checkIni(): array
     {
         $items = [
-            'error_reporting'        => ['recommended' => '5111'],
-            'display_errors'         => ['recommended' => '0'],
-            'display_startup_errors' => ['recommended' => '0'],
-            'log_errors'             => [],
-            'error_log'              => [],
-            'default_charset'        => ['recommended' => 'UTF-8'],
-            'memory_limit'           => ['remark' => '> post_max_size'],
-            'post_max_size'          => ['remark' => '> upload_max_filesize'],
-            'upload_max_filesize'    => ['remark' => '< post_max_size'],
-            'request_order'          => ['recommended' => 'GP'],
-            'variables_order'        => ['recommended' => 'GPCS'],
-            'date.timezone'          => ['recommended' => 'UTC'],
-            'mbstring.language'      => ['recommended' => 'neutral'],
+            'error_reporting'         => ['recommended' => '5111'],
+            'display_errors'          => ['recommended' => '0'],
+            'display_startup_errors'  => ['recommended' => '0'],
+            'log_errors'              => [],
+            'error_log'               => [],
+            'default_charset'         => ['recommended' => 'UTF-8'],
+            'memory_limit'            => ['remark' => '> post_max_size'],
+            'post_max_size'           => ['remark' => '> upload_max_filesize'],
+            'upload_max_filesize'     => ['remark' => '< post_max_size'],
+            'request_order'           => ['recommended' => 'GP'],
+            'variables_order'         => ['recommended' => 'GPCS'],
+            'date.timezone'           => ['recommended' => 'UTC'],
+            'mbstring.language'       => ['recommended' => 'neutral'],
+            'opcache.enable'          => ['recommended' => '1'],
+            'opcache.enable_cli'      => [],
+            'opcache.jit'             => [],
+            'opcache.jit_buffer_size' => [],
         ];
 
         $output = [];

--- a/tests/system/Security/CheckPhpIniTest.php
+++ b/tests/system/Security/CheckPhpIniTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Security;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockInputOutput;
+
+/**
+ * @internal
+ *
+ * @group Others
+ */
+final class CheckPhpIniTest extends CIUnitTestCase
+{
+    public function testCheckIni()
+    {
+        $output = CheckPhpIni::checkIni();
+
+        $expected = [
+            'global'      => '',
+            'current'     => '1',
+            'recommended' => '0',
+            'remark'      => '',
+        ];
+        $this->assertSame($expected, $output['display_errors']);
+    }
+
+    public function testRunCli()
+    {
+        // Set MockInputOutput to CLI.
+        $io = new MockInputOutput();
+        CLI::setInputOutput($io);
+
+        CheckPhpIni::run(true);
+
+        // Get the whole output string.
+        $output = $io->getOutput();
+
+        $this->assertStringContainsString('display_errors', $output);
+
+        // Remove MockInputOutput.
+        CLI::resetInputOutput();
+    }
+
+    public function testRunWeb()
+    {
+        $output = CheckPhpIni::run(false);
+
+        $this->assertStringContainsString('display_errors', $output);
+    }
+}

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -28,6 +28,8 @@ Commands
   :ref:`cli-generators-make-test` for the details.
 - Added ``spark config:check`` command to check Config values. See
   :ref:`confirming-config-values` for the details.
+- Added ``spark phpini:check`` command to check important PHP ini settings. See
+  :ref:`spark-phpini-check` for the details.
 - Added ``spark lang:find`` command to update translations keys. See :ref:`generating-translation-files-via-command` for the details.
 - The ``--dbgroup`` option has been added to the ``spark db:table`` command.
   See :ref:`Database Commands <db-command-specify-the-dbgroup>`.

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -74,6 +74,23 @@ you will need to modify the permissions for the **writable** folder inside
 your project, so that it is writable by the user or account used by your
 web server.
 
+.. _spark-phpini-check:
+
+Checking PHP ini Settings
+=========================
+
+.. versionadded:: 4.5.0
+
+PHP ini settings change the behaviors of PHP. CodeIgniter provides a command to
+check important PHP settings.
+
+.. code-block:: console
+
+    php spark phpini:check
+
+The *Recommended* column shows the recommended values for production environment.
+They may differ in development environments.
+
 ************************
 Local Development Server
 ************************

--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -81,8 +81,10 @@ Checking PHP ini Settings
 
 .. versionadded:: 4.5.0
 
-PHP ini settings change the behaviors of PHP. CodeIgniter provides a command to
+`PHP ini settings`_ change the behaviors of PHP. CodeIgniter provides a command to
 check important PHP settings.
+
+.. _PHP ini settings: https://www.php.net/manual/en/ini.list.php
 
 .. code-block:: console
 
@@ -90,6 +92,28 @@ check important PHP settings.
 
 The *Recommended* column shows the recommended values for production environment.
 They may differ in development environments.
+
+.. note::
+    If you cannot use the spark command, you can use ``CheckPhpIni::run(false)``
+    in your controller.
+
+    E.g.,
+
+    .. code-block:: php
+
+        <?php
+
+        namespace App\Controllers;
+
+        use CodeIgniter\Security\CheckPhpIni;
+
+        class Home extends BaseController
+        {
+            public function index(): string
+            {
+                return CheckPhpIni::run(false);
+            }
+        }
 
 ************************
 Local Development Server


### PR DESCRIPTION
**Description**
To easily check important php.ini settings.

```console
$ php spark phpini:check

CodeIgniter v4.4.6 Command Line Tool - Server Time: 2024-02-25 01:23:22 UTC+00:00

+-------------------------+---------+---------+-------------+-----------------------+
| Directive               | Global  | Current | Recommended | Remark                |
+-------------------------+---------+---------+-------------+-----------------------+
| error_reporting         | 32767   | 32767   | 5111        |                       |
| display_errors          | 1       | 1       | 0           |                       |
| display_startup_errors  | 1       | 1       | 0           |                       |
| log_errors              | 1       | 1       |             |                       |
| error_log               |         |         |             |                       |
| default_charset         | UTF-8   | UTF-8   | UTF-8       |                       |
| memory_limit            | 1G      | 1G      |             | > post_max_size       |
| post_max_size           | 8M      | 8M      |             | > upload_max_filesize |
| upload_max_filesize     | 2M      | 2M      |             | < post_max_size       |
| request_order           | GP      | GP      | GP          |                       |
| variables_order         | GPCS    | GPCS    | GPCS        |                       |
| date.timezone           | UTC     | UTC     | UTC         |                       |
| mbstring.language       | neutral | neutral | neutral     |                       |
| opcache.enable          | 1       | 1       | 1           |                       |
| opcache.enable_cli      | 0       | 0       |             |                       |
| opcache.jit             | tracing | tracing |             |                       |
| opcache.jit_buffer_size | 0       | 0       |             |                       |
+-------------------------+---------+---------+-------------+-----------------------+
```

Via Web:
```php
<?php

namespace App\Controllers;

use CodeIgniter\Security\CheckPhpIni;

class Home extends BaseController
{
    public function index(): string
    {
        return CheckPhpIni::run(false);
    }
}
```
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
