### PR TITLE
fix: Model::set() does not accept object

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1526,7 +1526,7 @@ class BaseBuilder
     /**
      * Allows key/value pairs to be set for insert(), update() or replace().
      *
-     * @param array|object|string $key    Field name, or an array of field/value pairs
+     * @param array|object|string $key    Field name, or an array of field/value pairs, or an object
      * @param mixed               $value  Field value, if $key is a single field
      * @param bool|null           $escape Whether to escape values
      *

--- a/system/Model.php
+++ b/system/Model.php
@@ -28,6 +28,7 @@ use Config\Database;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionProperty;
+use stdClass;
 
 /**
  * The Model class extends BaseModel and provides additional
@@ -674,7 +675,7 @@ class Model extends BaseModel
      * data here. This allows it to be used with any of the other
      * builder methods and still get validated data, like replace.
      *
-     * @param array|object|string               $key    Field name, or an array of field/value pairs
+     * @param array|object|string               $key    Field name, or an array of field/value pairs, or an object
      * @param bool|float|int|object|string|null $value  Field value, if $key is a single field
      * @param bool|null                         $escape Whether to escape values
      *
@@ -682,6 +683,10 @@ class Model extends BaseModel
      */
     public function set($key, $value = '', ?bool $escape = null)
     {
+        if (is_object($key)) {
+            $key = $key instanceof stdClass ? (array) $key : $this->objectToArray($key);
+        }
+
         $data = is_array($key) ? $key : [$key => $value];
 
         foreach (array_keys($data) as $k) {

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -378,6 +378,51 @@ final class UpdateModelTest extends LiveModelTestCase
         $this->model->update($id, $entity);
     }
 
+    public function testUpdateSetObject(): void
+    {
+        $this->createModel(UserModel::class);
+
+        $object          = new stdClass();
+        $object->name    = 'Jones Martin';
+        $object->email   = 'jones@example.org';
+        $object->country = 'India';
+
+        /** @var int|string $id */
+        $id = $this->model->insert($object);
+
+        /** @var stdClass $object */
+        $object       = $this->model->find($id);
+        $object->name = 'John Smith';
+
+        $return = $this->model->where('id', $id)->set($object)->update();
+
+        $this->assertTrue($return);
+    }
+
+    public function testUpdateSetEntity(): void
+    {
+        $this->createModel(UserModel::class);
+
+        $object          = new stdClass();
+        $object->id      = 1;
+        $object->name    = 'Jones Martin';
+        $object->email   = 'jones@example.org';
+        $object->country = 'India';
+
+        $id = $this->model->insert($object);
+
+        $entity = new Entity([
+            'id'      => 1,
+            'name'    => 'John Smith',
+            'email'   => 'john@example.org',
+            'country' => 'India',
+        ]);
+
+        $return = $this->model->where('id', $id)->set($entity)->update();
+
+        $this->assertTrue($return);
+    }
+
     public function testUpdateEntityWithPrimaryKeyCast(): void
     {
         if (


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=90502

> When you need a more flexible solution, you can leave the parameters empty and it functions like the Query Builder’s update command, with the added benefit of validation, events, etc:
https://codeigniter4.github.io/CodeIgniter4/models/model.html#update

So, `Model::set()` should accept object or Entity.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
