### PR TITLE
perf: add Services::get()

### DIFF
--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\API;
 use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
 
 /**
  * Provides common, more readable, methods to provide
@@ -307,7 +306,7 @@ trait ResponseTrait
      */
     protected function format($data = null)
     {
-        $format = Services::format();
+        $format = service('format');
 
         $mime = ($this->format === null) ? $format->getConfig()->supportedResponseFormats[0]
             : "application/{$this->format}";

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1266,7 +1266,7 @@ abstract class BaseModel
     public function paginate(?int $perPage = null, string $group = 'default', ?int $page = null, int $segment = 0)
     {
         // Since multiple models may use the Pager, the Pager must be shared.
-        $pager = Services::pager();
+        $pager = service('pager');
 
         if ($segment !== 0) {
             $pager->setSegment($segment, $group);

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\CLI;
 
 use Config\Generators;
-use Config\Services;
 use Throwable;
 
 /**
@@ -417,7 +416,7 @@ trait GeneratorTrait
         $namespace = $this->getNamespace();
 
         // Check if the namespace is actually defined and we are not just typing gibberish.
-        $base = Services::autoloader()->getNamespace($namespace);
+        $base = service('autoloader')->getNamespace($namespace);
 
         if (! $base = reset($base)) {
             CLI::error(

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -462,7 +462,7 @@ class CodeIgniter
         $uri = $this->request->getPath();
 
         if ($this->enableFilters) {
-            $filters = Services::filters();
+            $filters = service('filters');
 
             // If any filters were specified within the routes file,
             // we need to ensure it's active for the current request
@@ -518,7 +518,7 @@ class CodeIgniter
         $this->gatherOutput($cacheConfig, $returned);
 
         if ($this->enableFilters) {
-            $filters = Services::filters();
+            $filters = service('filters');
             $filters->setResponse($this->response);
 
             // Run "after" filters
@@ -649,7 +649,7 @@ class CodeIgniter
             Services::createRequest($this->config);
         }
 
-        $this->request = Services::request();
+        $this->request = service('request');
 
         $this->spoofRequestMethod();
     }
@@ -817,7 +817,7 @@ class CodeIgniter
         $this->benchmark->start('routing');
 
         if ($routes === null) {
-            $routes = Services::routes()->loadRoutes();
+            $routes = service('routes')->loadRoutes();
         }
 
         // $routes is defined in Config/Routes.php

--- a/system/Commands/Database/Migrate.php
+++ b/system/Commands/Database/Migrate.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use Config\Services;
 use Throwable;
 
 /**
@@ -68,7 +67,7 @@ class Migrate extends BaseCommand
      */
     public function run(array $params)
     {
-        $runner = Services::migrations();
+        $runner = service('migrations');
         $runner->clearCliMessages();
 
         CLI::write(lang('Migrations.latest'), 'yellow');

--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use Config\Services;
 use Throwable;
 
 /**
@@ -79,7 +78,7 @@ class MigrateRollback extends BaseCommand
             // @codeCoverageIgnoreEnd
         }
 
-        $runner = Services::migrations();
+        $runner = service('migrations');
 
         try {
             $batch = $params['b'] ?? CLI::getOption('b') ?? $runner->getLastBatch() - 1;

--- a/system/Commands/Database/MigrateStatus.php
+++ b/system/Commands/Database/MigrateStatus.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use Config\Services;
 
 /**
  * Displays a list of all migrations and whether they've been run or not.
@@ -83,11 +82,11 @@ class MigrateStatus extends BaseCommand
      */
     public function run(array $params)
     {
-        $runner     = Services::migrations();
+        $runner     = service('migrations');
         $paramGroup = $params['g'] ?? CLI::getOption('g');
 
         // Get all namespaces
-        $namespaces = Services::autoloader()->getNamespace();
+        $namespaces = service('autoloader')->getNamespace();
 
         // Collection of migration status
         $status = [];

--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Commands\Generators;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CLI\GeneratorTrait;
-use Config\Services;
 
 /**
  * Generates a skeleton command file.
@@ -82,7 +81,7 @@ class TestGenerator extends BaseCommand
 
         $this->classNameLang = 'CLI.generator.className.test';
 
-        $autoload = Services::autoloader();
+        $autoload = service('autoloader');
         $autoload->addNamespace('CodeIgniter', TESTPATH . 'system');
         $autoload->addNamespace('Tests', ROOTPATH . 'tests');
 
@@ -112,7 +111,7 @@ class TestGenerator extends BaseCommand
         $class      = $this->normalizeInputClassName();
         $classPaths = explode('\\', $class);
 
-        $namespaces = Services::autoloader()->getNamespace();
+        $namespaces = service('autoloader')->getNamespace();
 
         while ($classPaths !== []) {
             array_pop($classPaths);
@@ -176,7 +175,7 @@ class TestGenerator extends BaseCommand
      */
     private function searchTestFilePath(string $namespace): ?string
     {
-        $bases = Services::autoloader()->getNamespace($namespace);
+        $bases = service('autoloader')->getNamespace($namespace);
 
         $base = null;
 

--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Commands\Utilities;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Commands\Utilities\Routes\FilterCollector;
-use Config\Services;
 
 /**
  * Check filters for a route.
@@ -88,7 +87,7 @@ class FilterCheck extends BaseCommand
         $route  = $params[1];
 
         // Load Routes
-        Services::routes()->loadRoutes();
+        service('routes')->loadRoutes();
 
         $filterCollector = new FilterCollector();
 

--- a/system/Commands/Utilities/Namespaces.php
+++ b/system/Commands/Utilities/Namespaces.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Commands\Utilities;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use Config\Autoload;
-use Config\Services;
 
 /**
  * Lists namespaces set in Config\Autoload with their
@@ -96,7 +95,7 @@ class Namespaces extends BaseCommand
     {
         $maxLength = $params['m'];
 
-        $autoloader = Services::autoloader();
+        $autoloader = service('autoloader');
 
         $tbody = [];
 

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -23,7 +23,6 @@ use CodeIgniter\Router\DefinedRouteCollector;
 use CodeIgniter\Router\Router;
 use Config\Feature;
 use Config\Routing;
-use Config\Services;
 
 /**
  * Lists all the routes. This will include any Routes files
@@ -88,13 +87,13 @@ class Routes extends BaseCommand
 
         // Set HTTP_HOST
         if ($host) {
-            $request              = Services::request();
+            $request              = service('request');
             $_SERVER              = $request->getServer();
             $_SERVER['HTTP_HOST'] = $host;
             $request->setGlobal('server', $_SERVER);
         }
 
-        $collection = Services::routes()->loadRoutes();
+        $collection = service('routes')->loadRoutes();
 
         // Reset HTTP_HOST
         if ($host) {

--- a/system/Commands/Utilities/Routes/ControllerFinder.php
+++ b/system/Commands/Utilities/Routes/ControllerFinder.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Autoloader\FileLocatorInterface;
-use CodeIgniter\Config\Services;
 
 /**
  * Finds all controllers in a namespace for auto route listing.
@@ -36,7 +35,7 @@ final class ControllerFinder
     public function __construct(string $namespace)
     {
         $this->namespace = $namespace;
-        $this->locator   = Services::locator();
+        $this->locator   = service('locator');
     }
 
     /**

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -101,7 +101,7 @@ final class FilterCollector
 
     private function createRouter(Request $request): Router
     {
-        $routes = Services::routes();
+        $routes = service('routes');
 
         if ($this->resetRoutes) {
             $routes->resetRoutes();
@@ -114,6 +114,6 @@ final class FilterCollector
     {
         $config = config(FiltersConfig::class);
 
-        return new Filters($config, $request, Services::response());
+        return new Filters($config, $request, service('response'));
     }
 }

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -18,7 +18,6 @@ use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\Router\Router;
 use Config\Feature;
-use Config\Services;
 
 /**
  * Finds filters.
@@ -32,8 +31,8 @@ final class FilterFinder
 
     public function __construct(?Router $router = null, ?Filters $filters = null)
     {
-        $this->router  = $router ?? Services::router();
-        $this->filters = $filters ?? Services::filters();
+        $this->router  = $router ?? service('router');
+        $this->filters = $filters ?? service('filters');
     }
 
     private function getRouteFilters(string $uri): array

--- a/system/Commands/Utilities/Routes/SampleURIGenerator.php
+++ b/system/Commands/Utilities/Routes/SampleURIGenerator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Router\RouteCollection;
 use Config\App;
 
@@ -42,7 +41,7 @@ final class SampleURIGenerator
 
     public function __construct(?RouteCollection $routes = null)
     {
-        $this->routes = $routes ?? Services::routes();
+        $this->routes = $routes ?? service('routes');
     }
 
     /**

--- a/system/Common.php
+++ b/system/Common.php
@@ -71,7 +71,7 @@ if (! function_exists('cache')) {
      */
     function cache(?string $key = null)
     {
-        $cache = Services::cache();
+        $cache = service('cache');
 
         // No params - return cache object
         if ($key === null) {
@@ -244,7 +244,7 @@ if (! function_exists('cookies')) {
     function cookies(array $cookies = [], bool $getGlobal = true): CookieStore
     {
         if ($getGlobal) {
-            return Services::response()->getCookieStore();
+            return service('response')->getCookieStore();
         }
 
         return new CookieStore($cookies);
@@ -259,7 +259,7 @@ if (! function_exists('csrf_token')) {
      */
     function csrf_token(): string
     {
-        return Services::security()->getTokenName();
+        return service('security')->getTokenName();
     }
 }
 
@@ -271,7 +271,7 @@ if (! function_exists('csrf_header')) {
      */
     function csrf_header(): string
     {
-        return Services::security()->getHeaderName();
+        return service('security')->getHeaderName();
     }
 }
 
@@ -283,7 +283,7 @@ if (! function_exists('csrf_hash')) {
      */
     function csrf_hash(): string
     {
-        return Services::security()->getHash();
+        return service('security')->getHash();
     }
 }
 
@@ -317,7 +317,7 @@ if (! function_exists('csp_style_nonce')) {
      */
     function csp_style_nonce(): string
     {
-        $csp = Services::csp();
+        $csp = service('csp');
 
         if (! $csp->enabled()) {
             return '';
@@ -333,7 +333,7 @@ if (! function_exists('csp_script_nonce')) {
      */
     function csp_script_nonce(): string
     {
-        $csp = Services::csp();
+        $csp = service('csp');
 
         if (! $csp->enabled()) {
             return '';
@@ -486,13 +486,13 @@ if (! function_exists('force_https')) {
         ?RequestInterface $request = null,
         ?ResponseInterface $response = null
     ): void {
-        $request ??= Services::request();
+        $request ??= service('request');
 
         if (! $request instanceof IncomingRequest) {
             return;
         }
 
-        $response ??= Services::response();
+        $response ??= service('response');
 
         if ((ENVIRONMENT !== 'testing' && (is_cli() || $request->isSecure()))
             || $request->getServer('HTTPS') === 'test'
@@ -503,7 +503,7 @@ if (! function_exists('force_https')) {
         // If the session status is active, we should regenerate
         // the session ID for safety sake.
         if (ENVIRONMENT !== 'testing' && session_status() === PHP_SESSION_ACTIVE) {
-            Services::session()->regenerate(); // @codeCoverageIgnore
+            service('session')->regenerate(); // @codeCoverageIgnore
         }
 
         $uri = $request->getUri()->withScheme('https');
@@ -747,7 +747,7 @@ if (! function_exists('lang')) {
      */
     function lang(string $line, array $args = [], ?string $locale = null)
     {
-        $language = Services::language();
+        $language = service('language');
 
         // Get active locale
         $activeLocale = $language->getLocale();
@@ -836,7 +836,7 @@ if (! function_exists('old')) {
             session(); // @codeCoverageIgnore
         }
 
-        $request = Services::request();
+        $request = service('request');
 
         $value = $request->getOldInput($key);
 
@@ -934,7 +934,7 @@ if (! function_exists('request')) {
      */
     function request()
     {
-        return Services::request();
+        return service('request');
     }
 }
 
@@ -944,7 +944,7 @@ if (! function_exists('response')) {
      */
     function response(): ResponseInterface
     {
-        return Services::response();
+        return service('response');
     }
 }
 
@@ -965,7 +965,7 @@ if (! function_exists('route_to')) {
      */
     function route_to(string $method, ...$params)
     {
-        return Services::routes()->reverseRoute($method, ...$params);
+        return service('routes')->reverseRoute($method, ...$params);
     }
 }
 
@@ -983,7 +983,7 @@ if (! function_exists('session')) {
      */
     function session(?string $val = null)
     {
-        $session = Services::session();
+        $session = service('session');
 
         // Returning a single item?
         if (is_string($val)) {
@@ -1137,7 +1137,7 @@ if (! function_exists('timer')) {
      */
     function timer(?string $name = null, ?callable $callable = null)
     {
-        $timer = Services::timer();
+        $timer = service('timer');
 
         if ($name === null) {
             return $timer;
@@ -1194,7 +1194,7 @@ if (! function_exists('view_cell')) {
      */
     function view_cell(string $library, $params = null, int $ttl = 0, ?string $cacheName = null): string
     {
-        return Services::viewcell()
+        return service('viewcell')
             ->render($library, $params, $ttl, $cacheName);
     }
 }

--- a/system/Common.php
+++ b/system/Common.php
@@ -1009,6 +1009,10 @@ if (! function_exists('service')) {
      */
     function service(string $name, ...$params): ?object
     {
+        if ($params === []) {
+            return Services::get($name);
+        }
+
         return Services::$name(...$params);
     }
 }

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -13,7 +13,6 @@ namespace CodeIgniter\Config;
 
 use Config\Encryption;
 use Config\Modules;
-use Config\Services;
 use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
@@ -231,7 +230,7 @@ class BaseConfig
         }
 
         if (! static::$didDiscovery) {
-            $locator         = Services::locator();
+            $locator         = service('locator');
             $registrarsFiles = $locator->search('Config/Registrar.php');
 
             foreach ($registrarsFiles as $file) {

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -145,14 +145,14 @@ class BaseService
      * have been requested as a "shared" instance.
      * Keys should be lowercase service names.
      *
-     * @var array
+     * @var array<string, object> [key => instance]
      */
     protected static $instances = [];
 
     /**
      * Mock objects for testing which are returned if exist.
      *
-     * @var array
+     * @var array<string, object> [key => instance]
      */
     protected static $mocks = [];
 

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -190,9 +190,9 @@ class BaseService
      *
      * @param string $key Identifier of the entry to look for.
      *
-     * @return mixed Entry.
+     * @return object|null Entry.
      */
-    public static function get(string $key): mixed
+    public static function get(string $key): ?object
     {
         return static::$instances[$key] ?? static::__callStatic($key, []);
     }
@@ -200,10 +200,9 @@ class BaseService
     /**
      * Sets an entry.
      *
-     * @param string $key   Identifier of the entry.
-     * @param mixed  $value Normally an object.
+     * @param string $key Identifier of the entry.
      */
-    public static function set(string $key, mixed $value): void
+    public static function set(string $key, object $value): void
     {
         if (isset(static::$instances[$key])) {
             throw new InvalidArgumentException('The entry for "' . $key . '" is already set.');
@@ -215,10 +214,9 @@ class BaseService
     /**
      * Overrides an existing entry.
      *
-     * @param string $key   Identifier of the entry.
-     * @param mixed  $value Normally an object.
+     * @param string $key Identifier of the entry.
      */
-    public static function override(string $key, mixed $value): void
+    public static function override(string $key, object $value): void
     {
         static::$instances[$key] = $value;
     }

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -194,11 +194,7 @@ class BaseService
      */
     public static function get(string $key): mixed
     {
-        if (isset(static::$instances[$key])) {
-            return static::$instances[$key];
-        }
-
-        return static::__callStatic($key, []);
+        return static::$instances[$key] ?? static::__callStatic($key, []);
     }
 
     /**

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -76,6 +76,7 @@ use Config\Services as AppServices;
 use Config\Toolbar as ConfigToolbar;
 use Config\Validation as ConfigValidation;
 use Config\View as ConfigView;
+use InvalidArgumentException;
 
 /**
  * Services Configuration file.
@@ -176,6 +177,48 @@ class BaseService
      * @var list<string>
      */
     private static array $serviceNames = [];
+
+    /**
+     * Simple method to get an entry fast.
+     *
+     * @param string $key Identifier of the entry to look for.
+     *
+     * @return mixed Entry.
+     */
+    public static function get(string $key): mixed
+    {
+        if (isset(static::$instances[$key])) {
+            return static::$instances[$key];
+        }
+
+        return static::__callStatic($key, []);
+    }
+
+    /**
+     * Sets an entry.
+     *
+     * @param string $key   Identifier of the entry.
+     * @param mixed  $value Normally an object.
+     */
+    public static function set(string $key, mixed $value): void
+    {
+        if (isset(static::$instances[$key])) {
+            throw new InvalidArgumentException('The Entry for "' . $key . '" is already set.');
+        }
+
+        static::$instances[$key] = $value;
+    }
+
+    /**
+     * Overrides an existing entry.
+     *
+     * @param string $key   Identifier of the entry.
+     * @param mixed  $value Normally an object.
+     */
+    public static function override(string $key, mixed $value): void
+    {
+        static::$instances[$key] = $value;
+    }
 
     /**
      * Returns a shared instance of any of the class' services.
@@ -315,6 +358,7 @@ class BaseService
      */
     public static function injectMock(string $name, $mock)
     {
+        static::$instances[$name]         = $mock;
         static::$mocks[strtolower($name)] = $mock;
     }
 

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -206,7 +206,7 @@ class BaseService
     public static function set(string $key, mixed $value): void
     {
         if (isset(static::$instances[$key])) {
-            throw new InvalidArgumentException('The Entry for "' . $key . '" is already set.');
+            throw new InvalidArgumentException('The entry for "' . $key . '" is already set.');
         }
 
         static::$instances[$key] = $value;

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Config;
 
 use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Model;
-use Config\Services;
 use InvalidArgumentException;
 
 /**
@@ -284,7 +283,7 @@ final class Factories
         }
 
         // Have to do this the hard way...
-        $locator = Services::locator();
+        $locator = service('locator');
 
         // Check if the class alias was namespaced
         if (self::isNamespaced($alias)) {

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -292,7 +292,7 @@ class Services extends BaseService
 
         $config ??= config(FiltersConfig::class);
 
-        return new Filters($config, AppServices::request(), AppServices::response());
+        return new Filters($config, AppServices::get('request'), AppServices::get('response'));
     }
 
     /**
@@ -376,8 +376,8 @@ class Services extends BaseService
             return static::getSharedInstance('language', $locale)->setLocale($locale);
         }
 
-        if (AppServices::request() instanceof IncomingRequest) {
-            $requestLocale = AppServices::request()->getLocale();
+        if (AppServices::get('request') instanceof IncomingRequest) {
+            $requestLocale = AppServices::get('request')->getLocale();
         } else {
             $requestLocale = Locale::getDefault();
         }
@@ -432,7 +432,7 @@ class Services extends BaseService
             return static::getSharedInstance('negotiator', $request);
         }
 
-        $request ??= AppServices::request();
+        $request ??= AppServices::get('request');
 
         return new Negotiate($request);
     }
@@ -449,7 +449,7 @@ class Services extends BaseService
         }
 
         $config ??= config(Cache::class);
-        $cache ??= AppServices::cache();
+        $cache ??= AppServices::get('cache');
 
         return new ResponseCache($config, $cache);
     }
@@ -485,7 +485,7 @@ class Services extends BaseService
         $viewPath = $viewPath ?: (new Paths())->viewDirectory;
         $config ??= config(ViewConfig::class);
 
-        return new Parser($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
+        return new Parser($config, $viewPath, AppServices::get('locator'), CI_DEBUG, AppServices::get('logger'));
     }
 
     /**
@@ -504,7 +504,7 @@ class Services extends BaseService
         $viewPath = $viewPath ?: (new Paths())->viewDirectory;
         $config ??= config(ViewConfig::class);
 
-        return new View($config, $viewPath, AppServices::locator(), CI_DEBUG, AppServices::logger());
+        return new View($config, $viewPath, AppServices::get('locator'), CI_DEBUG, AppServices::get('logger'));
     }
 
     /**
@@ -565,7 +565,7 @@ class Services extends BaseService
 
         return new IncomingRequest(
             $config,
-            AppServices::uri(),
+            AppServices::get('uri'),
             'php://input',
             new UserAgent()
         );
@@ -600,7 +600,7 @@ class Services extends BaseService
 
         $config ??= config(App::class);
         $response = new RedirectResponse($config);
-        $response->setProtocolVersion(AppServices::request()->getProtocolVersion());
+        $response->setProtocolVersion(AppServices::get('request')->getProtocolVersion());
 
         return $response;
     }
@@ -617,7 +617,7 @@ class Services extends BaseService
             return static::getSharedInstance('routes');
         }
 
-        return new RouteCollection(AppServices::locator(), config(Modules::class), config(Routing::class));
+        return new RouteCollection(AppServices::get('locator'), config(Modules::class), config(Routing::class));
     }
 
     /**
@@ -632,8 +632,8 @@ class Services extends BaseService
             return static::getSharedInstance('router', $routes, $request);
         }
 
-        $routes ??= AppServices::routes();
-        $request ??= AppServices::request();
+        $routes ??= AppServices::get('routes');
+        $request ??= AppServices::get('request');
 
         return new Router($routes, $request);
     }
@@ -668,7 +668,7 @@ class Services extends BaseService
 
         $config ??= config(SessionConfig::class);
 
-        $logger = AppServices::logger();
+        $logger = AppServices::get('logger');
 
         $driverName = $config->driver;
 
@@ -685,7 +685,7 @@ class Services extends BaseService
             }
         }
 
-        $driver = new $driverName($config, AppServices::request()->getIPAddress());
+        $driver = new $driverName($config, AppServices::get('request')->getIPAddress());
         $driver->setLogger($logger);
 
         $session = new Session($driver, $config);
@@ -713,7 +713,7 @@ class Services extends BaseService
         }
 
         $config ??= config('App');
-        $superglobals ??= AppServices::superglobals();
+        $superglobals ??= AppServices::get('superglobals');
 
         return new SiteURIFactory($config, $superglobals);
     }
@@ -747,7 +747,7 @@ class Services extends BaseService
             return static::getSharedInstance('throttler');
         }
 
-        return new Throttler(AppServices::cache());
+        return new Throttler(AppServices::get('cache'));
     }
 
     /**
@@ -796,7 +796,7 @@ class Services extends BaseService
 
         if ($uri === null) {
             $appConfig = config(App::class);
-            $factory   = AppServices::siteurifactory($appConfig, AppServices::superglobals());
+            $factory   = AppServices::siteurifactory($appConfig, AppServices::get('superglobals'));
 
             return $factory->createFromGlobals();
         }
@@ -817,7 +817,7 @@ class Services extends BaseService
 
         $config ??= config(ValidationConfig::class);
 
-        return new Validation($config, AppServices::renderer());
+        return new Validation($config, AppServices::get('renderer'));
     }
 
     /**
@@ -832,7 +832,7 @@ class Services extends BaseService
             return static::getSharedInstance('viewcell');
         }
 
-        return new Cell(AppServices::cache());
+        return new Cell(AppServices::get('cache'));
     }
 
     /**

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -330,7 +330,7 @@ class Services extends BaseService
 
     /**
      * Acts as a factory for ImageHandler classes and returns an instance
-     * of the handler. Used like Services::image()->withFile($path)->rotate(90)->save();
+     * of the handler. Used like service('image')->withFile($path)->rotate(90)->save();
      *
      * @return BaseHandler
      */
@@ -544,7 +544,7 @@ class Services extends BaseService
             $request->setProtocolVersion($_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1');
         }
 
-        // Inject the request object into Services::request().
+        // Inject the request object into Services.
         static::$instances['request'] = $request;
     }
 

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -18,7 +18,6 @@ use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use CodeIgniter\Validation\ValidationInterface;
-use Config\Services;
 use Config\Validation;
 use Psr\Log\LoggerInterface;
 
@@ -120,7 +119,7 @@ class Controller
      */
     protected function cachePage(int $time)
     {
-        Services::responsecache()->setTtl($time);
+        service('responsecache')->setTtl($time);
     }
 
     /**
@@ -156,7 +155,7 @@ class Controller
      */
     private function setValidator($rules, array $messages): void
     {
-        $this->validator = Services::validation();
+        $this->validator = service('validation');
 
         // If you replace the $rules array with the name of the group
         if (is_string($rules)) {

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -375,10 +375,10 @@ class Toolbar
          * @var IncomingRequest|null $request
          */
         if (CI_DEBUG && ! is_cli()) {
-            $app = Services::codeigniter();
+            $app = service('codeigniter');
 
-            $request ??= Services::request();
-            $response ??= Services::response();
+            $request ??= service('request');
+            $response ??= service('response');
 
             // Disable the toolbar for downloads
             if ($response instanceof DownloadResponse) {
@@ -463,7 +463,7 @@ class Toolbar
             return;
         }
 
-        $request = Services::request();
+        $request = service('request');
 
         // If the request contains '?debugbar then we're
         // simply returning the loading script
@@ -512,7 +512,7 @@ class Toolbar
     {
         $data = json_decode($data, true);
 
-        if ($this->config->maxHistory !== 0 && preg_match('/\d+\.\d{6}/s', (string) Services::request()->getGet('debugbar_time'), $debugbarTime)) {
+        if ($this->config->maxHistory !== 0 && preg_match('/\d+\.\d{6}/s', (string) service('request')->getGet('debugbar_time'), $debugbarTime)) {
             $history = new History();
             $history->setFiles(
                 $debugbarTime[0],

--- a/system/Debug/Toolbar/Collectors/Config.php
+++ b/system/Debug/Toolbar/Collectors/Config.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Debug\Toolbar\Collectors;
 
 use CodeIgniter\CodeIgniter;
 use Config\App;
-use Config\Services;
 
 /**
  * Debug toolbar configuration
@@ -36,7 +35,7 @@ class Config
             'environment' => ENVIRONMENT,
             'baseURL'     => $config->baseURL,
             'timezone'    => app_timezone(),
-            'locale'      => Services::request()->getLocale(),
+            'locale'      => service('request')->getLocale(),
             'cspEnabled'  => $config->CSPEnabled,
         ];
     }

--- a/system/Debug/Toolbar/Collectors/Views.php
+++ b/system/Debug/Toolbar/Collectors/Views.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
 use CodeIgniter\View\RendererInterface;
-use Config\Services;
 
 /**
  * Views collector
@@ -77,7 +76,7 @@ class Views extends BaseCollector
 
     private function initViewer(): void
     {
-        $this->viewer ??= Services::renderer();
+        $this->viewer ??= service('renderer');
     }
 
     /**

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Events;
 
 use Config\Modules;
-use Config\Services;
 
 /**
  * Events
@@ -82,7 +81,7 @@ class Events
         $files  = [];
 
         if ($config->shouldDiscover('events')) {
-            $files = Services::locator()->search('Config/Events.php');
+            $files = service('locator')->search('Config/Events.php');
         }
 
         $files = array_filter(array_map(static function (string $file) {

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -18,7 +18,6 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
-use Config\Services;
 
 /**
  * CSRF filter.
@@ -52,7 +51,7 @@ class CSRF implements FilterInterface
             return;
         }
 
-        $security = Services::security();
+        $security = service('security');
 
         try {
             $security->verify($request);

--- a/system/Filters/DebugToolbar.php
+++ b/system/Filters/DebugToolbar.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Filters;
 
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
 
 /**
  * Debug toolbar filter
@@ -41,6 +40,6 @@ class DebugToolbar implements FilterInterface
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {
-        Services::toolbar()->prepare($request, $response);
+        service('toolbar')->prepare($request, $response);
     }
 }

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -21,7 +21,6 @@ use CodeIgniter\HTTP\ResponseInterface;
 use Config\Feature;
 use Config\Filters as FiltersConfig;
 use Config\Modules;
-use Config\Services;
 
 /**
  * Filters
@@ -136,7 +135,7 @@ class Filters
      */
     private function discoverFilters(): void
     {
-        $locator = Services::locator();
+        $locator = service('locator');
 
         // for access by custom filters
         $filters = $this->config;

--- a/system/Filters/ForceHTTPS.php
+++ b/system/Filters/ForceHTTPS.php
@@ -17,7 +17,6 @@ use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\App;
-use Config\Services;
 
 /**
  * Force HTTPS filter
@@ -43,7 +42,7 @@ class ForceHTTPS implements FilterInterface
             return;
         }
 
-        $response = Services::response();
+        $response = service('response');
 
         try {
             force_https(YEAR, $request, $response);

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -52,6 +52,6 @@ class Honeypot implements FilterInterface
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {
-        Services::honeypot()->attachHoneypot($response);
+        service('honeypot')->attachHoneypot($response);
     }
 }

--- a/system/Filters/PageCache.php
+++ b/system/Filters/PageCache.php
@@ -20,7 +20,6 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
 
 /**
  * Page Cache filter
@@ -31,7 +30,7 @@ class PageCache implements FilterInterface
 
     public function __construct()
     {
-        $this->pageCache = Services::responsecache();
+        $this->pageCache = service('responsecache');
     }
 
     /**
@@ -45,7 +44,7 @@ class PageCache implements FilterInterface
     {
         assert($request instanceof CLIRequest || $request instanceof IncomingRequest);
 
-        $response = Services::response();
+        $response = service('response');
 
         $cachedResponse = $this->pageCache->get($request, $response);
 

--- a/system/Filters/PerformanceMetrics.php
+++ b/system/Filters/PerformanceMetrics.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Filters;
 
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
 
 /**
  * Performance Metrics filter
@@ -43,7 +42,7 @@ class PerformanceMetrics implements FilterInterface
         $body = $response->getBody();
 
         if ($body !== null) {
-            $benchmark = Services::timer();
+            $benchmark = service('timer');
 
             $output = str_replace(
                 [

--- a/system/HTTP/Exceptions/RedirectException.php
+++ b/system/HTTP/Exceptions/RedirectException.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\HTTP\Exceptions;
 use CodeIgniter\Exceptions\HTTPExceptionInterface;
 use CodeIgniter\HTTP\ResponsableInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
 use Exception;
 use InvalidArgumentException;
 use LogicException;
@@ -71,13 +70,13 @@ class RedirectException extends Exception implements ResponsableInterface, HTTPE
     public function getResponse(): ResponseInterface
     {
         if (null === $this->response) {
-            $this->response = Services::response()
+            $this->response = service('response')
                 ->redirect(base_url($this->getMessage()), 'auto', $this->getCode());
         }
 
-        Services::logger()->info(
+        service('logger')->info(
             'REDIRECTED ROUTE at '
-            . ($this->response->getHeaderLine('Location') ?: substr($this->response->getHeaderLine('Refresh'), 6))
+             . ($this->response->getHeaderLine('Location') ?: substr($this->response->getHeaderLine('Refresh'), 6))
         );
 
         return $this->response;

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -58,7 +58,7 @@ class RedirectResponse extends Response
     {
         $namedRoute = $route;
 
-        $route = Services::routes()->reverseRoute($route, ...$params);
+        $route = service('routes')->reverseRoute($route, ...$params);
 
         if (! $route) {
             throw HTTPException::forInvalidRedirectRoute($namedRoute);
@@ -77,7 +77,7 @@ class RedirectResponse extends Response
      */
     public function back(?int $code = null, string $method = 'auto')
     {
-        Services::session();
+        service('session');
 
         return $this->redirect(previous_url(), $method, $code);
     }
@@ -92,7 +92,7 @@ class RedirectResponse extends Response
      */
     public function withInput()
     {
-        $session = Services::session();
+        $session = service('session');
         $session->setFlashdata('_ci_old_input', [
             'get'  => $_GET ?? [],
             'post' => $_POST ?? [],
@@ -114,10 +114,10 @@ class RedirectResponse extends Response
      */
     private function withErrors(): self
     {
-        $validation = Services::validation();
+        $validation = service('validation');
 
         if ($validation->getErrors()) {
-            $session = Services::session();
+            $session = service('session');
             $session->setFlashdata('_ci_validation_errors', $validation->getErrors());
         }
 
@@ -133,7 +133,7 @@ class RedirectResponse extends Response
      */
     public function with(string $key, $message)
     {
-        Services::session()->setFlashdata($key, $message);
+        service('session')->setFlashdata($key, $message);
 
         return $this;
     }

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -21,7 +21,6 @@ use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\PagerInterface;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use Config\Cookie as CookieConfig;
-use Config\Services;
 use DateTime;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -190,7 +189,7 @@ trait ResponseTrait
         $body = $this->body;
 
         if ($this->bodyFormat !== 'json') {
-            $body = Services::format()->getFormatter('application/json')->format($body);
+            $body = service('format')->getFormatter('application/json')->format($body);
         }
 
         return $body ?: null;
@@ -222,7 +221,7 @@ trait ResponseTrait
         $body = $this->body;
 
         if ($this->bodyFormat !== 'xml') {
-            $body = Services::format()->getFormatter('application/xml')->format($body);
+            $body = service('format')->getFormatter('application/xml')->format($body);
         }
 
         return $body;
@@ -247,7 +246,7 @@ trait ResponseTrait
 
         // Nothing much to do for a string...
         if (! is_string($body) || $format === 'json-unencoded') {
-            $body = Services::format()->getFormatter($mime)->format($body);
+            $body = service('format')->getFormatter($mime)->format($body);
         }
 
         return $body;
@@ -672,7 +671,7 @@ trait ResponseTrait
     private function dispatchCookies(): void
     {
         /** @var IncomingRequest $request */
-        $request = Services::request();
+        $request = service('request');
 
         foreach ($this->cookieStore->display() as $cookie) {
             if ($cookie->isSecure() && ! $request->isSecure()) {

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use CodeIgniter\Cookie\Cookie;
 use Config\Cookie as CookieConfig;
-use Config\Services;
 
 // =============================================================================
 // CodeIgniter Cookie Helpers
@@ -51,7 +50,7 @@ if (! function_exists('set_cookie')) {
         ?bool $httpOnly = null,
         ?string $sameSite = null
     ) {
-        $response = Services::response();
+        $response = service('response');
         $response->setCookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httpOnly, $sameSite);
     }
 }
@@ -77,7 +76,7 @@ if (! function_exists('get_cookie')) {
             $prefix = $cookie->prefix;
         }
 
-        $request = Services::request();
+        $request = service('request');
         $filter  = $xssClean ? FILTER_SANITIZE_FULL_SPECIAL_CHARS : FILTER_DEFAULT;
 
         return $request->getCookie($prefix . $index, $filter);
@@ -99,7 +98,7 @@ if (! function_exists('delete_cookie')) {
      */
     function delete_cookie($name, string $domain = '', string $path = '/', string $prefix = '')
     {
-        Services::response()->deleteCookie($name, $domain, $path, $prefix);
+        service('response')->deleteCookie($name, $domain, $path, $prefix);
     }
 }
 
@@ -109,6 +108,6 @@ if (! function_exists('has_cookie')) {
      */
     function has_cookie(string $name, ?string $value = null, string $prefix = ''): bool
     {
-        return Services::response()->hasCookie($name, $value, $prefix);
+        return service('response')->hasCookie($name, $value, $prefix);
     }
 }

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use Config\App;
-use Config\Services;
 use Config\Validation;
 
 // CodeIgniter Form Helpers
@@ -37,7 +36,7 @@ if (! function_exists('form_open')) {
         elseif (strpos($action, '://') === false) {
             // If an action has {locale}
             if (strpos($action, '{locale}') !== false) {
-                $action = str_replace('{locale}', Services::request()->getLocale(), $action);
+                $action = str_replace('{locale}', service('request')->getLocale(), $action);
             }
 
             $action = site_url($action);
@@ -61,7 +60,7 @@ if (! function_exists('form_open')) {
         $form = '<form action="' . $action . '"' . $attributes . ">\n";
 
         // Add CSRF field if enabled, but leave it out for GET requests and requests to external websites
-        $before = Services::filters()->getFilters()['before'];
+        $before = service('filters')->getFilters()['before'];
 
         if ((in_array('csrf', $before, true) || array_key_exists('csrf', $before)) && strpos($action, base_url()) !== false && ! stripos($form, 'method="get"')) {
             $form .= csrf_field($csrfId ?? null);
@@ -554,7 +553,7 @@ if (! function_exists('set_value')) {
      */
     function set_value(string $field, $default = '', bool $htmlEscape = true)
     {
-        $request = Services::request();
+        $request = service('request');
 
         // Try any old input data we may have first
         $value = $request->getOldInput($field);
@@ -575,7 +574,7 @@ if (! function_exists('set_select')) {
      */
     function set_select(string $field, string $value = '', bool $default = false): string
     {
-        $request = Services::request();
+        $request = service('request');
 
         // Try any old input data we may have first
         $input = $request->getOldInput($field);
@@ -611,7 +610,7 @@ if (! function_exists('set_checkbox')) {
      */
     function set_checkbox(string $field, string $value = '', bool $default = false): string
     {
-        $request = Services::request();
+        $request = service('request');
 
         // Try any old input data we may have first
         $input = $request->getOldInput($field);
@@ -631,7 +630,7 @@ if (! function_exists('set_checkbox')) {
             return '';
         }
 
-        $session     = Services::session();
+        $session     = service('session');
         $hasOldInput = $session->has('_ci_old_input');
 
         // Unchecked checkbox and radio inputs are not even submitted by browsers ...
@@ -651,7 +650,7 @@ if (! function_exists('set_radio')) {
      */
     function set_radio(string $field, string $value = '', bool $default = false): string
     {
-        $request = Services::request();
+        $request = service('request');
 
         // Try any old input data we may have first
         $oldInput = $request->getOldInput($field);
@@ -705,7 +704,7 @@ if (! function_exists('validation_errors')) {
             return $errors;
         }
 
-        $validation = Services::validation();
+        $validation = service('validation');
 
         return $validation->getErrors();
     }
@@ -720,7 +719,7 @@ if (! function_exists('validation_list_errors')) {
     function validation_list_errors(string $template = 'list'): string
     {
         $config = config(Validation::class);
-        $view   = Services::renderer();
+        $view   = service('renderer');
 
         if (! array_key_exists($template, $config->templates)) {
             throw ValidationException::forInvalidTemplate($template);
@@ -740,7 +739,7 @@ if (! function_exists('validation_show_error')) {
     function validation_show_error(string $field, string $template = 'single'): string
     {
         $config = config(Validation::class);
-        $view   = Services::renderer();
+        $view   = service('renderer');
 
         $errors = array_filter(validation_errors(), static fn ($key) => preg_match(
             '/^' . str_replace(['\.\*', '\*\.'], ['\..+', '.+\.'], preg_quote($field, '/')) . '$/',

--- a/system/Helpers/security_helper.php
+++ b/system/Helpers/security_helper.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-use Config\Services;
-
 // CodeIgniter Security Helpers
 
 if (! function_exists('sanitize_filename')) {
@@ -21,7 +19,7 @@ if (! function_exists('sanitize_filename')) {
      */
     function sanitize_filename(string $filename): string
     {
-        return Services::security()->sanitizeFilename($filename);
+        return service('security')->sanitizeFilename($filename);
     }
 }
 

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -17,7 +17,6 @@ use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Router\Exceptions\RouterException;
 use Config\App;
-use Config\Services;
 
 // CodeIgniter URL Helpers
 
@@ -33,7 +32,7 @@ if (! function_exists('site_url')) {
      */
     function site_url($relativePath = '', ?string $scheme = null, ?App $config = null): string
     {
-        $currentURI = Services::request()->getUri();
+        $currentURI = service('request')->getUri();
 
         assert($currentURI instanceof SiteURI);
 
@@ -53,7 +52,7 @@ if (! function_exists('base_url')) {
      */
     function base_url($relativePath = '', ?string $scheme = null): string
     {
-        $currentURI = Services::request()->getUri();
+        $currentURI = service('request')->getUri();
 
         assert($currentURI instanceof SiteURI);
 
@@ -73,7 +72,7 @@ if (! function_exists('current_url')) {
      */
     function current_url(bool $returnObject = false, ?IncomingRequest $request = null)
     {
-        $request ??= Services::request();
+        $request ??= service('request');
         /** @var CLIRequest|IncomingRequest $request */
         $uri = $request->getUri();
 
@@ -113,9 +112,9 @@ if (! function_exists('uri_string')) {
      */
     function uri_string(): string
     {
-        // The value of Services::request()->getUri()->getPath() returns
+        // The value of service('request')->getUri()->getPath() returns
         // full URI path.
-        $uri = Services::request()->getUri();
+        $uri = service('request')->getUri();
 
         $path = $uri instanceof SiteURI ? $uri->getRoutePath() : $uri->getPath();
 

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Language;
 
-use Config\Services;
 use InvalidArgumentException;
 use MessageFormatter;
 
@@ -250,7 +249,7 @@ class Language
      */
     protected function requireFile(string $path): array
     {
-        $files   = Services::locator()->search($path, 'php', false);
+        $files   = service('locator')->search($path, 'php', false);
         $strings = [];
 
         foreach ($files as $file) {

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1145,7 +1145,7 @@ class RouteCollection implements RouteCollectionInterface
      */
     public function view(string $from, string $view, ?array $options = null): RouteCollectionInterface
     {
-        $to = static fn (...$data) => Services::renderer()
+        $to = static fn (...$data) => service('renderer')
             ->setData(['segments' => $data], 'raw')
             ->render($view, $options);
 
@@ -1258,7 +1258,7 @@ class RouteCollection implements RouteCollectionInterface
      */
     protected function localizeRoute(string $route): string
     {
-        return strtr($route, ['{locale}' => Services::request()->getLocale()]);
+        return strtr($route, ['{locale}' => service('request')->getLocale()]);
     }
 
     /**
@@ -1423,7 +1423,7 @@ class RouteCollection implements RouteCollectionInterface
         }
 
         if ($locale === null) {
-            $locale = Services::request()->getLocale();
+            $locale = service('request')->getLocale();
         }
 
         return strtr($route, ['{locale}' => $locale]);

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -23,7 +23,6 @@ use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Session\Session;
 use Config\Cookie as CookieConfig;
 use Config\Security as SecurityConfig;
-use Config\Services;
 use ErrorException;
 use InvalidArgumentException;
 use LogicException;
@@ -207,7 +206,7 @@ class Security implements SecurityInterface
             $this->configureSession();
         }
 
-        $this->request      = Services::request();
+        $this->request      = service('request');
         $this->hashInCookie = $this->request->getCookie($this->cookieName);
 
         $this->restoreHash();
@@ -223,7 +222,7 @@ class Security implements SecurityInterface
 
     private function configureSession(): void
     {
-        $this->session = Services::session();
+        $this->session = service('session');
     }
 
     private function configureCookie(CookieConfig $cookie): void
@@ -534,7 +533,7 @@ class Security implements SecurityInterface
             ]
         );
 
-        $response = Services::response();
+        $response = service('response');
         $response->setCookie($this->cookie);
     }
 

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Session;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\I18n\Time;
 use Config\Cookie as CookieConfig;
-use Config\Services;
 use Config\Session as SessionConfig;
 use Psr\Log\LoggerAwareTrait;
 use SessionHandlerInterface;
@@ -406,7 +405,7 @@ class Session implements SessionInterface
 
     private function removeOldSessionCookie(): void
     {
-        $response              = Services::response();
+        $response              = service('response');
         $cookieStoreInResponse = $response->getCookieStore();
 
         if (! $cookieStoreInResponse->has($this->config->cookieName)) {
@@ -931,7 +930,7 @@ class Session implements SessionInterface
         $expiration   = $this->config->expiration === 0 ? 0 : Time::now()->getTimestamp() + $this->config->expiration;
         $this->cookie = $this->cookie->withValue(session_id())->withExpires($expiration);
 
-        $response = Services::response();
+        $response = service('response');
         $response->setCookie($this->cookie);
     }
 }

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -497,7 +497,7 @@ abstract class CIUnitTestCase extends TestCase
     protected function createApplication()
     {
         // Initialize the autoloader.
-        Services::autoloader()->initialize(new Autoload(), new Modules());
+        service('autoloader')->initialize(new Autoload(), new Modules());
 
         $app = new MockCodeIgniter(new App());
         $app->initialize();

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -100,13 +100,13 @@ trait ControllerTestTrait
         }
 
         if (! $this->uri instanceof URI) {
-            $factory   = Services::siteurifactory($this->appConfig, Services::superglobals(), false);
+            $factory   = Services::siteurifactory($this->appConfig, service('superglobals'), false);
             $this->uri = $factory->createFromGlobals();
         }
 
         if (empty($this->request)) {
             // Do some acrobatics, so we can use the Request service with our own URI
-            $tempUri = Services::uri();
+            $tempUri = service('uri');
             Services::injectMock('uri', $this->uri);
 
             $this->withRequest(Services::incomingrequest($this->appConfig, false));
@@ -120,7 +120,7 @@ trait ControllerTestTrait
         }
 
         if (empty($this->logger)) {
-            $this->logger = Services::logger();
+            $this->logger = service('logger');
         }
     }
 
@@ -280,7 +280,7 @@ trait ControllerTestTrait
      */
     public function withUri(string $uri)
     {
-        $factory   = Services::siteurifactory();
+        $factory   = service('siteurifactory');
         $this->uri = $factory->createFromString($uri);
         Services::injectMock('uri', $this->uri);
 

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -48,7 +48,7 @@ trait FeatureTestTrait
      */
     protected function withRoutes(?array $routes = null)
     {
-        $collection = Services::routes();
+        $collection = service('routes');
 
         if ($routes !== null) {
             $collection->resetRoutes();
@@ -190,7 +190,7 @@ trait FeatureTestTrait
 
         // Initialize the RouteCollection
         if (! $routes = $this->routes) {
-            $routes = Services::routes()->loadRoutes();
+            $routes = service('routes')->loadRoutes();
         }
 
         $routes->setHTTPVerb($method);
@@ -211,7 +211,7 @@ trait FeatureTestTrait
             ->run($routes, true);
 
         // Reset directory if it has been set
-        Services::router()->setDirectory(null);
+        service('router')->setDirectory(null);
 
         return new TestResponse($response);
     }
@@ -313,7 +313,7 @@ trait FeatureTestTrait
         $path  = $parts[0];
         $query = $parts[1] ?? '';
 
-        $superglobals = Services::superglobals();
+        $superglobals = service('superglobals');
         $superglobals->setServer('QUERY_STRING', $query);
 
         $uri->setPath($path);
@@ -418,7 +418,7 @@ trait FeatureTestTrait
             }
 
             if ($params !== null && $formatMime !== '') {
-                $formatted = Services::format()->getFormatter($formatMime)->format($params);
+                $formatted = service('format')->getFormatter($formatMime)->format($params);
                 // "withBodyFormat() and $params of call()" has higher priority than withBody().
                 $request->setBody($formatted);
             }

--- a/system/Test/FilterTestTrait.php
+++ b/system/Test/FilterTestTrait.php
@@ -21,7 +21,6 @@ use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\RouteCollection;
 use Config\Filters as FiltersConfig;
-use Config\Services;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -96,15 +95,15 @@ trait FilterTestTrait
         // Create our own Request and Response so we can
         // use the same ones for Filters and FilterInterface
         // yet isolate them from outside influence
-        $this->request ??= clone Services::request();
-        $this->response ??= clone Services::response();
+        $this->request ??= clone service('request');
+        $this->response ??= clone service('response');
 
         // Create our config and Filters instance to reuse for performance
         $this->filtersConfig ??= config(FiltersConfig::class);
         $this->filters ??= new Filters($this->filtersConfig, $this->request, $this->response);
 
         if ($this->collection === null) {
-            $this->collection = Services::routes()->loadRoutes();
+            $this->collection = service('routes')->loadRoutes();
         }
 
         $this->doneFilterSetUp = true;

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -17,7 +17,6 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\I18n\Time;
-use Config\Services;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\IsEqual;
 
@@ -390,7 +389,7 @@ class TestResponse
         }
 
         if (is_array($test)) {
-            $test = Services::format()->getFormatter('application/json')->format($test);
+            $test = service('format')->getFormatter('application/json')->format($test);
         }
 
         Assert::assertJsonStringEqualsJsonString($test, $json, 'Response does not contain matching JSON.');

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -17,7 +17,6 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use Config\Mimes;
-use Config\Services;
 use InvalidArgumentException;
 
 /**
@@ -40,7 +39,7 @@ class FileRules
     public function __construct(?RequestInterface $request = null)
     {
         if ($request === null) {
-            $request = Services::request();
+            $request = service('request');
         }
 
         assert($request instanceof IncomingRequest || $request instanceof CLIRequest);

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -93,7 +93,7 @@ class Cell
         }
 
         if (method_exists($instance, 'initController')) {
-            $instance->initController(Services::request(), Services::response(), Services::logger());
+            $instance->initController(Services::request(), service('response'), service('logger'));
         }
 
         if (! method_exists($instance, $method)) {

--- a/system/View/Filters.php
+++ b/system/View/Filters.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use Config\Services;
 use NumberFormatter;
 
 /**
@@ -194,7 +193,7 @@ class Filters
      */
     public static function nl2br(string $value): string
     {
-        $typography = Services::typography();
+        $typography = service('typography');
 
         return $typography->nl2brExceptPre($value);
     }
@@ -205,7 +204,7 @@ class Filters
      */
     public static function prose(string $value): string
     {
-        $typography = Services::typography();
+        $typography = service('typography');
 
         return $typography->autoTypography($value);
     }

--- a/system/View/Plugins.php
+++ b/system/View/Plugins.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\View;
 
 use CodeIgniter\HTTP\URI;
-use Config\Services;
 
 /**
  * View plugins
@@ -80,7 +79,7 @@ class Plugins
      */
     public static function ValidationErrors(array $params = []): string
     {
-        $validator = Services::validation();
+        $validator = service('validation');
         if ($params === []) {
             return $validator->listErrors();
         }

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -17,7 +17,6 @@ use CodeIgniter\Autoloader\FileLocatorInterface;
 use CodeIgniter\Debug\Toolbar\Collectors\Views;
 use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\View\Exceptions\ViewException;
-use Config\Services;
 use Config\Toolbar;
 use Config\View as ViewConfig;
 use Psr\Log\LoggerInterface;
@@ -152,8 +151,8 @@ class View implements RendererInterface
     ) {
         $this->config   = $config;
         $this->viewPath = rtrim($viewPath, '\\/ ') . DIRECTORY_SEPARATOR;
-        $this->loader   = $loader ?? Services::locator();
-        $this->logger   = $logger ?? Services::logger();
+        $this->loader   = $loader ?? service('locator');
+        $this->logger   = $logger ?? service('logger');
         $this->debug    = $debug ?? CI_DEBUG;
         $this->saveData = (bool) $config->saveData;
     }
@@ -262,7 +261,7 @@ class View implements RendererInterface
         );
 
         // Check if DebugToolbar is enabled.
-        $filters              = Services::filters();
+        $filters              = service('filters');
         $requiredAfterFilters = $filters->getRequiredFilters('after')[0];
         if (in_array('toolbar', $requiredAfterFilters, true)) {
             $debugBarEnabled = true;

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -105,6 +105,9 @@ final class CommonSingleServiceTest extends CIUnitTestCase
     {
         static $services = [];
         static $excl     = [
+            'get',
+            'set',
+            'override',
             '__callStatic',
             'createRequest',
             'serviceExists',


### PR DESCRIPTION
**Description**
- add `Services::get()` method to get the shared instance fast.
- `service()` uses `Services::get()`

```
 Test 			Time 	Memory
services::timer() 	0.1337 	0 Bytes
services::get('timer') 	0.0406 	0 Bytes
service('timer') 	0.0528 	0 Bytes
```

```php
<?php

namespace App\Controllers;

use CodeIgniter\Debug\Iterator;
use Config\Services;

class Home extends BaseController
{
    public function index(): string
    {
        $iterator = new Iterator();

        Services::timer();

        $iterator->add('Services::timer()', static function () {
            $timer = Services::timer();
        });

        $iterator->add("Services::get('timer')", static function () {
            $timer = Services::get('timer');
        });

        $iterator->add("service('timer')", static function () {
            $timer = service('timer');
        });

        return $iterator->run(300000);
    }
}
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
