### PR TITLE
docs: change comment position in Tutorial code

### DIFF
--- a/user_guide_src/source/tutorial/static_pages/002.php
+++ b/user_guide_src/source/tutorial/static_pages/002.php
@@ -2,7 +2,8 @@
 
 namespace App\Controllers;
 
-use CodeIgniter\Exceptions\PageNotFoundException; // Add this line
+// Add this line to import the class.
+use CodeIgniter\Exceptions\PageNotFoundException;
 
 class Pages extends BaseController
 {


### PR DESCRIPTION
**Description**
Because new php-cs-fixer moves the comment line.

```diff
      ---------- begin diff ----------
--- /home/runner/work/CodeIgniter4/CodeIgniter4/user_guide_src/source/tutorial/static_pages/002.php
+++ /home/runner/work/CodeIgniter4/CodeIgniter4/user_guide_src/source/tutorial/static_pages/002.php
@@ -2,7 +2,9 @@
 
 namespace App\Controllers;
 
-use CodeIgniter\Exceptions\PageNotFoundException; // Add this line
+use CodeIgniter\Exceptions\PageNotFoundException;
+
+ // Add this line
 
 class Pages extends BaseController
 {

      ----------- end diff -----------
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/8608835712/job/23591835999?pr=8731

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
