### PR TITLE
docs: suppress Psalm errors

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.21.1@8c473e2437be8b6a8fd8f630f0f11a16b114c494">
+<files psalm-version="5.22.2@d768d914152dbbf3486c36398802f74e80cfde48">
   <file src="app/Config/View.php">
     <UndefinedDocblockClass>
       <code><![CDATA[array<string, list<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
       <code><![CDATA[array<string, list<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
       <code><![CDATA[array<string, parser_callable_string>]]></code>
-      <code>public $filters = [];</code>
-      <code>public $plugins = [];</code>
-      <code>public $plugins = [];</code>
+      <code><![CDATA[public $filters = [];]]></code>
+      <code><![CDATA[public $plugins = [];]]></code>
+      <code><![CDATA[public $plugins = [];]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="system/Cache/Handlers/MemcachedHandler.php">
     <UndefinedClass>
-      <code>Memcache</code>
-      <code>Memcache</code>
-      <code>Memcache</code>
+      <code><![CDATA[Memcache]]></code>
+      <code><![CDATA[Memcache]]></code>
+      <code><![CDATA[Memcache]]></code>
     </UndefinedClass>
     <UndefinedDocblockClass>
       <code><![CDATA[$this->memcached]]></code>
@@ -23,67 +23,20 @@
       <code><![CDATA[$this->memcached]]></code>
       <code><![CDATA[$this->memcached]]></code>
       <code><![CDATA[$this->memcached]]></code>
-      <code>Memcache|Memcached</code>
+      <code><![CDATA[Memcache|Memcached]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="system/Commands/Utilities/Routes/ControllerMethodReader.php">
     <DuplicateArrayKey>
-      <code>$routeWithoutController</code>
-      <code>$routeWithoutController</code>
+      <code><![CDATA[$routeWithoutController]]></code>
+      <code><![CDATA[$routeWithoutController]]></code>
     </DuplicateArrayKey>
   </file>
   <file src="system/Config/View.php">
     <UndefinedDocblockClass>
-      <code><![CDATA[array<string, list<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
-      <code><![CDATA[array<string, list<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
       <code><![CDATA[array<string, parser_callable_string>]]></code>
-      <code><![CDATA[protected $coreFilters = [
-        'abs'            => '\abs',
-        'capitalize'     => '\CodeIgniter\View\Filters::capitalize',
-        'date'           => '\CodeIgniter\View\Filters::date',
-        'date_modify'    => '\CodeIgniter\View\Filters::date_modify',
-        'default'        => '\CodeIgniter\View\Filters::default',
-        'esc'            => '\CodeIgniter\View\Filters::esc',
-        'excerpt'        => '\CodeIgniter\View\Filters::excerpt',
-        'highlight'      => '\CodeIgniter\View\Filters::highlight',
-        'highlight_code' => '\CodeIgniter\View\Filters::highlight_code',
-        'limit_words'    => '\CodeIgniter\View\Filters::limit_words',
-        'limit_chars'    => '\CodeIgniter\View\Filters::limit_chars',
-        'local_currency' => '\CodeIgniter\View\Filters::local_currency',
-        'local_number'   => '\CodeIgniter\View\Filters::local_number',
-        'lower'          => '\strtolower',
-        'nl2br'          => '\CodeIgniter\View\Filters::nl2br',
-        'number_format'  => '\number_format',
-        'prose'          => '\CodeIgniter\View\Filters::prose',
-        'round'          => '\CodeIgniter\View\Filters::round',
-        'strip_tags'     => '\strip_tags',
-        'title'          => '\CodeIgniter\View\Filters::title',
-        'upper'          => '\strtoupper',
-    ];]]></code>
-      <code><![CDATA[protected $corePlugins = [
-        'csp_script_nonce'  => '\CodeIgniter\View\Plugins::cspScriptNonce',
-        'csp_style_nonce'   => '\CodeIgniter\View\Plugins::cspStyleNonce',
-        'current_url'       => '\CodeIgniter\View\Plugins::currentURL',
-        'previous_url'      => '\CodeIgniter\View\Plugins::previousURL',
-        'mailto'            => '\CodeIgniter\View\Plugins::mailto',
-        'safe_mailto'       => '\CodeIgniter\View\Plugins::safeMailto',
-        'lang'              => '\CodeIgniter\View\Plugins::lang',
-        'validation_errors' => '\CodeIgniter\View\Plugins::validationErrors',
-        'route'             => '\CodeIgniter\View\Plugins::route',
-        'siteURL'           => '\CodeIgniter\View\Plugins::siteURL',
-    ];]]></code>
-      <code><![CDATA[protected $corePlugins = [
-        'csp_script_nonce'  => '\CodeIgniter\View\Plugins::cspScriptNonce',
-        'csp_style_nonce'   => '\CodeIgniter\View\Plugins::cspStyleNonce',
-        'current_url'       => '\CodeIgniter\View\Plugins::currentURL',
-        'previous_url'      => '\CodeIgniter\View\Plugins::previousURL',
-        'mailto'            => '\CodeIgniter\View\Plugins::mailto',
-        'safe_mailto'       => '\CodeIgniter\View\Plugins::safeMailto',
-        'lang'              => '\CodeIgniter\View\Plugins::lang',
-        'validation_errors' => '\CodeIgniter\View\Plugins::validationErrors',
-        'route'             => '\CodeIgniter\View\Plugins::route',
-        'siteURL'           => '\CodeIgniter\View\Plugins::siteURL',
-    ];]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="system/Database/BasePreparedQuery.php">
@@ -93,43 +46,43 @@
   </file>
   <file src="system/Database/OCI8/Connection.php">
     <UndefinedConstant>
-      <code>OCI_COMMIT_ON_SUCCESS</code>
-      <code>OCI_COMMIT_ON_SUCCESS</code>
-      <code>OCI_COMMIT_ON_SUCCESS</code>
-      <code>OCI_NO_AUTO_COMMIT</code>
-      <code>SQLT_CHR</code>
+      <code><![CDATA[OCI_COMMIT_ON_SUCCESS]]></code>
+      <code><![CDATA[OCI_COMMIT_ON_SUCCESS]]></code>
+      <code><![CDATA[OCI_COMMIT_ON_SUCCESS]]></code>
+      <code><![CDATA[OCI_NO_AUTO_COMMIT]]></code>
+      <code><![CDATA[SQLT_CHR]]></code>
     </UndefinedConstant>
   </file>
   <file src="system/Debug/Toolbar/Views/toolbar.tpl.php">
     <InaccessibleMethod>
-      <code>renderTimeline</code>
+      <code><![CDATA[renderTimeline]]></code>
     </InaccessibleMethod>
     <UndefinedGlobalVariable>
-      <code>$config</code>
+      <code><![CDATA[$config]]></code>
     </UndefinedGlobalVariable>
   </file>
   <file src="system/Email/Email.php">
     <LoopInvalidation>
-      <code>$timestamp</code>
+      <code><![CDATA[$timestamp]]></code>
     </LoopInvalidation>
   </file>
   <file src="system/HTTP/Files/FileCollection.php">
     <EmptyArrayAccess>
-      <code>$output[$name]</code>
+      <code><![CDATA[$output[$name]]]></code>
     </EmptyArrayAccess>
   </file>
   <file src="system/Helpers/text_helper.php">
     <LoopInvalidation>
-      <code>$count</code>
-      <code>$count</code>
-      <code>$count</code>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$count]]></code>
     </LoopInvalidation>
   </file>
   <file src="system/I18n/TimeTrait.php">
     <MissingImmutableAnnotation>
-      <code>#[ReturnTypeWillChange]</code>
-      <code>#[ReturnTypeWillChange]</code>
-      <code>#[ReturnTypeWillChange]</code>
+      <code><![CDATA[#[ReturnTypeWillChange]]]></code>
+      <code><![CDATA[#[ReturnTypeWillChange]]]></code>
+      <code><![CDATA[#[ReturnTypeWillChange]]]></code>
     </MissingImmutableAnnotation>
   </file>
   <file src="system/Test/ControllerResponse.php">
@@ -139,39 +92,39 @@
   </file>
   <file src="system/View/Parser.php">
     <UndefinedDocblockClass>
-      <code><![CDATA[array<string, list<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
-      <code><![CDATA[array<string, list<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
-      <code>protected $plugins = [];</code>
-      <code>protected $plugins = [];</code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
+      <code><![CDATA[array<string, array<parser_callable_string>|parser_callable_string|parser_callable>]]></code>
+      <code><![CDATA[protected $plugins = [];]]></code>
+      <code><![CDATA[protected $plugins = [];]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="tests/_support/Config/Filters.php">
     <UndefinedGlobalVariable>
-      <code>$filters</code>
+      <code><![CDATA[$filters]]></code>
     </UndefinedGlobalVariable>
   </file>
   <file src="tests/_support/Config/Routes.php">
     <UndefinedGlobalVariable>
-      <code>$routes</code>
-      <code>$routes</code>
-      <code>$routes</code>
-      <code>$routes</code>
-      <code>$routes</code>
+      <code><![CDATA[$routes]]></code>
+      <code><![CDATA[$routes]]></code>
+      <code><![CDATA[$routes]]></code>
+      <code><![CDATA[$routes]]></code>
+      <code><![CDATA[$routes]]></code>
     </UndefinedGlobalVariable>
   </file>
   <file src="tests/_support/View/Cells/colors.php">
     <InvalidScope>
-      <code>$this</code>
+      <code><![CDATA[$this]]></code>
     </InvalidScope>
   </file>
   <file src="tests/system/CLI/ConsoleTest.php">
     <DuplicateArrayKey>
-      <code>$command</code>
+      <code><![CDATA[$command]]></code>
     </DuplicateArrayKey>
   </file>
   <file src="tests/system/CommonFunctionsTest.php">
     <UndefinedClass>
-      <code>UnexsistenceClass</code>
+      <code><![CDATA[UnexsistenceClass]]></code>
     </UndefinedClass>
   </file>
   <file src="tests/system/Config/FactoriesTest.php">
@@ -183,14 +136,14 @@
   </file>
   <file src="tests/system/Database/Live/OCI8/CallStoredProcedureTest.php">
     <UndefinedConstant>
-      <code>OCI_ASSOC</code>
-      <code>OCI_B_CURSOR</code>
-      <code>OCI_RETURN_NULLS</code>
+      <code><![CDATA[OCI_ASSOC]]></code>
+      <code><![CDATA[OCI_B_CURSOR]]></code>
+      <code><![CDATA[OCI_RETURN_NULLS]]></code>
     </UndefinedConstant>
   </file>
   <file src="tests/system/Entity/EntityTest.php">
     <EmptyArrayAccess>
-      <code>$current[$key]</code>
+      <code><![CDATA[$current[$key]]]></code>
     </EmptyArrayAccess>
   </file>
   <file src="tests/system/HTTP/RedirectResponseTest.php">
@@ -200,7 +153,7 @@
   </file>
   <file src="tests/system/Test/ControllerTestTraitTest.php">
     <UndefinedClass>
-      <code>NeverHeardOfIt</code>
+      <code><![CDATA[NeverHeardOfIt]]></code>
     </UndefinedClass>
   </file>
 </files>

--- a/system/Config/View.php
+++ b/system/Config/View.php
@@ -59,6 +59,8 @@ class View extends BaseConfig
     /**
      * Built-in View filters.
      *
+     * @psalm-suppress UndefinedDocblockClass
+     *
      * @var         array<string, string>
      * @phpstan-var array<string, parser_callable_string>
      */
@@ -88,6 +90,8 @@ class View extends BaseConfig
 
     /**
      * Built-in View plugins.
+     *
+     * @psalm-suppress UndefinedDocblockClass
      *
      * @var         array<string, callable|list<string>|string>
      * @phpstan-var array<string, array<parser_callable_string>|parser_callable_string|parser_callable>


### PR DESCRIPTION
**Description**
Related #8530

I don't know why Psalm does not understand `@phpstan-type`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
