### PR TITLE
feat: add BaseConnection::resetTransStatus()

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -898,6 +898,16 @@ abstract class BaseConnection implements ConnectionInterface
     }
 
     /**
+     * Reset transaction status - to restart transactions after strict mode failure
+     */
+    public function resetTransStatus(): static
+    {
+        $this->transStatus = true;
+
+        return $this;
+    }
+
+    /**
      * Begin Transaction
      */
     abstract protected function _transBegin(): bool;

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -134,6 +134,8 @@ Others
 ------
 
 - Added a new configuration ``foundRows`` for MySQLi to use ``MYSQLI_CLIENT_FOUND_ROWS``.
+- Added the ``BaseConnection::resetTransStatus()`` method to reset the transaction
+  status. See :ref:`transactions-resetting-transaction-status` for details.
 
 Model
 =====

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -52,11 +52,13 @@ or failure of any given query.
 Strict Mode
 ===========
 
-By default, CodeIgniter runs all transactions in Strict Mode. When strict
-mode is enabled, if you are running multiple groups of transactions, if
-one group fails all subsequent groups will be rolled back. If strict mode is
-disabled, each group is treated independently, meaning a failure of one
-group will not affect any others.
+By default, CodeIgniter runs all transactions in Strict Mode.
+
+When strict mode is enabled, if you are running multiple groups of transactions,
+if one group fails all subsequent groups will be rolled back.
+
+If strict mode is disabled, each group is treated independently, meaning a failure
+of one group will not affect any others.
 
 Strict Mode can be disabled as follows:
 

--- a/user_guide_src/source/database/transactions.rst
+++ b/user_guide_src/source/database/transactions.rst
@@ -14,7 +14,7 @@ transactions.
 
 .. contents::
     :local:
-    :depth: 2
+    :depth: 3
 
 CodeIgniter's Approach to Transactions
 ======================================
@@ -63,6 +63,21 @@ of one group will not affect any others.
 Strict Mode can be disabled as follows:
 
 .. literalinclude:: transactions/002.php
+
+.. _transactions-resetting-transaction-status:
+
+Resetting Transaction Status
+----------------------------
+
+.. versionadded:: 4.6.0
+
+When strict mode is enabled, if one transaction fails, all subsequent transactions
+will be rolled back.
+
+If you wan to restart transactions after a failure, you can reset the transaction
+status:
+
+.. literalinclude:: transactions/009.php
 
 .. _transactions-managing-errors:
 

--- a/user_guide_src/source/database/transactions/009.php
+++ b/user_guide_src/source/database/transactions/009.php
@@ -1,0 +1,3 @@
+<?php
+
+$this->db->resetTransStatus();


### PR DESCRIPTION
**Description**
See #6909 https://github.com/codeigniter4/CodeIgniter4/pull/6886#issuecomment-1324182519

To restart transactions after strict mode failure.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
