### PR TITLE
fix: `spark db:table` causes errors w/z table name including special chars

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1907,11 +1907,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/BaseBuilder.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:__construct\\(\\) has parameter \\$tableName with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/BaseBuilder.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:_deleteBatch\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/BaseBuilder.php',

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\BaseConnection;
 use Config\Database;
 use InvalidArgumentException;
@@ -194,7 +195,7 @@ class ShowTableInfo extends BaseCommand
         CLI::newLine();
 
         $this->removeDBPrefix();
-        $thead = $this->db->getFieldNames($tableName);
+        $thead = $this->db->getFieldNames($tableName, true);
         $this->restoreDBPrefix();
 
         // If there is a field named `id`, sort by it.
@@ -253,7 +254,7 @@ class ShowTableInfo extends BaseCommand
         $this->tbody = [];
 
         $this->removeDBPrefix();
-        $builder = $this->db->table($tableName);
+        $builder = new BaseBuilder($tableName, $this->db, null, true);
         $builder->limit($limitRows);
         if ($sortField !== null) {
             $builder->orderBy($sortField, $this->sortDesc ? 'DESC' : 'ASC');

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1507,11 +1507,13 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Fetch Field Names
      *
+     * @param bool $prefixed Set true if it already has the DB prefix.
+     *
      * @return array|false
      *
      * @throws DatabaseException
      */
-    public function getFieldNames(string $table)
+    public function getFieldNames(string $table, bool $prefixed = false)
     {
         // Is there a cached result?
         if (isset($this->dataCache['field_names'][$table])) {
@@ -1522,7 +1524,7 @@ abstract class BaseConnection implements ConnectionInterface
             $this->initialize();
         }
 
-        if (false === ($sql = $this->_listColumns($table))) {
+        if (false === ($sql = $this->_listColumns($table, $prefixed))) {
             if ($this->DBDebug) {
                 throw new DatabaseException('This feature is not available for the database you are using.');
             }
@@ -1736,9 +1738,14 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
      *
+     * @param bool $prefixed Set true if it already has the DB prefix.
+     *
      * @return false|string
      */
-    abstract protected function _listColumns(string $table = '');
+    abstract protected function _listColumns(
+        string $table = '',
+        bool $prefixed = false
+    );
 
     /**
      * Platform-specific field data information.

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -404,10 +404,14 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param bool $prefixed Set true if it already has the DB prefix.
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns(string $table = '', bool $prefixed = false): string
     {
-        return 'SHOW COLUMNS FROM ' . $this->protectIdentifiers($table, true, null, false);
+        $tableName = $prefixed ? $this->escapeIdentifier($table) : $this->protectIdentifiers($table, true, null, false);
+
+        return 'SHOW COLUMNS FROM ' . $tableName;
     }
 
     /**

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -267,7 +267,7 @@ class Connection extends BaseConnection
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns(string $table = '', bool $prefixed = false): string
     {
         if (strpos($table, '.') !== false) {
             sscanf($table, '%[^.].%s', $owner, $table);

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -287,7 +287,7 @@ class Connection extends BaseConnection
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns(string $table = '', bool $prefixed = false): string
     {
         return 'SELECT "column_name"
 			FROM "information_schema"."columns"

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -222,7 +222,7 @@ class Connection extends BaseConnection
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns(string $table = '', bool $prefixed = false): string
     {
         return 'SELECT [COLUMN_NAME] '
             . ' FROM [INFORMATION_SCHEMA].[COLUMNS]'

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -203,7 +203,7 @@ class Connection extends BaseConnection
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns(string $table = '', bool $prefixed = false): string
     {
         return 'PRAGMA TABLE_INFO(' . $this->protectIdentifiers($table, true, null, false) . ')';
     }
@@ -213,7 +213,7 @@ class Connection extends BaseConnection
      *
      * @throws DatabaseException
      */
-    public function getFieldNames(string $table)
+    public function getFieldNames(string $table, bool $prefixed = false)
     {
         // Is there a cached result?
         if (isset($this->dataCache['field_names'][$table])) {

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -198,7 +198,7 @@ class MockConnection extends BaseConnection
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns(string $table = '', bool $prefixed = false): string
     {
         return '';
     }


### PR DESCRIPTION
**Description**
Fixes #6765

This PR is an attempt to fix #6765.
However, there are a lot of API changes and I feel they are not very good.
Comments are welcome.

- [x] MySQLi
- [ ] SQLite3
- [ ] Postgre
- [ ] SQLSRV
- [ ] OCI8

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
