### PR TITLE
test: remove meaningless `TestCaseTest::testPHPUnitHeadersEmitted()`

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -176,6 +176,7 @@ class Response extends Message implements ResponseInterface
      *
      * @return $this
      *
+     * @internal For testing purposes only.
      * @testTag only available to test code
      */
     public function pretend(bool $pretend = true)

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -13,8 +13,6 @@ namespace CodeIgniter\Test;
 
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Events\Events;
-use CodeIgniter\HTTP\Response;
-use Config\App;
 use Tests\Support\Test\TestForReflectionHelper;
 
 /**
@@ -72,31 +70,6 @@ final class TestCaseTest extends CIUnitTestCase
         CLI::write('first.');
         $expected = PHP_EOL . 'first.' . PHP_EOL;
         $this->assertSame($expected, $this->getStreamFilterBuffer());
-    }
-
-    /**
-     * PHPunit emits headers before we get nominal control of
-     * the output stream, making header testing awkward, to say
-     * the least. This test is intended to make sure that this
-     * is happening as expected.
-     *
-     * TestCaseEmissionsTest is intended to circumvent PHPunit,
-     * and allow us to test our own header emissions.
-     */
-    public function testPHPUnitHeadersEmitted(): void
-    {
-        $response = new Response(new App());
-        $response->pretend(true);
-
-        $body = 'Hello';
-        $response->setBody($body);
-
-        ob_start();
-        $response->send();
-        ob_end_clean();
-
-        $this->assertHeaderEmitted('Content-type: text/html;');
-        $this->assertHeaderNotEmitted('Set-Cookie: foo=bar;');
     }
 
     public function testCloseEnough(): void


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/8069#issuecomment-1963302623

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
