### PR TITLE
docs: add commnets on Postgre::convertDSN()

### DIFF
--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -65,6 +65,9 @@ class Connection extends BaseConnection
         }
 
         // Convert DSN string
+        // @TODO This format is for PDO_PGSQL.
+        //      https://www.php.net/manual/en/ref.pdo-pgsql.connection.php
+        //      Should deprecate?
         if (mb_strpos($this->DSN, 'pgsql:') === 0) {
             $this->convertDSN();
         }

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -198,6 +198,9 @@ final class ConfigTest extends CIUnitTestCase
      */
     public function testConvertDSN(string $input, string $expected): void
     {
+        // @TODO This format is for PDO_PGSQL.
+        //      https://www.php.net/manual/en/ref.pdo-pgsql.connection.php
+        //      Should deprecate?
         $this->dsnGroupPostgreNative['DSN'] = $input;
         $conn                               = Config::connect($this->dsnGroupPostgreNative, false);
         $this->assertInstanceOf(BaseConnection::class, $conn);


### PR DESCRIPTION
**Description**
I don't know why `Postgre` driver supports PDO_PGSQL DSN.
It came from https://github.com/codeigniter4/CodeIgniter4/commit/30063c9f#diff-d627f02b770edc4ab06280dbc671681df326dc7790e9bc7b1cf268a5da58e465

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
