### PR TITLE
feat: fix `spark db:table` causes errors with table name including special chars

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2537,11 +2537,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Database/BaseConnection.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$aliasedTables type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/BaseConnection.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$dataCache type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/BaseConnection.php',

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Commands\Database;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\TableName;
 use Config\Database;
 use InvalidArgumentException;
 
@@ -194,7 +195,7 @@ class ShowTableInfo extends BaseCommand
         CLI::newLine();
 
         $this->removeDBPrefix();
-        $thead = $this->db->getFieldNames($tableName);
+        $thead = $this->db->getFieldNames(TableName::fromActualName($this->db, $tableName));
         $this->restoreDBPrefix();
 
         // If there is a field named `id`, sort by it.
@@ -253,7 +254,7 @@ class ShowTableInfo extends BaseCommand
         $this->tbody = [];
 
         $this->removeDBPrefix();
-        $builder = $this->db->table($tableName);
+        $builder = $this->db->table(TableName::fromActualName($this->db, $tableName));
         $builder->limit($limitRows);
         if ($sortField !== null) {
             $builder->orderBy($sortField, $this->sortDesc ? 'DESC' : 'ASC');

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3018,10 +3018,10 @@ class BaseBuilder
             $table = preg_replace('/\s+AS\s+/i', ' ', $table);
 
             // Grab the alias
-            $table = trim(strrchr($table, ' '));
+            $alias = trim(strrchr($table, ' '));
 
             // Store the alias, if it doesn't already exist
-            $this->db->addTableAlias($table);
+            $this->db->addTableAlias($alias);
         }
     }
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -298,7 +298,7 @@ class BaseBuilder
     /**
      * Constructor
      *
-     * @param array|string $tableName tablename or tablenames with or without aliases
+     * @param array|string|TableName $tableName tablename or tablenames with or without aliases
      *
      * Examples of $tableName: `mytable`, `jobs j`, `jobs j, users u`, `['jobs j','users u']`
      *
@@ -315,14 +315,19 @@ class BaseBuilder
          */
         $this->db = $db;
 
+        if ($tableName instanceof TableName) {
+            $this->tableName = $tableName->getTableName();
+            $this->QBFrom[]  = $tableName->getEscapedTableName();
+            $this->db->addTableAlias($tableName->getAlias());
+        }
         // If it contains `,`, it has multiple tables
-        if (is_string($tableName) && strpos($tableName, ',') === false) {
+        elseif (is_string($tableName) && strpos($tableName, ',') === false) {
             $this->tableName = $tableName;  // @TODO remove alias if exists
+            $this->from($tableName);
         } else {
             $this->tableName = '';
+            $this->from($tableName);
         }
-
-        $this->from($tableName);
 
         if ($options !== null && $options !== []) {
             foreach ($options as $key => $value) {

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -337,7 +337,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Array of table aliases.
      *
-     * @var array
+     * @var list<string>
      */
     protected $aliasedTables = [];
 
@@ -561,10 +561,10 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @return $this
      */
-    public function addTableAlias(string $table)
+    public function addTableAlias(string $alias)
     {
-        if (! in_array($table, $this->aliasedTables, true)) {
-            $this->aliasedTables[] = $table;
+        if (! in_array($alias, $this->aliasedTables, true)) {
+            $this->aliasedTables[] = $alias;
         }
 
         return $this;

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1197,6 +1197,10 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function escapeIdentifier(string $item): string
     {
+        if ($item === '') {
+            return '';
+        }
+
         return $this->escapeChar
             . str_replace(
                 $this->escapeChar,

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\TableName;
 use LogicException;
 use mysqli;
 use mysqli_result;
@@ -404,10 +405,23 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
-        return 'SHOW COLUMNS FROM ' . $this->protectIdentifiers($table, true, null, false);
+        if ($table instanceof TableName) {
+            $tableName = $table->getEscapedTableName();
+        } else {
+            $tableName = $this->protectIdentifiers(
+                $table,
+                true,
+                null,
+                false
+            );
+        }
+
+        return 'SHOW COLUMNS FROM ' . $tableName;
     }
 
     /**

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\OCI8;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Query;
+use CodeIgniter\Database\TableName;
 use ErrorException;
 use stdClass;
 
@@ -266,18 +267,25 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
-        if (strpos($table, '.') !== false) {
-            sscanf($table, '%[^.].%s', $owner, $table);
+        if ($table instanceof TableName) {
+            $tableName = $this->escape(strtoupper($table->getActualTableName()));
+            $owner     = $this->username;
+        } elseif (strpos($table, '.') !== false) {
+            sscanf($table, '%[^.].%s', $owner, $tableName);
+            $tableName = $this->escape(strtoupper($this->DBPrefix . $tableName));
         } else {
-            $owner = $this->username;
+            $owner     = $this->username;
+            $tableName = $this->escape(strtoupper($this->DBPrefix . $table));
         }
 
         return 'SELECT COLUMN_NAME FROM ALL_TAB_COLUMNS
 			WHERE UPPER(OWNER) = ' . $this->escape(strtoupper($owner)) . '
-				AND UPPER(TABLE_NAME) = ' . $this->escape(strtoupper($this->DBPrefix . $table));
+				AND UPPER(TABLE_NAME) = ' . $tableName;
     }
 
     /**

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\Postgre;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\Database\TableName;
 use ErrorException;
 use PgSql\Connection as PgSqlConnection;
 use PgSql\Result as PgSqlResult;
@@ -286,13 +287,20 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
+        if ($table instanceof TableName) {
+            $tableName = $this->escape($table->getActualTableName());
+        } else {
+            $tableName = $this->escape($this->DBPrefix . strtolower($table));
+        }
+
         return 'SELECT "column_name"
 			FROM "information_schema"."columns"
-			WHERE LOWER("table_name") = '
-                . $this->escape($this->DBPrefix . strtolower($table))
+			WHERE LOWER("table_name") = ' . $tableName
                 . ' ORDER BY "ordinal_position"';
     }
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database\SQLSRV;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\TableName;
 use stdClass;
 
 /**
@@ -221,12 +222,20 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
+        if ($table instanceof TableName) {
+            $tableName = $this->escape(strtolower($table->getActualTableName()));
+        } else {
+            $tableName = $this->escape($this->DBPrefix . strtolower($table));
+        }
+
         return 'SELECT [COLUMN_NAME] '
             . ' FROM [INFORMATION_SCHEMA].[COLUMNS]'
-            . ' WHERE  [TABLE_NAME] = ' . $this->escape($this->DBPrefix . $table)
+            . ' WHERE  [TABLE_NAME] = ' . $tableName
             . ' AND [TABLE_SCHEMA] = ' . $this->escape($this->schema);
     }
 

--- a/system/Database/TableName.php
+++ b/system/Database/TableName.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+/**
+ * Represents a table name in SQL.
+ *
+ * @see \CodeIgniter\Database\TableNameTest
+ */
+class TableName
+{
+    /**
+     * @param string $dbPrefix         DB prefix
+     * @param string $table            Table name (w/o DB prefix)
+     * @param string $escapedTableName Escaped table name (w/z DB prefix)
+     * @param string $escapedAliasName Escaped alias name
+     * @param string $schema           Schema name
+     * @param string $database         Database name
+     * @param string $alias            Alias name
+     */
+    protected function __construct(
+        private string $dbPrefix,
+        private string $table,
+        private string $escapedTableName,
+        private string $escapedAliasName,
+        private string $schema = '',
+        private string $database = '',
+        private string $alias = ''
+    ) {
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param string $table Table name (w/o DB prefix)
+     * @param string $alias Alias name
+     */
+    public static function create(BaseConnection $db, string $table, string $alias = ''): self
+    {
+        $escapedTableName = $db->escapeIdentifier($db->DBPrefix . $table);
+        $escapedAliasName = $db->escapeIdentifier($alias);
+
+        return new self(
+            $db->DBPrefix,
+            $table,
+            $escapedTableName,
+            $escapedAliasName,
+            '',
+            '',
+            $alias
+        );
+    }
+
+    /**
+     * Creates a new instance from an actual table name.
+     *
+     * @param string $table Actual table name with DB prefix
+     * @param string $alias Alias name
+     */
+    public static function fromActualName(BaseConnection $db, string $table, string $alias = ''): self
+    {
+        $escapedTableName = $db->escapeIdentifier($table);
+        $escapedAliasName = $db->escapeIdentifier($alias);
+
+        return new self(
+            '',
+            $table,
+            $escapedTableName,
+            $escapedAliasName,
+            '',
+            '',
+            $alias
+        );
+    }
+
+    /**
+     * Creates a new instance from full name.
+     *
+     * @param string $table    Table name (w/o DB prefix)
+     * @param string $schema   Schema name
+     * @param string $database Database name
+     * @param string $alias    Alias name
+     */
+    public static function fromFullName(
+        BaseConnection $db,
+        string $table,
+        string $schema = '',
+        string $database = '',
+        string $alias = ''
+    ): self {
+        $escapedTableName = '';
+        if ($database !== '') {
+            $escapedTableName .= $db->escapeIdentifier($database) . '.';
+        }
+        if ($schema !== '') {
+            $escapedTableName .= $db->escapeIdentifier($schema) . '.';
+        }
+        $escapedTableName .= $db->escapeIdentifier($db->DBPrefix . $table);
+
+        $escapedAliasName = $db->escapeIdentifier($alias);
+
+        return new self(
+            $db->DBPrefix,
+            $table,
+            $escapedTableName,
+            $escapedAliasName,
+            $schema,
+            $database,
+            $alias
+        );
+    }
+
+    /**
+     * Returns the single segment table name w/o DB prefix.
+     */
+    public function getTableName(): string
+    {
+        return $this->table;
+    }
+
+    /**
+     * Returns the actual single segment table name w/z DB prefix.
+     */
+    public function getActualTableName(): string
+    {
+        return $this->dbPrefix . $this->table;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    public function getSchema(): string
+    {
+        return $this->schema;
+    }
+
+    public function getDatabase(): string
+    {
+        return $this->database;
+    }
+
+    /**
+     * Returns the escaped table name.
+     */
+    public function getEscapedTableName(): string
+    {
+        return $this->escapedTableName;
+    }
+
+    /**
+     * Returns the escaped table name with alias.
+     */
+    public function getEscapedTableNameWithAlias(): string
+    {
+        if ($this->escapedAliasName === '') {
+            return $this->escapedTableName;
+        }
+
+        return $this->escapedTableName . ' ' . $this->escapedAliasName;
+    }
+}

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -17,6 +17,7 @@ use CodeIgniter\CodeIgniter;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\Query;
+use CodeIgniter\Database\TableName;
 
 /**
  * @extends BaseConnection<object|resource, object|resource>
@@ -197,8 +198,10 @@ class MockConnection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
         return '';
     }

--- a/tests/system/Database/TableNameTest.php
+++ b/tests/system/Database/TableNameTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+
+/**
+ * @internal
+ *
+ * @group Others
+ */
+final class TableNameTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = new MockConnection([
+            'database' => 'test',
+            'DBPrefix' => 'db_',
+            'schema'   => 'dbo',
+        ]);
+    }
+
+    public function testInstantiate(): void
+    {
+        $table = 'table';
+
+        $tableName = TableName::create($this->db, $table);
+
+        $this->assertInstanceOf(TableName::class, $tableName);
+    }
+
+    public function testCreateAndTableName(): void
+    {
+        $table = 'table';
+
+        $tableName = TableName::create($this->db, $table);
+
+        $this->assertSame($table, $tableName->getTableName());
+        $this->assertSame('db_table', $tableName->getActualTableName());
+    }
+
+    public function testFromActualNameAndTableName(): void
+    {
+        $table = 'table';
+
+        $tableName = TableName::fromActualName($this->db, $table);
+
+        $this->assertSame($table, $tableName->getTableName());
+        $this->assertSame($table, $tableName->getActualTableName());
+    }
+
+    public function testGetAlias(): void
+    {
+        $table = 'table';
+        $alias = 't';
+
+        $tableName = TableName::create($this->db, $table, $alias);
+
+        $this->assertSame($alias, $tableName->getAlias());
+    }
+
+    public function testGetSchema(): void
+    {
+        $table    = 'table';
+        $schema   = 'dbo';
+        $database = 'test';
+
+        $tableName = TableName::fromFullName($this->db, $table, $schema, $database);
+
+        $this->assertSame($schema, $tableName->getSchema());
+    }
+
+    public function testGetDatabase(): void
+    {
+        $table    = 'table';
+        $schema   = 'dbo';
+        $database = 'test';
+
+        $tableName = TableName::fromFullName($this->db, $table, $schema, $database);
+
+        $this->assertSame($database, $tableName->getDatabase());
+    }
+
+    public function testGetEscapedTableName(): void
+    {
+        $table = 'table';
+
+        $tableName = TableName::create($this->db, $table);
+
+        $this->assertSame('"db_table"', $tableName->getEscapedTableName());
+    }
+
+    public function testGetEscapedTableNameFullName(): void
+    {
+        $table    = 'table';
+        $schema   = 'dbo';
+        $database = 'test';
+
+        $tableName = TableName::fromFullName($this->db, $table, $schema, $database);
+
+        $this->assertSame('"test"."dbo"."db_table"', $tableName->getEscapedTableName());
+    }
+
+    public function testGetEscapedTableNameWithAlias(): void
+    {
+        $table = 'table';
+        $alias = 't';
+
+        $tableName = TableName::create($this->db, $table, $alias);
+
+        $this->assertSame('"db_table" "t"', $tableName->getEscapedTableNameWithAlias());
+    }
+
+    public function testGetEscapedTableNameWithAliasWithoutAlias(): void
+    {
+        $table = 'table';
+
+        $tableName = TableName::create($this->db, $table);
+
+        $this->assertSame('"db_table"', $tableName->getEscapedTableNameWithAlias());
+    }
+
+    public function testGetEscapedTableNameWithAliasFullName(): void
+    {
+        $table    = 'table';
+        $schema   = 'dbo';
+        $database = 'test';
+        $alias    = 't';
+
+        $tableName = TableName::fromFullName($this->db, $table, $schema, $database, $alias);
+
+        $this->assertSame(
+            '"test"."dbo"."db_table" "t"',
+            $tableName->getEscapedTableNameWithAlias()
+        );
+    }
+}


### PR DESCRIPTION
**Description**
Alternative: #8695
Fixes #6765

- add `TableName` class
- fix `spark db:table` causes errors with table name including special chars

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
