### PR TITLE
docs: fix incorrect CURLRequest allow_redirects description

### DIFF
--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -157,7 +157,7 @@ or any of the shortcut methods.
 allow_redirects
 ===============
 
-By default, cURL will not follow all "Location:" headers the remote servers send
+By default, cURL will not follow any "Location:" headers the remote servers send
 back. The ``allow_redirects`` option allows you to modify how that works.
 
 If you set the value to ``true``, then it will follow redirects:

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -157,16 +157,19 @@ or any of the shortcut methods.
 allow_redirects
 ===============
 
-By default, cURL will follow all "Location:" headers the remote servers send back. The ``allow_redirects`` option
-allows you to modify how that works.
+By default, cURL will not follow all "Location:" headers the remote servers send
+back. The ``allow_redirects`` option allows you to modify how that works.
 
-If you set the value to ``false``, then it will not follow any redirects at all:
-
-.. literalinclude:: curlrequest/013.php
-
-Setting it to ``true`` will apply the default settings to the request:
+If you set the value to ``true``, then it will follow redirects:
 
 .. literalinclude:: curlrequest/014.php
+
+.. warning:: Please note that enabling redirects may redirect to a URL that you
+    do not expect and may enable SSRF attacks.
+
+Setting it to ``false`` will apply the default settings to the request:
+
+.. literalinclude:: curlrequest/013.php
 
 You can pass in array as the value of the ``allow_redirects`` option to specify new settings in place of the defaults:
 

--- a/user_guide_src/source/libraries/curlrequest/014.php
+++ b/user_guide_src/source/libraries/curlrequest/014.php
@@ -3,7 +3,7 @@
 $client->request('GET', 'http://example.com', ['allow_redirects' => true]);
 /*
  * Sets the following defaults:
- * 'max'       => 5, // Maximum number of redirects to follow before stopping
- * 'strict'    => true, // Ensure POST requests stay POST requests through redirects
- * 'protocols' => ['http', 'https'] // Restrict redirects to one or more protocols
+ *   'max'       => 5,                // Maximum number of redirects to follow before stopping
+ *   'strict'    => true,             // Ensure POST requests stay POST requests through redirects
+ *   'protocols' => ['http', 'https'] // Restrict redirects to one or more protocols
  */


### PR DESCRIPTION
**Description**
- fix description

```php
<?php

namespace App\Controllers;

class Home extends BaseController
{
    public function index(): string
    {
        $client   = \Config\Services::curlrequest();
        $response = $client->request('GET', 'http://google.com');

        return $response->getBody();
    }
}
```

You will see:
> 301 Moved
The document has moved [here](http://www.google.com/).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
