### PR TITLE
docs: Fix typo in Toolbar.php

### DIFF
--- a/app/Config/Toolbar.php
+++ b/app/Config/Toolbar.php
@@ -49,7 +49,7 @@ class Toolbar extends BaseConfig
      * Collect Var Data
      * --------------------------------------------------------------------------
      *
-     * If set to false var data from the views will not be colleted. Useful to
+     * If set to false var data from the views will not be collected. Useful to
      * avoid high memory usage when there are lots of data passed to the view.
      *
      * @var bool


### PR DESCRIPTION
**Description**

Small typo in Toolbar.php

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
