### PR TITLE
docs: add new 4.5 features to "Security Guidelines"

### DIFF
--- a/user_guide_src/source/concepts/security.rst
+++ b/user_guide_src/source/concepts/security.rst
@@ -78,7 +78,9 @@ CodeIgniter provisions
 - :doc:`../libraries/validation` library
 - :doc:`Security </libraries/security>` library provides for
   :ref:`CSRF protection <cross-site-request-forgery>`
+- :doc:`../libraries/sessions` library
 - :doc:`../libraries/throttler` for rate limit
+- :doc:`../libraries/cors` filter
 - :php:func:`log_message()` function for logging
 - An official authentication and authorization framework :ref:`CodeIgniter Shield <shield>`
 - Easy to add third party authentication
@@ -325,6 +327,8 @@ Secure installation processes should be implemented, including:
 CodeIgniter provisions
 ======================
 
+- :ref:`spark config:check <confirming-config-values>` command
+- :ref:`spark phpini:check <spark-phpini-check>` command
 - :ref:`Production mode <environment-constant>` by default
 - :ref:`secureheaders` filter
 


### PR DESCRIPTION
**Description**
Follow-up #8652

- update "Security Guidelines" for 4.5

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
