### PR TITLE
fix: esc() for 'raw' context

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -426,6 +426,15 @@ if (! function_exists('esc')) {
      */
     function esc($data, string $context = 'html', ?string $encoding = null)
     {
+        $context = strtolower($context);
+
+        // Provide a way to NOT escape data since
+        // this could be called automatically by
+        // the View library.
+        if ($context === 'raw') {
+            return $data;
+        }
+
         if (is_array($data)) {
             foreach ($data as &$value) {
                 $value = esc($value, $context);
@@ -433,15 +442,6 @@ if (! function_exists('esc')) {
         }
 
         if (is_string($data)) {
-            $context = strtolower($context);
-
-            // Provide a way to NOT escape data since
-            // this could be called automatically by
-            // the View library.
-            if ($context === 'raw') {
-                return $data;
-            }
-
             if (! in_array($context, ['html', 'js', 'css', 'url', 'attr'], true)) {
                 throw new InvalidArgumentException('Invalid escape context provided.');
             }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -247,6 +247,27 @@ final class CommonFunctionsTest extends CIUnitTestCase
         esc('<script>', '0');
     }
 
+    public function testEscapeArray(): void
+    {
+        $data = [
+            'a' => [
+                'b' => 'c&',
+            ],
+            'd' => 'e>',
+        ];
+        $expected           = $data;
+        $expected['a']['b'] = 'c&amp;';
+        $expected['d']      = 'e&gt;';
+        $this->assertSame($expected, esc($data));
+    }
+
+    public function testEscapeRecursiveArrayRaw(): void
+    {
+        $data      = ['a' => 'b', 'c' => 'd'];
+        $data['e'] = &$data;
+        $this->assertSame($data, esc($data, 'raw'));
+    }
+
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled


### PR DESCRIPTION
**Description**
Fixes #8624

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
