### PR TITLE
refactor: move footer info to top in error_exception.php

### DIFF
--- a/app/Views/errors/html/debug.css
+++ b/app/Views/errors/html/debug.css
@@ -67,7 +67,6 @@ p.lead {
 .environment {
     background: var(--dark-bg-color);
     color: var(--light-text-color);
-    border-top: 1px solid #e7e7e7;
     text-align: center;
 }
 

--- a/app/Views/errors/html/debug.css
+++ b/app/Views/errors/html/debug.css
@@ -19,7 +19,6 @@ body {
 }
 h1 {
     font-weight: lighter;
-    letter-spacing: 0.8;
     font-size: 3rem;
     color: var(--dark-text-color);
     margin: 0;

--- a/app/Views/errors/html/debug.css
+++ b/app/Views/errors/html/debug.css
@@ -108,7 +108,7 @@ p.lead {
 }
 .tabs a:link,
 .tabs a:visited {
-    padding: 0rem 1rem;
+    padding: 0 1rem;
     line-height: 2.7;
     text-decoration: none;
     color: var(--dark-text-color);

--- a/app/Views/errors/html/debug.css
+++ b/app/Views/errors/html/debug.css
@@ -43,7 +43,7 @@ p.lead {
     color: var(--dark-text-color);
 }
 .header .container {
-    padding: 1rem 1.75rem 1.75rem 1.75rem;
+    padding: 1rem;
 }
 .header h1 {
     font-size: 2.5rem;
@@ -147,9 +147,6 @@ p.lead {
     border: 1px solid #bcdff1;
     border-radius: 5px;
     color: #31708f;
-}
-ul, ol {
-    line-height: 1.8;
 }
 
 table {

--- a/app/Views/errors/html/debug.css
+++ b/app/Views/errors/html/debug.css
@@ -65,13 +65,10 @@ p.lead {
     display: inline;
 }
 
-.footer {
+.environment {
     background: var(--dark-bg-color);
     color: var(--light-text-color);
-}
-.footer .container {
     border-top: 1px solid #e7e7e7;
-    margin-top: 1rem;
     text-align: center;
 }
 

--- a/app/Views/errors/html/debug.css
+++ b/app/Views/errors/html/debug.css
@@ -68,6 +68,7 @@ p.lead {
     background: var(--dark-bg-color);
     color: var(--light-text-color);
     text-align: center;
+    padding: 0.2rem;
 }
 
 .source {

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -23,6 +23,12 @@ $errorId = uniqid('error', true);
 
     <!-- Header -->
     <div class="header">
+        <div class="environment">
+            Displayed at <?= esc(date('H:i:sa')) ?> &mdash;
+            PHP: <?= esc(PHP_VERSION) ?>  &mdash;
+            CodeIgniter: <?= esc(CodeIgniter::CI_VERSION) ?> --
+            Environment: <?= ENVIRONMENT ?>
+        </div>
         <div class="container">
             <h1><?= esc($title), esc($exception->getCode() ? ' #' . $exception->getCode() : '') ?></h1>
             <p>
@@ -400,19 +406,6 @@ $errorId = uniqid('error', true);
 
     </div> <!-- /container -->
     <?php endif; ?>
-
-    <div class="footer">
-        <div class="container">
-
-            <p>
-                Displayed at <?= esc(date('H:i:sa')) ?> &mdash;
-                PHP: <?= esc(PHP_VERSION) ?>  &mdash;
-                CodeIgniter: <?= esc(CodeIgniter::CI_VERSION) ?> --
-                Environment: <?= ENVIRONMENT ?>
-            </p>
-
-        </div>
-    </div>
 
 </body>
 </html>

--- a/user_guide_src/source/installation/upgrade_447.rst
+++ b/user_guide_src/source/installation/upgrade_447.rst
@@ -16,6 +16,14 @@ Please refer to the upgrade instructions corresponding to your installation meth
 Mandatory File Changes
 **********************
 
+Error Files
+===========
+
+The error page has been updated. Please update the following files:
+
+- app/Views/errors/html/debug.css
+- app/Views/errors/html/error_exception.php
+
 ****************
 Breaking Changes
 ****************


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/8616#issuecomment-1997478306
It is useful when reporting errors.

Before:
![Screehshot 2024-03-15 9 18 50](https://github.com/codeigniter4/CodeIgniter4/assets/87955/794f0a7c-cda1-4952-8391-07378d9627f6)

After:
![Screenshot 2024-03-15 11 57 39](https://github.com/codeigniter4/CodeIgniter4/assets/87955/409e5c48-15f5-49b6-a2e3-f61711e98c71)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
