### PR TITLE
chore: update test-deptrac.yml

### DIFF
--- a/.github/workflows/test-deptrac.yml
+++ b/.github/workflows/test-deptrac.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run architectural inspection
         run: |
-            sudo phive --no-progress install --global qossmic/deptrac --trust-gpg-keys B8F640134AB1782E
-            deptrac analyze --cache-file=build/deptrac.cache
+            composer require --dev qossmic/deptrac-shim
+            vendor/bin/deptrac analyze --cache-file=build/deptrac.cache
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**
The current workflow does not work when the phar file is updated.

```
Run sudo phive --no-progress install --global qossmic/deptrac --trust-gpg-keys B8F640134AB1782E
Phive 0.15.2 - Copyright (C) 2015-2024 by Arne Blankerts, Sebastian Heuer and Contributors
Downloading https://api.github.com/rate_limit
Downloading https://github.com/qossmic/deptrac/releases/download/2.0.0-alpha/deptrac.phar
Downloading https://github.com/qossmic/deptrac/releases/download/2.0.0-alpha/deptrac.phar.asc
Downloading key 47436587D82C4A39
Trying to connect to keys.openpgp.org (37.218.245.50)
Downloading https://keys.openpgp.org/pks/lookup?op=get&options=mr&search=0x47436587D82C4A39
Successfully downloaded key.

	Fingerprint: 57CB 556F 242F C8D4 FD48 3C2C 4743 6587 D82C 4A39

	Gennadi McKelvey <gennadi.mckelvey@qossmic.com>

	Created: 2023-11-30

Error:    Needs tty to be able to confirm
Import this key? [y|N] 
Error: Process completed with exit code 4.
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/8289348048/job/22685608378?pr=8626

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
