### PR TITLE
refactor: remove deprecated BaseService::discoverServices()

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -303,12 +303,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 3,
-	'path' => __DIR__ . '/system/Config/BaseService.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in a negated boolean, array given\\.$#',
-	'count' => 1,
+	'count' => 2,
 	'path' => __DIR__ . '/system/Config/BaseService.php',
 ];
 $ignoreErrors[] = [

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -318,62 +318,6 @@ class BaseService
         static::$mocks[strtolower($name)] = $mock;
     }
 
-    /**
-     * Will scan all psr4 namespaces registered with system to look
-     * for new Config\Services files. Caches a copy of each one, then
-     * looks for the service method in each, returning an instance of
-     * the service, if available.
-     *
-     * @return object|null
-     *
-     * @deprecated
-     *
-     * @codeCoverageIgnore
-     */
-    protected static function discoverServices(string $name, array $arguments)
-    {
-        if (! static::$discovered) {
-            if ((new Modules())->shouldDiscover('services')) {
-                $locator = static::locator();
-                $files   = $locator->search('Config/Services');
-
-                if (empty($files)) {
-                    // no files at all found - this would be really, really bad
-                    return null;
-                }
-
-                // Get instances of all service classes and cache them locally.
-                foreach ($files as $file) {
-                    $classname = $locator->findQualifiedNameFromPath($file);
-
-                    if ($classname === false) {
-                        continue;
-                    }
-
-                    if ($classname !== Services::class) {
-                        static::$services[] = new $classname();
-                    }
-                }
-            }
-
-            static::$discovered = true;
-        }
-
-        if (! static::$services) {
-            // we found stuff, but no services - this would be really bad
-            return null;
-        }
-
-        // Try to find the desired service method
-        foreach (static::$services as $class) {
-            if (method_exists($class, $name)) {
-                return $class::$name(...$arguments);
-            }
-        }
-
-        return null;
-    }
-
     protected static function buildServicesCache(): void
     {
         if (! static::$discovered) {

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -406,7 +406,10 @@ Others
 ------
 
 - **Cache:** The deprecated ``CodeIgniter\Cache\Exceptions\ExceptionInterface`` has been removed.
-- **Config:** The deprecated ``CodeIgniter\Config\Config`` class has been removed.
+- **Config:**
+    - The deprecated ``CodeIgniter\Config\Config`` class has been removed.
+    - The deprecated ``CodeIgniter\Config\BaseService::discoverServices()`` method
+      has been removed.
 - **Controller:** The deprecated ``Controller::loadHelpers()`` method has been removed.
 - **Exceptions:** The deprecated ``CodeIgniter\Exceptions\CastException`` class has been removed.
 - **Entity:** The deprecated ``CodeIgniter\Entity`` class has been removed. Use


### PR DESCRIPTION
**Description**
- remove deprecated BaseService::discoverServices()

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
