### PR TITLE
chore: fix `create-new-changelog.php` for minor update

### DIFF
--- a/admin/create-new-changelog.php
+++ b/admin/create-new-changelog.php
@@ -29,7 +29,9 @@ $minor               = $versionParts[0] . '.' . $versionParts[1];
 $isMinorUpdate       = ($minorCurrent !== $minor);
 
 // Creates a branch for release.
-system('git switch develop');
+if (! $isMinorUpdate) {
+    system('git switch develop');
+}
 system('git switch -c docs-changelog-' . $version);
 system('git switch docs-changelog-' . $version);
 


### PR DESCRIPTION
**Description**
Does not work for minor update.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
