### PR TITLE
fix: update `debugbar:clear` code because of file changes

### DIFF
--- a/system/Commands/Housekeeping/ClearDebugbar.php
+++ b/system/Commands/Housekeeping/ClearDebugbar.php
@@ -57,7 +57,7 @@ class ClearDebugbar extends BaseCommand
     {
         helper('filesystem');
 
-        if (! delete_files(WRITEPATH . 'debugbar')) {
+        if (! delete_files(WRITEPATH . 'debugbar', false, true)) {
             // @codeCoverageIgnoreStart
             CLI::error('Error deleting the debugbar JSON files.');
             CLI::newLine();

--- a/tests/system/Commands/ClearDebugbarTest.php
+++ b/tests/system/Commands/ClearDebugbarTest.php
@@ -61,7 +61,7 @@ final class ClearDebugbarTest extends CIUnitTestCase
         $result = $this->getStreamFilterBuffer();
 
         $this->assertFileDoesNotExist(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . "debugbar_{$this->time}.json");
-        $this->assertFileExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . '.gitkeep');
+        $this->assertFileExists(WRITEPATH . 'debugbar' . DIRECTORY_SEPARATOR . 'index.html');
         $this->assertStringContainsString('Debugbar cleared.', $result);
     }
 }

--- a/writable/index.html
+++ b/writable/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>


### PR DESCRIPTION
**Description**
Follow-up #8734

- update ClearDebugbar.php
- update test code
- add writable/index.html

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
