### PR TITLE
fix: duplicate Cache-Control header with Session

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -692,8 +692,8 @@ class Services extends BaseService
         if (session_status() === PHP_SESSION_NONE) {
             // PHP Session emits the headers according to `session.cache_limiter`.
             // See https://www.php.net/manual/en/function.session-cache-limiter.php.
-            // The headers are not managed by the CI's Response class.
-            // So removes the CI's default Cache-Control header.
+            // The headers are not managed by CI's Response class.
+            // So, we remove CI's default Cache-Control header.
             AppServices::response()->removeHeader('Cache-Control');
 
             $session->start();

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -690,6 +690,12 @@ class Services extends BaseService
         $session->setLogger($logger);
 
         if (session_status() === PHP_SESSION_NONE) {
+            // PHP Session emits the headers according to `session.cache_limiter`.
+            // See https://www.php.net/manual/en/function.session-cache-limiter.php.
+            // The headers are not managed by the CI's Response class.
+            // So removes the CI's default Cache-Control header.
+            AppServices::response()->removeHeader('Cache-Control');
+
             $session->start();
         }
 


### PR DESCRIPTION
**Description**
Fixes #7266

- remove the default CI4 `Cache-Control` header before the Session starts.

Before:
```
HTTP/1.1 200 OK
Host: localhost:8080
Date: Sat, 02 Mar 2024 12:54:18 GMT
Connection: close
X-Powered-By: PHP/7.4.33
Expires: Thu, 19 Nov 1981 08:52:00 GMT             // PHP Session
Cache-Control: no-store, no-cache, must-revalidate // PHP Session
Pragma: no-cache                                   // PHP Session
Cache-Control: no-store, max-age=0, no-cache       // CI4
Content-Type: text/html; charset=UTF-8
```

After:
```
HTTP/1.1 200 OK
Host: localhost:8080
Date: Sat, 02 Mar 2024 12:56:08 GMT
Connection: close
X-Powered-By: PHP/7.4.33
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate
Pragma: no-cache
Content-Type: text/html; charset=UTF-8
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
