### PR TITLE
fix: [CURLRequest] construct param $config is not used

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -5337,11 +5337,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/HTTP/CURLRequest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Constructor of class CodeIgniter\\\\HTTP\\\\CURLRequest has an unused parameter \\$config\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/HTTP/CURLRequest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\HTTP\\\\CURLRequest\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/HTTP/CURLRequest.php',

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -116,7 +116,7 @@ class CURLRequest extends OutgoingRequest
 
         parent::__construct(Method::GET, $uri);
 
-        $this->responseOrig = $response ?? new Response(config(App::class));
+        $this->responseOrig = $response ?? new Response($config);
         // Remove the default Content-Type header.
         $this->responseOrig->removeHeader('Content-Type');
 


### PR DESCRIPTION
**Description**
The construct parameter should be used.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
