### PR TITLE
fix: BaseService getSharedInstance should properly cache null

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -192,7 +192,7 @@ class BaseService
             return static::$mocks[$key];
         }
 
-        if (! isset(static::$instances[$key])) {
+        if (! array_key_exists($key, static::$instances)) {
             // Make sure $getShared is false
             $params[] = false;
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
When we have service which returns null the getSharedInstance will not return the cached value. We should have the null values cached. One example is when using service to return currently logged in user. In case there is no user logged in the return value will be null. With current behavior each time user service is called getSharedInstance will always call the non shared variant. This will make the service method access the session data every time checking if there is an active user session.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
