### PR TITLE
test: add tests for form_helper with CSRF filter

### DIFF
--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -80,11 +80,11 @@ final class FormHelperTest extends CIUnitTestCase
         $this->setRequest();
         $this->setCsrfFilter();
 
-        $Value    = csrf_hash();
-        $Name     = csrf_token();
+        $value    = csrf_hash();
+        $name     = csrf_token();
         $expected = <<<EOH
             <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
-            <input type="hidden" name="{$Name}" value="{$Value}">
+            <input type="hidden" name="{$name}" value="{$value}">
             EOH;
 
         $attributes = [
@@ -133,11 +133,11 @@ final class FormHelperTest extends CIUnitTestCase
         $this->setRequest();
         $this->setCsrfFilter();
 
-        $Value    = csrf_hash();
-        $Name     = csrf_token();
+        $value    = csrf_hash();
+        $name     = csrf_token();
         $expected = <<<EOH
             <form action="http://example.com/index.php" name="form" id="form" method="POST" accept-charset="utf-8">
-            <input type="hidden" name="{$Name}" value="{$Value}">
+            <input type="hidden" name="{$name}" value="{$value}">
             EOH;
         $attributes = [
             'name'   => 'form',
@@ -168,11 +168,11 @@ final class FormHelperTest extends CIUnitTestCase
         $this->setRequest();
         $this->setCsrfFilter();
 
-        $Value    = csrf_hash();
-        $Name     = csrf_token();
+        $value    = csrf_hash();
+        $name     = csrf_token();
         $expected = <<<EOH
             <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="post" accept-charset="utf-8">
-            <input type="hidden" name="{$Name}" value="{$Value}">
+            <input type="hidden" name="{$name}" value="{$value}">
             EOH;
         $attributes = [
             'name' => 'form',
@@ -207,11 +207,11 @@ final class FormHelperTest extends CIUnitTestCase
         $this->setRequest();
         $this->setCsrfFilter();
 
-        $Value    = csrf_hash();
-        $Name     = csrf_token();
+        $value    = csrf_hash();
+        $name     = csrf_token();
         $expected = <<<EOH
             <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" accept-charset="utf-8">
-            <input type="hidden" name="{$Name}" value="{$Value}">
+            <input type="hidden" name="{$name}" value="{$value}">
             <input type="hidden" name="foo" value="bar">
 
             EOH;
@@ -251,11 +251,11 @@ final class FormHelperTest extends CIUnitTestCase
         $this->setRequest();
         $this->setCsrfFilter();
 
-        $Value    = csrf_hash();
-        $Name     = csrf_token();
+        $value    = csrf_hash();
+        $name     = csrf_token();
         $expected = <<<EOH
             <form action="http://example.com/index.php/foo/bar" name="form" id="form" method="POST" enctype="multipart/form-data" accept-charset="utf-8">
-            <input type="hidden" name="{$Name}" value="{$Value}">
+            <input type="hidden" name="{$name}" value="{$value}">
             EOH;
         $attributes = [
             'name'   => 'form',

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -75,7 +75,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_open('foo/bar', $attributes));
     }
 
-    public function testFormOpenBasicWithCSRF(): void
+    public function testFormOpenBasicWithCsrf(): void
     {
         $this->setRequest();
         $this->setCsrfFilter();
@@ -128,7 +128,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_open('', $attributes));
     }
 
-    public function testFormOpenWithoutActionWithCSRF(): void
+    public function testFormOpenWithoutActionWithCsrf(): void
     {
         $this->setRequest();
         $this->setCsrfFilter();
@@ -163,7 +163,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_open('foo/bar', $attributes));
     }
 
-    public function testFormOpenWithoutMethodWithCSRF(): void
+    public function testFormOpenWithoutMethodWithCsrf(): void
     {
         $this->setRequest();
         $this->setCsrfFilter();
@@ -202,7 +202,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_open('foo/bar', $attributes, $hidden));
     }
 
-    public function testFormOpenWithHiddenWithCSRF(): void
+    public function testFormOpenWithHiddenWithCsrf(): void
     {
         $this->setRequest();
         $this->setCsrfFilter();
@@ -246,7 +246,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_open_multipart('foo/bar', $attributesString));
     }
 
-    public function testFormOpenMultipartWithCSRF(): void
+    public function testFormOpenMultipartWithCsrf(): void
     {
         $this->setRequest();
         $this->setCsrfFilter();
@@ -320,7 +320,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_input($data));
     }
 
-    public function testFormInputXHTML(): void
+    public function testFormInputXhtml(): void
     {
         $this->disableHtml5();
 
@@ -385,7 +385,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_upload('attachment'));
     }
 
-    public function testFormUploadXHTML(): void
+    public function testFormUploadXhtml(): void
     {
         $this->disableHtml5();
 
@@ -721,7 +721,7 @@ final class FormHelperTest extends CIUnitTestCase
         $this->assertSame($expected, form_checkbox('newsletter', 'accept', true));
     }
 
-    public function testFormCheckboxXHTML(): void
+    public function testFormCheckboxXhtml(): void
     {
         $this->disableHtml5();
 


### PR DESCRIPTION
**Description**
- add tests for form_helper with CSRF filter

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
