### PR TITLE
chore: Revert disabling custom fixers for PHP 7.4

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -43,20 +43,16 @@ $finder = Finder::create()
 $overrides = [];
 
 $options = [
-    'cacheFile' => 'build/.php-cs-fixer.cache',
-    'finder'    => $finder,
+    'cacheFile'    => 'build/.php-cs-fixer.cache',
+    'finder'       => $finder,
+    'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
+    'customRules'  => [
+        NoCodeSeparatorCommentFixer::name() => true,
+    ],
 ];
 
-$config = Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
+return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
     'CodeIgniter 4 framework',
     'CodeIgniter Foundation',
     'admin@codeigniter.com'
 );
-
-$config
-    ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
-    ->setRules(array_merge($config->getRules(), [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ]));
-
-return $config;

--- a/.php-cs-fixer.no-header.php
+++ b/.php-cs-fixer.no-header.php
@@ -32,16 +32,12 @@ $finder = Finder::create()
 $overrides = [];
 
 $options = [
-    'cacheFile' => 'build/.php-cs-fixer.no-header.cache',
-    'finder'    => $finder,
+    'cacheFile'    => 'build/.php-cs-fixer.no-header.cache',
+    'finder'       => $finder,
+    'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
+    'customRules'  => [
+        NoCodeSeparatorCommentFixer::name() => true,
+    ],
 ];
 
-$config = Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
-
-$config
-    ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
-    ->setRules(array_merge($config->getRules(), [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ]));
-
-return $config;
+return Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();

--- a/.php-cs-fixer.tests.php
+++ b/.php-cs-fixer.tests.php
@@ -38,20 +38,16 @@ $overrides = [
 ];
 
 $options = [
-    'cacheFile' => 'build/.php-cs-fixer.tests.cache',
-    'finder'    => $finder,
+    'cacheFile'    => 'build/.php-cs-fixer.tests.cache',
+    'finder'       => $finder,
+    'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
+    'customRules'  => [
+        NoCodeSeparatorCommentFixer::name() => true,
+    ],
 ];
 
-$config = Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
+return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
     'CodeIgniter 4 framework',
     'CodeIgniter Foundation',
     'admin@codeigniter.com'
 );
-
-$config
-    ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
-    ->setRules(array_merge($config->getRules(), [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ]));
-
-return $config;

--- a/.php-cs-fixer.user-guide.php
+++ b/.php-cs-fixer.user-guide.php
@@ -42,16 +42,12 @@ $overrides = [
 ];
 
 $options = [
-    'cacheFile' => 'build/.php-cs-fixer.user-guide.cache',
-    'finder'    => $finder,
+    'cacheFile'    => 'build/.php-cs-fixer.user-guide.cache',
+    'finder'       => $finder,
+    'customFixers' => FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
+    'customRules'  => [
+        NoCodeSeparatorCommentFixer::name() => true,
+    ],
 ];
 
-$config = Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();
-
-$config
-    ->registerCustomFixers(FixerGenerator::create('vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'))
-    ->setRules(array_merge($config->getRules(), [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ]));
-
-return $config;
+return Factory::create(new CodeIgniter4(), $overrides, $options)->forProjects();


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Reverts the changes to #7712 now that v4.5.0 is out.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
