### PR TITLE
docs: add escaping to variables in sample code

### DIFF
--- a/user_guide_src/source/outgoing/alternative_php.rst
+++ b/user_guide_src/source/outgoing/alternative_php.rst
@@ -15,11 +15,11 @@ Alternative Echos
 
 Normally to echo, or print out a variable you would do this::
 
-    <?php echo $variable; ?>
+    <?php echo esc($variable); ?>
 
 With the alternative syntax you can instead do it this way::
 
-    <?= $variable ?>
+    <?= esc($variable) ?>
 
 Alternative Control Structures
 ==============================

--- a/user_guide_src/source/outgoing/alternative_php/001.php
+++ b/user_guide_src/source/outgoing/alternative_php/001.php
@@ -2,7 +2,7 @@
 
 <?php foreach ($todo as $item): ?>
 
-    <li><?= $item ?></li>
+    <li><?= esc($item) ?></li>
 
 <?php endforeach ?>
 


### PR DESCRIPTION
**Description**
It is bad practice to output variables without escaping in HTML.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
