### PR TITLE
docs: add note to Time::difference() and DST

### DIFF
--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -379,6 +379,12 @@ the original time:
 
 .. literalinclude:: time/039.php
 
+.. note:: When calculating the difference in the number of days, unexpected results
+    may be returned if a day is not 24 hours long due to Daylight Saving Time
+    (DST).
+
+        .. literalinclude:: time/042.php
+
 You can use either ``getX()`` methods, or access the calculate values as if they were properties:
 
 .. literalinclude:: time/040.php

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -366,7 +366,9 @@ Viewing Differences
 ===================
 
 To compare two Times directly, you would use the ``difference()`` method, which returns a ``CodeIgniter\I18n\TimeDifference``
-instance. The first parameter is either a Time instance, a DateTime instance, or a string with the date/time. If
+instance.
+
+The first parameter is either a Time instance, a DateTime instance, or a string with the date/time. If
 a string is passed in the first parameter, the second parameter can be a timezone string:
 
 .. literalinclude:: time/038.php

--- a/user_guide_src/source/libraries/time/042.php
+++ b/user_guide_src/source/libraries/time/042.php
@@ -1,0 +1,10 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$current = Time::parse('2024-03-31', 'Europe/Madrid');
+$test    = Time::parse('2024-04-01', 'Europe/Madrid');
+
+$diff = $current->difference($test);
+
+echo $diff->getDays(); // 0


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=90472

This may be a bug, but I don't know how to fix.
```php
        $current = Time::parse('2024-03-31', 'Europe/Madrid');
        $test    = Time::parse('2024-04-01', 'Europe/Madrid');

        $diff = $current->difference($test);

        echo $diff->getDays(); // 0

        $current = new DateTimeImmutable('2024-03-31', new DateTimeZone('Europe/Madrid'));
        $test    = new DateTimeImmutable('2024-04-01', new DateTimeZone('Europe/Madrid'));

        $diff = $current->diff($test);

        echo $diff->format("%a"); // 1
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
