### PR TITLE
fix: `Pager::only([])` does not work

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -8042,17 +8042,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Pager/Pager.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in an if condition, array given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Pager/Pager.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Pager\\\\Pager\\:\\:\\$groups type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Pager/Pager.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property CodeIgniter\\\\Pager\\\\Pager\\:\\:\\$only type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Pager/Pager.php',
 ];

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -60,9 +60,9 @@ class Pager implements PagerInterface
     /**
      * List of only permitted queries
      *
-     * @var array
+     * @var list<string>|null
      */
-    protected $only = [];
+    protected $only;
 
     /**
      * Constructor.
@@ -276,7 +276,7 @@ class Pager implements PagerInterface
             $uri->addQuery($this->groups[$group]['pageSelector'], $page);
         }
 
-        if ($this->only) {
+        if ($this->only !== null) {
             $query = array_intersect_key($_GET, array_flip($this->only));
 
             if (! $segment) {

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -165,6 +165,10 @@ final class PagerTest extends CIUnitTestCase
             'http://example.com/?foo=bar&page=5',
             $this->pager->only(['foo'])->getPageURI(5)
         );
+        $this->assertSame(
+            'http://example.com/?page=5',
+            $this->pager->only([])->getPageURI(5)
+        );
     }
 
     public function testStoreWithSegments(): void
@@ -180,6 +184,10 @@ final class PagerTest extends CIUnitTestCase
         $this->assertSame(
             'http://example.com/5?foo=bar',
             $this->pager->only(['foo'])->getPageURI(5)
+        );
+        $this->assertSame(
+            'http://example.com/5',
+            $this->pager->only([])->getPageURI(5)
         );
     }
 


### PR DESCRIPTION
**Description**
Closes #8698
See https://github.com/codeigniter4/CodeIgniter4/issues/8698#issuecomment-2033999881

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
