### PR TITLE
refactor: remove unnecessary BaseService::$services assignment

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -167,6 +167,8 @@ class BaseService
      * A cache of other service classes we've found.
      *
      * @var array
+     *
+     * @deprecated 4.5.0 No longer used.
      */
     protected static $services = [];
 
@@ -335,7 +337,6 @@ class BaseService
 
                     if ($classname !== Services::class) {
                         self::$serviceNames[] = $classname;
-                        static::$services[]   = new $classname();
                     }
                 }
             }

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -450,6 +450,8 @@ Deprecations
 
 - **CodeIgniter:** The ``determinePath()`` method has been deprecated. No longer
   used.
+- **Services:** The ``BaseService::$services`` property has been deprecated. No
+  longer used.
 - **Response:** The constructor parameter ``$config`` has been deprecated. No
   longer used.
 - **Filters:**


### PR DESCRIPTION
**Description**
- deprecate `BaseService::$services`. It is not used elsewhere.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
