### PR TITLE
docs: add/fix PHPDoc types in MockCache

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -3107,36 +3107,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Test/Mock/MockCURLRequest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot unset offset string on array\\<int, int\\>\\|null\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:assertHas\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:assertHasValue\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:assertMissing\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:get\\(\\) should be covariant with return type \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Cache\\\\CacheInterface\\:\\:get\\(\\)$#',
-	'count' => 2,
-	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(mixed\\) of method CodeIgniter\\\\Test\\\\Mock\\\\MockCache\\:\\:remember\\(\\) should be covariant with return type \\(array\\|bool\\|float\\|int\\|object\\|string\\|null\\) of method CodeIgniter\\\\Cache\\\\Handlers\\\\BaseHandler\\:\\:remember\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
 	'count' => 2,
 	'path' => __DIR__ . '/system/Test/Mock/MockCache.php',

--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -54,7 +54,7 @@ class MockCache extends BaseHandler implements CacheInterface
      *
      * @param string $key Cache item name
      *
-     * @return mixed
+     * @return bool|null
      */
     public function get(string $key)
     {
@@ -66,7 +66,7 @@ class MockCache extends BaseHandler implements CacheInterface
     /**
      * Get an item from the cache, or execute the given Closure and store the result.
      *
-     * @return mixed
+     * @return bool|null
      */
     public function remember(string $key, int $ttl, Closure $callback)
     {
@@ -266,6 +266,8 @@ class MockCache extends BaseHandler implements CacheInterface
      * Asserts that the cache has an item named $key.
      * The value is not checked since storing false or null
      * values is valid.
+     *
+     * @return void
      */
     public function assertHas(string $key)
     {
@@ -276,6 +278,8 @@ class MockCache extends BaseHandler implements CacheInterface
      * Asserts that the cache has an item named $key with a value matching $value.
      *
      * @param mixed $value
+     *
+     * @return void
      */
     public function assertHasValue(string $key, $value = null)
     {
@@ -292,6 +296,8 @@ class MockCache extends BaseHandler implements CacheInterface
 
     /**
      * Asserts that the cache does NOT have an item named $key.
+     *
+     * @return void
      */
     public function assertMissing(string $key)
     {


### PR DESCRIPTION
**Description**
PHPStan update now causes an error.
PHPDoc types have been fixed along with it.

```
 ------ ---------------------------------------------------------------------------------------------------- 
  Line   system/Test/Mock/MockCache.php                                                                      
 ------ ---------------------------------------------------------------------------------------------------- 
         Ignored error pattern #^Cannot unset offset string on array<int, int>\|null\.$# in path             
         /Users/kenji/work/codeigniter/official/CodeIgniter4/system/Test/Mock/MockCache.php was not matched  
         in reported errors.                                                                                 
 ------ ---------------------------------------------------------------------------------------------------- 
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
