### PR TITLE
Update database connection docs with information on how to connect to a MySQL server over a socket

### DIFF
--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -66,6 +66,16 @@ add the config variables as a query string:
     database character set), which are present in the rest of the configuration
     fields, CodeIgniter will append them.
 
+Configuring a MySQL socket connection
+-------------------------------------
+
+To connect to a MySQL server over a filesystem socket, the path to the socket should be specified in 
+the ``'hostname'`` setting. CodeIgniter's MySQLi driver will notice this and configure the 
+connection properly.
+
+.. literalinclude:: configuration/011.php
+    :lines: 11-18
+
 Failovers
 ---------
 

--- a/user_guide_src/source/database/configuration/011.php
+++ b/user_guide_src/source/database/configuration/011.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Database\Config;
+
+class Database extends Config
+{
+    // ...
+
+    // MySQLi over a socket
+    public array $default = [
+        // ...
+        'hostname' => '/cloudsql/toolbox-tests:europe-north1:toolbox-db"',
+        // ...
+        'DBDriver' => 'MySQLi',
+        // ...
+    ];
+
+    // ...
+}


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Added a section on how to connect to a MySQL server over a socket. I'm developing for Google Cloud Run / Cloud SQL and had to use the CodeIgniter source to understand how to connect to the Cloud SQL socket created with `--add-cloudsql-instances` parameter passed to `gcloud deploy`.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
