### PR TITLE
fix: `BaseConnection::escape()` does not accept Stringable

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -17,6 +17,7 @@ use Closure;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Events\Events;
 use stdClass;
+use Stringable;
 use Throwable;
 
 /**
@@ -1309,12 +1310,15 @@ abstract class BaseConnection implements ConnectionInterface
             return array_map($this->escape(...), $str);
         }
 
-        /** @psalm-suppress NoValue I don't know why ERROR. */
-        if (is_string($str) || (is_object($str) && method_exists($str, '__toString'))) {
+        if ($str instanceof Stringable) {
             if ($str instanceof RawSql) {
                 return $str->__toString();
             }
 
+            $str = (string) $str;
+        }
+
+        if (is_string($str)) {
             return "'" . $this->escapeString($str) . "'";
         }
 

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1383,7 +1383,7 @@ abstract class BaseConnection implements ConnectionInterface
      * Calls the individual driver for platform
      * specific escaping for LIKE conditions
      *
-     * @param list<string>|string $str
+     * @param list<string|Stringable>|string|Stringable $str
      *
      * @return list<string>|string
      */

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1332,8 +1332,8 @@ abstract class BaseConnection implements ConnectionInterface
     /**
      * Escape String
      *
-     * @param list<string>|string $str  Input string
-     * @param bool                $like Whether or not the string will be used in a LIKE condition
+     * @param list<string|Stringable>|string|Stringable $str  Input string
+     * @param bool                                      $like Whether the string will be used in a LIKE condition
      *
      * @return list<string>|string
      */
@@ -1345,6 +1345,14 @@ abstract class BaseConnection implements ConnectionInterface
             }
 
             return $str;
+        }
+
+        if ($str instanceof Stringable) {
+            if ($str instanceof RawSql) {
+                return $str->__toString();
+            }
+
+            $str = (string) $str;
         }
 
         $str = $this->_escapeString($str);

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -20,6 +20,7 @@ use ErrorException;
 use PgSql\Connection as PgSqlConnection;
 use PgSql\Result as PgSqlResult;
 use stdClass;
+use Stringable;
 
 /**
  * Connection for Postgre
@@ -233,12 +234,15 @@ class Connection extends BaseConnection
             $this->initialize();
         }
 
-        /** @psalm-suppress NoValue I don't know why ERROR. */
-        if (is_string($str) || (is_object($str) && method_exists($str, '__toString'))) {
+        if ($str instanceof Stringable) {
             if ($str instanceof RawSql) {
                 return $str->__toString();
             }
 
+            $str = (string) $str;
+        }
+
+        if (is_string($str)) {
             return pg_escape_literal($this->connID, $str);
         }
 
@@ -246,7 +250,6 @@ class Connection extends BaseConnection
             return $str ? 'TRUE' : 'FALSE';
         }
 
-        /** @psalm-suppress NoValue I don't know why ERROR. */
         return parent::escape($str);
     }
 

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -21,22 +21,22 @@ use DateTimeImmutable;
  *
  * Requires the intl PHP extension.
  *
- * @property int    $age         read-only
- * @property string $day         read-only
- * @property string $dayOfWeek   read-only
- * @property string $dayOfYear   read-only
- * @property bool   $dst         read-only
- * @property string $hour        read-only
- * @property bool   $local       read-only
- * @property string $minute      read-only
- * @property string $month       read-only
- * @property string $quarter     read-only
- * @property string $second      read-only
- * @property int    $timestamp   read-only
- * @property bool   $utc         read-only
- * @property string $weekOfMonth read-only
- * @property string $weekOfYear  read-only
- * @property string $year        read-only
+ * @property-read int    $age
+ * @property-read string $day
+ * @property-read string $dayOfWeek
+ * @property-read string $dayOfYear
+ * @property-read bool   $dst
+ * @property-read string $hour
+ * @property-read bool   $local
+ * @property-read string $minute
+ * @property-read string $month
+ * @property-read string $quarter
+ * @property-read string $second
+ * @property-read int    $timestamp
+ * @property-read bool   $utc
+ * @property-read string $weekOfMonth
+ * @property-read string $weekOfYear
+ * @property-read string $year
  *
  * @see \CodeIgniter\I18n\TimeTest
  */

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\I18n;
 
 use DateTimeImmutable;
+use Stringable;
 
 /**
  * A localized date/time package inspired
@@ -40,7 +41,7 @@ use DateTimeImmutable;
  *
  * @see \CodeIgniter\I18n\TimeTest
  */
-class Time extends DateTimeImmutable
+class Time extends DateTimeImmutable implements Stringable
 {
     use TimeTrait;
 }

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -71,10 +71,28 @@ final class EscapeTest extends CIUnitTestCase
         $this->assertSame($expected, $sql);
     }
 
+    public function testEscapeStringStringable(): void
+    {
+        $expected = "SELECT * FROM brands WHERE name = '2024-01-01 12:00:00'";
+        $sql      = "SELECT * FROM brands WHERE name = '"
+            . $this->db->escapeString(new Time('2024-01-01 12:00:00')) . "'";
+
+        $this->assertSame($expected, $sql);
+    }
+
     public function testEscapeLikeString(): void
     {
         $expected = "SELECT * FROM brands WHERE column LIKE '%10!% more%' ESCAPE '!'";
         $sql      = "SELECT * FROM brands WHERE column LIKE '%" . $this->db->escapeLikeString('10% more') . "%' ESCAPE '!'";
+
+        $this->assertSame($expected, $sql);
+    }
+
+    public function testEscapeLikeStringStringable(): void
+    {
+        $expected = "SELECT * FROM brands WHERE column LIKE '%2024-01-01 12:00:00%' ESCAPE '!'";
+        $sql      = "SELECT * FROM brands WHERE column LIKE '%"
+            . $this->db->escapeLikeString(new Time('2024-01-01 12:00:00')) . "%' ESCAPE '!'";
 
         $this->assertSame($expected, $sql);
     }

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\Live;
 
 use CodeIgniter\Database\RawSql;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 
@@ -50,6 +51,14 @@ final class EscapeTest extends CIUnitTestCase
     {
         $expected = "SELECT * FROM brands WHERE name = 'O" . $this->char . "'Doules'";
         $sql      = 'SELECT * FROM brands WHERE name = ' . $this->db->escape("O'Doules");
+
+        $this->assertSame($expected, $sql);
+    }
+
+    public function testEscapeStringable(): void
+    {
+        $expected = "SELECT * FROM brands WHERE name = '2024-01-01 12:00:00'";
+        $sql      = 'SELECT * FROM brands WHERE name = ' . $this->db->escape(new Time('2024-01-01 12:00:00'));
 
         $this->assertSame($expected, $sql);
     }


### PR DESCRIPTION
**Description**
Supersedes #8739

- `BaseConnection::escape()` accepts Stringable
- `BaseConnection::escapeString()` accepts Stringable
- `Time` implements `Stringable`
 
```
TypeError: CodeIgniter\Database\SQLite3\Connection::_escapeString(): Argument #1 ($str) must be of type string, CodeIgniter\I18n\Time given
```

See also https://github.com/codeigniter4/shield/issues/1092

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
