### PR TITLE
docs: fix PHPDoc types for Filters

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -5767,36 +5767,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Files/File.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\CSRF\\:\\:after\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/CSRF.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\CSRF\\:\\:before\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/CSRF.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\DebugToolbar\\:\\:after\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/DebugToolbar.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\DebugToolbar\\:\\:before\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/DebugToolbar.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\FilterInterface\\:\\:after\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/FilterInterface.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\FilterInterface\\:\\:before\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/FilterInterface.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Argument \\#1 \\$name \\(\'Config\\\\\\\\Modules\'\\) passed to function config does not extend CodeIgniter\\\\\\\\Config\\\\\\\\BaseConfig\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',
@@ -5862,26 +5832,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Honeypot\\:\\:after\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Honeypot.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Honeypot\\:\\:before\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Honeypot.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\InvalidChars\\:\\:after\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/InvalidChars.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\InvalidChars\\:\\:before\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/InvalidChars.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Filters\\\\InvalidChars\\:\\:checkControl\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/InvalidChars.php',
@@ -5900,16 +5850,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Filters\\\\InvalidChars\\:\\:checkEncoding\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/InvalidChars.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\SecureHeaders\\:\\:after\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/SecureHeaders.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\SecureHeaders\\:\\:before\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/SecureHeaders.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Format\\\\FormatterInterface\\:\\:format\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',

--- a/system/Filters/CSRF.php
+++ b/system/Filters/CSRF.php
@@ -38,7 +38,7 @@ class CSRF implements FilterInterface
      * sent back to the client, allowing for error pages,
      * redirects, etc.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return RedirectResponse|void
      *
@@ -66,7 +66,7 @@ class CSRF implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return void
      */

--- a/system/Filters/DebugToolbar.php
+++ b/system/Filters/DebugToolbar.php
@@ -25,7 +25,7 @@ class DebugToolbar implements FilterInterface
     /**
      * We don't need to do anything here.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      */
     public function before(RequestInterface $request, $arguments = null)
     {
@@ -35,7 +35,7 @@ class DebugToolbar implements FilterInterface
      * If the debug flag is set (CI_DEBUG) then collect performance
      * and debug information and display it in a toolbar.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {

--- a/system/Filters/FilterInterface.php
+++ b/system/Filters/FilterInterface.php
@@ -29,7 +29,7 @@ interface FilterInterface
      * sent back to the client, allowing for error pages,
      * redirects, etc.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return RequestInterface|ResponseInterface|string|void
      */
@@ -41,7 +41,7 @@ interface FilterInterface
      * to stop execution of other after filters, short of
      * throwing an Exception or Error.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return ResponseInterface|void
      */

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -94,7 +94,7 @@ class Filters
     /**
      * Any arguments to be passed to filtersClass.
      *
-     * @var array<class-string, array<string, list<string>>|null> [classname => arguments]
+     * @var array<class-string, list<string>|null> [classname => arguments]
      */
     protected $argumentsClass = [];
 

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -28,7 +28,7 @@ class Honeypot implements FilterInterface
      * Checks if Honeypot field is empty, if not then the
      * requester is a bot
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @throws HoneypotException
      */
@@ -46,7 +46,7 @@ class Honeypot implements FilterInterface
     /**
      * Attach a honeypot to the current response.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {

--- a/system/Filters/InvalidChars.php
+++ b/system/Filters/InvalidChars.php
@@ -45,7 +45,7 @@ class InvalidChars implements FilterInterface
     /**
      * Check invalid characters.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return void
      */
@@ -72,7 +72,7 @@ class InvalidChars implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return void
      */

--- a/system/Filters/SecureHeaders.php
+++ b/system/Filters/SecureHeaders.php
@@ -49,7 +49,7 @@ class SecureHeaders implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return void
      */
@@ -60,7 +60,7 @@ class SecureHeaders implements FilterInterface
     /**
      * Add security headers.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
      * @return void
      */

--- a/user_guide_src/source/libraries/throttler/002.php
+++ b/user_guide_src/source/libraries/throttler/002.php
@@ -13,9 +13,9 @@ class Throttle implements FilterInterface
      * This is a demo implementation of using the Throttler class
      * to implement rate limiting for your application.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
-     * @return mixed
+     * @return ResponseInterface|void
      */
     public function before(RequestInterface $request, $arguments = null)
     {
@@ -31,9 +31,9 @@ class Throttle implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param array|null $arguments
+     * @param list<string>|null $arguments
      *
-     * @return mixed
+     * @return void
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {


### PR DESCRIPTION
**Description**
- fix PHPDoc types for Filters

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
