### PR TITLE
fix: [FileLocator] Cannot declare class XXX, because the name is already in use

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -28,6 +28,13 @@ class FileLocator implements FileLocatorInterface
      */
     protected $autoloader;
 
+    /**
+     * List of classnames that did not exist.
+     *
+     * @var list<class-string>
+     */
+    private array $invalidClassnames = [];
+
     public function __construct(Autoloader $autoloader)
     {
         $this->autoloader = $autoloader;
@@ -288,14 +295,20 @@ class FileLocator implements FileLocatorInterface
                         ),
                         '\\'
                     );
-
                 // Remove the file extension (.php)
                 $className = mb_substr($className, 0, -4);
+
+                if (in_array($className, $this->invalidClassnames, true)) {
+                    continue;
+                }
 
                 // Check if this exists
                 if (class_exists($className)) {
                     return $className;
                 }
+
+                // If the class does not exist, it is an invalid classname.
+                $this->invalidClassnames[] = $className;
             }
         }
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/shield/issues/1091

If you define a namespace in another namespace,

```php
    public $psr4 = [
        APP_NAMESPACE => APPPATH,
        'Shield'      => APPPATH . 'ThirdParty/Shield',
    ];
```

The file path `app/ThirdParty/Shield/Config/Auth.php` could be
1. `App\ThirdParty\Shield\Config\Auth`
2. `Shield\Config\Auth`

`findQualifiedNameFromPath()` tries to find `App\ThirdParty\Shield\Config\Auth` more than once,
then the following error occurs:
> Cannot declare class Shield\Config\Auth, because the name is already in use

The error does not occur if `app/Config/Auth.php` exists.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
