### PR TITLE
docs: fix @param types in UploadedFile

### DIFF
--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -15,8 +15,6 @@ use CodeIgniter\Files\File;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\Mimes;
 use Exception;
-use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Value object representing a single file uploaded through an
@@ -80,12 +78,12 @@ class UploadedFile extends File implements UploadedFileInterface
     /**
      * Accepts the file information as would be filled in from the $_FILES array.
      *
-     * @param string $path         The temporary location of the uploaded file.
-     * @param string $originalName The client-provided filename.
-     * @param string $mimeType     The type of file as provided by PHP
-     * @param int    $size         The size of the file, in bytes
-     * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
-     * @param string $clientPath   The webkit relative path of the uploaded file.
+     * @param string      $path         The temporary location of the uploaded file.
+     * @param string      $originalName The client-provided filename.
+     * @param string|null $mimeType     The type of file as provided by PHP
+     * @param int|null    $size         The size of the file, in bytes
+     * @param int|null    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param string|null $clientPath   The webkit relative path of the uploaded file.
      */
     public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null)
     {
@@ -122,16 +120,12 @@ class UploadedFile extends File implements UploadedFileInterface
      * @see http://php.net/is_uploaded_file
      * @see http://php.net/move_uploaded_file
      *
-     * @param string $targetPath Path to which to move the uploaded file.
-     * @param string $name       the name to rename the file to.
-     * @param bool   $overwrite  State for indicating whether to overwrite the previously generated file with the same
-     *                           name or not.
+     * @param string      $targetPath Path to which to move the uploaded file.
+     * @param string|null $name       the name to rename the file to.
+     * @param bool        $overwrite  State for indicating whether to overwrite the previously generated file with the same
+     *                                name or not.
      *
      * @return bool
-     *
-     * @throws InvalidArgumentException if the $path specified is invalid.
-     * @throws RuntimeException         on any error during the move operation.
-     * @throws RuntimeException         on the second or subsequent call to the method.
      */
     public function move(string $targetPath, ?string $name = null, bool $overwrite = false)
     {
@@ -345,8 +339,8 @@ class UploadedFile extends File implements UploadedFileInterface
      * By default, upload files are saved in writable/uploads directory. The YYYYMMDD folder
      * and random file name will be created.
      *
-     * @param string $folderName the folder name to writable/uploads directory.
-     * @param string $fileName   the name to rename the file to.
+     * @param string|null $folderName the folder name to writable/uploads directory.
+     * @param string|null $fileName   the name to rename the file to.
      *
      * @return string file full path
      */

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -26,12 +26,12 @@ interface UploadedFileInterface
     /**
      * Accepts the file information as would be filled in from the $_FILES array.
      *
-     * @param string $path         The temporary location of the uploaded file.
-     * @param string $originalName The client-provided filename.
-     * @param string $mimeType     The type of file as provided by PHP
-     * @param int    $size         The size of the file, in bytes
-     * @param int    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
-     * @param string $clientPath   The webkit relative path of the uploaded file.
+     * @param string      $path         The temporary location of the uploaded file.
+     * @param string      $originalName The client-provided filename.
+     * @param string|null $mimeType     The type of file as provided by PHP
+     * @param int|null    $size         The size of the file, in bytes
+     * @param int|null    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param string|null $clientPath   The webkit relative path of the uploaded file.
      */
     public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null);
 
@@ -57,13 +57,12 @@ interface UploadedFileInterface
      * @see http://php.net/is_uploaded_file
      * @see http://php.net/move_uploaded_file
      *
-     * @param string $targetPath Path to which to move the uploaded file.
-     * @param string $name       the name to rename the file to.
+     * @param string      $targetPath Path to which to move the uploaded file.
+     * @param string|null $name       the name to rename the file to.
      *
      * @return bool
      *
      * @throws InvalidArgumentException if the $path specified is invalid.
-     * @throws RuntimeException         on any error during the move operation.
      * @throws RuntimeException         on the second or subsequent call to the method.
      */
     public function move(string $targetPath, ?string $name = null);


### PR DESCRIPTION
**Description**
- fix `@param` types

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
