### PR TITLE
fix: [Validation] FileRules cause error if getimagesize() returns false

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -242,7 +242,13 @@ class FileRules
             $allowedHeight = $params[1] ?? 0;
 
             // Get uploaded image size
-            $info       = getimagesize($file->getTempName());
+            $info = getimagesize($file->getTempName());
+
+            if ($info === false) {
+                // Cannot get the image size.
+                return false;
+            }
+
             $fileWidth  = $info[0];
             $fileHeight = $info[1];
 


### PR DESCRIPTION


**Description**
Fixes #8591

```
ErrorException
Trying to access array offset on value of type bool
SYSTEMPATH/Validation/FileRules.php at line 246
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
