### PR TITLE
fix: move Kint loading to Autoloader

### DIFF
--- a/.github/workflows/test-phpcpd.yml
+++ b/.github/workflows/test-phpcpd.yml
@@ -57,4 +57,5 @@ jobs:
             --exclude system/Debug/Exceptions.php
             --exclude system/HTTP/SiteURI.php
             --exclude system/Validation/Rules.php
+            --exclude system/Autoloader/Autoloader.php
             -- app/ public/ system/

--- a/public/index.php
+++ b/public/index.php
@@ -52,13 +52,6 @@ $paths = new Config\Paths();
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
-// DEFINE ENVIRONMENT
-if (! defined('ENVIRONMENT')) {
-    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
-    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
-    unset($env);
-}
-
 // LOAD THE FRAMEWORK BOOTSTRAP FILE
 require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 

--- a/public/index.php
+++ b/public/index.php
@@ -52,6 +52,16 @@ $paths = new Config\Paths();
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
+// LOAD ENVIRONMENT BOOTSTRAP
+if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
+    require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
+} else {
+    header('HTTP/1.1 503 Service Unavailable.', true, 503);
+    echo 'The application environment is not set correctly.';
+
+    exit(EXIT_ERROR); // EXIT_ERROR
+}
+
 // LOAD THE FRAMEWORK BOOTSTRAP FILE
 require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 

--- a/public/index.php
+++ b/public/index.php
@@ -52,9 +52,16 @@ $paths = new Config\Paths();
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
+// DEFINE ENVIRONMENT
+if (! defined('ENVIRONMENT')) {
+    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
+    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
+    unset($env);
+}
+
 // LOAD ENVIRONMENT BOOTSTRAP
-if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
-    require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
+if (is_file($paths->appDirectory . '/Config/Boot/' . ENVIRONMENT . '.php')) {
+    require_once $paths->appDirectory . '/Config/Boot/' . ENVIRONMENT . '.php';
 } else {
     header('HTTP/1.1 503 Service Unavailable.', true, 503);
     echo 'The application environment is not set correctly.';

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,11 @@
 <?php
 
-// Check PHP version.
+/*
+ *---------------------------------------------------------------
+ * CHECK PHP VERSION
+ *---------------------------------------------------------------
+ */
+
 $minPhpVersion = '8.1'; // If you update this, don't forget to update `spark`.
 if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
     $message = sprintf(
@@ -11,6 +16,12 @@ if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
 
     exit($message);
 }
+
+/*
+ *---------------------------------------------------------------
+ * SET THE CURRENT DIRECTORY
+ *---------------------------------------------------------------
+ */
 
 // Path to the front controller (this file)
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR);
@@ -29,25 +40,26 @@ if (getcwd() . DIRECTORY_SEPARATOR !== FCPATH) {
  * and fires up an environment-specific bootstrapping.
  */
 
-// Load our paths config file
+// LOAD OUR PATHS CONFIG FILE
 // This is the line that might need to be changed, depending on your folder structure.
 require FCPATH . '../app/Config/Paths.php';
 // ^^^ Change this line if you move your application folder
 
 $paths = new Config\Paths();
 
+// LOAD DOTENV FILE
 // Load environment settings from .env files into $_SERVER and $_ENV
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
-// Define ENVIRONMENT
+// DEFINE ENVIRONMENT
 if (! defined('ENVIRONMENT')) {
     $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
     define('ENVIRONMENT', ($env !== false) ? $env : 'production');
     unset($env);
 }
 
-// Location of the framework bootstrap file.
+// LOAD THE FRAMEWORK BOOTSTRAP FILE
 require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 // Load Config Cache

--- a/public/index.php
+++ b/public/index.php
@@ -36,17 +36,19 @@ require FCPATH . '../app/Config/Paths.php';
 
 $paths = new Config\Paths();
 
-// Location of the framework bootstrap file.
-require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
-
 // Load environment settings from .env files into $_SERVER and $_ENV
-require_once SYSTEMPATH . 'Config/DotEnv.php';
-(new CodeIgniter\Config\DotEnv(ROOTPATH))->load();
+require_once $paths->systemDirectory . '/Config/DotEnv.php';
+(new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
 // Define ENVIRONMENT
 if (! defined('ENVIRONMENT')) {
-    define('ENVIRONMENT', env('CI_ENVIRONMENT', 'production'));
+    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
+    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
+    unset($env);
 }
+
+// Location of the framework bootstrap file.
+require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 // Load Config Cache
 // $factoriesCache = new \CodeIgniter\Cache\FactoriesCache();

--- a/spark
+++ b/spark
@@ -80,6 +80,16 @@ $paths = new Config\Paths();
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
+// LOAD ENVIRONMENT BOOTSTRAP
+if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
+    require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
+} else {
+    header('HTTP/1.1 503 Service Unavailable.', true, 503);
+    echo 'The application environment is not set correctly.';
+
+    exit(EXIT_ERROR); // EXIT_ERROR
+}
+
 // LOAD THE FRAMEWORK BOOTSTRAP FILE
 require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 

--- a/spark
+++ b/spark
@@ -80,13 +80,6 @@ $paths = new Config\Paths();
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
-// DEFINE ENVIRONMENT
-if (! defined('ENVIRONMENT')) {
-    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
-    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
-    unset($env);
-}
-
 // LOAD THE FRAMEWORK BOOTSTRAP FILE
 require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 

--- a/spark
+++ b/spark
@@ -12,7 +12,7 @@
 
 /*
  * --------------------------------------------------------------------
- * CodeIgniter command-line tools
+ * CODEIGNITER COMMAND-LINE TOOLS
  * --------------------------------------------------------------------
  * The main entry point into the CLI system and allows you to run
  * commands and perform maintenance on your application.
@@ -26,7 +26,12 @@ if (strpos(PHP_SAPI, 'cgi') === 0) {
     exit("The cli tool is not supported when running php-cgi. It needs php-cli to function!\n\n");
 }
 
-// Check PHP version.
+/*
+ *---------------------------------------------------------------
+ * CHECK PHP VERSION
+ *---------------------------------------------------------------
+ */
+
 $minPhpVersion = '8.1'; // If you update this, don't forget to update `public/index.php`.
 if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
     $message = sprintf(
@@ -41,6 +46,12 @@ if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
 // We want errors to be shown when using it from the CLI.
 error_reporting(E_ALL);
 ini_set('display_errors', '1');
+
+/*
+ *---------------------------------------------------------------
+ * SET THE CURRENT DIRECTORY
+ *---------------------------------------------------------------
+ */
 
 // Path to the front controller
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR);
@@ -57,34 +68,46 @@ chdir(FCPATH);
  * and fires up an environment-specific bootstrapping.
  */
 
-// Load our paths config file
+// LOAD OUR PATHS CONFIG FILE
 // This is the line that might need to be changed, depending on your folder structure.
 require FCPATH . '../app/Config/Paths.php';
 // ^^^ Change this line if you move your application folder
 
 $paths = new Config\Paths();
 
+// LOAD DOTENV FILE
 // Load environment settings from .env files into $_SERVER and $_ENV
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
-// Define ENVIRONMENT
+// DEFINE ENVIRONMENT
 if (! defined('ENVIRONMENT')) {
     $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
     define('ENVIRONMENT', ($env !== false) ? $env : 'production');
     unset($env);
 }
 
-// Location of the framework bootstrap file.
+// LOAD THE FRAMEWORK BOOTSTRAP FILE
 require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
-// Grab our CodeIgniter
+/*
+ * ---------------------------------------------------------------
+ * GRAB OUR CODEIGNITER INSTANCE
+ * ---------------------------------------------------------------
+ */
+
 $app = Config\Services::codeigniter();
 $app->initialize();
 
-// Grab our Console
+/*
+ * ---------------------------------------------------------------
+ * GRAB OUR CONSOLE
+ * ---------------------------------------------------------------
+ */
+
 $console = new CodeIgniter\CLI\Console();
 
+// SHOW HEADER
 // Show basic information before we do anything else.
 if (is_int($suppress = array_search('--no-header', $_SERVER['argv'], true))) {
     unset($_SERVER['argv'][$suppress]); // @codeCoverageIgnore
@@ -92,6 +115,12 @@ if (is_int($suppress = array_search('--no-header', $_SERVER['argv'], true))) {
 }
 
 $console->showHeader($suppress);
+
+/*
+ *---------------------------------------------------------------
+ * EXECUTE THE COMMAND
+ *---------------------------------------------------------------
+ */
 
 // fire off the command in the main framework.
 $exit = $console->run();

--- a/spark
+++ b/spark
@@ -64,17 +64,19 @@ require FCPATH . '../app/Config/Paths.php';
 
 $paths = new Config\Paths();
 
-// Location of the framework bootstrap file.
-require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
-
 // Load environment settings from .env files into $_SERVER and $_ENV
-require_once SYSTEMPATH . 'Config/DotEnv.php';
-(new CodeIgniter\Config\DotEnv(ROOTPATH))->load();
+require_once $paths->systemDirectory . '/Config/DotEnv.php';
+(new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
 // Define ENVIRONMENT
 if (! defined('ENVIRONMENT')) {
-    define('ENVIRONMENT', env('CI_ENVIRONMENT', 'production'));
+    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
+    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
+    unset($env);
 }
+
+// Location of the framework bootstrap file.
+require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 // Grab our CodeIgniter
 $app = Config\Services::codeigniter();

--- a/spark
+++ b/spark
@@ -80,9 +80,16 @@ $paths = new Config\Paths();
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new CodeIgniter\Config\DotEnv($paths->appDirectory . '/../'))->load();
 
+// DEFINE ENVIRONMENT
+if (! defined('ENVIRONMENT')) {
+    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
+    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
+    unset($env);
+}
+
 // LOAD ENVIRONMENT BOOTSTRAP
-if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
-    require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
+if (is_file($paths->appDirectory . '/Config/Boot/' . ENVIRONMENT . '.php')) {
+    require_once $paths->appDirectory . '/Config/Boot/' . ENVIRONMENT . '.php';
 } else {
     header('HTTP/1.1 503 Service Unavailable.', true, 503);
     echo 'The application environment is not set correctly.';

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -498,7 +498,6 @@ class Autoloader
         } elseif (class_exists(Kint::class)) {
             // In case that Kint is already loaded via Composer.
             Kint::$enabled_mode = false;
-            // @codeCoverageIgnore
         }
 
         helper('kint');

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -17,8 +17,13 @@ use CodeIgniter\Exceptions\ConfigException;
 use Composer\Autoload\ClassLoader;
 use Composer\InstalledVersions;
 use Config\Autoload;
+use Config\Kint as KintConfig;
 use Config\Modules;
+use Config\Services;
 use InvalidArgumentException;
+use Kint;
+use Kint\Renderer\CliRenderer;
+use Kint\Renderer\RichRenderer;
 use RuntimeException;
 
 /**
@@ -480,5 +485,78 @@ class Autoloader
     public function loadHelpers(): void
     {
         helper($this->helpers);
+    }
+
+    /**
+     * Initializes Kint
+     */
+    public function initializeKint(bool $debug = false): void
+    {
+        if ($debug) {
+            $this->autoloadKint();
+            $this->configureKint();
+        } elseif (class_exists(Kint::class)) {
+            // In case that Kint is already loaded via Composer.
+            Kint::$enabled_mode = false;
+            // @codeCoverageIgnore
+        }
+
+        helper('kint');
+    }
+
+    private function autoloadKint(): void
+    {
+        // If we have KINT_DIR it means it's already loaded via composer
+        if (! defined('KINT_DIR')) {
+            spl_autoload_register(function ($class) {
+                $class = explode('\\', $class);
+
+                if (array_shift($class) !== 'Kint') {
+                    return;
+                }
+
+                $file = SYSTEMPATH . 'ThirdParty/Kint/' . implode('/', $class) . '.php';
+
+                if (is_file($file)) {
+                    require_once $file;
+                }
+            });
+
+            require_once SYSTEMPATH . 'ThirdParty/Kint/init.php';
+        }
+    }
+
+    private function configureKint(): void
+    {
+        $config = new KintConfig();
+
+        Kint::$depth_limit         = $config->maxDepth;
+        Kint::$display_called_from = $config->displayCalledFrom;
+        Kint::$expanded            = $config->expanded;
+
+        if (isset($config->plugins) && is_array($config->plugins)) {
+            Kint::$plugins = $config->plugins;
+        }
+
+        $csp = Services::csp();
+        if ($csp->enabled()) {
+            RichRenderer::$js_nonce  = $csp->getScriptNonce();
+            RichRenderer::$css_nonce = $csp->getStyleNonce();
+        }
+
+        RichRenderer::$theme  = $config->richTheme;
+        RichRenderer::$folder = $config->richFolder;
+        RichRenderer::$sort   = $config->richSort;
+        if (isset($config->richObjectPlugins) && is_array($config->richObjectPlugins)) {
+            RichRenderer::$value_plugins = $config->richObjectPlugins;
+        }
+        if (isset($config->richTabPlugins) && is_array($config->richTabPlugins)) {
+            RichRenderer::$tab_plugins = $config->richTabPlugins;
+        }
+
+        CliRenderer::$cli_colors         = $config->cliColors;
+        CliRenderer::$force_utf8         = $config->cliForceUTF8;
+        CliRenderer::$detect_width       = $config->cliDetectWidth;
+        CliRenderer::$min_terminal_width = $config->cliMinWidth;
     }
 }

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -202,8 +202,6 @@ class CodeIgniter
 
         // Set default timezone on the server
         date_default_timezone_set($this->config->appTimezone ?? 'UTC');
-
-        $this->initializeKint();
     }
 
     /**
@@ -240,6 +238,8 @@ class CodeIgniter
      * Initializes Kint
      *
      * @return void
+     *
+     * @deprecated 4.5.0 Moved to Autoloader.
      */
     protected function initializeKint()
     {
@@ -255,6 +255,9 @@ class CodeIgniter
         helper('kint');
     }
 
+    /**
+     * @deprecated 4.5.0 Moved to Autoloader.
+     */
     private function autoloadKint(): void
     {
         // If we have KINT_DIR it means it's already loaded via composer
@@ -277,6 +280,9 @@ class CodeIgniter
         }
     }
 
+    /**
+     * @deprecated 4.5.0 Moved to Autoloader.
+     */
     private function configureKint(): void
     {
         $config = new KintConfig();

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -186,9 +186,6 @@ class CodeIgniter
      */
     public function initialize()
     {
-        // Setup Exception Handling
-        Services::exceptions()->initialize();
-
         // Run this check for manual installations
         if (! is_file(COMPOSER_PATH)) {
             $this->resolvePlatformExtensions(); // @codeCoverageIgnore

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -186,11 +186,6 @@ class CodeIgniter
      */
     public function initialize()
     {
-        // Run this check for manual installations
-        if (! is_file(COMPOSER_PATH)) {
-            $this->resolvePlatformExtensions(); // @codeCoverageIgnore
-        }
-
         // Set default locale on the server
         Locale::setDefault($this->config->defaultLocale ?? 'en');
 
@@ -206,6 +201,8 @@ class CodeIgniter
      * @throws FrameworkException
      *
      * @codeCoverageIgnore
+     *
+     * @deprecated 4.5.0 Moved to system/bootstrap.php.
      */
     protected function resolvePlatformExtensions()
     {

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -186,9 +186,6 @@ class CodeIgniter
      */
     public function initialize()
     {
-        // Define environment variables
-        $this->bootstrapEnvironment();
-
         // Setup Exception Handling
         Services::exceptions()->initialize();
 
@@ -584,6 +581,8 @@ class CodeIgniter
      * is wrong. At the very least, they should have error reporting setup.
      *
      * @return void
+     *
+     * @deprecated 4.5.0 Moved to system/bootstrap.php.
      */
     protected function bootstrapEnvironment()
     {

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -34,25 +34,6 @@ define('ENVIRONMENT', 'testing');
 defined('CI_DEBUG') || define('CI_DEBUG', true);
 
 /*
- *---------------------------------------------------------------
- * BOOTSTRAP THE APPLICATION
- *---------------------------------------------------------------
- * This process sets up the path constants, loads and registers
- * our autoloader, along with Composer's, loads our constants
- * and fires up an environment-specific bootstrapping.
- */
-
-// LOAD OUR PATHS CONFIG FILE
-// Load framework paths from their config file
-require CONFIGPATH . 'Paths.php';
-$paths = new Paths();
-
-// LOAD DOTENV FILE
-// Load environment settings from .env files into $_SERVER and $_ENV
-require_once $paths->systemDirectory . '/Config/DotEnv.php';
-(new DotEnv($paths->appDirectory . '/../'))->load();
-
-/*
  * ---------------------------------------------------------------
  * SETUP OUR PATH CONSTANTS
  * ---------------------------------------------------------------
@@ -84,6 +65,25 @@ defined('FCPATH') || define('FCPATH', realpath(PUBLICPATH) . DIRECTORY_SEPARATOR
 defined('SUPPORTPATH')   || define('SUPPORTPATH', realpath(TESTPATH . '_support/') . DIRECTORY_SEPARATOR);
 defined('COMPOSER_PATH') || define('COMPOSER_PATH', (string) realpath(HOMEPATH . 'vendor/autoload.php'));
 defined('VENDORPATH')    || define('VENDORPATH', realpath(HOMEPATH . 'vendor') . DIRECTORY_SEPARATOR);
+
+/*
+ *---------------------------------------------------------------
+ * BOOTSTRAP THE APPLICATION
+ *---------------------------------------------------------------
+ * This process sets up the path constants, loads and registers
+ * our autoloader, along with Composer's, loads our constants
+ * and fires up an environment-specific bootstrapping.
+ */
+
+// LOAD OUR PATHS CONFIG FILE
+// Load framework paths from their config file
+require CONFIGPATH . 'Paths.php';
+$paths = new Paths();
+
+// LOAD DOTENV FILE
+// Load environment settings from .env files into $_SERVER and $_ENV
+require_once $paths->systemDirectory . '/Config/DotEnv.php';
+(new DotEnv($paths->appDirectory . '/../'))->load();
 
 /*
  * ---------------------------------------------------------------

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -52,6 +52,11 @@ defined('CONFIGPATH') || define('CONFIGPATH', realpath($source . 'app/Config') .
 defined('PUBLICPATH') || define('PUBLICPATH', realpath($source . 'public') . DIRECTORY_SEPARATOR);
 unset($source);
 
+// LOAD OUR PATHS CONFIG FILE
+// Load framework paths from their config file
+require CONFIGPATH . 'Paths.php';
+$paths = new Paths();
+
 // Define necessary framework path constants
 defined('APPPATH')    || define('APPPATH', realpath(rtrim($paths->appDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
 defined('ROOTPATH')   || define('ROOTPATH', realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
@@ -74,11 +79,6 @@ defined('VENDORPATH')    || define('VENDORPATH', realpath(HOMEPATH . 'vendor') .
  * our autoloader, along with Composer's, loads our constants
  * and fires up an environment-specific bootstrapping.
  */
-
-// LOAD OUR PATHS CONFIG FILE
-// Load framework paths from their config file
-require CONFIGPATH . 'Paths.php';
-$paths = new Paths();
 
 // LOAD DOTENV FILE
 // Load environment settings from .env files into $_SERVER and $_ENV

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -39,6 +39,10 @@ unset($source);
 require CONFIGPATH . 'Paths.php';
 $paths = new Paths();
 
+// Load environment settings from .env files into $_SERVER and $_ENV
+require_once $paths->systemDirectory . '/Config/DotEnv.php';
+(new DotEnv($paths->appDirectory . '/../'))->load();
+
 // Define necessary framework path constants
 defined('APPPATH')       || define('APPPATH', realpath(rtrim($paths->appDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
 defined('WRITEPATH')     || define('WRITEPATH', realpath(rtrim($paths->writableDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
@@ -50,6 +54,11 @@ defined('TESTPATH')      || define('TESTPATH', realpath(HOMEPATH . 'tests/') . D
 defined('SUPPORTPATH')   || define('SUPPORTPATH', realpath(TESTPATH . '_support/') . DIRECTORY_SEPARATOR);
 defined('COMPOSER_PATH') || define('COMPOSER_PATH', (string) realpath(HOMEPATH . 'vendor/autoload.php'));
 defined('VENDORPATH')    || define('VENDORPATH', realpath(HOMEPATH . 'vendor') . DIRECTORY_SEPARATOR);
+
+// Load environment bootstrap
+if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
+    require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
+}
 
 // Load Common.php from App then System
 if (is_file(APPPATH . 'Common.php')) {

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -87,6 +87,11 @@ require_once APPPATH . 'Config/Services.php';
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 Services::autoloader()->loadHelpers();
+
+// Setup Exception Handling
+Services::exceptions()->initialize();
+
+// Initialize Kint
 Services::autoloader()->initializeKint(CI_DEBUG);
 
 // Now load Composer's if it's available

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -160,11 +160,6 @@ Services::exceptions()->initialize();
 
 Services::autoloader()->initializeKint(CI_DEBUG);
 
-// Now load Composer's if it's available
-if (is_file(COMPOSER_PATH)) {
-    require_once COMPOSER_PATH;
-}
-
 /*
  * ---------------------------------------------------------------
  * LOAD ROUTES

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -52,11 +52,6 @@ $paths = new Paths();
 require_once $paths->systemDirectory . '/Config/DotEnv.php';
 (new DotEnv($paths->appDirectory . '/../'))->load();
 
-// Set environment values that would otherwise stop the framework from functioning during tests.
-if (! isset($_SERVER['app.baseURL'])) {
-    $_SERVER['app.baseURL'] = 'http://example.com/';
-}
-
 /*
  * ---------------------------------------------------------------
  * SETUP OUR PATH CONSTANTS

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -78,6 +78,7 @@ require_once APPPATH . 'Config/Services.php';
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 Services::autoloader()->loadHelpers();
+Services::autoloader()->initializeKint(CI_DEBUG);
 
 // Now load Composer's if it's available
 if (is_file(COMPOSER_PATH)) {

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -68,27 +68,6 @@ if (! defined('TESTPATH')) {
 
 /*
  * ---------------------------------------------------------------
- * LOAD ENVIRONMENT BOOTSTRAP
- * ---------------------------------------------------------------
- *
- * Load any custom boot files based upon the current environment.
- * If no boot file exists, we shouldn't continue because something
- * is wrong. At the very least, they should have error reporting setup.
- */
-
-if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
-    require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
-} else {
-    // @codeCoverageIgnoreStart
-    header('HTTP/1.1 503 Service Unavailable.', true, 503);
-    echo 'The application environment is not set correctly.';
-
-    exit(EXIT_ERROR); // EXIT_ERROR
-    // @codeCoverageIgnoreEnd
-}
-
-/*
- * ---------------------------------------------------------------
  * GRAB OUR CONSTANTS
  * ---------------------------------------------------------------
  */

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -18,6 +18,18 @@ use Config\Services;
 
 /*
  * ---------------------------------------------------------------
+ * DEFINE ENVIRONMENT
+ * ---------------------------------------------------------------
+ */
+
+if (! defined('ENVIRONMENT')) {
+    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
+    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
+    unset($env);
+}
+
+/*
+ * ---------------------------------------------------------------
  * SETUP OUR PATH CONSTANTS
  * ---------------------------------------------------------------
  *

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -76,13 +76,19 @@ if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
 
 /*
  * ---------------------------------------------------------------
- * GRAB OUR CONSTANTS & COMMON
+ * GRAB OUR CONSTANTS
  * ---------------------------------------------------------------
  */
 
 if (! defined('APP_NAMESPACE')) {
     require_once APPPATH . 'Config/Constants.php';
 }
+
+/*
+ * ---------------------------------------------------------------
+ * LOAD COMMON FUNCTIONS
+ * ---------------------------------------------------------------
+ */
 
 // Require app/Common.php file if exists.
 if (is_file(APPPATH . 'Common.php')) {

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -55,6 +55,27 @@ if (! defined('TESTPATH')) {
 
 /*
  * ---------------------------------------------------------------
+ * LOAD ENVIRONMENT BOOTSTRAP
+ * ---------------------------------------------------------------
+ *
+ * Load any custom boot files based upon the current environment.
+ * If no boot file exists, we shouldn't continue because something
+ * is wrong. At the very least, they should have error reporting setup.
+ */
+
+if (is_file(APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php')) {
+    require_once APPPATH . 'Config/Boot/' . ENVIRONMENT . '.php';
+} else {
+    // @codeCoverageIgnoreStart
+    header('HTTP/1.1 503 Service Unavailable.', true, 503);
+    echo 'The application environment is not set correctly.';
+
+    exit(EXIT_ERROR); // EXIT_ERROR
+    // @codeCoverageIgnoreEnd
+}
+
+/*
+ * ---------------------------------------------------------------
  * GRAB OUR CONSTANTS & COMMON
  * ---------------------------------------------------------------
  */

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -135,4 +135,14 @@ require_once APPPATH . 'Config/Services.php';
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 Services::autoloader()->loadHelpers();
+
+/*
+ * ---------------------------------------------------------------
+ * SET EXCEPTION AND ERROR HANDLERS
+ * ---------------------------------------------------------------
+ */
+
+Services::exceptions()->initialize();
+
+// Initialize Kint
 Services::autoloader()->initializeKint(CI_DEBUG);

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -19,18 +19,6 @@ use Config\Services;
 
 /*
  * ---------------------------------------------------------------
- * DEFINE ENVIRONMENT
- * ---------------------------------------------------------------
- */
-
-if (! defined('ENVIRONMENT')) {
-    $env = $_ENV['CI_ENVIRONMENT'] ?? $_SERVER['CI_ENVIRONMENT'] ?? getenv('CI_ENVIRONMENT');
-    define('ENVIRONMENT', ($env !== false) ? $env : 'production');
-    unset($env);
-}
-
-/*
- * ---------------------------------------------------------------
  * SETUP OUR PATH CONSTANTS
  * ---------------------------------------------------------------
  *

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -106,3 +106,4 @@ require_once APPPATH . 'Config/Services.php';
 // Initialize and register the loader with the SPL autoloader stack.
 Services::autoloader()->initialize(new Autoload(), new Modules())->register();
 Services::autoloader()->loadHelpers();
+Services::autoloader()->initializeKint(CI_DEBUG);

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -26,11 +26,10 @@ use Config\Services;
  * so they are available in the config files that are loaded.
  */
 
+/** @var Paths $paths */
+
 // The path to the application directory.
 if (! defined('APPPATH')) {
-    /**
-     * @var Paths $paths
-     */
     define('APPPATH', realpath(rtrim($paths->appDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
 }
 
@@ -41,25 +40,16 @@ if (! defined('ROOTPATH')) {
 
 // The path to the system directory.
 if (! defined('SYSTEMPATH')) {
-    /**
-     * @var Paths $paths
-     */
     define('SYSTEMPATH', realpath(rtrim($paths->systemDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
 }
 
 // The path to the writable directory.
 if (! defined('WRITEPATH')) {
-    /**
-     * @var Paths $paths
-     */
     define('WRITEPATH', realpath(rtrim($paths->writableDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
 }
 
 // The path to the tests directory
 if (! defined('TESTPATH')) {
-    /**
-     * @var Paths $paths
-     */
     define('TESTPATH', realpath(rtrim($paths->testsDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
 }
 

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
+use CodeIgniter\Exceptions\FrameworkException;
 use Config\Autoload;
 use Config\Modules;
 use Config\Paths;
@@ -144,5 +145,37 @@ Services::autoloader()->loadHelpers();
 
 Services::exceptions()->initialize();
 
-// Initialize Kint
+/*
+ * ---------------------------------------------------------------
+ * CHECK SYSTEM FOR MISSING REQUIRED PHP EXTENSIONS
+ * ---------------------------------------------------------------
+ */
+
+// Run this check for manual installations
+if (! is_file(COMPOSER_PATH)) {
+    $requiredExtensions = [
+        'intl',
+        'json',
+        'mbstring',
+    ];
+
+    $missingExtensions = [];
+
+    foreach ($requiredExtensions as $extension) {
+        if (! extension_loaded($extension)) {
+            $missingExtensions[] = $extension;
+        }
+    }
+
+    if ($missingExtensions !== []) {
+        throw FrameworkException::forMissingExtension(implode(', ', $missingExtensions));
+    }
+}
+
+/*
+ * ---------------------------------------------------------------
+ * INITIALIZE KINT
+ * ---------------------------------------------------------------
+ */
+
 Services::autoloader()->initializeKint(CI_DEBUG);

--- a/system/bootstrap.php
+++ b/system/bootstrap.php
@@ -153,15 +153,13 @@ Services::exceptions()->initialize();
 
 // Run this check for manual installations
 if (! is_file(COMPOSER_PATH)) {
-    $requiredExtensions = [
+    $missingExtensions = [];
+
+    foreach ([
         'intl',
         'json',
         'mbstring',
-    ];
-
-    $missingExtensions = [];
-
-    foreach ($requiredExtensions as $extension) {
+    ] as $extension) {
         if (! extension_loaded($extension)) {
             $missingExtensions[] = $extension;
         }
@@ -170,6 +168,8 @@ if (! is_file(COMPOSER_PATH)) {
     if ($missingExtensions !== []) {
         throw FrameworkException::forMissingExtension(implode(', ', $missingExtensions));
     }
+
+    unset($missingExtensions);
 }
 
 /*

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -26,7 +26,6 @@ use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Session\Handlers\FileHandler;
 use CodeIgniter\Session\Session;
 use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Test\Mock\MockIncomingRequest;
 use CodeIgniter\Test\Mock\MockSecurity;
 use CodeIgniter\Test\Mock\MockSession;
@@ -710,8 +709,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $config->CSPEnabled = true;
 
         // Initialize Kint
-        $app = new MockCodeIgniter($config);
-        $app->initialize();
+        Services::autoloader()->initializeKint(CI_DEBUG);
 
         $cliDetection        = Kint::$cli_detection;
         Kint::$cli_detection = false;
@@ -736,8 +734,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $config->CSPEnabled = true;
 
         // Initialize Kint
-        $app = new MockCodeIgniter($config);
-        $app->initialize();
+        Services::autoloader()->initializeKint(CI_DEBUG);
 
         Kint::$cli_detection = false;
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -443,8 +443,20 @@ Changes
 Deprecations
 ************
 
-- **CodeIgniter:** The ``determinePath()`` method has been deprecated. No longer
-  used.
+- **CodeIgniter:**
+    - The ``determinePath()`` method has been deprecated. No longer used.
+    - The ``resolvePlatformExtensions()`` method has been deprecated. No longer
+      used. It has been moved to the ``CodeIgniter\Boot::checkMissingExtensions()``
+      method.
+    - The ``bootstrapEnvironment()`` method has been deprecated. No longer used.
+      It has been moved to the ``CodeIgniter\Boot::loadEnvironmentBootstrap()``
+      method.
+    - The ``initializeKint()`` method has been deprecated. No longer used. It has
+      been moved to the ``Autoloader``.
+    - The ``autoloadKint()`` method has been deprecated. No longer used. It has
+      been moved to the ``Autoloader``.
+    - The ``configureKint()`` method has been deprecated. No longer used. It has
+      been moved to the ``Autoloader``.
 - **Response:** The constructor parameter ``$config`` has been deprecated. No
   longer used.
 - **Filters:**

--- a/user_guide_src/source/installation/upgrade_450.rst
+++ b/user_guide_src/source/installation/upgrade_450.rst
@@ -15,6 +15,26 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Mandatory File Changes
 **********************
 
+index.php and spark
+===================
+
+The following files received significant changes and
+**you must merge the updated versions** with your application:
+
+- ``public/index.php``
+- ``spark``
+
+.. important:: If you don't update the above files, CodeIgniter will not work
+    properly after running ``composer update``.
+
+    The upgrade procedure, for example, is as follows:
+
+    .. code-block:: console
+
+        composer update
+        cp vendor/codeigniter4/framework/public/index.php public/index.php
+        cp vendor/codeigniter4/framework/spark spark
+
 Breaking Changes
 ****************
 


### PR DESCRIPTION
**Description**
- move Kint loading to Autoloader
   - `CodeIgniter::initializeKint()` registers an autoloader. So it is better to be in Autoloader.
   - Config caching cannot load Kint files. See https://forum.codeigniter.com/showthread.php?tid=88992&pid=414620#pid414620

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
