### PR TITLE
perf: add Factories::get()

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -117,11 +117,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/CLI/CLI.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in &&, string given on the left side\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Cache/Handlers/BaseHandler.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to function property_exists\\(\\) with Config\\\\Cache and \'file\' will always evaluate to true\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Cache/Handlers/FileHandler.php',
@@ -218,11 +213,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Assigning non\\-falsy\\-string directly on offset \'HTTP_HOST\' of \\$_SERVER is discouraged\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Utilities/Routes.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in an if condition, Config\\\\Routing given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Utilities/Routes.php',
 ];
@@ -343,11 +333,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Accessing offset \'SERVER_PROTOCOL\' directly on \\$_SERVER is discouraged\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Config/Services.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Argument \\#1 \\$name \\(\'Config\\\\\\\\Modules\'\\) passed to function config does not extend CodeIgniter\\\\\\\\Config\\\\\\\\BaseConfig\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Config/Services.php',
 ];
@@ -1297,11 +1282,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Entity/Entity.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Argument \\#1 \\$name \\(\'Config\\\\\\\\Modules\'\\) passed to function config does not extend CodeIgniter\\\\\\\\Config\\\\\\\\BaseConfig\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Events/Events.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Events\\\\Events\\:\\:on\\(\\) has parameter \\$callback with no signature specified for callable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Events/Events.php',
@@ -1335,11 +1315,6 @@ $ignoreErrors[] = [
 	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
 	'count' => 3,
 	'path' => __DIR__ . '/system/Files/File.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Argument \\#1 \\$name \\(\'Config\\\\\\\\Modules\'\\) passed to function config does not extend CodeIgniter\\\\\\\\Config\\\\\\\\BaseConfig\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',

--- a/system/CLI/BaseCommand.php
+++ b/system/CLI/BaseCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\CLI;
 
+use CodeIgniter\Config\Factories;
 use Config\Exceptions;
 use Psr\Log\LoggerInterface;
 use ReflectionException;
@@ -126,7 +127,7 @@ abstract class BaseCommand
     {
         $exception = $e;
         $message   = $e->getMessage();
-        $config    = config(Exceptions::class);
+        $config    = Factories::get('config', Exceptions::class);
 
         require $config->errorViewPath . '/cli/error_exception.php';
     }

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\CLI;
 
 use CodeIgniter\CodeIgniter;
+use CodeIgniter\Config\Factories;
 use Config\App;
 use Config\Services;
 use Exception;
@@ -35,7 +36,7 @@ class Console
     public function run()
     {
         // Create CLIRequest
-        $appConfig = config(App::class);
+        $appConfig = Factories::get('config', App::class);
         Services::createRequest($appConfig, true);
         // Load Routes
         Services::routes()->loadRoutes();

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\CLI;
 
+use CodeIgniter\Config\Factories;
 use Config\Generators;
 use Config\Services;
 use Throwable;
@@ -336,7 +337,7 @@ trait GeneratorTrait
     protected function renderTemplate(array $data = []): string
     {
         try {
-            $template = $this->templatePath ?? config(Generators::class)->views[$this->name];
+            $template = $this->templatePath ?? Factories::get('config', Generators::class)->views[$this->name];
 
             return view($template, $data, ['debug' => false]);
         } catch (Throwable $e) {

--- a/system/Cache/Handlers/BaseHandler.php
+++ b/system/Cache/Handlers/BaseHandler.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Cache\Handlers;
 
 use Closure;
 use CodeIgniter\Cache\CacheInterface;
+use CodeIgniter\Config\Factories;
 use Config\Cache;
 use Exception;
 use InvalidArgumentException;
@@ -66,7 +67,7 @@ abstract class BaseHandler implements CacheInterface
             throw new InvalidArgumentException('Cache key cannot be empty.');
         }
 
-        $reserved = config(Cache::class)->reservedCharacters ?? self::RESERVED_CHARACTERS;
+        $reserved = Factories::get('config', Cache::class)->reservedCharacters ?? self::RESERVED_CHARACTERS;
         if ($reserved && strpbrk($key, $reserved) !== false) {
             throw new InvalidArgumentException('Cache key contains reserved characters ' . $reserved);
         }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -13,6 +13,7 @@ namespace CodeIgniter;
 
 use Closure;
 use CodeIgniter\Cache\ResponseCache;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Debug\Timer;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\FrameworkException;
@@ -355,7 +356,7 @@ class CodeIgniter
             $this->response = $possibleResponse;
         } else {
             try {
-                $this->response = $this->handleRequest($routes, config(Cache::class), $returnResponse);
+                $this->response = $this->handleRequest($routes, Factories::get('config', Cache::class), $returnResponse);
             } catch (ResponsableInterface|DeprecatedRedirectException $e) {
                 $this->outputBufferingEnd();
                 if ($e instanceof DeprecatedRedirectException) {
@@ -469,7 +470,7 @@ class CodeIgniter
             if ($routeFilters !== null) {
                 $filters->enableFilters($routeFilters, 'before');
 
-                if (! config(Feature::class)->oldFilterOrder) {
+                if (! Factories::get('config', Feature::class)->oldFilterOrder) {
                     $routeFilters = array_reverse($routeFilters);
                 }
 
@@ -965,7 +966,7 @@ class CodeIgniter
 
             unset($override);
 
-            $cacheConfig = config(Cache::class);
+            $cacheConfig = Factories::get('config', Cache::class);
             $this->gatherOutput($cacheConfig, $returned);
 
             return $this->response;

--- a/system/Commands/Cache/ClearCache.php
+++ b/system/Commands/Cache/ClearCache.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Commands\Cache;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Config\Factories;
 use Config\Cache;
 
 /**
@@ -65,7 +66,7 @@ class ClearCache extends BaseCommand
      */
     public function run(array $params)
     {
-        $config  = config(Cache::class);
+        $config  = Factories::get('config', Cache::class);
         $handler = $params[0] ?? $config->handler;
 
         if (! array_key_exists($handler, $config->validHandlers)) {

--- a/system/Commands/Cache/InfoCache.php
+++ b/system/Commands/Cache/InfoCache.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Commands\Cache;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 
@@ -57,7 +58,7 @@ class InfoCache extends BaseCommand
      */
     public function run(array $params)
     {
-        $config = config(Cache::class);
+        $config = Factories::get('config', Cache::class);
         helper('number');
 
         if ($config->handler !== 'file') {

--- a/system/Commands/Database/CreateDatabase.php
+++ b/system/Commands/Database/CreateDatabase.php
@@ -84,7 +84,7 @@ class CreateDatabase extends BaseCommand
         }
 
         try {
-            $config = config(Database::class);
+            $config = Factories::get('config', Database::class);
 
             // Set to an empty database to prevent connection errors.
             $group = ENVIRONMENT === 'testing' ? 'tests' : $config->defaultGroup;

--- a/system/Commands/Generators/CellGenerator.php
+++ b/system/Commands/Generators/CellGenerator.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Generators;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\GeneratorTrait;
+use CodeIgniter\Config\Factories;
 use Config\Generators;
 
 /**
@@ -81,13 +82,13 @@ class CellGenerator extends BaseCommand
 
         $params = array_merge($params, ['suffix' => null]);
 
-        $this->templatePath  = config(Generators::class)->views[$this->name]['class'];
+        $this->templatePath  = Factories::get('config', Generators::class)->views[$this->name]['class'];
         $this->template      = 'cell.tpl.php';
         $this->classNameLang = 'CLI.generator.className.cell';
 
         $this->generateClass($params);
 
-        $this->templatePath  = config(Generators::class)->views[$this->name]['view'];
+        $this->templatePath  = Factories::get('config', Generators::class)->views[$this->name]['view'];
         $this->template      = 'cell_view.tpl.php';
         $this->classNameLang = 'CLI.generator.viewName.cell';
 

--- a/system/Commands/Generators/MigrationGenerator.php
+++ b/system/Commands/Generators/MigrationGenerator.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Commands\Generators;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\GeneratorTrait;
+use CodeIgniter\Config\Factories;
 use Config\Database;
 use Config\Migrations;
 use Config\Session as SessionConfig;
@@ -110,10 +111,10 @@ class MigrationGenerator extends BaseCommand
             $data['session']  = true;
             $data['table']    = is_string($table) ? $table : 'ci_sessions';
             $data['DBGroup']  = is_string($DBGroup) ? $DBGroup : 'default';
-            $data['DBDriver'] = config(Database::class)->{$data['DBGroup']}['DBDriver'];
+            $data['DBDriver'] = Factories::get('config', Database::class)->{$data['DBGroup']}['DBDriver'];
 
             /** @var SessionConfig|null $session */
-            $session = config(SessionConfig::class);
+            $session = Factories::get('config', SessionConfig::class);
 
             $data['matchIP'] = $session->matchIP;
         }

--- a/system/Commands/Translation/LocalizationFinder.php
+++ b/system/Commands/Translation/LocalizationFinder.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Translation;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Helpers\Array\ArrayHelper;
 use Config\App;
 use Locale;
@@ -67,10 +68,10 @@ class LocalizationFinder extends BaseCommand
         }
 
         if (is_string($optionLocale)) {
-            if (! in_array($optionLocale, config(App::class)->supportedLocales, true)) {
+            if (! in_array($optionLocale, Factories::get('config', App::class)->supportedLocales, true)) {
                 CLI::error(
                     'Error: "' . $optionLocale . '" is not supported. Supported locales: '
-                    . implode(', ', config(App::class)->supportedLocales)
+                    . implode(', ', Factories::get('config', App::class)->supportedLocales)
                 );
 
                 return EXIT_USER_INPUT;

--- a/system/Commands/Utilities/ConfigCheck.php
+++ b/system/Commands/Utilities/ConfigCheck.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Commands\Utilities;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Config\Factories;
 use Kint\Kint;
 
 /**
@@ -87,7 +88,7 @@ final class ConfigCheck extends BaseCommand
         /** @var class-string<BaseConfig> $class */
         $class = $params[0];
 
-        $config = config($class);
+        $config = Factories::get('config', $class);
 
         if ($config === null) {
             CLI::error('No such Config class: ' . $class);

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -19,6 +19,7 @@ use CodeIgniter\Commands\Utilities\Routes\AutoRouteCollector;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\AutoRouteCollector as AutoRouteCollectorImproved;
 use CodeIgniter\Commands\Utilities\Routes\FilterCollector;
 use CodeIgniter\Commands\Utilities\Routes\SampleURIGenerator;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Router\DefinedRouteCollector;
 use CodeIgniter\Router\Router;
 use Config\Feature;
@@ -126,7 +127,7 @@ class Routes extends BaseCommand
         }
 
         if ($collection->shouldAutoRoute()) {
-            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved ?? false;
+            $autoRoutesImproved = Factories::get('config', Feature::class)->autoRoutesImproved ?? false;
 
             if ($autoRoutesImproved) {
                 $autoRouteCollector = new AutoRouteCollectorImproved(
@@ -140,7 +141,7 @@ class Routes extends BaseCommand
                 $autoRoutes = $autoRouteCollector->get();
 
                 // Check for Module Routes.
-                if ($routingConfig = config(Routing::class)) {
+                if ($routingConfig = Factories::get('config', Routing::class)) {
                     foreach ($routingConfig->moduleRoutes as $uri => $namespace) {
                         $autoRouteCollector = new AutoRouteCollectorImproved(
                             $namespace,

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 
+use CodeIgniter\Config\Factories;
 use Config\Routing;
 use ReflectionClass;
 use ReflectionMethod;
@@ -45,7 +46,7 @@ final class ControllerMethodReader
         $this->namespace   = $namespace;
         $this->httpMethods = $httpMethods;
 
-        $config                        = config(Routing::class);
+        $config                        = Factories::get('config', Routing::class);
         $this->translateURIDashes      = $config->translateURIDashes;
         $this->translateUriToCamelCase = $config->translateUriToCamelCase;
     }

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\Method;
@@ -112,7 +113,7 @@ final class FilterCollector
 
     private function createFilters(Request $request): Filters
     {
-        $config = config(FiltersConfig::class);
+        $config = Factories::get('config', FiltersConfig::class);
 
         return new Filters($config, $request, Services::response());
     }

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
@@ -58,7 +59,7 @@ final class FilterFinder
 
             $this->filters->enableFilters($routeFilters, 'before');
 
-            if (! config(Feature::class)->oldFilterOrder) {
+            if (! Factories::get('config', Feature::class)->oldFilterOrder) {
                 $routeFilters = array_reverse($routeFilters);
             }
 

--- a/system/Commands/Utilities/Routes/SampleURIGenerator.php
+++ b/system/Commands/Utilities/Routes/SampleURIGenerator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Router\RouteCollection;
 use Config\App;
@@ -57,7 +58,7 @@ final class SampleURIGenerator
         if (strpos($routeKey, '{locale}') !== false) {
             $sampleUri = str_replace(
                 '{locale}',
-                config(App::class)->defaultLocale,
+                Factories::get('config', App::class)->defaultLocale,
                 $routeKey
             );
         }

--- a/system/Common.php
+++ b/system/Common.php
@@ -50,7 +50,7 @@ if (! function_exists('app_timezone')) {
      */
     function app_timezone(): string
     {
-        $config = config(App::class);
+        $config = Factories::get('config', App::class);
 
         return $config->appTimezone;
     }
@@ -1063,7 +1063,7 @@ if (! function_exists('slash_item')) {
      */
     function slash_item(string $item): ?string
     {
-        $config = config(App::class);
+        $config = Factories::get('config', App::class);
 
         if (! property_exists($config, $item)) {
             return null;
@@ -1171,7 +1171,7 @@ if (! function_exists('view')) {
     {
         $renderer = Services::renderer();
 
-        $config   = config(View::class);
+        $config   = Factories::get('config', View::class);
         $saveData = $config->saveData;
 
         if (array_key_exists('saveData', $options)) {

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -141,8 +141,8 @@ final class Factories
         $options = array_merge(self::getOptions($component), $options);
 
         if (! $options['getShared']) {
-            if (isset(self::$aliases[$component][$alias])) {
-                $class = self::$aliases[$component][$alias];
+            if (isset(self::$aliases[$options['component']][$alias])) {
+                $class = self::$aliases[$options['component']][$alias];
 
                 return new $class(...$arguments);
             }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -395,7 +395,7 @@ final class Factories
             // Handle Config as a special case to prevent logic loops
             ? self::$configOptions
             // Load values from the best Factory configuration (will include Registrars)
-            : config('Factory')->{$component} ?? [];
+            : Factories::get('config', 'Factory')->{$component} ?? [];
 
         // The setOptions() reset the component. So getOptions() may reset
         // the component.

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -174,6 +174,20 @@ final class Factories
     }
 
     /**
+     * Simple method to get the shared instance fast.
+     */
+    public static function get(string $component, string $alias): ?object
+    {
+        if (isset(self::$aliases[$component][$alias])) {
+            $class = self::$aliases[$component][$alias];
+
+            return self::$instances[$component][$class];
+        }
+
+        return self::__callStatic($component, [$alias]);
+    }
+
+    /**
      * Gets the defined instance. If not exists, creates new one.
      *
      * @return object|null

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -667,6 +667,7 @@ class Services extends BaseService
         }
 
         $config ??= Factories::get('config', SessionConfig::class);
+        assert($config instanceof SessionConfig);
 
         $logger = AppServices::logger();
 

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -122,7 +122,7 @@ class Services extends BaseService
             return static::getSharedInstance('cache', $config);
         }
 
-        $config ??= config(Cache::class);
+        $config ??= Factories::get('config', Cache::class);
 
         return CacheFactory::getHandler($config);
     }
@@ -141,7 +141,7 @@ class Services extends BaseService
             return static::getSharedInstance('clirequest', $config);
         }
 
-        $config ??= config(App::class);
+        $config ??= Factories::get('config', App::class);
 
         return new CLIRequest($config);
     }
@@ -157,7 +157,7 @@ class Services extends BaseService
             return static::getSharedInstance('codeigniter', $config);
         }
 
-        $config ??= config(App::class);
+        $config ??= Factories::get('config', App::class);
 
         return new CodeIgniter($config);
     }
@@ -187,7 +187,7 @@ class Services extends BaseService
             return static::getSharedInstance('csp', $config);
         }
 
-        $config ??= config(ContentSecurityPolicyConfig::class);
+        $config ??= Factories::get('config', ContentSecurityPolicyConfig::class);
 
         return new ContentSecurityPolicy($config);
     }
@@ -204,7 +204,7 @@ class Services extends BaseService
             return static::getSharedInstance('curlrequest', $options, $response, $config);
         }
 
-        $config ??= config(App::class);
+        $config ??= Factories::get('config', App::class);
         $response ??= new Response($config);
 
         return new CURLRequest(
@@ -229,7 +229,7 @@ class Services extends BaseService
         }
 
         if (empty($config) || ! (is_array($config) || $config instanceof EmailConfig)) {
-            $config = config(EmailConfig::class);
+            $config = Factories::get('config', EmailConfig::class);
         }
 
         return new Email($config);
@@ -248,7 +248,7 @@ class Services extends BaseService
             return static::getSharedInstance('encrypter', $config);
         }
 
-        $config ??= config(EncryptionConfig::class);
+        $config ??= Factories::get('config', EncryptionConfig::class);
         $encryption = new Encryption($config);
 
         return $encryption->initialize($config);
@@ -271,7 +271,7 @@ class Services extends BaseService
             return static::getSharedInstance('exceptions', $config);
         }
 
-        $config ??= config(ExceptionsConfig::class);
+        $config ??= Factories::get('config', ExceptionsConfig::class);
 
         return new Exceptions($config);
     }
@@ -290,7 +290,7 @@ class Services extends BaseService
             return static::getSharedInstance('filters', $config);
         }
 
-        $config ??= config(FiltersConfig::class);
+        $config ??= Factories::get('config', FiltersConfig::class);
 
         return new Filters($config, AppServices::request(), AppServices::response());
     }
@@ -306,7 +306,7 @@ class Services extends BaseService
             return static::getSharedInstance('format', $config);
         }
 
-        $config ??= config(FormatConfig::class);
+        $config ??= Factories::get('config', FormatConfig::class);
 
         return new Format($config);
     }
@@ -323,7 +323,7 @@ class Services extends BaseService
             return static::getSharedInstance('honeypot', $config);
         }
 
-        $config ??= config(HoneypotConfig::class);
+        $config ??= Factories::get('config', HoneypotConfig::class);
 
         return new Honeypot($config);
     }
@@ -340,7 +340,7 @@ class Services extends BaseService
             return static::getSharedInstance('image', $handler, $config);
         }
 
-        $config ??= config(Images::class);
+        $config ??= Factories::get('config', Images::class);
         assert($config instanceof Images);
 
         $handler = $handler ?: $config->defaultHandler;
@@ -414,7 +414,7 @@ class Services extends BaseService
             return static::getSharedInstance('migrations', $config, $db);
         }
 
-        $config ??= config(Migrations::class);
+        $config ??= Factories::get('config', Migrations::class);
 
         return new MigrationRunner($config, $db);
     }
@@ -448,7 +448,7 @@ class Services extends BaseService
             return static::getSharedInstance('responsecache', $config, $cache);
         }
 
-        $config ??= config(Cache::class);
+        $config ??= Factories::get('config', Cache::class);
         $cache ??= AppServices::cache();
 
         return new ResponseCache($config, $cache);
@@ -465,7 +465,7 @@ class Services extends BaseService
             return static::getSharedInstance('pager', $config, $view);
         }
 
-        $config ??= config(PagerConfig::class);
+        $config ??= Factories::get('config', PagerConfig::class);
         $view ??= AppServices::renderer(null, null, false);
 
         return new Pager($config, $view);
@@ -483,7 +483,7 @@ class Services extends BaseService
         }
 
         $viewPath = $viewPath ?: (new Paths())->viewDirectory;
-        $config ??= config(ViewConfig::class);
+        $config ??= Factories::get('config', ViewConfig::class);
 
         return new Parser($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
     }
@@ -502,7 +502,7 @@ class Services extends BaseService
         }
 
         $viewPath = $viewPath ?: (new Paths())->viewDirectory;
-        $config ??= config(ViewConfig::class);
+        $config ??= Factories::get('config', ViewConfig::class);
 
         return new View($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
     }
@@ -561,7 +561,7 @@ class Services extends BaseService
             return static::getSharedInstance('request', $config);
         }
 
-        $config ??= config(App::class);
+        $config ??= Factories::get('config', App::class);
 
         return new IncomingRequest(
             $config,
@@ -582,7 +582,7 @@ class Services extends BaseService
             return static::getSharedInstance('response', $config);
         }
 
-        $config ??= config(App::class);
+        $config ??= Factories::get('config', App::class);
 
         return new Response($config);
     }
@@ -598,7 +598,7 @@ class Services extends BaseService
             return static::getSharedInstance('redirectresponse', $config);
         }
 
-        $config ??= config(App::class);
+        $config ??= Factories::get('config', App::class);
         $response = new RedirectResponse($config);
         $response->setProtocolVersion(AppServices::request()->getProtocolVersion());
 
@@ -617,7 +617,7 @@ class Services extends BaseService
             return static::getSharedInstance('routes');
         }
 
-        return new RouteCollection(AppServices::locator(), config(Modules::class), config(Routing::class));
+        return new RouteCollection(AppServices::locator(), Factories::get('config', Modules::class), Factories::get('config', Routing::class));
     }
 
     /**
@@ -650,7 +650,7 @@ class Services extends BaseService
             return static::getSharedInstance('security', $config);
         }
 
-        $config ??= config(SecurityConfig::class);
+        $config ??= Factories::get('config', SecurityConfig::class);
 
         return new Security($config);
     }
@@ -666,14 +666,14 @@ class Services extends BaseService
             return static::getSharedInstance('session', $config);
         }
 
-        $config ??= config(SessionConfig::class);
+        $config ??= Factories::get('config', SessionConfig::class);
 
         $logger = AppServices::logger();
 
         $driverName = $config->driver;
 
         if ($driverName === DatabaseHandler::class) {
-            $DBGroup = $config->DBGroup ?? config(Database::class)->defaultGroup;
+            $DBGroup = $config->DBGroup ?? Factories::get('config', Database::class)->defaultGroup;
             $db      = Database::connect($DBGroup);
 
             $driver = $db->getPlatform();
@@ -712,7 +712,7 @@ class Services extends BaseService
             return static::getSharedInstance('siteurifactory', $config, $superglobals);
         }
 
-        $config ??= config('App');
+        $config ??= Factories::get('config', App::class);
         $superglobals ??= AppServices::superglobals();
 
         return new SiteURIFactory($config, $superglobals);
@@ -776,7 +776,7 @@ class Services extends BaseService
             return static::getSharedInstance('toolbar', $config);
         }
 
-        $config ??= config(ToolbarConfig::class);
+        $config ??= Factories::get('config', ToolbarConfig::class);
 
         return new Toolbar($config);
     }
@@ -795,7 +795,7 @@ class Services extends BaseService
         }
 
         if ($uri === null) {
-            $appConfig = config(App::class);
+            $appConfig = Factories::get('config', App::class);
             $factory   = AppServices::siteurifactory($appConfig, AppServices::superglobals());
 
             return $factory->createFromGlobals();
@@ -815,7 +815,7 @@ class Services extends BaseService
             return static::getSharedInstance('validation', $config);
         }
 
-        $config ??= config(ValidationConfig::class);
+        $config ??= Factories::get('config', ValidationConfig::class);
 
         return new Validation($config, AppServices::renderer());
     }

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -160,7 +161,7 @@ class Controller
 
         // If you replace the $rules array with the name of the group
         if (is_string($rules)) {
-            $validation = config(Validation::class);
+            $validation = Factories::get('config', Validation::class);
 
             // If the rule wasn't found in the \Config\Validation, we
             // should throw an exception so the developer can find it.

--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database;
 
 use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Config\Factories;
 use Config\Database as DbConfig;
 use InvalidArgumentException;
 
@@ -60,7 +61,7 @@ class Config extends BaseConfig
             $config = $group;
             $group  = 'custom-' . md5(json_encode($config));
         } else {
-            $dbConfig = config(DbConfig::class);
+            $dbConfig = Factories::get('config', DbConfig::class);
 
             if ($group === null) {
                 $group = (ENVIRONMENT === 'testing') ? 'tests' : $dbConfig->defaultGroup;
@@ -134,7 +135,7 @@ class Config extends BaseConfig
      */
     public static function seeder(?string $group = null)
     {
-        $config = config(DbConfig::class);
+        $config = Factories::get('config', DbConfig::class);
 
         return new Seeder($config, static::connect($group));
     }

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database;
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\I18n\Time;
@@ -141,7 +142,7 @@ class MigrationRunner
 
         // Even if a DB connection is passed, since it is a test,
         // it is assumed to use the default group name
-        $this->group = is_string($db) ? $db : config(Database::class)->defaultGroup;
+        $this->group = is_string($db) ? $db : Factories::get('config', Database::class)->defaultGroup;
 
         $this->db = db_connect($db);
     }

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\SQLSRV;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
@@ -313,7 +314,7 @@ class Builder extends BaseBuilder
         // DatabaseException:
         //   [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The number of
         //   rows provided for a FETCH clause must be greater then zero.
-        if (! config(Feature::class)->limitZeroAsAll && $this->QBLimit === 0) {
+        if (! Factories::get('config', Feature::class)->limitZeroAsAll && $this->QBLimit === 0) {
             return "SELECT * \nFROM " . $this->_fromTables() . ' WHERE 1=0 ';
         }
 

--- a/system/Debug/Toolbar/Collectors/Config.php
+++ b/system/Debug/Toolbar/Collectors/Config.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
 use CodeIgniter\CodeIgniter;
+use CodeIgniter\Config\Factories;
 use Config\App;
 use Config\Services;
 
@@ -27,7 +28,7 @@ class Config
      */
     public static function display(): array
     {
-        $config = config(App::class);
+        $config = Factories::get('config', App::class);
 
         return [
             'ciVersion'   => CodeIgniter::CI_VERSION,

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Database\Query;
 use CodeIgniter\I18n\Time;
 use Config\Toolbar;
@@ -85,7 +86,7 @@ class Database extends BaseCollector
      */
     public static function collect(Query $query)
     {
-        $config = config(Toolbar::class);
+        $config = Factories::get('config', Toolbar::class);
 
         // Provide default in case it's not set
         $max = $config->maxQueries ?: 100;

--- a/system/Encryption/Handlers/BaseHandler.php
+++ b/system/Encryption/Handlers/BaseHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Encryption\Handlers;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Encryption\EncrypterInterface;
 use Config\Encryption;
 
@@ -26,7 +27,7 @@ abstract class BaseHandler implements EncrypterInterface
      */
     public function __construct(?Encryption $config = null)
     {
-        $config ??= config(Encryption::class);
+        $config ??= Factories::get('config', Encryption::class);
 
         // make the parameters conveniently accessible
         foreach (get_object_vars($config) as $key => $value) {

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Events;
 
+use CodeIgniter\Config\Factories;
 use Config\Modules;
 use Config\Services;
 
@@ -77,7 +78,7 @@ class Events
             return;
         }
 
-        $config = config(Modules::class);
+        $config = Factories::get('config', Modules::class);
         $events = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'Events.php';
         $files  = [];
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Filters as BaseFiltersConfig;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Filters\Exceptions\FilterException;
@@ -117,7 +118,7 @@ class Filters
         $this->request = &$request;
         $this->setResponse($response);
 
-        $this->modules = $modules ?? config(Modules::class);
+        $this->modules = $modules ?? Factories::get('config', Modules::class);
 
         if ($this->modules->shouldDiscover('filters')) {
             $this->discoverFilters();
@@ -303,7 +304,7 @@ class Filters
     {
         // For backward compatibility. For users who do not update Config\Filters.
         if (! isset($this->config->required[$position])) {
-            $baseConfig = config(BaseFiltersConfig::class); // @phpstan-ignore-line
+            $baseConfig = Factories::get('config', BaseFiltersConfig::class);
             $filters    = $baseConfig->required[$position];
             $aliases    = $baseConfig->aliases;
         } else {
@@ -716,7 +717,7 @@ class Filters
         }
 
         if (isset($filters['after'])) {
-            if (! config(Feature::class)->oldFilterOrder) {
+            if (! Factories::get('config', Feature::class)->oldFilterOrder) {
                 $filters['after'] = array_reverse($filters['after']);
             }
 

--- a/system/Filters/ForceHTTPS.php
+++ b/system/Filters/ForceHTTPS.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -37,7 +38,7 @@ class ForceHTTPS implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
-        $config = config(App::class);
+        $config = Factories::get('config', App::class);
 
         if ($config->forceGlobalSecureRequests !== true) {
             return;

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
 use Config\CURLRequest as ConfigCURLRequest;
@@ -116,12 +117,12 @@ class CURLRequest extends OutgoingRequest
 
         parent::__construct(Method::GET, $uri);
 
-        $this->responseOrig   = $response ?? new Response(config(App::class));
+        $this->responseOrig   = $response ?? new Response(Factories::get('config', App::class));
         $this->baseURI        = $uri->useRawQueryString();
         $this->defaultOptions = $options;
 
         /** @var ConfigCURLRequest|null $configCURLRequest */
-        $configCURLRequest  = config(ConfigCURLRequest::class);
+        $configCURLRequest  = Factories::get('config', ConfigCURLRequest::class);
         $this->shareOptions = $configCURLRequest->shareOptions ?? true;
 
         $this->config = $this->defaultConfig;

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use Config\App;
 use Config\ContentSecurityPolicy as ContentSecurityPolicyConfig;
 
@@ -270,7 +271,7 @@ class ContentSecurityPolicy
      */
     public function __construct(ContentSecurityPolicyConfig $config)
     {
-        $appConfig        = config(App::class);
+        $appConfig        = Factories::get('config', App::class);
         $this->CSPEnabled = $appConfig->CSPEnabled;
 
         foreach (get_object_vars($config) as $setting => $value) {

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\DownloadException;
 use CodeIgniter\Files\File;
 use Config\App;
@@ -69,7 +70,7 @@ class DownloadResponse extends Response
      */
     public function __construct(string $filename, bool $setMime)
     {
-        parent::__construct(config(App::class));
+        parent::__construct(Factories::get('config', App::class));
 
         $this->filename = $filename;
         $this->setMime  = $setMime;

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Validation\FormatRules;
 use Config\App;
@@ -61,7 +62,7 @@ trait RequestTrait
             'valid_ip',
         ];
 
-        $proxyIPs = config(App::class)->proxyIPs;
+        $proxyIPs = Factories::get('config', App::class)->proxyIPs;
 
         if (! empty($proxyIPs) && (! is_array($proxyIPs) || is_int(array_key_first($proxyIPs)))) {
             throw new ConfigException(

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
@@ -162,7 +163,7 @@ class Response extends Message implements ResponseInterface
 
         $this->cookieStore = new CookieStore([]);
 
-        $cookie = config(CookieConfig::class);
+        $cookie = Factories::get('config', CookieConfig::class);
 
         Cookie::setDefaults($cookie);
 

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\Cookie\Exceptions\CookieException;
@@ -523,7 +524,7 @@ trait ResponseTrait
             return $this;
         }
 
-        $cookieConfig = config(CookieConfig::class);
+        $cookieConfig = Factories::get('config', CookieConfig::class);
 
         $secure ??= $cookieConfig->secure;
         $httponly ??= $cookieConfig->httponly;

--- a/system/HTTP/SiteURI.php
+++ b/system/HTTP/SiteURI.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\HTTP;
 
 use BadMethodCallException;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
@@ -380,7 +381,7 @@ class SiteURI extends URI
     {
         $relativePath = $this->stringifyRelativePath($relativePath);
 
-        $config            = clone config(App::class);
+        $config            = clone Factories::get('config', App::class);
         $config->indexPage = '';
 
         $host = $this->getHost();
@@ -423,7 +424,7 @@ class SiteURI extends URI
         // Check current host.
         $host = $config === null ? $this->getHost() : null;
 
-        $config ??= config(App::class);
+        $config ??= Factories::get('config', App::class);
 
         $uri = new self($config, $relativePath, $host, $scheme);
 

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\HTTP;
 
 use BadMethodCallException;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
 use InvalidArgumentException;
@@ -650,7 +651,7 @@ class URI
     private function changeSchemeAndPath(string $scheme, string $path): array
     {
         // Check if this is an internal URI
-        $config  = config(App::class);
+        $config  = Factories::get('config', App::class);
         $baseUri = new self($config->baseURL);
 
         if (

--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
+use CodeIgniter\Config\Factories;
 use Config\UserAgents;
 
 /**
@@ -106,7 +107,7 @@ class UserAgent
      */
     public function __construct(?UserAgents $config = null)
     {
-        $this->config = $config ?? config(UserAgents::class);
+        $this->config = $config ?? Factories::get('config', UserAgents::class);
 
         if (isset($_SERVER['HTTP_USER_AGENT'])) {
             $this->agent = trim($_SERVER['HTTP_USER_AGENT']);

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use Config\Cookie as CookieConfig;
 use Config\Services;
@@ -72,7 +73,7 @@ if (! function_exists('get_cookie')) {
     function get_cookie($index, bool $xssClean = false, ?string $prefix = '')
     {
         if ($prefix === '') {
-            $cookie = config(CookieConfig::class);
+            $cookie = Factories::get('config', CookieConfig::class);
 
             $prefix = $cookie->prefix;
         }

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use Config\App;
 use Config\Services;
@@ -54,7 +55,7 @@ if (! function_exists('form_open')) {
             $attributes .= ' method="post"';
         }
         if (stripos($attributes, 'accept-charset=') === false) {
-            $config = config(App::class);
+            $config = Factories::get('config', App::class);
             $attributes .= ' accept-charset="' . strtolower($config->charset) . '"';
         }
 
@@ -719,7 +720,7 @@ if (! function_exists('validation_list_errors')) {
      */
     function validation_list_errors(string $template = 'list'): string
     {
-        $config = config(Validation::class);
+        $config = Factories::get('config', Validation::class);
         $view   = Services::renderer();
 
         if (! array_key_exists($template, $config->templates)) {
@@ -739,7 +740,7 @@ if (! function_exists('validation_show_error')) {
      */
     function validation_show_error(string $field, string $template = 'single'): string
     {
-        $config = config(Validation::class);
+        $config = Factories::get('config', Validation::class);
         $view   = Services::renderer();
 
         $errors = array_filter(validation_errors(), static fn ($key) => preg_match(

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\SiteURI;
@@ -134,7 +135,7 @@ if (! function_exists('index_page')) {
     function index_page(?App $altConfig = null): string
     {
         // use alternate config if provided, else default one
-        $config = $altConfig ?? config(App::class);
+        $config = $altConfig ?? Factories::get('config', App::class);
 
         return $config->indexPage;
     }
@@ -154,7 +155,7 @@ if (! function_exists('anchor')) {
     function anchor($uri = '', string $title = '', $attributes = '', ?App $altConfig = null): string
     {
         // use alternate config if provided, else default one
-        $config = $altConfig ?? config(App::class);
+        $config = $altConfig ?? Factories::get('config', App::class);
 
         $siteUrl = is_array($uri) ? site_url($uri, null, $config) : (preg_match('#^(\w+:)?//#i', $uri) ? $uri : site_url($uri, null, $config));
         // eliminate trailing slash
@@ -187,7 +188,7 @@ if (! function_exists('anchor_popup')) {
     function anchor_popup($uri = '', string $title = '', $attributes = false, ?App $altConfig = null): string
     {
         // use alternate config if provided, else default one
-        $config = $altConfig ?? config(App::class);
+        $config = $altConfig ?? Factories::get('config', App::class);
 
         $siteUrl = preg_match('#^(\w+:)?//#i', $uri) ? $uri : site_url($uri, null, $config);
         $siteUrl = rtrim($siteUrl, '/');

--- a/system/HotReloader/DirectoryHasher.php
+++ b/system/HotReloader/DirectoryHasher.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HotReloader;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\FrameworkException;
 use Config\Toolbar;
 use FilesystemIterator;
@@ -44,7 +45,7 @@ final class DirectoryHasher
     {
         $hashes = [];
 
-        $watchedDirectories = config(Toolbar::class)->watchedDirectories;
+        $watchedDirectories = Factories::get('config', Toolbar::class)->watchedDirectories;
 
         foreach ($watchedDirectories as $directory) {
             if (is_dir(ROOTPATH . $directory)) {

--- a/system/HotReloader/IteratorFilter.php
+++ b/system/HotReloader/IteratorFilter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HotReloader;
 
+use CodeIgniter\Config\Factories;
 use Config\Toolbar;
 use RecursiveFilterIterator;
 use RecursiveIterator;
@@ -30,7 +31,7 @@ final class IteratorFilter extends RecursiveFilterIterator implements RecursiveI
     {
         parent::__construct($iterator);
 
-        $this->watchedExtensions = config(Toolbar::class)->watchedExtensions;
+        $this->watchedExtensions = Factories::get('config', Toolbar::class)->watchedExtensions;
     }
 
     /**

--- a/system/Publisher/Publisher.php
+++ b/system/Publisher/Publisher.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Publisher;
 
 use CodeIgniter\Autoloader\FileLocatorInterface;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Files\FileCollection;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Publisher\Exceptions\PublisherException;
@@ -165,11 +166,11 @@ class Publisher extends FileCollection
         $this->replacer = new ContentReplacer();
 
         // Restrictions are intentionally not injected to prevent overriding
-        $this->restrictions = config(PublisherConfig::class)->restrictions;
+        $this->restrictions = Factories::get('config', PublisherConfig::class)->restrictions;
 
         // Make sure the destination is allowed
         foreach (array_keys($this->restrictions) as $directory) {
-            if (strpos($this->destination, $directory) === 0) {
+            if (strpos($this->destination, (string) $directory) === 0) {
                 return;
             }
         }

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Router\Exceptions\MethodNotFoundException;
 use Config\Routing;
@@ -142,7 +143,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         $this->defaultController    = $defaultController;
         $this->defaultMethod        = $defaultMethod;
 
-        $routingConfig                 = config(Routing::class);
+        $routingConfig                 = Factories::get('config', Routing::class);
         $this->moduleRoutes            = $routingConfig->moduleRoutes;
         $this->translateUriToCamelCase = $routingConfig->translateUriToCamelCase;
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Router;
 
 use Closure;
 use CodeIgniter\Autoloader\FileLocatorInterface;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Exceptions\RouterException;
@@ -1416,7 +1417,7 @@ class RouteCollection implements RouteCollectionInterface
 
         // Check invalid locale
         if ($locale !== null) {
-            $config = config(App::class);
+            $config = Factories::get('config', App::class);
             if (! in_array($locale, $config->supportedLocales, true)) {
                 $locale = null;
             }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Router;
 
 use Closure;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\Method;
@@ -146,7 +147,7 @@ class Router implements RouterInterface
         $this->translateURIDashes = $this->collection->shouldTranslateURIDashes();
 
         if ($this->collection->shouldAutoRoute()) {
-            $autoRoutesImproved = config(Feature::class)->autoRoutesImproved ?? false;
+            $autoRoutesImproved = Factories::get('config', Feature::class)->autoRoutesImproved ?? false;
             if ($autoRoutesImproved) {
                 $this->autoRouter = new AutoRouterImproved(
                     $this->collection->getRegisteredControllers('*'),
@@ -438,7 +439,7 @@ class Router implements RouterInterface
                     );
 
                     if ($this->collection->shouldUseSupportedLocalesOnly()
-                        && ! in_array($matched['locale'], config(App::class)->supportedLocales, true)) {
+                        && ! in_array($matched['locale'], Factories::get('config', App::class)->supportedLocales, true)) {
                         // Throw exception to prevent the autorouter, if enabled,
                         // from trying to find a route
                         throw PageNotFoundException::forLocaleNotSupported($matched['locale']);

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Security;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Method;
@@ -199,7 +200,7 @@ class Security implements SecurityInterface
         $this->rawCookieName = $config->cookieName;
 
         if ($this->isCSRFCookie()) {
-            $cookie = config(CookieConfig::class);
+            $cookie = Factories::get('config', CookieConfig::class);
 
             $this->configureCookie($cookie);
         } else {

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session\Handlers;
 
+use CodeIgniter\Config\Factories;
 use Config\Cookie as CookieConfig;
 use Config\Session as SessionConfig;
 use Psr\Log\LoggerAwareTrait;
@@ -113,7 +114,7 @@ abstract class BaseHandler implements SessionHandlerInterface
         $this->matchIP    = $config->matchIP;
         $this->savePath   = $config->savePath;
 
-        $cookie = config(CookieConfig::class);
+        $cookie = Factories::get('config', CookieConfig::class);
 
         // Session cookies have no prefix.
         $this->cookieDomain = $cookie->domain;

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session\Handlers;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Session\Exceptions\SessionException;
@@ -75,7 +76,7 @@ class DatabaseHandler extends BaseHandler
         parent::__construct($config, $ipAddress);
 
         // Store Session configurations
-        $this->DBGroup = $config->DBGroup ?? config(Database::class)->defaultGroup;
+        $this->DBGroup = $config->DBGroup ?? Factories::get('config', Database::class)->defaultGroup;
         // Add sessionCookieName for multiple session cookies.
         $this->idPrefix = $config->cookieName . ':';
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\I18n\Time;
 use Config\Cookie as CookieConfig;
@@ -188,7 +189,7 @@ class Session implements SessionInterface
 
         $this->config = $config;
 
-        $cookie = config(CookieConfig::class);
+        $cookie = Factories::get('config', CookieConfig::class);
 
         $this->cookie = (new Cookie($this->config->cookieName, '', [
             'expires'  => $this->config->expiration === 0 ? 0 : Time::now()->getTimestamp() + $this->config->expiration,

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -336,7 +336,7 @@ abstract class CIUnitTestCase extends TestCase
     {
         $_SESSION = [];
 
-        $config  = config(Session::class);
+        $config  = Factories::get('config', Session::class);
         $session = new MockSession(new ArrayHandler($config, '0.0.0.0'), $config);
 
         Services::injectMock('session', $session);

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -11,6 +11,7 @@
 
 namespace CodeIgniter\Test;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Controller;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -96,7 +97,7 @@ trait ControllerTestTrait
         helper('url');
 
         if (empty($this->appConfig)) {
-            $this->appConfig = config(App::class);
+            $this->appConfig = Factories::get('config', App::class);
         }
 
         if (! $this->uri instanceof URI) {

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Model;
@@ -119,7 +120,7 @@ class Fabricator
 
         // If no locale was specified then use the App default
         if ($locale === null) {
-            $locale = config(App::class)->defaultLocale;
+            $locale = Factories::get('config', App::class)->defaultLocale;
         }
 
         // There is no easy way to retrieve the locale from Faker so we will store it

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -304,7 +305,7 @@ trait FeatureTestTrait
      */
     protected function setupRequest(string $method, ?string $path = null): IncomingRequest
     {
-        $config = config(App::class);
+        $config = Factories::get('config', App::class);
         $uri    = new SiteURI($config);
 
         // $path may have a query in it

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Test;
 
 use Closure;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\Filters\Filters;
@@ -100,7 +101,7 @@ trait FilterTestTrait
         $this->response ??= clone Services::response();
 
         // Create our config and Filters instance to reuse for performance
-        $this->filtersConfig ??= config(FiltersConfig::class);
+        $this->filtersConfig ??= Factories::get('config', FiltersConfig::class);
         $this->filters ??= new Filters($this->filtersConfig, $this->request, $this->response);
 
         if ($this->collection === null) {

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\View;
 
 use CodeIgniter\Autoloader\FileLocatorInterface;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Debug\Toolbar\Collectors\Views;
 use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\View\Exceptions\ViewException;
@@ -275,7 +276,7 @@ class View implements RendererInterface
             $this->debug && $debugBarEnabled
             && (! isset($options['debug']) || $options['debug'] === true)
         ) {
-            $toolbarCollectors = config(Toolbar::class)->collectors;
+            $toolbarCollectors = Factories::get('config', Toolbar::class)->collectors;
 
             if (in_array(Views::class, $toolbarCollectors, true)) {
                 // Clean up our path names to make them a little cleaner

--- a/system/View/ViewDecoratorTrait.php
+++ b/system/View/ViewDecoratorTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
+use CodeIgniter\Config\Factories;
 use CodeIgniter\View\Exceptions\ViewException;
 use Config\View as ViewConfig;
 
@@ -24,7 +25,7 @@ trait ViewDecoratorTrait
      */
     protected function decorateOutput(string $html): string
     {
-        $decorators = $this->config->decorators ?? config(ViewConfig::class)->decorators;
+        $decorators = $this->config->decorators ?? Factories::get('config', ViewConfig::class)->decorators;
 
         foreach ($decorators as $decorator) {
             if (! is_subclass_of($decorator, ViewDecoratorInterface::class)) {

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -465,4 +465,25 @@ final class FactoriesTest extends CIUnitTestCase
 
         $this->assertFalse(Factories::isUpdated('config'));
     }
+
+    public function testGet()
+    {
+        $config = Factories::config('App');
+
+        $this->assertSame($config, Factories::get('config', 'App'));
+    }
+
+    public function testGetNonexistentInstance()
+    {
+        $config = Factories::get('config', 'App');
+
+        $this->assertSame($config, Factories::config('App'));
+    }
+
+    public function testGetNonexistentClass()
+    {
+        $config = Factories::get('config', 'NonexistentInstance');
+
+        $this->assertNull($config);
+    }
 }


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/6889#issuecomment-1974170688

- add method to get the shared instance fast.

### Benchmark

```
Test 			Time 	Memory
config() 		0.5684 	0 Bytes
factories::get() 	0.1305 	0 Bytes
```
```php
<?php

namespace App\Controllers;

use CodeIgniter\Config\Factories;
use CodeIgniter\Debug\Iterator;

class Home extends BaseController
{
    public function index(): string
    {
        $iterator = new Iterator();

        $iterator->add('config()', static function () {
            $config = config('App');
        });

        $iterator->add('Factories::get()', static function () {
            $config = Factories::get('config', 'App');
        });

        return $iterator->run(30000);
    }
}
```
### Profiling

Before:
![Profile Factories before](https://github.com/codeigniter4/CodeIgniter4/assets/87955/c4fb42ea-0317-42e6-9db3-9acd62a22563)

After:
![Profile Factories after](https://github.com/codeigniter4/CodeIgniter4/assets/87955/ac39ba46-e349-4460-b2d1-1002d8ea5dd9)

### Environment

```console
$ php -v
PHP 8.1.2-1ubuntu2.14 (cli) (built: Aug 18 2023 11:41:11) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.2, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.2-1ubuntu2.14, Copyright (c), by Zend Technologies

$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.3 LTS"

$ apache2 -v
Server version: Apache/2.4.52 (Ubuntu)
Server built:   2023-10-26T13:44:44
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
