### PR TITLE
refactor: DB config properties

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -10,14 +10,12 @@ use CodeIgniter\Database\Config;
 class Database extends Config
 {
     /**
-     * The directory that holds the Migrations
-     * and Seeds directories.
+     * The directory that holds the Migrations and Seeds directories.
      */
     public string $filesPath = APPPATH . 'Database' . DIRECTORY_SEPARATOR;
 
     /**
-     * Lets you choose which connection group to
-     * use if no other is specified.
+     * Lets you choose which connection group to use if no other is specified.
      */
     public string $defaultGroup = 'default';
 
@@ -53,8 +51,7 @@ class Database extends Config
     ];
 
     /**
-     * This database connection is used when
-     * running PHPUnit database tests.
+     * This database connection is used when running PHPUnit database tests.
      *
      * @var array<string, mixed>
      */

--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -50,6 +50,111 @@ class Database extends Config
         ],
     ];
 
+    //    /**
+    //     * Sample database connection for SQLite3.
+    //     *
+    //     * @var array<string, mixed>
+    //     */
+    //    public array $default = [
+    //        'database'    => 'database.db',
+    //        'DBDriver'    => 'SQLite3',
+    //        'DBPrefix'    => '',
+    //        'DBDebug'     => true,
+    //        'swapPre'     => '',
+    //        'failover'    => [],
+    //        'foreignKeys' => true,
+    //        'busyTimeout' => 1000,
+    //        'dateFormat'  => [
+    //            'date'     => 'Y-m-d',
+    //            'datetime' => 'Y-m-d H:i:s',
+    //            'time'     => 'H:i:s',
+    //        ],
+    //    ];
+
+    //    /**
+    //     * Sample database connection for Postgre.
+    //     *
+    //     * @var array<string, mixed>
+    //     */
+    //    public array $default = [
+    //        'DSN'        => '',
+    //        'hostname'   => 'localhost',
+    //        'username'   => 'root',
+    //        'password'   => 'root',
+    //        'database'   => 'ci4',
+    //        'schema'     => 'public',
+    //        'DBDriver'   => 'Postgre',
+    //        'DBPrefix'   => '',
+    //        'pConnect'   => false,
+    //        'DBDebug'    => true,
+    //        'charset'    => 'utf8',
+    //        'swapPre'    => '',
+    //        'failover'   => [],
+    //        'port'       => 5432,
+    //        'dateFormat' => [
+    //            'date'     => 'Y-m-d',
+    //            'datetime' => 'Y-m-d H:i:s',
+    //            'time'     => 'H:i:s',
+    //        ],
+    //    ];
+
+    //    /**
+    //     * Sample database connection for SQLSRV.
+    //     *
+    //     * @var array<string, mixed>
+    //     */
+    //    public array $default = [
+    //        'DSN'        => '',
+    //        'hostname'   => 'localhost',
+    //        'username'   => 'root',
+    //        'password'   => 'root',
+    //        'database'   => 'ci4',
+    //        'schema'     => 'dbo',
+    //        'DBDriver'   => 'SQLSRV',
+    //        'DBPrefix'   => '',
+    //        'pConnect'   => false,
+    //        'DBDebug'    => true,
+    //        'charset'    => 'utf8',
+    //        'swapPre'    => '',
+    //        'encrypt'    => false,
+    //        'failover'   => [],
+    //        'port'       => 1433,
+    //        'dateFormat' => [
+    //            'date'     => 'Y-m-d',
+    //            'datetime' => 'Y-m-d H:i:s',
+    //            'time'     => 'H:i:s',
+    //        ],
+    //    ];
+
+    //    /**
+    //     * Sample database connection for OCI8.
+    //     *
+    //     * You may need the following environment variables:
+    //     *   NLS_LANG                = 'AMERICAN_AMERICA.UTF8'
+    //     *   NLS_DATE_FORMAT         = 'YYYY-MM-DD HH24:MI:SS'
+    //     *   NLS_TIMESTAMP_FORMAT    = 'YYYY-MM-DD HH24:MI:SS'
+    //     *   NLS_TIMESTAMP_TZ_FORMAT = 'YYYY-MM-DD HH24:MI:SS'
+    //     *
+    //     * @var array<string, mixed>
+    //     */
+    //    public array $default = [
+    //        'DSN'        => 'localhost:1521/XEPDB1',
+    //        'username'   => 'root',
+    //        'password'   => 'root',
+    //        'DBDriver'   => 'OCI8',
+    //        'DBPrefix'   => '',
+    //        'pConnect'   => false,
+    //        'DBDebug'    => true,
+    //        'charset'    => 'AL32UTF8',
+    //        'swapPre'    => '',
+    //        'failover'   => [],
+    //        'dateFormat' => [
+    //            'date'     => 'Y-m-d',
+    //            'datetime' => 'Y-m-d H:i:s',
+    //            'time'     => 'H:i:s',
+    //        ],
+    //    ];
+
     /**
      * This database connection is used when running PHPUnit database tests.
      *

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -3168,7 +3168,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-	'count' => 6,
+	'count' => 4,
 	'path' => __DIR__ . '/system/Database/MySQLi/Forge.php',
 ];
 $ignoreErrors[] = [

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -181,7 +181,9 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Whether we're running in strict SQL mode.
      *
-     * @var bool
+     * @var bool|null
+     *
+     * @deprecated 4.5.0 Will move to MySQLi\Connection.
      */
     protected $strictOn;
 

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -144,7 +144,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @var string
      */
-    protected $charset = 'utf8mb4';
+    protected $charset = '';
 
     /**
      * Collation
@@ -153,7 +153,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @var string
      */
-    protected $DBCollat = 'utf8mb4_general_ci';
+    protected $DBCollat = '';
 
     /**
      * Swap Prefix

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -116,11 +116,11 @@ class Forge extends BaseForge
             }
         }
 
-        if (! empty($this->db->charset) && ! strpos($sql, 'CHARACTER SET') && ! strpos($sql, 'CHARSET')) {
+        if ($this->db->charset !== '' && ! strpos($sql, 'CHARACTER SET') && ! strpos($sql, 'CHARSET')) {
             $sql .= ' DEFAULT CHARACTER SET = ' . $this->db->escapeString($this->db->charset);
         }
 
-        if (! empty($this->db->DBCollat) && ! strpos($sql, 'COLLATE')) {
+        if ($this->db->DBCollat !== '' && ! strpos($sql, 'COLLATE')) {
             $sql .= ' COLLATE = ' . $this->db->escapeString($this->db->DBCollat);
         }
 

--- a/user_guide_src/source/changelogs/v4.5.0.rst
+++ b/user_guide_src/source/changelogs/v4.5.0.rst
@@ -502,6 +502,8 @@ Deprecations
 - **FeatureTestTrait:** The feature that the ``call()`` and ``withRoutes()``
   methods accept the lowercase HTTP methods has been deprecated. Use correct
   uppercase HTTP methods instead.
+- **Database:** The ``BaseConnection::$strictOn`` has been deprecated. It will be
+  moved to ``MySQLi\Connection`` in the future.
 
 **********
 Bugs Fixed


### PR DESCRIPTION
**Description**
- remove inappropriate default values
- add sample db config as comments
- deprecate BaseConnection::$strictOn

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
