### PR TITLE
docs: fix PHPDoc types in BaseModel

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -227,11 +227,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/BaseModel.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\BaseModel\\:\\:setValidationRules\\(\\) has parameter \\$validationRules with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/BaseModel.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\BaseModel\\:\\:transformDataToArray\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/BaseModel.php',
@@ -11392,16 +11387,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/_support/Models/UserModel.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Tests\\\\Support\\\\Models\\\\ValidErrorsModel\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, array\\<int\\|string, array\\<string, string\\>\\|string\\>\\|string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/_support/Models/ValidErrorsModel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property Tests\\\\Support\\\\Models\\\\ValidModel\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, array\\<int, string\\>\\|string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/_support/Models/ValidModel.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property Tests\\\\Support\\\\SomeEntity\\:\\:\\$attributes type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/_support/SomeEntity.php',
@@ -16302,37 +16287,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Models/UpdateModelTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/Models/ValidationModelRuleGroupTest\\.php\\:368\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Models/ValidationModelRuleGroupTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/Models/ValidationModelRuleGroupTest\\.php\\:406\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Models/ValidationModelRuleGroupTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/Models/ValidationModelRuleGroupTest\\.php\\:446\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Models/ValidationModelRuleGroupTest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property class@anonymous/tests/system/Models/ValidationModelTest\\.php\\:243\\:\\:\\$grouptest has no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Models/ValidationModelTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/Models/ValidationModelTest\\.php\\:380\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Models/ValidationModelTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/Models/ValidationModelTest\\.php\\:418\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Models/ValidationModelTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/Models/ValidationModelTest\\.php\\:458\\:\\:\\$validationRules \\(array\\<int, string\\>\\|string\\) does not accept default value of type array\\<string, string\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Models/ValidationModelTest.php',
 ];

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -173,11 +173,14 @@ abstract class BaseModel
     protected $db;
 
     /**
-     * Rules used to validate data in insert, update, and save methods.
+     * Rules used to validate data in insert(), update(), and save() methods.
+     *
      * The array must match the format of data passed to the Validation
      * library.
      *
-     * @var list<string>|string
+     * @see https://codeigniter4.github.io/userguide/models/model.html#setting-validation-rules
+     *
+     * @var array<string, array<string, array<string, string>|string>|string>|string
      */
     protected $validationRules = [];
 
@@ -1448,7 +1451,7 @@ abstract class BaseModel
      * Allows to set (and reset) validation rules.
      * It could be used when you have to change default or override current validate rules.
      *
-     * @param array $validationRules Value
+     * @param array<string, array<string, array<string, string>|string>|string> $validationRules Value
      *
      * @return $this
      */


### PR DESCRIPTION
**Description**
- fix PHPDoc types

```
 ------ ------------------------------------------------------------------------- 
  Line   src/Models/LoginModel.php                                                
 ------ ------------------------------------------------------------------------- 
  37     Property CodeIgniter\Shield\Models\LoginModel::$validationRules          
         (list<string>|string) does not accept default value of type              
         array{ip_address: 'required', id_type: 'required', identifier:           
         'permit_empty|string', user_agent: 'permit_empty|string', user_id:       
         'permit_empty', date: 'required'}.                                       
         💡 Type #1 from the union: array{ip_address: 'required', id_type:         
            'required', identifier: 'permit_empty|string', user_agent:            
            'permit_empty|string', user_id: 'permit_empty', date: 'required'} is  
            not a list.                                                           
 ------ ------------------------------------------------------------------------- 
```
https://github.com/codeigniter4/shield/actions/runs/8480994004/job/23237640319

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
