### PR TITLE
feat: fix spark db:table causes errors with table name including special chars

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2139,12 +2139,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$aliasedTables type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/BaseConnection.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$dataCache type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/BaseConnection.php',

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Commands\Database;
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Database\BaseConnection;
+use CodeIgniter\Database\TableName;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use Config\Database;
 
@@ -199,7 +200,7 @@ class ShowTableInfo extends BaseCommand
         CLI::newLine();
 
         $this->removeDBPrefix();
-        $thead = $this->db->getFieldNames($tableName);
+        $thead = $this->db->getFieldNames(TableName::fromActualName($this->db, $tableName));
         $this->restoreDBPrefix();
 
         // If there is a field named `id`, sort by it.
@@ -277,7 +278,7 @@ class ShowTableInfo extends BaseCommand
         $this->tbody = [];
 
         $this->removeDBPrefix();
-        $builder = $this->db->table($tableName);
+        $builder = $this->db->table(TableName::fromActualName($this->db, $tableName));
         $builder->limit($limitRows);
         if ($sortField !== null) {
             $builder->orderBy($sortField, $this->sortDesc ? 'DESC' : 'ASC');

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -298,7 +298,7 @@ class BaseBuilder
     /**
      * Constructor
      *
-     * @param array|string $tableName tablename or tablenames with or without aliases
+     * @param array|string|TableName $tableName tablename or tablenames with or without aliases
      *
      * Examples of $tableName: `mytable`, `jobs j`, `jobs j, users u`, `['jobs j','users u']`
      *
@@ -315,14 +315,19 @@ class BaseBuilder
          */
         $this->db = $db;
 
+        if ($tableName instanceof TableName) {
+            $this->tableName = $tableName->getTableName();
+            $this->QBFrom[]  = $this->db->escapeIdentifier($tableName);
+            $this->db->addTableAlias($tableName->getAlias());
+        }
         // If it contains `,`, it has multiple tables
-        if (is_string($tableName) && ! str_contains($tableName, ',')) {
+        elseif (is_string($tableName) && ! str_contains($tableName, ',')) {
             $this->tableName = $tableName;  // @TODO remove alias if exists
+            $this->from($tableName);
         } else {
             $this->tableName = '';
+            $this->from($tableName);
         }
-
-        $this->from($tableName);
 
         if ($options !== null && $options !== []) {
             foreach ($options as $key => $value) {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3038,10 +3038,10 @@ class BaseBuilder
             $table = preg_replace('/\s+AS\s+/i', ' ', $table);
 
             // Grab the alias
-            $table = trim(strrchr($table, ' '));
+            $alias = trim(strrchr($table, ' '));
 
             // Store the alias, if it doesn't already exist
-            $this->db->addTableAlias($table);
+            $this->db->addTableAlias($alias);
         }
     }
 

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -340,7 +340,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Array of table aliases.
      *
-     * @var array
+     * @var list<string>
      */
     protected $aliasedTables = [];
 
@@ -576,10 +576,10 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * @return $this
      */
-    public function addTableAlias(string $table)
+    public function addTableAlias(string $alias)
     {
-        if (! in_array($table, $this->aliasedTables, true)) {
-            $this->aliasedTables[] = $table;
+        if (! in_array($alias, $this->aliasedTables, true)) {
+            $this->aliasedTables[] = $alias;
         }
 
         return $this;

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -578,6 +578,10 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function addTableAlias(string $alias)
     {
+        if ($alias === '') {
+            return $this;
+        }
+
         if (! in_array($alias, $this->aliasedTables, true)) {
             $this->aliasedTables[] = $alias;
         }
@@ -925,7 +929,7 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Returns a non-shared new instance of the query builder for this connection.
      *
-     * @param array|string $tableName
+     * @param array|string|TableName $tableName
      *
      * @return BaseBuilder
      *
@@ -1054,10 +1058,10 @@ abstract class BaseConnection implements ConnectionInterface
      * insert the table prefix (if it exists) in the proper position, and escape only
      * the correct identifiers.
      *
-     * @param array|int|string $item
-     * @param bool             $prefixSingle       Prefix a table name with no segments?
-     * @param bool             $protectIdentifiers Protect table or column names?
-     * @param bool             $fieldExists        Supplied $item contains a column name?
+     * @param array|int|string|TableName $item
+     * @param bool                       $prefixSingle       Prefix a table name with no segments?
+     * @param bool                       $protectIdentifiers Protect table or column names?
+     * @param bool                       $fieldExists        Supplied $item contains a column name?
      *
      * @return         array|string
      * @phpstan-return ($item is array ? array : string)
@@ -1076,6 +1080,11 @@ abstract class BaseConnection implements ConnectionInterface
             }
 
             return $escapedArray;
+        }
+
+        if ($item instanceof TableName) {
+            /** @psalm-suppress NoValue I don't know why ERROR. */
+            return $this->escapeTableName($item);
         }
 
         // If you pass `['column1', 'column2']`, `$item` will be int because the array keys are int.
@@ -1220,12 +1229,16 @@ abstract class BaseConnection implements ConnectionInterface
      *
      * This function escapes single identifier.
      *
-     * @param non-empty-string $item
+     * @param non-empty-string|TableName $item
      */
-    public function escapeIdentifier(string $item): string
+    public function escapeIdentifier($item): string
     {
         if ($item === '') {
             return '';
+        }
+
+        if ($item instanceof TableName) {
+            return $this->escapeTableName($item);
         }
 
         return $this->escapeChar
@@ -1235,6 +1248,17 @@ abstract class BaseConnection implements ConnectionInterface
                 $item
             )
             . $this->escapeChar;
+    }
+
+    /**
+     * Returns escaped table name with alias.
+     */
+    private function escapeTableName(TableName $tableName): string
+    {
+        $alias = $tableName->getAlias();
+
+        return $this->escapeIdentifier($tableName->getActualTableName())
+            . (($alias !== '') ? ' ' . $this->escapeIdentifier($alias) : '');
     }
 
     /**
@@ -1550,12 +1574,16 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Fetch Field Names
      *
+     * @param string|TableName $tableName
+     *
      * @return false|list<string>
      *
      * @throws DatabaseException
      */
-    public function getFieldNames(string $table)
+    public function getFieldNames($tableName)
     {
+        $table = ($tableName instanceof TableName) ? $tableName->getTableName() : $tableName;
+
         // Is there a cached result?
         if (isset($this->dataCache['field_names'][$table])) {
             return $this->dataCache['field_names'][$table];
@@ -1565,7 +1593,7 @@ abstract class BaseConnection implements ConnectionInterface
             $this->initialize();
         }
 
-        if (false === ($sql = $this->_listColumns($table))) {
+        if (false === ($sql = $this->_listColumns($tableName))) {
             if ($this->DBDebug) {
                 throw new DatabaseException('This feature is not available for the database you are using.');
             }
@@ -1781,9 +1809,11 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
      *
+     * @param string|TableName $table
+     *
      * @return false|string
      */
-    abstract protected function _listColumns(string $table = '');
+    abstract protected function _listColumns($table = '');
 
     /**
      * Platform-specific field data information.

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1224,6 +1224,10 @@ abstract class BaseConnection implements ConnectionInterface
      */
     public function escapeIdentifier(string $item): string
     {
+        if ($item === '') {
+            return '';
+        }
+
         return $this->escapeChar
             . str_replace(
                 $this->escapeChar,

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database\MySQLi;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\TableName;
 use CodeIgniter\Exceptions\LogicException;
 use mysqli;
 use mysqli_result;
@@ -422,10 +423,19 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
-        return 'SHOW COLUMNS FROM ' . $this->protectIdentifiers($table, true, null, false);
+        $tableName = $this->protectIdentifiers(
+            $table,
+            true,
+            null,
+            false
+        );
+
+        return 'SHOW COLUMNS FROM ' . $tableName;
     }
 
     /**

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\Postgre;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\Database\TableName;
 use ErrorException;
 use PgSql\Connection as PgSqlConnection;
 use PgSql\Result as PgSqlResult;
@@ -300,13 +301,20 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
+        if ($table instanceof TableName) {
+            $tableName = $this->escape($table->getActualTableName());
+        } else {
+            $tableName = $this->escape($this->DBPrefix . strtolower($table));
+        }
+
         return 'SELECT "column_name"
 			FROM "information_schema"."columns"
-			WHERE LOWER("table_name") = '
-                . $this->escape($this->DBPrefix . strtolower($table))
+			WHERE LOWER("table_name") = ' . $tableName
                 . ' ORDER BY "ordinal_position"';
     }
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database\SQLSRV;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\TableName;
 use stdClass;
 
 /**
@@ -225,12 +226,20 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
+        if ($table instanceof TableName) {
+            $tableName = $this->escape(strtolower($table->getActualTableName()));
+        } else {
+            $tableName = $this->escape($this->DBPrefix . strtolower($table));
+        }
+
         return 'SELECT [COLUMN_NAME] '
             . ' FROM [INFORMATION_SCHEMA].[COLUMNS]'
-            . ' WHERE  [TABLE_NAME] = ' . $this->escape($this->DBPrefix . $table)
+            . ' WHERE  [TABLE_NAME] = ' . $tableName
             . ' AND [TABLE_SCHEMA] = ' . $this->escape($this->schema);
     }
 

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Database\SQLite3;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\TableName;
 use Exception;
 use SQLite3;
 use SQLite3Result;
@@ -209,19 +210,31 @@ class Connection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
-        return 'PRAGMA TABLE_INFO(' . $this->protectIdentifiers($table, true, null, false) . ')';
+        if ($table instanceof TableName) {
+            $tableName = $this->escapeIdentifier($table);
+        } else {
+            $tableName = $this->protectIdentifiers($table, true, null, false);
+        }
+
+        return 'PRAGMA TABLE_INFO(' . $tableName . ')';
     }
 
     /**
+     * @param string|TableName $tableName
+     *
      * @return false|list<string>
      *
      * @throws DatabaseException
      */
-    public function getFieldNames(string $table)
+    public function getFieldNames($tableName)
     {
+        $table = ($tableName instanceof TableName) ? $tableName->getTableName() : $tableName;
+
         // Is there a cached result?
         if (isset($this->dataCache['field_names'][$table])) {
             return $this->dataCache['field_names'][$table];
@@ -231,7 +244,7 @@ class Connection extends BaseConnection
             $this->initialize();
         }
 
-        $sql = $this->_listColumns($table);
+        $sql = $this->_listColumns($tableName);
 
         $query                                  = $this->query($sql);
         $this->dataCache['field_names'][$table] = [];

--- a/system/Database/TableName.php
+++ b/system/Database/TableName.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+/**
+ * Represents a table name in SQL.
+ *
+ * @see \CodeIgniter\Database\TableNameTest
+ */
+class TableName
+{
+    /**
+     * @param string $actualTable  Actual table name
+     * @param string $logicalTable Logical table name (w/o DB prefix)
+     * @param string $schema       Schema name
+     * @param string $database     Database name
+     * @param string $alias        Alias name
+     */
+    protected function __construct(
+        private readonly string $actualTable,
+        private readonly string $logicalTable = '',
+        private readonly string $schema = '',
+        private readonly string $database = '',
+        private readonly string $alias = ''
+    ) {
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param string $table Table name (w/o DB prefix)
+     * @param string $alias Alias name
+     */
+    public static function create(BaseConnection $db, string $table, string $alias = ''): self
+    {
+        return new self(
+            $db->DBPrefix . $table,
+            $table,
+            '',
+            '',
+            $alias
+        );
+    }
+
+    /**
+     * Creates a new instance from an actual table name.
+     *
+     * @param string $actualTable Actual table name with DB prefix
+     * @param string $alias       Alias name
+     */
+    public static function fromActualName(BaseConnection $db, string $actualTable, string $alias = ''): self
+    {
+        $prefix       = $db->DBPrefix;
+        $logicalTable = '';
+
+        if (str_starts_with($actualTable, $prefix)) {
+            $logicalTable = substr($actualTable, strlen($prefix));
+        }
+
+        return new self(
+            $actualTable,
+            $logicalTable,
+            '',
+            $alias
+        );
+    }
+
+    /**
+     * Creates a new instance from full name.
+     *
+     * @param string $table    Table name (w/o DB prefix)
+     * @param string $schema   Schema name
+     * @param string $database Database name
+     * @param string $alias    Alias name
+     */
+    public static function fromFullName(
+        BaseConnection $db,
+        string $table,
+        string $schema = '',
+        string $database = '',
+        string $alias = ''
+    ): self {
+        return new self(
+            $db->DBPrefix . $table,
+            $table,
+            $schema,
+            $database,
+            $alias
+        );
+    }
+
+    /**
+     * Returns the single segment table name w/o DB prefix.
+     */
+    public function getTableName(): string
+    {
+        return $this->logicalTable;
+    }
+
+    /**
+     * Returns the actual single segment table name w/z DB prefix.
+     */
+    public function getActualTableName(): string
+    {
+        return $this->actualTable;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    public function getSchema(): string
+    {
+        return $this->schema;
+    }
+
+    public function getDatabase(): string
+    {
+        return $this->database;
+    }
+}

--- a/system/Database/TableName.php
+++ b/system/Database/TableName.php
@@ -16,6 +16,8 @@ namespace CodeIgniter\Database;
 /**
  * Represents a table name in SQL.
  *
+ * @interal
+ *
  * @see \CodeIgniter\Database\TableNameTest
  */
 class TableName

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -17,6 +17,7 @@ use CodeIgniter\CodeIgniter;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\BaseResult;
 use CodeIgniter\Database\Query;
+use CodeIgniter\Database\TableName;
 
 /**
  * @extends BaseConnection<object|resource, object|resource>
@@ -202,8 +203,10 @@ class MockConnection extends BaseConnection
 
     /**
      * Generates a platform-specific query string so that the column names can be fetched.
+     *
+     * @param string|TableName $table
      */
-    protected function _listColumns(string $table = ''): string
+    protected function _listColumns($table = ''): string
     {
         return '';
     }

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
+use CodeIgniter\Database\TableName;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use PHPUnit\Framework\Attributes\Group;
@@ -35,6 +36,16 @@ final class AliasTest extends CIUnitTestCase
     public function testAlias(): void
     {
         $builder = $this->db->table('jobs j');
+
+        $expectedSQL = 'SELECT * FROM "jobs" "j"';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testTableName(): void
+    {
+        $tableName = TableName::create($this->db, 'jobs', 'j');
+        $builder   = $this->db->table($tableName);
 
         $expectedSQL = 'SELECT * FROM "jobs" "j"';
 

--- a/tests/system/Database/TableNameTest.php
+++ b/tests/system/Database/TableNameTest.php
@@ -15,11 +15,12 @@ namespace CodeIgniter\Database;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal
  */
-#[\PHPUnit\Framework\Attributes\Group('Others')]
+#[Group('Others')]
 final class TableNameTest extends CIUnitTestCase
 {
     protected function setUp(): void

--- a/tests/system/Database/TableNameTest.php
+++ b/tests/system/Database/TableNameTest.php
@@ -18,9 +18,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 
 /**
  * @internal
- *
- * @group Others
  */
+#[\PHPUnit\Framework\Attributes\Group('Others')]
 final class TableNameTest extends CIUnitTestCase
 {
     protected function setUp(): void

--- a/tests/system/Database/TableNameTest.php
+++ b/tests/system/Database/TableNameTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Mock\MockConnection;
+
+/**
+ * @internal
+ *
+ * @group Others
+ */
+final class TableNameTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = new MockConnection([
+            'database' => 'test',
+            'DBPrefix' => 'db_',
+            'schema'   => 'dbo',
+        ]);
+    }
+
+    public function testInstantiate(): void
+    {
+        $table = 'table';
+
+        $tableName = TableName::create($this->db, $table);
+
+        $this->assertInstanceOf(TableName::class, $tableName);
+    }
+
+    public function testCreateAndTableName(): void
+    {
+        $table = 'table';
+
+        $tableName = TableName::create($this->db, $table);
+
+        $this->assertSame($table, $tableName->getTableName());
+        $this->assertSame('db_table', $tableName->getActualTableName());
+    }
+
+    public function testFromActualNameAndTableNameWithPrefix(): void
+    {
+        $actualTable = 'db_table';
+
+        $tableName = TableName::fromActualName($this->db, $actualTable);
+
+        $this->assertSame('table', $tableName->getTableName());
+        $this->assertSame($actualTable, $tableName->getActualTableName());
+    }
+
+    public function testFromActualNameAndTableNameWithoutPrefix(): void
+    {
+        $actualTable = 'table';
+
+        $tableName = TableName::fromActualName($this->db, $actualTable);
+
+        $this->assertSame('', $tableName->getTableName());
+        $this->assertSame($actualTable, $tableName->getActualTableName());
+    }
+
+    public function testGetAlias(): void
+    {
+        $table = 'table';
+        $alias = 't';
+
+        $tableName = TableName::create($this->db, $table, $alias);
+
+        $this->assertSame($alias, $tableName->getAlias());
+    }
+
+    public function testGetSchema(): void
+    {
+        $table    = 'table';
+        $schema   = 'dbo';
+        $database = 'test';
+
+        $tableName = TableName::fromFullName($this->db, $table, $schema, $database);
+
+        $this->assertSame($schema, $tableName->getSchema());
+    }
+
+    public function testGetDatabase(): void
+    {
+        $table    = 'table';
+        $schema   = 'dbo';
+        $database = 'test';
+
+        $tableName = TableName::fromFullName($this->db, $table, $schema, $database);
+
+        $this->assertSame($database, $tableName->getDatabase());
+    }
+}

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -84,6 +84,22 @@ Method Signature Changes
 - **View:** The return type of the ``renderSection()`` method has been
   changed to ``string``, and now the method does not call ``echo``.
 
+Removed Type Definitions
+------------------------
+
+- **Database:**
+    - The type ``string`` of the first parameter in
+      ``BaseConnection::escapeIdentifier()`` has been removed.
+    - The type ``string`` of the first parameter in
+      ``BaseConnection::getFieldNames()`` and ``SQLite3\Connection::getFieldNames()``
+      have been removed.
+    - The type ``string`` of the first parameter in
+      ``BaseConnection::_listColumns()`` and ``MySQLi\Connection::_listColumns()``
+      and ``OCI8\Connection::_listColumns()``
+      and ``Postgre\Connection::_listColumns()``
+      and ``SQLSRV\Connection::_listColumns()``
+      and ``SQLite3\Connection::_listColumns()`` have been removed.
+
 .. _v460-removed-deprecated-items:
 
 Removed Deprecated Items


### PR DESCRIPTION
**Description**
Superesedes #8696
Fixes #6765

- add `TableName` class
- fix `spark db:table` causes errors with table name including special chars

```console
$ ./spark db:table

CodeIgniter v4.5.1 Command Line Tool - Server Time: 2024-05-02 02:19:47 UTC+00:00

+-----------+----------+----------+----------+----------+------+
| hostname  | database | username | DBDriver | DBPrefix | port |
+-----------+----------+----------+----------+----------+------+
| localhost | ci4      | root     | MySQLi   |          | 3306 |
+-----------+----------+----------+----------+----------+------+

Here is the list of your database tables:
  [0]  , CONCAT('',`password`) AS `email`
  [1]  migrations

Which table do you want to see? [0, 1]: 0

Data of Table ", CONCAT('',`password`) AS `email`":

+----+------+
| id | name |
+----+------+
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
