### PR TITLE
fix: isWriteType() to recognize CTE; always excluding RETURNING

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1657,7 +1657,7 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function isWriteType($sql): bool
     {
-        return (bool) preg_match('/^\s*(WITH\s(\s|.)+(\s|[)]))?"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX|MERGE)\s/i', $sql);
+        return (bool) preg_match('/^\s*(WITH\s.+(\s|[)]))?"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX|MERGE)\s/is', $sql);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1657,7 +1657,7 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function isWriteType($sql): bool
     {
-        return (bool) preg_match('/^\s*(WITH\s.+(\s|[)]))?"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX|MERGE)\s/is', $sql);
+        return (bool) preg_match('/^\s*(WITH\s.+(\s|[)]))?"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX|MERGE)\s(?!.*\sRETURNING\s)/is', $sql);
     }
 
     /**

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1657,7 +1657,7 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function isWriteType($sql): bool
     {
-        return (bool) preg_match('/^\s*"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX|MERGE)\s/i', $sql);
+        return (bool) preg_match('/^\s*(WITH\s(\s|.)+(\s|[)]))?"?(SET|INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|TRUNCATE|LOAD|COPY|ALTER|RENAME|GRANT|REVOKE|LOCK|UNLOCK|REINDEX|MERGE)\s/i', $sql);
     }
 
     /**

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -567,20 +567,4 @@ class Connection extends BaseConnection
     {
         return (bool) pg_query($this->connID, 'ROLLBACK');
     }
-
-    /**
-     * Determines if a query is a "write" type.
-     *
-     * Overrides BaseConnection::isWriteType, adding additional read query types.
-     *
-     * @param string $sql
-     */
-    public function isWriteType($sql): bool
-    {
-        if (preg_match('#^\s*(WITH\s.+(\s|[)]))?(INSERT|UPDATE|DELETE).*RETURNING\s.+(\,\s?.+)*$#is', $sql)) {
-            return false;
-        }
-
-        return parent::isWriteType($sql);
-    }
 }

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -577,7 +577,7 @@ class Connection extends BaseConnection
      */
     public function isWriteType($sql): bool
     {
-        if (preg_match('#^(INSERT|UPDATE).*RETURNING\s.+(\,\s?.+)*$#is', $sql)) {
+        if (preg_match('#^\s*(WITH\s(\s|.)+(\s|[)]))?(INSERT|UPDATE|DELETE).*RETURNING\s.+(\,\s?.+)*$#is', $sql)) {
             return false;
         }
 

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -577,7 +577,7 @@ class Connection extends BaseConnection
      */
     public function isWriteType($sql): bool
     {
-        if (preg_match('#^\s*(WITH\s(\s|.)+(\s|[)]))?(INSERT|UPDATE|DELETE).*RETURNING\s.+(\,\s?.+)*$#is', $sql)) {
+        if (preg_match('#^\s*(WITH\s.+(\s|[)]))?(INSERT|UPDATE|DELETE).*RETURNING\s.+(\,\s?.+)*$#is', $sql)) {
             return false;
         }
 

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -28,20 +28,6 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     protected $refresh = true;
     protected $seed    = CITestSeeder::class;
 
-    /**
-     * Whether CodeIgniter considers RETURNING in isWriteType.
-     *
-     * Currently, only Postgre is supported by CodeIgniter.
-     * This method should be updated if support for RETURNING
-     * is expanded for other databases.
-     *
-     * @param string $dbDriver
-     */
-    private function testReturning($dbDriver): bool
-    {
-        return $dbDriver === 'Postgre';
-    }
-
     public function testSet(): void
     {
         $sql = 'SET FOREIGN_KEY_CHECKS=0';
@@ -110,11 +96,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     {
         $sql = "INSERT INTO my_table (col1, col2) VALUES ('Joe', 'Cool') RETURNING id;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testInsertMultiReturning(): void
@@ -125,33 +107,21 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING id;
             SQL;
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testInsertWithOneReturning(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval) INSERT INTO my_table (col1, col2) SELECT 'Joe', seqval FROM seqvals RETURNING id;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testInsertWithOneReturningNoSpace(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)INSERT INTO my_table (col1, col2) SELECT 'Joe', seqval FROM seqvals RETURNING id;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testInsertWithMultiReturning(): void
@@ -164,11 +134,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING id;
             SQL;
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testUpdateBuilder(): void
@@ -229,11 +195,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     {
         $sql = "UPDATE my_table SET col1 = 'foo' WHERE id = 2 RETURNING *;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testUpdateMultiReturning(): void
@@ -245,33 +207,21 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testUpdateWithOneReturning(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval) UPDATE my_table SET col1 = seqval FROM seqvals WHERE id = 2 RETURNING *;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testUpdateWithOneReturningNoSpace(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)UPDATE my_table SET col1 = seqval FROM seqvals WHERE id = 2 RETURNING *;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testUpdateWithMultiReturning(): void
@@ -285,11 +235,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testDeleteBuilder(): void
@@ -348,11 +294,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     {
         $sql = 'DELETE FROM my_table WHERE id = 2 RETURNING *;';
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testDeleteMultiReturning(): void
@@ -363,33 +305,21 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testDeleteWithOneReturning(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval) DELETE FROM my_table JOIN seqvals ON col1 = seqval RETURNING *;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testDeleteWithOneReturningNoSpace(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)DELETE FROM my_table JOIN seqvals ON col1 = seqval RETURNING *;";
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testDeleteWithMultiReturning(): void
@@ -403,11 +333,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        if ($this->testReturning($this->db->DBDriver)) {
-            $this->assertFalse($this->db->isWriteType($sql));
-        } else {
-            $this->assertTrue($this->db->isWriteType($sql));
-        }
+        $this->assertFalse($this->db->isWriteType($sql));
     }
 
     public function testReplace(): void

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -39,12 +39,11 @@ final class WriteTypeQueryTest extends CIUnitTestCase
      */
     private function testAssertTypeReturning($dbDriver): string
     {
-        $assertType = 'assertTrue';
         if ($dbDriver === 'Postgre') {
-            $assertType = 'assertFalse';
+            return 'assertFalse';
         }
 
-        return $assertType;
+        return 'assertTrue';
     }
 
     public function testSet(): void

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -48,11 +48,49 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $this->assertTrue($this->db->isWriteType($sql));
 
-        if ($this->db->DBDriver === 'Postgre') {
-            $sql = "INSERT INTO my_table (col1, col2) VALUES ('Joe', 'Cool') RETURNING id;";
+        $sql = "WITH seqvals AS (SELECT '3' AS seqval)INSERT INTO my_table (col1, col2) SELECT 'Joe', seqval FROM seqvals;";
 
-            $this->assertFalse($this->db->isWriteType($sql));
+        $this->assertTrue($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            WITH seqvals AS (SELECT '3' AS seqval)
+            INSERT INTO my_table (col1, col2)
+            SELECT 'Joe', seqval
+            FROM seqvals;
+        SQL;
+
+        $this->assertTrue($this->db->isWriteType($sql));
+
+        $assertionType = 'assertTrue';
+        if ($this->db->DBDriver === 'Postgre') {
+            $assertionType = 'assertFalse';
         }
+
+        $sql = "INSERT INTO my_table (col1, col2) VALUES ('Joe', 'Cool') RETURNING id;";
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = "WITH seqvals AS (SELECT '3' AS seqval)INSERT INTO my_table (col1, col2) SELECT 'Joe', seqval FROM seqvals RETURNING id;";
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            INSERT INTO my_table (col1, col2)
+            VALUES ('Joe', 'Cool')
+            RETURNING id;
+        SQL;
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            WITH seqvals AS (SELECT '3' AS seqval)
+            INSERT INTO my_table (col1, col2)
+            SELECT 'Joe', seqval
+            FROM seqvals
+            RETURNING id;
+        SQL;
+
+        $this->$assertionType($this->db->isWriteType($sql));
     }
 
     public function testUpdate(): void
@@ -63,11 +101,52 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $this->assertTrue($this->db->isWriteType($sql));
 
-        if ($this->db->DBDriver === 'Postgre') {
-            $sql = "UPDATE my_table SET col1 = 'foo' WHERE id = 2 RETURNING *;";
+        $sql = "WITH seqvals AS (SELECT '3' AS seqval)UPDATE my_table SET col1 = seqval FROM seqvals WHERE id = 2;";
 
-            $this->assertFalse($this->db->isWriteType($sql));
+        $this->assertTrue($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            WITH seqvals AS (SELECT '3' AS seqval)
+            UPDATE my_table
+            SET col1 = seqval
+            FROM seqvals
+            WHERE id = 2;
+        SQL;
+
+        $this->assertTrue($this->db->isWriteType($sql));
+
+        $assertionType = 'assertTrue';
+        if ($this->db->DBDriver === 'Postgre') {
+            $assertionType = 'assertFalse';
         }
+
+        $sql = "UPDATE my_table SET col1 = 'foo' WHERE id = 2 RETURNING *;";
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = "WITH seqvals AS (SELECT '3' AS seqval)UPDATE my_table SET col1 = seqval FROM seqvals WHERE id = 2 RETURNING *;";
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            UPDATE my_table
+            SET col1 = 'foo'
+            WHERE id = 2
+            RETURNING *;
+        SQL;
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            WITH seqvals AS (SELECT '3' AS seqval)
+            UPDATE my_table
+            SET col1 = seqval
+            FROM seqvals
+            WHERE id = 2
+            RETURNING *;
+        SQL;
+
+        $this->$assertionType($this->db->isWriteType($sql));
     }
 
     public function testDelete(): void
@@ -76,6 +155,56 @@ final class WriteTypeQueryTest extends CIUnitTestCase
         $sql     = $builder->testMode()->delete(['id' => 1], null, true);
 
         $this->assertTrue($this->db->isWriteType($sql));
+
+        $sql = "DELETE FROM my_table WHERE id = 2;";
+
+        $this->assertTrue($this->db->isWriteType($sql));
+
+        $sql = "WITH seqvals AS (SELECT '3' AS seqval)DELETE FROM my_table JOIN seqvals ON col1 = seqval;";
+
+        $this->assertTrue($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            WITH seqvals AS
+            (SELECT '3' AS seqval)
+            DELETE FROM my_table
+            JOIN seqvals
+            ON col1 = seqval;
+        SQL;
+
+        $this->assertTrue($this->db->isWriteType($sql));
+
+        $assertionType = 'assertTrue';
+        if ($this->db->DBDriver === 'Postgre') {
+            $assertionType = 'assertFalse';
+        }
+
+        $sql = "DELETE FROM my_table WHERE id = 2 RETURNING *;";
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = "WITH seqvals AS (SELECT '3' AS seqval)DELETE FROM my_table JOIN seqvals ON col1 = seqval RETURNING *;";
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            DELETE FROM my_table
+            WHERE id = 2
+            RETURNING *;
+        SQL;
+
+        $this->$assertionType($this->db->isWriteType($sql));
+
+        $sql = <<<SQL
+            WITH seqvals AS
+            (SELECT '3' AS seqval)
+            DELETE FROM my_table
+            JOIN seqvals
+            ON col1 = seqval
+            RETURNING *;
+        SQL;
+
+        $this->$assertionType($this->db->isWriteType($sql));
     }
 
     public function testReplace(): void

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -52,12 +52,12 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $this->assertTrue($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            WITH seqvals AS (SELECT '3' AS seqval)
-            INSERT INTO my_table (col1, col2)
-            SELECT 'Joe', seqval
-            FROM seqvals;
-        SQL;
+        $sql = <<<'SQL'
+                WITH seqvals AS (SELECT '3' AS seqval)
+                INSERT INTO my_table (col1, col2)
+                SELECT 'Joe', seqval
+                FROM seqvals;
+            SQL;
 
         $this->assertTrue($this->db->isWriteType($sql));
 
@@ -68,29 +68,29 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $sql = "INSERT INTO my_table (col1, col2) VALUES ('Joe', 'Cool') RETURNING id;";
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)INSERT INTO my_table (col1, col2) SELECT 'Joe', seqval FROM seqvals RETURNING id;";
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            INSERT INTO my_table (col1, col2)
-            VALUES ('Joe', 'Cool')
-            RETURNING id;
-        SQL;
+        $sql = <<<'SQL'
+                INSERT INTO my_table (col1, col2)
+                VALUES ('Joe', 'Cool')
+                RETURNING id;
+            SQL;
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            WITH seqvals AS (SELECT '3' AS seqval)
-            INSERT INTO my_table (col1, col2)
-            SELECT 'Joe', seqval
-            FROM seqvals
-            RETURNING id;
-        SQL;
+        $sql = <<<'SQL'
+                WITH seqvals AS (SELECT '3' AS seqval)
+                INSERT INTO my_table (col1, col2)
+                SELECT 'Joe', seqval
+                FROM seqvals
+                RETURNING id;
+            SQL;
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
     }
 
     public function testUpdate(): void
@@ -105,13 +105,13 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $this->assertTrue($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            WITH seqvals AS (SELECT '3' AS seqval)
-            UPDATE my_table
-            SET col1 = seqval
-            FROM seqvals
-            WHERE id = 2;
-        SQL;
+        $sql = <<<'SQL'
+                WITH seqvals AS (SELECT '3' AS seqval)
+                UPDATE my_table
+                SET col1 = seqval
+                FROM seqvals
+                WHERE id = 2;
+            SQL;
 
         $this->assertTrue($this->db->isWriteType($sql));
 
@@ -122,31 +122,31 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $sql = "UPDATE my_table SET col1 = 'foo' WHERE id = 2 RETURNING *;";
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)UPDATE my_table SET col1 = seqval FROM seqvals WHERE id = 2 RETURNING *;";
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            UPDATE my_table
-            SET col1 = 'foo'
-            WHERE id = 2
-            RETURNING *;
-        SQL;
+        $sql = <<<'SQL'
+                UPDATE my_table
+                SET col1 = 'foo'
+                WHERE id = 2
+                RETURNING *;
+            SQL;
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            WITH seqvals AS (SELECT '3' AS seqval)
-            UPDATE my_table
-            SET col1 = seqval
-            FROM seqvals
-            WHERE id = 2
-            RETURNING *;
-        SQL;
+        $sql = <<<'SQL'
+                WITH seqvals AS (SELECT '3' AS seqval)
+                UPDATE my_table
+                SET col1 = seqval
+                FROM seqvals
+                WHERE id = 2
+                RETURNING *;
+            SQL;
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
     }
 
     public function testDelete(): void
@@ -156,7 +156,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $this->assertTrue($this->db->isWriteType($sql));
 
-        $sql = "DELETE FROM my_table WHERE id = 2;";
+        $sql = 'DELETE FROM my_table WHERE id = 2;';
 
         $this->assertTrue($this->db->isWriteType($sql));
 
@@ -164,13 +164,13 @@ final class WriteTypeQueryTest extends CIUnitTestCase
 
         $this->assertTrue($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            WITH seqvals AS
-            (SELECT '3' AS seqval)
-            DELETE FROM my_table
-            JOIN seqvals
-            ON col1 = seqval;
-        SQL;
+        $sql = <<<'SQL'
+                WITH seqvals AS
+                (SELECT '3' AS seqval)
+                DELETE FROM my_table
+                JOIN seqvals
+                ON col1 = seqval;
+            SQL;
 
         $this->assertTrue($this->db->isWriteType($sql));
 
@@ -179,32 +179,32 @@ final class WriteTypeQueryTest extends CIUnitTestCase
             $assertionType = 'assertFalse';
         }
 
-        $sql = "DELETE FROM my_table WHERE id = 2 RETURNING *;";
+        $sql = 'DELETE FROM my_table WHERE id = 2 RETURNING *;';
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)DELETE FROM my_table JOIN seqvals ON col1 = seqval RETURNING *;";
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            DELETE FROM my_table
-            WHERE id = 2
-            RETURNING *;
-        SQL;
+        $sql = <<<'SQL'
+                DELETE FROM my_table
+                WHERE id = 2
+                RETURNING *;
+            SQL;
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
 
-        $sql = <<<SQL
-            WITH seqvals AS
-            (SELECT '3' AS seqval)
-            DELETE FROM my_table
-            JOIN seqvals
-            ON col1 = seqval
-            RETURNING *;
-        SQL;
+        $sql = <<<'SQL'
+                WITH seqvals AS
+                (SELECT '3' AS seqval)
+                DELETE FROM my_table
+                JOIN seqvals
+                ON col1 = seqval
+                RETURNING *;
+            SQL;
 
-        $this->$assertionType($this->db->isWriteType($sql));
+        $this->{$assertionType}($this->db->isWriteType($sql));
     }
 
     public function testReplace(): void

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -79,8 +79,7 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     {
         $sql = <<<'SQL'
                 INSERT INTO my_table (col1, col2)
-                VALUES ('Joe', 'Cool')
-                RETURNING id;
+                VALUES ('Joe', 'Cool');
             SQL;
 
         $this->assertTrue($this->db->isWriteType($sql));

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -29,21 +29,17 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     protected $seed    = CITestSeeder::class;
 
     /**
-     * Whether CodeIgniter ignores RETURNING for isWriteType.
+     * Whether CodeIgniter considers RETURNING in isWriteType.
      *
      * Currently, only Postgre is supported by CodeIgniter.
      * This method should be updated if support for RETURNING
-     * is expanded to other databases.
+     * is expanded for other databases.
      *
      * @param string $dbDriver
      */
-    private function testAssertTypeReturning($dbDriver): string
+    private function testReturning($dbDriver): bool
     {
-        if ($dbDriver === 'Postgre') {
-            return 'assertFalse';
-        }
-
-        return 'assertTrue';
+        return $dbDriver === 'Postgre';
     }
 
     public function testSet(): void
@@ -114,9 +110,11 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     {
         $sql = "INSERT INTO my_table (col1, col2) VALUES ('Joe', 'Cool') RETURNING id;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testInsertMultiReturning(): void
@@ -127,27 +125,33 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING id;
             SQL;
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testInsertWithOneReturning(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval) INSERT INTO my_table (col1, col2) SELECT 'Joe', seqval FROM seqvals RETURNING id;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testInsertWithOneReturningNoSpace(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)INSERT INTO my_table (col1, col2) SELECT 'Joe', seqval FROM seqvals RETURNING id;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testInsertWithMultiReturning(): void
@@ -160,9 +164,11 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING id;
             SQL;
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testUpdateBuilder(): void
@@ -223,9 +229,11 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     {
         $sql = "UPDATE my_table SET col1 = 'foo' WHERE id = 2 RETURNING *;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testUpdateMultiReturning(): void
@@ -237,27 +245,33 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testUpdateWithOneReturning(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval) UPDATE my_table SET col1 = seqval FROM seqvals WHERE id = 2 RETURNING *;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testUpdateWithOneReturningNoSpace(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)UPDATE my_table SET col1 = seqval FROM seqvals WHERE id = 2 RETURNING *;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testUpdateWithMultiReturning(): void
@@ -271,9 +285,11 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testDeleteBuilder(): void
@@ -332,9 +348,11 @@ final class WriteTypeQueryTest extends CIUnitTestCase
     {
         $sql = 'DELETE FROM my_table WHERE id = 2 RETURNING *;';
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testDeleteMultiReturning(): void
@@ -345,27 +363,33 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testDeleteWithOneReturning(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval) DELETE FROM my_table JOIN seqvals ON col1 = seqval RETURNING *;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testDeleteWithOneReturningNoSpace(): void
     {
         $sql = "WITH seqvals AS (SELECT '3' AS seqval)DELETE FROM my_table JOIN seqvals ON col1 = seqval RETURNING *;";
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testDeleteWithMultiReturning(): void
@@ -379,9 +403,11 @@ final class WriteTypeQueryTest extends CIUnitTestCase
                 RETURNING *;
             SQL;
 
-        $assertType = $this->testAssertTypeReturning($this->db->DBDriver);
-
-        $this->{$assertType}($this->db->isWriteType($sql));
+        if ($this->testReturning($this->db->DBDriver)) {
+            $this->assertFalse($this->db->isWriteType($sql));
+        } else {
+            $this->assertTrue($this->db->isWriteType($sql));
+        }
     }
 
     public function testReplace(): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

This pull request attempts to fix some issues I ran into with queries being miscategorized as isWriteType or not, particularly with PostgreSQL:

- Operations with CTE (flagged by WITH) were not being counted as isWriteType, even if followed by an appropriate operator like INSERT/UPDATE.
- In Postgre, INSERT/UPDATE operations with RETURNING were being counted as isWriteType if there was whitespace before INSERT/UPDATE.
- In Postgre, DELETE operations with RETURNING were always being counted as isWriteType.

**Edit:** this pull request has been modified to remove the Postgre override of isWriteType, and to incorporate RETURNING handling in isWriteType on a uniform basis for all database types.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
