### PR TITLE
fix: [ImageMagickHandler] early terminate processing of invalid library path

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -7723,7 +7723,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 9,
+	'count' => 8,
 	'path' => __DIR__ . '/system/Images/Handlers/ImageMagickHandler.php',
 ];
 $ignoreErrors[] = [

--- a/system/Images/Handlers/ImageMagickHandler.php
+++ b/system/Images/Handlers/ImageMagickHandler.php
@@ -32,8 +32,6 @@ class ImageMagickHandler extends BaseHandler
     protected $resource;
 
     /**
-     * Constructor.
-     *
      * @param Images $config
      *
      * @throws ImageException
@@ -44,6 +42,22 @@ class ImageMagickHandler extends BaseHandler
 
         if (! (extension_loaded('imagick') || class_exists(Imagick::class))) {
             throw ImageException::forMissingExtension('IMAGICK'); // @codeCoverageIgnore
+        }
+
+        $cmd = $this->config->libraryPath;
+
+        if ($cmd === '') {
+            throw ImageException::forInvalidImageLibraryPath($cmd);
+        }
+
+        if (preg_match('/convert$/i', $cmd) !== 1) {
+            $cmd = rtrim($cmd, '\/') . '/convert';
+
+            $this->config->libraryPath = $cmd;
+        }
+
+        if (! is_file($cmd)) {
+            throw ImageException::forInvalidImageLibraryPath($cmd);
         }
     }
 
@@ -184,17 +198,8 @@ class ImageMagickHandler extends BaseHandler
      */
     protected function process(string $action, int $quality = 100): array
     {
-        // Do we have a vaild library path?
-        if (empty($this->config->libraryPath)) {
-            throw ImageException::forInvalidImageLibraryPath($this->config->libraryPath);
-        }
-
         if ($action !== '-version') {
             $this->supportedFormatCheck();
-        }
-
-        if (! preg_match('/convert$/i', $this->config->libraryPath)) {
-            $this->config->libraryPath = rtrim($this->config->libraryPath, '/') . '/convert';
         }
 
         $cmd = $this->config->libraryPath;

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -14,6 +14,7 @@ namespace CodeIgniter\Images;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Images\Handlers\BaseHandler;
+use CodeIgniter\Images\Handlers\ImageMagickHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Images;
 use Imagick;
@@ -75,6 +76,33 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
         }
 
         $this->handler = Services::image('imagick', $config, false);
+    }
+
+    /**
+     * @dataProvider provideNonexistentLibraryPathTerminatesProcessing
+     */
+    public function testNonexistentLibraryPathTerminatesProcessing(string $path, string $invalidPath): void
+    {
+        $this->expectException(ImageException::class);
+        $this->expectExceptionMessage(lang('Images.libPathInvalid', [$invalidPath]));
+
+        $config = new Images();
+
+        $config->libraryPath = $path;
+
+        new ImageMagickHandler($config);
+    }
+
+    /**
+     * @return iterable<string, list<string>>
+     */
+    public static function provideNonexistentLibraryPathTerminatesProcessing(): iterable
+    {
+        yield 'empty string' => ['', ''];
+
+        yield 'invalid file' => ['/var/log/convert', '/var/log/convert'];
+
+        yield 'nonexistent file' => ['/var/www/file', '/var/www/file/convert'];
     }
 
     public function testGetVersion(): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
We should check if the `convert` program exists before doing any processing. Currently, it just checks for a non-empty string in the config file, which is insufficient.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
