### PR TITLE
feat: `spark config:check` detects Config Caching

### DIFF
--- a/system/Commands/Utilities/ConfigCheck.php
+++ b/system/Commands/Utilities/ConfigCheck.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities;
 
+use CodeIgniter\Cache\FactoriesCache;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Config\BaseConfig;
+use Config\Optimize;
 use Kint\Kint;
 
 /**
@@ -87,6 +89,14 @@ final class ConfigCheck extends BaseCommand
         /** @var class-string<BaseConfig> $class */
         $class = $params[0];
 
+        // Load Config cache if it is enabled.
+        $configCacheEnabled = class_exists(Optimize::class)
+            && (new Optimize())->configCacheEnabled;
+        if ($configCacheEnabled) {
+            $factoriesCache = new FactoriesCache();
+            $factoriesCache->load('config');
+        }
+
         $config = config($class);
 
         if ($config === null) {
@@ -102,6 +112,10 @@ final class ConfigCheck extends BaseCommand
                 CLI::color($this->getVarDump($config), 'cyan')
             );
         }
+
+        CLI::newLine();
+        $state = CLI::color($configCacheEnabled ? 'Enabled' : 'Disabled', 'green');
+        CLI::write('Config Caching: ' . $state);
 
         return EXIT_SUCCESS;
     }

--- a/user_guide_src/source/general/configuration.rst
+++ b/user_guide_src/source/general/configuration.rst
@@ -378,10 +378,11 @@ Confirming Config Values
 ************************
 
 The actual Config object property values are changed at runtime by the :ref:`registrars`
-and :ref:`Environment Variables <configuration-classes-and-environment-variables>`.
+and :ref:`Environment Variables <configuration-classes-and-environment-variables>`,
+and :ref:`factories-config-caching`.
 
 CodeIgniter has the following :doc:`command <../cli/spark_commands>` to check
-Config values.
+the actual Config values.
 
 .. _spark-config-check:
 
@@ -417,3 +418,9 @@ The output is like the following:
         public 'CSPEnabled' -> boolean false
     )
 
+    Config Caching: Disabled
+
+You can see if Config Caching is eabled or not.
+
+.. note:: If Config Caching is enabled, the cached values are used permanently.
+    See :ref:`factories-config-caching` for details.


### PR DESCRIPTION
**Description**
- `spark config:check` detects Config Caching.
- it shows Config Caching state at the bottom.

```console
$ php spark config:check Security

CodeIgniter v4.4.7 Command Line Tool - Server Time: 2024-04-05 00:14:18 UTC+00:00

Config\Security#32 (9) (
    public 'csrfProtection' -> string (6) "cookie"
    public 'tokenRandomize' -> boolean false
    public 'tokenName' -> string (14) "csrf_test_name"
    public 'headerName' -> string (12) "X-CSRF-TOKEN"
    public 'cookieName' -> string (16) "csrf_cookie_name"
    public 'expires' -> integer 7200
    public 'regenerate' -> boolean true
    public 'redirect' -> boolean false
    public 'samesite' -> string (3) "Lax"
)

Config Caching: Disabled
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
