### PR TITLE
fix: [DebugBar] Toolbar display may be broken

### DIFF
--- a/admin/css/debug-toolbar/README.md
+++ b/admin/css/debug-toolbar/README.md
@@ -1,0 +1,1 @@
+See [contributing/css.md](../../../contributing/css.md).

--- a/admin/css/debug-toolbar/toolbar.scss
+++ b/admin/css/debug-toolbar/toolbar.scss
@@ -85,6 +85,8 @@
         display: flex;
         font-weight: normal;
         margin: 0 0 0 auto;
+        padding: 0;
+        font-family: $base-font;
 
         svg {
             width: 16px;

--- a/admin/css/debug-toolbar/toolbar.scss
+++ b/admin/css/debug-toolbar/toolbar.scss
@@ -28,8 +28,8 @@
     width: 36px;
 
     // Spacing
-    margin: 0px;
-    padding: 0px;
+    margin: 0;
+    padding: 0;
 
     // Content
     clear: both;

--- a/contributing/css.md
+++ b/contributing/css.md
@@ -10,7 +10,7 @@ Open your terminal, and navigate to CodeIgniter's root folder. To
 generate the CSS file, use the following command:
 
 ```console
-sass --no-source-map admin/css/debug-toolbar/toolbar.scss system/Debug/Toolbar/Views/toolbar.css`
+sass --no-source-map admin/css/debug-toolbar/toolbar.scss system/Debug/Toolbar/Views/toolbar.css
 ```
 
 Details:

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -52,6 +52,8 @@
   display: flex;
   font-weight: normal;
   margin: 0 0 0 auto;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 }
 #debug-bar h1 svg {
   width: 16px;

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -13,8 +13,8 @@
   z-index: 10000;
   height: 36px;
   width: 36px;
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
   clear: both;
   text-align: center;
   cursor: pointer;


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=90624

If a dev changes CSS for `h1`, the toolbar dislpay will be broken.

Before:
![Screenshot 2024-04-13 9 15 02](https://github.com/codeigniter4/CodeIgniter4/assets/87955/1756690f-ba58-437e-99a7-d688345ff55a)
After:
![Screenshot 2024-04-13 9 15 09](https://github.com/codeigniter4/CodeIgniter4/assets/87955/ede0e189-bdc1-4887-8951-160f46d862c6)

```diff
--- a/app/Views/welcome_message.php
+++ b/app/Views/welcome_message.php
@@ -34,6 +34,16 @@
         .menu {
             padding: .4rem 2rem;
         }
+        h1 {
+            font-size: 1.8em;
+            font-weight: 400;
+            font-family:'Open Sans', Sans-serif;
+            text-transform: uppercase;
+            color: #464646;
+            background-color: #f4f9eb;
+            padding: 1.4em 0 1.4em 20px;
+            margin: 0 0 1em;
+        }
         header ul {
             border-bottom: 1px solid rgba(242, 242, 242, 1);
             list-style-type: none;
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
