### PR TITLE
perf: add Factories::get() v2

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -214,6 +214,10 @@ if (! function_exists('config')) {
      */
     function config(string $name, bool $getShared = true)
     {
+        if ($getShared) {
+            return Factories::get('config', $name);
+        }
+
         return Factories::config($name, ['getShared' => $getShared]);
     }
 }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -141,8 +141,8 @@ final class Factories
         $options = array_merge(self::getOptions($component), $options);
 
         if (! $options['getShared']) {
-            if (isset(self::$aliases[$component][$alias])) {
-                $class = self::$aliases[$component][$alias];
+            if (isset(self::$aliases[$options['component']][$alias])) {
+                $class = self::$aliases[$options['component']][$alias];
 
                 return new $class(...$arguments);
             }

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -174,6 +174,20 @@ final class Factories
     }
 
     /**
+     * Simple method to get the shared instance fast.
+     */
+    public static function get(string $component, string $alias): ?object
+    {
+        if (isset(self::$aliases[$component][$alias])) {
+            $class = self::$aliases[$component][$alias];
+
+            return self::$instances[$component][$class];
+        }
+
+        return self::__callStatic($component, [$alias]);
+    }
+
+    /**
      * Gets the defined instance. If not exists, creates new one.
      *
      * @return object|null

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -465,4 +465,25 @@ final class FactoriesTest extends CIUnitTestCase
 
         $this->assertFalse(Factories::isUpdated('config'));
     }
+
+    public function testGet()
+    {
+        $config = Factories::config('App');
+
+        $this->assertSame($config, Factories::get('config', 'App'));
+    }
+
+    public function testGetNonexistentInstance()
+    {
+        $config = Factories::get('config', 'App');
+
+        $this->assertSame($config, Factories::config('App'));
+    }
+
+    public function testGetNonexistentClass()
+    {
+        $config = Factories::get('config', 'NonexistentInstance');
+
+        $this->assertNull($config);
+    }
 }


### PR DESCRIPTION
**Description**
See #8598

- add method to get the shared instance fast.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
