### PR TITLE
fix: Factories::get() cannot get defined classes

### DIFF
--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -180,7 +180,9 @@ final class Factories
         if (isset(self::$aliases[$component][$alias])) {
             $class = self::$aliases[$component][$alias];
 
-            return self::$instances[$component][$class];
+            if (isset(self::$instances[$component][$class])) {
+                return self::$instances[$component][$class];
+            }
         }
 
         return self::__callStatic($component, [$alias]);

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -411,6 +411,19 @@ final class FactoriesTest extends CIUnitTestCase
         $this->assertInstanceOf(EntityModel::class, $model);
     }
 
+    public function testDefineAndGet(): void
+    {
+        Factories::define(
+            'models',
+            UserModel::class,
+            EntityModel::class
+        );
+
+        $model = Factories::get('models', UserModel::class);
+
+        $this->assertInstanceOf(EntityModel::class, $model);
+    }
+
     public function testGetComponentInstances()
     {
         Factories::config('App');


### PR DESCRIPTION
**Description**
If we define() and get(), the error like this occurs:
```
ErrorException: Undefined array key "models"
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
