### PR TITLE
docs: add missing "Upgrade Image Manipulation Class"

### DIFF
--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -240,6 +240,7 @@ Upgrading Libraries
     upgrade_encryption
     upgrade_file_upload
     upgrade_html_tables
+    upgrade_images
     upgrade_localization
     upgrade_migrations
     upgrade_pagination

--- a/user_guide_src/source/installation/upgrade_images.rst
+++ b/user_guide_src/source/installation/upgrade_images.rst
@@ -1,0 +1,42 @@
+Upgrade Image Manipulation Class
+################################
+
+.. contents::
+    :local:
+    :depth: 2
+
+Documentations
+==============
+
+- `Image Manipulation Class Documentation CodeIgniter 3.X <https://www.codeigniter.com/userguide3/libraries/image_lib.html>`_
+- :doc:`Image Manipulation Class Documentation CodeIgniter 4.X <../libraries/images>`
+
+What has been changed
+=====================
+- The preferences passed to the constructor or ``initialize()`` method in CI3
+  have been changed to be specified in the new methods in CI4.
+- Some preferences like ``create_thumb`` are removed.
+- In CI4, the ``save()`` method must be called to save the manipulated image.
+- The ``display_errors()`` has been removed, and an exception will be thrown
+  if an error occurs.
+
+Upgrade Guide
+=============
+1. Within your class change the ``$this->load->library('image_lib');`` to
+   ``$image = \Config\Services::image();``.
+2. Change the preferences passed to the constructor or ``initialize()`` method
+   to be specified in the corresponding methods.
+3. Call the ``save()`` method to save the file.
+
+Code Example
+============
+
+CodeIgniter Version 3.x
+------------------------
+
+.. literalinclude:: upgrade_images/ci3sample/001.php
+
+CodeIgniter Version 4.x
+-----------------------
+
+.. literalinclude:: upgrade_images/001.php

--- a/user_guide_src/source/installation/upgrade_images/001.php
+++ b/user_guide_src/source/installation/upgrade_images/001.php
@@ -1,0 +1,8 @@
+<?php
+
+$image = \Config\Services::image();
+
+$image
+    ->withFile('/path/to/image/mypic.jpg')
+    ->resize(75, 50, true)
+    ->save('/path/to/image/mypic_thumb.jpg');

--- a/user_guide_src/source/installation/upgrade_images/ci3sample/001.php
+++ b/user_guide_src/source/installation/upgrade_images/ci3sample/001.php
@@ -1,0 +1,12 @@
+<?php
+
+$config['image_library']  = 'gd2';
+$config['source_image']   = '/path/to/image/mypic.jpg';
+$config['create_thumb']   = TRUE;
+$config['maintain_ratio'] = TRUE;
+$config['width']          = 75;
+$config['height']         = 50;
+
+$this->load->library('image_lib', $config);
+
+$this->image_lib->resize();


### PR DESCRIPTION
**Description**
Closes #8684

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
