### PR TITLE
Prep for 4.4.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [v4.4.7](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.7) (2024-03-29)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.6...v4.4.7)
+
+### Breaking Changes
+* fix: Time::difference() DST bug by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8661
+
+### Fixed Bugs
+* fix: [Validation] FileRules cause error if getimagesize() returns false by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8592
+* fix: isWriteType() to recognize CTE; always excluding RETURNING by @markconnellypro in https://github.com/codeigniter4/CodeIgniter4/pull/8599
+* fix: duplicate Cache-Control header with Session by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8601
+* fix: [DebugBar] scroll to top by @ddevsr in https://github.com/codeigniter4/CodeIgniter4/pull/8595
+* fix: Model::shouldUpdate() logic by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8614
+* fix: esc() for 'raw' context by @Cleric-K in https://github.com/codeigniter4/CodeIgniter4/pull/8633
+* docs: fix incorrect CURLRequest allow_redirects description by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8653
+* fix: Model::set() does not accept object by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8670
+
+### Refactoring
+* refactor: replace PHP_VERSION by PHP_VERSION_ID by @justbyitself in https://github.com/codeigniter4/CodeIgniter4/pull/8618
+* refactor: apply early return pattern by @justbyitself in https://github.com/codeigniter4/CodeIgniter4/pull/8621
+* refactor: move footer info to top in error_exception.php by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/8626
+
 ## [v4.4.6](https://github.com/codeigniter4/CodeIgniter4/tree/v4.4.6) (2024-02-24)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.4.5...v4.4.6)
 

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -10,7 +10,7 @@
         <output>api/build/</output>
         <cache>api/cache/</cache>
     </paths>
-    <version number="4.4.6">
+    <version number="4.4.7">
         <api format="php">
             <source dsn=".">
                 <path>system</path>

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -54,7 +54,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.4.6';
+    public const CI_VERSION = '4.4.7';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/v4.4.7.rst
+++ b/user_guide_src/source/changelogs/v4.4.7.rst
@@ -2,7 +2,7 @@
 Version 4.4.7
 #############
 
-Release Date: Unreleased
+Release Date: March 29, 2024
 
 **4.4.7 release of CodeIgniter4**
 
@@ -32,18 +32,6 @@ BREAKING
   unexpected results were returned if the date included a day different from 24
   hours due to Daylight Saving Time (DST). This bug has been fixed. See
   :ref:`Note in Times and Dates <time-viewing-differences>` for details.
-
-***************
-Message Changes
-***************
-
-*******
-Changes
-*******
-
-************
-Deprecations
-************
 
 **********
 Bugs Fixed

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2019-' + str(year_now) + ' CodeIgniter Foundation'
 version = '4.4'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.4.6'
+release = '4.4.7'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_447.rst
+++ b/user_guide_src/source/installation/upgrade_447.rst
@@ -89,10 +89,6 @@ In the unlikely event that you wish to maintain the behavior of the previous
 versions, change the time zone of both dates being compared to UTC before passing
 them to ``Time::difference()``.
 
-*********************
-Breaking Enhancements
-*********************
-
 *************
 Project Files
 *************
@@ -115,7 +111,6 @@ Config
 - app/Config/App.php
     - The property ``$permittedURIChars`` was added. See :ref:`urls-uri-security`
       for details.
-- @TODO
 
 All Changes
 ===========
@@ -123,4 +118,19 @@ All Changes
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
+- app/Config/Cache.php
+- app/Config/ContentSecurityPolicy.php
+- app/Config/Database.php
+- app/Config/Exceptions.php
+- app/Config/Filters.php
+- app/Config/Format.php
+- app/Config/Logger.php
+- app/Config/Mimes.php
+- app/Config/Routing.php
+- app/Config/Toolbar.php
+- app/Config/Validation.php
+- app/Config/View.php
+- app/Controllers/BaseController.php
+- app/Views/errors/html/debug.css
+- app/Views/errors/html/error_exception.php
+- composer.json


### PR DESCRIPTION
**Description**
Updates changelog and version references for 4.4.7.

Previous version: #8574
Release Code: TODO
New Changelog: TODO

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
