### PR TITLE
docs: remove useless @return BaseConnection|ConnectionInterface on BaseBuilder::db()

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -332,8 +332,6 @@ class BaseBuilder
 
     /**
      * Returns the current database connection
-     *
-     * @return BaseConnection|ConnectionInterface
      */
     public function db(): ConnectionInterface
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -332,6 +332,8 @@ class BaseBuilder
 
     /**
      * Returns the current database connection
+     *
+     * @return BaseConnection
      */
     public function db(): ConnectionInterface
     {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

`BaseConnection` is implements `ConnectionInterface` so it can be removed from `@return` doc. Detected by run latest `"rector/rector": "dev-main"`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
