### PR TITLE
docs: make CI3 notation consistent

### DIFF
--- a/user_guide_src/source/incoming/controllers.rst
+++ b/user_guide_src/source/incoming/controllers.rst
@@ -185,7 +185,7 @@ Auto Routing (Improved)
 Since v4.2.0, the new more secure Auto Routing has been introduced.
 
 .. note:: If you are familiar with Auto Routing, which was enabled by default
-    from CodeIgniter 3 through 4.1.x, you can see the differences in
+    from CodeIgniter 3.x through 4.1.x, you can see the differences in
     :ref:`ChangeLog v4.2.0 <v420-new-improved-auto-routing>`.
 
 This section describes the functionality of the new auto-routing.

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -705,7 +705,7 @@ Auto Routing (Improved)
 Since v4.2.0, the new more secure Auto Routing has been introduced.
 
 .. note:: If you are familiar with Auto Routing, which was enabled by default
-    from CodeIgniter 3 through 4.1.x, you can see the differences in
+    from CodeIgniter 3.x through 4.1.x, you can see the differences in
     :ref:`ChangeLog v4.2.0 <v420-new-improved-auto-routing>`.
 
 When no defined route is found that matches the URI, the system will attempt to match that URI against the controllers and methods when Auto Routing is enabled.

--- a/user_guide_src/source/installation/index.rst
+++ b/user_guide_src/source/installation/index.rst
@@ -7,7 +7,7 @@ or using `Composer <https://getcomposer.org>`_.
 Which is right for you?
 
 - We recommend the Composer installation because it keeps CodeIgniter up to date easily.
-- If you would like the simple "download & go" install that CodeIgniter3
+- If you would like the simple "download & go" install that CodeIgniter 3
   is known for, choose the manual installation.
 
 However you choose to install and run CodeIgniter4, the latest

--- a/user_guide_src/source/installation/upgrade_4xx.rst
+++ b/user_guide_src/source/installation/upgrade_4xx.rst
@@ -149,8 +149,8 @@ Helpers
 - `String Helper <https://www.codeigniter.com/userguide3/helpers/string_helper.html>`_ functions
   in CI3 are included in :doc:`../helpers/text_helper` in CI4.
 - In CI4, ``redirect()`` is completely changed from CI3's.
-    - `redirect() Documentation CodeIgniter 3.X <https://codeigniter.com/userguide3/helpers/url_helper.html#redirect>`_
-    - `redirect() Documentation CodeIgniter 4.X <../general/common_functions.html#redirect>`_
+    - `redirect() Documentation CodeIgniter 3.x <https://codeigniter.com/userguide3/helpers/url_helper.html#redirect>`_
+    - `redirect() Documentation CodeIgniter 4.x <../general/common_functions.html#redirect>`_
     - In CI4, :php:func:`redirect()` returns a ``RedirectResponse`` instance instead of
       redirecting and terminating script execution. You must return it from Controllers
       or Controller Filters.

--- a/user_guide_src/source/installation/upgrade_configuration.rst
+++ b/user_guide_src/source/installation/upgrade_configuration.rst
@@ -8,8 +8,8 @@ Upgrade Configuration
 Documentations
 ==============
 
-- `Config Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/config.html>`_
-- :doc:`Configuration Documentation CodeIgniter 4.X </general/configuration>`
+- `Config Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/config.html>`_
+- :doc:`Configuration Documentation CodeIgniter 4.x </general/configuration>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_controllers.rst
+++ b/user_guide_src/source/installation/upgrade_controllers.rst
@@ -8,8 +8,8 @@ Upgrade Controllers
 Documentations
 ==============
 
-- `Controller Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/general/controllers.html>`_
-- :doc:`Controller Documentation CodeIgniter 4.X </incoming/controllers>`
+- `Controller Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/general/controllers.html>`_
+- :doc:`Controller Documentation CodeIgniter 4.x </incoming/controllers>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_database.rst
+++ b/user_guide_src/source/installation/upgrade_database.rst
@@ -8,8 +8,8 @@ Upgrade Database
 Documentations
 ==============
 
-- `Database Reference Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/database/index.html>`_
-- :doc:`Working with Databases Documentation CodeIgniter 4.X </database/index>`
+- `Database Reference Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/database/index.html>`_
+- :doc:`Working with Databases Documentation CodeIgniter 4.x </database/index>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_emails.rst
+++ b/user_guide_src/source/installation/upgrade_emails.rst
@@ -8,8 +8,8 @@ Upgrade Emails
 Documentations
 ==============
 
-- `Email Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/email.html>`_
-- :doc:`Email Documentation CodeIgniter 4.X </libraries/email>`
+- `Email Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/email.html>`_
+- :doc:`Email Documentation CodeIgniter 4.x </libraries/email>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_encryption.rst
+++ b/user_guide_src/source/installation/upgrade_encryption.rst
@@ -8,8 +8,8 @@ Upgrade Encryption
 Documentations
 **************
 
-- `Encryption Library Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/encryption.html>`_
-- :doc:`Encryption Service Documentation CodeIgniter 4.X </libraries/encryption>`
+- `Encryption Library Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/encryption.html>`_
+- :doc:`Encryption Service Documentation CodeIgniter 4.x </libraries/encryption>`
 
 What has been changed
 *********************

--- a/user_guide_src/source/installation/upgrade_file_upload.rst
+++ b/user_guide_src/source/installation/upgrade_file_upload.rst
@@ -7,8 +7,8 @@ Upgrade Working with Uploaded Files
 
 Documentations
 ==============
-- `File Uploading Class Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/file_uploading.html>`_
-- :doc:`Working with Uploaded Files Documentation CodeIgniter 4.X </libraries/uploaded_files>`
+- `File Uploading Class Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/file_uploading.html>`_
+- :doc:`Working with Uploaded Files Documentation CodeIgniter 4.x </libraries/uploaded_files>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_html_tables.rst
+++ b/user_guide_src/source/installation/upgrade_html_tables.rst
@@ -8,8 +8,8 @@ Upgrade HTML Tables
 Documentations
 ==============
 
-- `HTML Table Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/table.html>`_
-- :doc:`HTML Table Documentation CodeIgniter 4.X </outgoing/table>`
+- `HTML Table Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/table.html>`_
+- :doc:`HTML Table Documentation CodeIgniter 4.x </outgoing/table>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_images.rst
+++ b/user_guide_src/source/installation/upgrade_images.rst
@@ -8,8 +8,8 @@ Upgrade Image Manipulation Class
 Documentations
 ==============
 
-- `Image Manipulation Class Documentation CodeIgniter 3.X <https://www.codeigniter.com/userguide3/libraries/image_lib.html>`_
-- :doc:`Image Manipulation Class Documentation CodeIgniter 4.X <../libraries/images>`
+- `Image Manipulation Class Documentation CodeIgniter 3.x <https://www.codeigniter.com/userguide3/libraries/image_lib.html>`_
+- :doc:`Image Manipulation Class Documentation CodeIgniter 4.x <../libraries/images>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_localization.rst
+++ b/user_guide_src/source/installation/upgrade_localization.rst
@@ -8,8 +8,8 @@ Upgrade Localization
 Documentations
 ==============
 
-- `Language Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/language.html>`_
-- :doc:`Localization Documentation CodeIgniter 4.X </outgoing/localization>`
+- `Language Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/language.html>`_
+- :doc:`Localization Documentation CodeIgniter 4.x </outgoing/localization>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_migrations.rst
+++ b/user_guide_src/source/installation/upgrade_migrations.rst
@@ -8,8 +8,8 @@ Upgrade Migrations
 Documentations
 ==============
 
-- `Database Migrations Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/migration.html>`_
-- :doc:`Database Migrations Documentation CodeIgniter 4.X </dbmgmt/migration>`
+- `Database Migrations Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/migration.html>`_
+- :doc:`Database Migrations Documentation CodeIgniter 4.x </dbmgmt/migration>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_models.rst
+++ b/user_guide_src/source/installation/upgrade_models.rst
@@ -8,8 +8,8 @@ Upgrade Models
 Documentations
 ==============
 
-- `Model Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/general/models.html>`_
-- :doc:`Model Documentation CodeIgniter 4.X </models/model>`
+- `Model Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/general/models.html>`_
+- :doc:`Model Documentation CodeIgniter 4.x </models/model>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_pagination.rst
+++ b/user_guide_src/source/installation/upgrade_pagination.rst
@@ -8,8 +8,8 @@ Upgrade Pagination
 Documentations
 ==============
 
-- `Pagination Class Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/pagination.html>`_
-- :doc:`Pagination Documentation CodeIgniter 4.X </libraries/pagination>`
+- `Pagination Class Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/pagination.html>`_
+- :doc:`Pagination Documentation CodeIgniter 4.x </libraries/pagination>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_responses.rst
+++ b/user_guide_src/source/installation/upgrade_responses.rst
@@ -7,8 +7,8 @@ Upgrade HTTP Responses
 
 Documentations
 ==============
-- `Output Class Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/output.html>`_
-- :doc:`HTTP Responses Documentation CodeIgniter 4.X </outgoing/response>`
+- `Output Class Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/output.html>`_
+- :doc:`HTTP Responses Documentation CodeIgniter 4.x </outgoing/response>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_routing.rst
+++ b/user_guide_src/source/installation/upgrade_routing.rst
@@ -8,8 +8,8 @@ Upgrade Routing
 Documentations
 ==============
 
-- `URI Routing Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/general/routing.html>`_
-- :doc:`URI Routing Documentation CodeIgniter 4.X </incoming/routing>`
+- `URI Routing Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/general/routing.html>`_
+- :doc:`URI Routing Documentation CodeIgniter 4.x </incoming/routing>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_security.rst
+++ b/user_guide_src/source/installation/upgrade_security.rst
@@ -8,8 +8,8 @@ Upgrade Security
 Documentations
 ==============
 
-- `Security Class Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/security.html>`_
-- :doc:`Security Documentation CodeIgniter 4.X </libraries/security>`
+- `Security Class Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/security.html>`_
+- :doc:`Security Documentation CodeIgniter 4.x </libraries/security>`
 
 .. note::
     If you use the :doc:`../helpers/form_helper` and enable the CSRF filter globally, then :php:func:`form_open()` will automatically insert a hidden CSRF field in your forms. So you do not have to upgrade this by yourself.

--- a/user_guide_src/source/installation/upgrade_sessions.rst
+++ b/user_guide_src/source/installation/upgrade_sessions.rst
@@ -8,8 +8,8 @@ Upgrade Sessions
 Documentations
 ==============
 
-- `Session Library Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/sessions.html>`_
-- :doc:`Session Library Documentation CodeIgniter 4.X </libraries/sessions>`
+- `Session Library Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/sessions.html>`_
+- :doc:`Session Library Documentation CodeIgniter 4.x </libraries/sessions>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_validations.rst
+++ b/user_guide_src/source/installation/upgrade_validations.rst
@@ -8,8 +8,8 @@ Upgrade Validations
 Documentations of Library
 =========================
 
-- `Form Validation Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/form_validation.html>`_
-- :doc:`Validation Documentation CodeIgniter 4.X </libraries/validation>`
+- `Form Validation Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/form_validation.html>`_
+- :doc:`Validation Documentation CodeIgniter 4.x </libraries/validation>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_view_parser.rst
+++ b/user_guide_src/source/installation/upgrade_view_parser.rst
@@ -8,8 +8,8 @@ Upgrade View Parser
 Documentations
 ==============
 
-- `Template Parser Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/libraries/parser.html>`_
-- :doc:`View Parser Documentation CodeIgniter 4.X </outgoing/view_parser>`
+- `Template Parser Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/libraries/parser.html>`_
+- :doc:`View Parser Documentation CodeIgniter 4.x </outgoing/view_parser>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/installation/upgrade_views.rst
+++ b/user_guide_src/source/installation/upgrade_views.rst
@@ -8,8 +8,8 @@ Upgrade Views
 Documentations
 ==============
 
-- `View Documentation CodeIgniter 3.X <http://codeigniter.com/userguide3/general/views.html>`_
-- :doc:`View Documentation CodeIgniter 4.X </outgoing/views>`
+- `View Documentation CodeIgniter 3.x <http://codeigniter.com/userguide3/general/views.html>`_
+- :doc:`View Documentation CodeIgniter 4.x </outgoing/views>`
 
 What has been changed
 =====================

--- a/user_guide_src/source/libraries/uploaded_files.rst
+++ b/user_guide_src/source/libraries/uploaded_files.rst
@@ -5,8 +5,8 @@ Working with Uploaded Files
 CodeIgniter makes working with files uploaded through a form much simpler and more secure than using PHP's ``$_FILES``
 array directly. This extends the :doc:`File class </libraries/files>` and thus gains all of the features of that class.
 
-.. note:: This is not the same as the File Uploading class in CodeIgniter v3.x. This provides a raw
-    interface to the uploaded files with a few small features.
+.. note:: This is not the same as the File Uploading class in CodeIgniter 3.
+    This provides a raw interface to the uploaded files with a few small features.
 
 .. contents::
     :local:
@@ -309,7 +309,7 @@ getClientPath()
 
 .. versionadded:: 4.4.0
 
-Returns the `webkit relative path <https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath>`_ of the uploaded file when the client has uploaded files via directory upload.  
+Returns the `webkit relative path <https://developer.mozilla.org/en-US/docs/Web/API/File/webkitRelativePath>`_ of the uploaded file when the client has uploaded files via directory upload.
 In PHP versions below 8.1, this returns ``null``
 
 .. literalinclude:: uploaded_files/023.php


### PR DESCRIPTION
**Description**
It seems we often use `3.x` instead of `3.X`.
See https://codeigniter.com/user_guide/installation/upgrade_4xx.html

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
