### PR TITLE
refactor: apply early return pattern

### DIFF
--- a/system/Commands/Utilities/Routes/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/ControllerMethodReader.php
@@ -159,19 +159,17 @@ final class ControllerMethodReader
         string $classname,
         string $methodName
     ): array {
-        $output = [];
-
-        if ($classShortname === $defaultController) {
-            $pattern                = '#' . preg_quote(lcfirst($defaultController), '#') . '\z#';
-            $routeWithoutController = rtrim(preg_replace($pattern, '', $uriByClass), '/');
-            $routeWithoutController = $routeWithoutController ?: '/';
-
-            $output[] = [
-                'route'   => $routeWithoutController,
-                'handler' => '\\' . $classname . '::' . $methodName,
-            ];
+        if ($classShortname !== $defaultController) {
+            return [];
         }
 
-        return $output;
+        $pattern                = '#' . preg_quote(lcfirst($defaultController), '#') . '\z#';
+        $routeWithoutController = rtrim(preg_replace($pattern, '', $uriByClass), '/');
+        $routeWithoutController = $routeWithoutController ?: '/';
+
+        return [
+            'route'   => $routeWithoutController,
+            'handler' => '\\' . $classname . '::' . $methodName,
+        ];
     }
 }

--- a/system/Commands/Utilities/Routes/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/ControllerMethodReader.php
@@ -167,9 +167,9 @@ final class ControllerMethodReader
         $routeWithoutController = rtrim(preg_replace($pattern, '', $uriByClass), '/');
         $routeWithoutController = $routeWithoutController ?: '/';
 
-        return [
+        return [[
             'route'   => $routeWithoutController,
             'handler' => '\\' . $classname . '::' . $methodName,
-        ];
+        ]];
     }
 }


### PR DESCRIPTION
Apply early return (or return early) pattern. 
It's more readable and a bit shorter


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide