### PR TITLE
chore: add version-compare-func-call-to-constant rule

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -18,6 +18,7 @@ use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector;
 use Rector\CodeQuality\Rector\FuncCall\SingleInArrayToCompareRector;
+use Rector\CodingStyle\Rector\FuncCall\VersionCompareFuncCallToConstantRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\CodeQuality\Rector\If_\CombineIfRector;
 use Rector\CodeQuality\Rector\If_\ShortenElseIfRector;
@@ -149,6 +150,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(CompleteDynamicPropertiesRector::class);
     $rectorConfig->rule(BooleanInIfConditionRuleFixerRector::class);
     $rectorConfig->rule(SingleInArrayToCompareRector::class);
+    $rectorConfig->rule(VersionCompareFuncCallToConstantRector::class);
 
     $rectorConfig
         ->ruleWithConfiguration(StringClassNameToClassConstantRector::class, [


### PR DESCRIPTION
Add Rector rule in order to replace PHP_VERSION by PHP_VERSION_ID.
@samsonasik suggestion: https://github.com/codeigniter4/CodeIgniter4/pull/8618#issuecomment-1988232650