### PR TITLE
refactor: replace array_merge by PHP 7.4 spread operator

### DIFF
--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -144,8 +144,8 @@ class AutoloadConfig
             $this->classmap['CIDatabaseTestCase']         = SYSTEMPATH . 'Test/CIDatabaseTestCase.php';
         }
 
-        $this->psr4     = array_merge($this->corePsr4, $this->psr4);
-        $this->classmap = array_merge($this->coreClassmap, $this->classmap);
+        $this->psr4     = [...$this->corePsr4, ...$this->psr4];
+        $this->classmap = [...$this->coreClassmap, ...$this->classmap];
         $this->files    = [...$this->coreFiles, ...$this->files];
     }
 }


### PR DESCRIPTION
Replaced `array_merge` by PHP 7.4 spread operator (`...`). Spread operator syntax is shorter and faster. In fact, spread operator is already used in this file (AutoloadConfig.php).
