### PR TITLE
fix: [CURLRequest] `getHeaderLine('Content-Type')` causes InvalidArgumentException

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -12907,11 +12907,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/HTTP/CLIRequestTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Access to an undefined property CodeIgniter\\\\HTTP\\\\CURLRequest\\:\\:\\$curl_options\\.$#',
-	'count' => 39,
-	'path' => __DIR__ . '/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Assigning \'10\' directly on offset \'HTTP_CONTENT_LENGTH\' of \\$_SERVER is discouraged\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php',
@@ -12928,16 +12923,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Assigning \'site1\\.com\' directly on offset \'HTTP_HOST\' of \\$_SERVER is discouraged\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CodeIgniter\\\\HTTP\\\\CURLRequest\\:\\:setOutput\\(\\)\\.$#',
-	'count' => 3,
-	'path' => __DIR__ . '/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\HTTP\\\\CURLRequestDoNotShareOptionsTest\\:\\:getRequest\\(\\) has no return type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php',
 ];

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -116,7 +116,10 @@ class CURLRequest extends OutgoingRequest
 
         parent::__construct(Method::GET, $uri);
 
-        $this->responseOrig   = $response ?? new Response(config(App::class));
+        $this->responseOrig = $response ?? new Response(config(App::class));
+        // Remove the default Content-Type header.
+        $this->responseOrig->removeHeader('Content-Type');
+
         $this->baseURI        = $uri->useRawQueryString();
         $this->defaultOptions = $options;
 

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -404,20 +404,20 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     public function testAuthDigestOption(): void
     {
         $output = "HTTP/1.1 401 Unauthorized
-		Server: ddos-guard
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
-		Server: ddos-guard
-		Connection: keep-alive
-		Keep-Alive: timeout=60
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		Date: Tue, 07 Jul 2020 15:13:14 GMT
-		Expires: Thu, 19 Nov 1981 08:52:00 GMT
-		Cache-Control: no-store, no-cache, must-revalidate
-		Pragma: no-cache
-		Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
-		Content-Type: application/xml; charset=utf-8
-		Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
+Server: ddos-guard
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
+Server: ddos-guard
+Connection: keep-alive
+Keep-Alive: timeout=60
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+Date: Tue, 07 Jul 2020 15:13:14 GMT
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
 
         $this->request->setOutput($output);
 
@@ -457,20 +457,20 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
     public function testSetAuthDigest(): void
     {
         $output = "HTTP/1.1 401 Unauthorized
-		Server: ddos-guard
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
-		Server: ddos-guard
-		Connection: keep-alive
-		Keep-Alive: timeout=60
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		Date: Tue, 07 Jul 2020 15:13:14 GMT
-		Expires: Thu, 19 Nov 1981 08:52:00 GMT
-		Cache-Control: no-store, no-cache, must-revalidate
-		Pragma: no-cache
-		Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
-		Content-Type: application/xml; charset=utf-8
-		Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
+Server: ddos-guard
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
+Server: ddos-guard
+Connection: keep-alive
+Keep-Alive: timeout=60
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+Date: Tue, 07 Jul 2020 15:13:14 GMT
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
 
         $this->request->setOutput($output);
 

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -29,7 +29,7 @@ use CURLFile;
  */
 final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
 {
-    private CURLRequest $request;
+    private MockCURLRequest $request;
 
     protected function setUp(): void
     {
@@ -39,7 +39,7 @@ final class CURLRequestDoNotShareOptionsTest extends CIUnitTestCase
         $this->request = $this->getRequest();
     }
 
-    protected function getRequest(array $options = [])
+    protected function getRequest(array $options = []): MockCURLRequest
     {
         $uri = isset($options['base_uri']) ? new URI($options['base_uri']) : new URI();
         $app = new App();

--- a/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestDoNotShareOptionsTest.php
@@ -784,7 +784,6 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 
         $responseHeaderKeys = [
             'Cache-Control',
-            'Content-Type',
             'Server',
             'Connection',
             'Keep-Alive',
@@ -792,6 +791,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
             'Date',
             'Expires',
             'Pragma',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -823,10 +823,10 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
 
         $responseHeaderKeys = [
             'Cache-Control',
-            'Content-Type',
             'Server',
             'Expires',
             'Pragma',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -846,8 +846,8 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
 
         $responseHeaderKeys = [
             'Cache-Control',
-            'Content-Type',
             'Expires',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -1140,5 +1140,22 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
 
         $this->assertArrayHasKey(CURLOPT_USERAGENT, $options);
         $this->assertSame($agent, $options[CURLOPT_USERAGENT]);
+    }
+
+    public function testGetHeaderLineContentType(): void
+    {
+        $output = 'HTTP/2 200
+date: Thu, 11 Apr 2024 07:26:00 GMT
+content-type: text/html; charset=UTF-8
+cache-control: no-store, max-age=0, no-cache
+server: cloudflare
+content-encoding: br
+alt-svc: h3=":443"; ma=86400' . "\x0d\x0a\x0d\x0aResponse Body";
+
+        $this->request->setOutput($output);
+
+        $response = $this->request->request('get', 'http://example.com');
+
+        $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
     }
 }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -387,20 +387,20 @@ final class CURLRequestTest extends CIUnitTestCase
     public function testAuthDigestOption(): void
     {
         $output = "HTTP/1.1 401 Unauthorized
-		Server: ddos-guard
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
-		Server: ddos-guard
-		Connection: keep-alive
-		Keep-Alive: timeout=60
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		Date: Tue, 07 Jul 2020 15:13:14 GMT
-		Expires: Thu, 19 Nov 1981 08:52:00 GMT
-		Cache-Control: no-store, no-cache, must-revalidate
-		Pragma: no-cache
-		Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
-		Content-Type: application/xml; charset=utf-8
-		Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
+Server: ddos-guard
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
+Server: ddos-guard
+Connection: keep-alive
+Keep-Alive: timeout=60
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+Date: Tue, 07 Jul 2020 15:13:14 GMT
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
 
         $this->request->setOutput($output);
 
@@ -440,20 +440,20 @@ final class CURLRequestTest extends CIUnitTestCase
     public function testSetAuthDigest(): void
     {
         $output = "HTTP/1.1 401 Unauthorized
-		Server: ddos-guard
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
-		Server: ddos-guard
-		Connection: keep-alive
-		Keep-Alive: timeout=60
-		Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
-		Date: Tue, 07 Jul 2020 15:13:14 GMT
-		Expires: Thu, 19 Nov 1981 08:52:00 GMT
-		Cache-Control: no-store, no-cache, must-revalidate
-		Pragma: no-cache
-		Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
-		Content-Type: application/xml; charset=utf-8
-		Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
+Server: ddos-guard
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+WWW-Authenticate: Digest\x0d\x0a\x0d\x0aHTTP/1.1 200 OK
+Server: ddos-guard
+Connection: keep-alive
+Keep-Alive: timeout=60
+Set-Cookie: __ddg1=z177j4mLtqzC07v0zviU; Domain=.site.ru; HttpOnly; Path=/; Expires=Wed, 07-Jul-2021 15:13:14 GMT
+Date: Tue, 07 Jul 2020 15:13:14 GMT
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Set-Cookie: PHPSESSID=80pd3hlg38mvjnelpvokp9lad0; path=/
+Content-Type: application/xml; charset=utf-8
+Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>";
 
         $this->request->setOutput($output);
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -782,7 +782,6 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
 
         $responseHeaderKeys = [
             'Cache-Control',
-            'Content-Type',
             'Server',
             'Connection',
             'Keep-Alive',
@@ -790,6 +789,7 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
             'Date',
             'Expires',
             'Pragma',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -836,10 +836,10 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello1</title>";
 
         $responseHeaderKeys = [
             'Cache-Control',
-            'Content-Type',
             'Server',
             'Expires',
             'Pragma',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));
@@ -859,8 +859,8 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Hello2</title>";
 
         $responseHeaderKeys = [
             'Cache-Control',
-            'Content-Type',
             'Expires',
+            'Content-Type',
             'Transfer-Encoding',
         ];
         $this->assertSame($responseHeaderKeys, array_keys($response->headers()));


### PR DESCRIPTION
**Description**
Fixes #8750

- remove the default Response Content-Type header

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
