### PR TITLE
fix: `BaseConnection::_escapeString()` should accept Stringable

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -17,6 +17,7 @@ use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Events\Events;
 use stdClass;
+use Stringable;
 use Throwable;
 
 /**
@@ -1328,8 +1329,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Escape String
      *
-     * @param list<string>|string $str  Input string
-     * @param bool                $like Whether or not the string will be used in a LIKE condition
+     * @param list<string|Stringable>|string|Stringable $str  Input string
+     * @param bool                                      $like Whether the string will be used in a LIKE condition
      *
      * @return list<string>|string
      */
@@ -1371,7 +1372,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Calls the individual driver for platform
      * specific escaping for LIKE conditions
      *
-     * @param list<string>|string $str
+     * @param list<string|Stringable>|string|Stringable $str
      *
      * @return list<string>|string
      */
@@ -1385,7 +1386,7 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * Will likely be overridden in child classes.
      */
-    protected function _escapeString(string $str): string
+    protected function _escapeString(string|Stringable $str): string
     {
         return str_replace("'", "''", remove_invisible_characters($str, false));
     }

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -20,6 +20,7 @@ use mysqli;
 use mysqli_result;
 use mysqli_sql_exception;
 use stdClass;
+use Stringable;
 use Throwable;
 
 /**
@@ -342,7 +343,7 @@ class Connection extends BaseConnection
     /**
      * Platform-dependant string escape
      */
-    protected function _escapeString(string $str): string
+    protected function _escapeString(string|Stringable $str): string
     {
         if (! $this->connID) {
             $this->initialize();

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -20,6 +20,7 @@ use ErrorException;
 use PgSql\Connection as PgSqlConnection;
 use PgSql\Result as PgSqlResult;
 use stdClass;
+use Stringable;
 
 /**
  * Connection for Postgre
@@ -253,7 +254,7 @@ class Connection extends BaseConnection
     /**
      * Platform-dependant string escape
      */
-    protected function _escapeString(string $str): string
+    protected function _escapeString(string|Stringable $str): string
     {
         if (! $this->connID) {
             $this->initialize();

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\SQLSRV;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use stdClass;
+use Stringable;
 
 /**
  * Connection for SQLSRV
@@ -182,7 +183,7 @@ class Connection extends BaseConnection
     /**
      * Platform-dependant string escape
      */
-    protected function _escapeString(string $str): string
+    protected function _escapeString(string|Stringable $str): string
     {
         return str_replace("'", "''", remove_invisible_characters($str, false));
     }

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -19,6 +19,7 @@ use Exception;
 use SQLite3;
 use SQLite3Result;
 use stdClass;
+use Stringable;
 
 /**
  * Connection for SQLite3
@@ -171,7 +172,7 @@ class Connection extends BaseConnection
     /**
      * Platform-dependant string escape
      */
-    protected function _escapeString(string $str): string
+    protected function _escapeString(string|Stringable $str): string
     {
         if (! $this->connID instanceof SQLite3) {
             $this->initialize();

--- a/user_guide_src/source/changelogs/v4.5.1.rst
+++ b/user_guide_src/source/changelogs/v4.5.1.rst
@@ -14,6 +14,10 @@ Release Date: Unreleased
 BREAKING
 ********
 
+- **QueryBuilder:** Fixed a bug where ``BaseBuilder::_escapeString()`` did not
+  accept ``Stringable``. Therefore, the parameter type of that method has been
+  changed from ``string`` to ``string|Stringable``.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/installation/upgrade_451.rst
+++ b/user_guide_src/source/installation/upgrade_451.rst
@@ -20,6 +20,10 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+- **QueryBuilder:** Due to a bug fix, the parameter type of ``BaseBuilder::_escapeString()``
+  has been changed from ``string`` to ``string|Stringable``. If you are extending
+  this method, update the method paramtere type.
+
 *********************
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/installation/upgrade_451.rst
+++ b/user_guide_src/source/installation/upgrade_451.rst
@@ -22,7 +22,7 @@ Breaking Changes
 
 - **QueryBuilder:** Due to a bug fix, the parameter type of ``BaseBuilder::_escapeString()``
   has been changed from ``string`` to ``string|Stringable``. If you are extending
-  this method, update the method paramtere type.
+  this method, update the method parameter type.
 
 *********************
 Breaking Enhancements


### PR DESCRIPTION
**Description**
It was accepted in 4.4 because of no strict types.
In 4.5, Stringable should be also accepted.

See also https://github.com/codeigniter4/shield/issues/1092

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
