### PR TITLE
fix: the error view is determined by Exception code

### DIFF
--- a/system/Debug/ExceptionHandler.php
+++ b/system/Debug/ExceptionHandler.php
@@ -97,8 +97,8 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
             . DIRECTORY_SEPARATOR . 'errors' . DIRECTORY_SEPARATOR . $addPath;
 
         // Determine the views
-        $view    = $this->determineView($exception, $path);
-        $altView = $this->determineView($exception, $altPath);
+        $view    = $this->determineView($exception, $path, $statusCode);
+        $altView = $this->determineView($exception, $altPath, $statusCode);
 
         // Check if the view exists
         $viewFile = null;
@@ -119,13 +119,16 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
     }
 
     /**
-     * Determines the view to display based on the exception thrown,
-     * whether an HTTP or CLI request, etc.
+     * Determines the view to display based on the exception thrown, HTTP status
+     * code, whether an HTTP or CLI request, etc.
      *
      * @return string The filename of the view file to use
      */
-    protected function determineView(Throwable $exception, string $templatePath): string
-    {
+    protected function determineView(
+        Throwable $exception,
+        string $templatePath,
+        int $statusCode = 500
+    ): string {
         // Production environments should have a custom exception file.
         $view = 'production.php';
 
@@ -147,8 +150,8 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
         $templatePath = rtrim($templatePath, '\\/ ') . DIRECTORY_SEPARATOR;
 
         // Allow for custom views based upon the status code
-        if (is_file($templatePath . 'error_' . $exception->getCode() . '.php')) {
-            return 'error_' . $exception->getCode() . '.php';
+        if (is_file($templatePath . 'error_' . $statusCode . '.php')) {
+            return 'error_' . $statusCode . '.php';
         }
 
         return $view;

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -69,7 +69,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
         $templatePath = APPPATH . 'Views/errors/html';
         $viewFile     = $determineView($exception, $templatePath);
 
-        $this->assertSame('error_404.php', $viewFile);
+        $this->assertSame('error_exception.php', $viewFile);
     }
 
     public function testDetermineViewsDisplayErrorsOffRuntimeException(): void

--- a/user_guide_src/source/changelogs/v4.4.8.rst
+++ b/user_guide_src/source/changelogs/v4.4.8.rst
@@ -14,6 +14,11 @@ Release Date: Unreleased
 BREAKING
 ********
 
+- A bug that caused the :doc:`Exception handler <../general/errors>` to display
+  incorrect error view file corresponding to the exception code has been fixed.
+  The third parameter ``int $statusCode = 500`` has been added to
+  ``CodeIgniter\Debug\ExceptionHandler::determineView()`` for this purpose.
+
 ***************
 Message Changes
 ***************


### PR DESCRIPTION
**Description**
It should be determined by the HTTP status code.
Otherwise, if by chance an exception with code 404 is thrown, a 404 Not Found page will be displayed.

```php
<?php

namespace App\Controllers;

use Exception;

class Home extends BaseController
{
    public function index(): string
    {
        throw new Exception('This is an exception message', 404);
    }
}
```

Before:
404 - Page Not Found
```
404
This is an exception message
```
HTTP Status: 500

After:
Exception
```
Exception #404
This is an exception message 
```
HTTP Status: 500

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
