### PR TITLE
chore: move PHPUnit cache to build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,5 @@ nb-configuration.xml
 
 /results/
 /phpunit*.xml
-/.phpunit.*.cache
-/.phpunit.cache
 
 /.php-cs-fixer.php

--- a/admin/framework/.gitignore
+++ b/admin/framework/.gitignore
@@ -124,5 +124,3 @@ nb-configuration.xml
 
 /results/
 /phpunit*.xml
-/.phpunit.*.cache
-

--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     bootstrap="system/Test/bootstrap.php"
     backupGlobals="false"
+    beStrictAboutOutputDuringTests="true"
     colors="true"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    columns="max"
+    failOnRisky="true"
+    failOnWarning="true"
     cacheDirectory="build/.phpunit.cache">
     <coverage includeUncoveredFiles="true">
         <report>

--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -1,48 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="system/Test/bootstrap.php" backupGlobals="false" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
-  <coverage includeUncoveredFiles="true">
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/logs/html"/>
-      <php outputFile="build/logs/coverage.serialized"/>
-      <text outputFile="php://stdout" showUncoveredFiles="false"/>
-    </report>
-  </coverage>
-  <testsuites>
-    <testsuite name="App">
-      <directory>./tests</directory>
-    </testsuite>
-  </testsuites>
-  <logging>
-    <testdoxHtml outputFile="build/logs/testdox.html"/>
-    <testdoxText outputFile="build/logs/testdox.txt"/>
-    <junit outputFile="build/logs/logfile.xml"/>
-  </logging>
-  <php>
-    <server name="app.baseURL" value="http://example.com/"/>
-    <!-- Directory containing phpunit.xml -->
-    <const name="HOMEPATH" value="./"/>
-    <!-- Directory containing the Paths config file -->
-    <const name="CONFIGPATH" value="./app/Config/"/>
-    <!-- Directory containing the front controller (index.php) -->
-    <const name="PUBLICPATH" value="./public/"/>
-    <!-- Database configuration -->
-    <!-- Uncomment to provide your own database for testing
-		<env name="database.tests.hostname" value="localhost"/>
-		<env name="database.tests.database" value="tests"/>
-		<env name="database.tests.username" value="tests_user"/>
-		<env name="database.tests.password" value=""/>
-		<env name="database.tests.DBDriver" value="MySQLi"/>
-		<env name="database.tests.DBPrefix" value="tests_"/>
-		-->
-  </php>
-  <source>
-    <include>
-      <directory suffix=".php">./app</directory>
-    </include>
-    <exclude>
-      <directory suffix=".php">./app/Views</directory>
-      <file>./app/Config/Routes.php</file>
-    </exclude>
-  </source>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="system/Test/bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    cacheDirectory=".phpunit.cache">
+    <coverage includeUncoveredFiles="true">
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/logs/html"/>
+            <php outputFile="build/logs/coverage.serialized"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+        </report>
+    </coverage>
+    <testsuites>
+        <testsuite name="App">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <testdoxHtml outputFile="build/logs/testdox.html"/>
+        <testdoxText outputFile="build/logs/testdox.txt"/>
+        <junit outputFile="build/logs/logfile.xml"/>
+    </logging>
+    <php>
+        <server name="app.baseURL" value="http://example.com/"/>
+        <!-- Directory containing phpunit.xml -->
+        <const name="HOMEPATH" value="./"/>
+        <!-- Directory containing the Paths config file -->
+        <const name="CONFIGPATH" value="./app/Config/"/>
+        <!-- Directory containing the front controller (index.php) -->
+        <const name="PUBLICPATH" value="./public/"/>
+        <!-- Database configuration -->
+        <!-- Uncomment to provide your own database for testing
+            <env name="database.tests.hostname" value="localhost"/>
+            <env name="database.tests.database" value="tests"/>
+            <env name="database.tests.username" value="tests_user"/>
+            <env name="database.tests.password" value=""/>
+            <env name="database.tests.DBDriver" value="MySQLi"/>
+            <env name="database.tests.DBPrefix" value="tests_"/>
+            -->
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./app/Views</directory>
+            <file>./app/Config/Routes.php</file>
+        </exclude>
+    </source>
 </phpunit>

--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -32,6 +32,15 @@
         <testdoxText outputFile="build/logs/testdox.txt"/>
         <junit outputFile="build/logs/logfile.xml"/>
     </logging>
+    <source>
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./app/Views</directory>
+            <file>./app/Config/Routes.php</file>
+        </exclude>
+    </source>
     <php>
         <server name="app.baseURL" value="http://example.com/"/>
         <!-- Directory containing phpunit.xml -->
@@ -50,13 +59,4 @@
             <env name="database.tests.DBPrefix" value="tests_"/>
             -->
     </php>
-    <source>
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">./app/Views</directory>
-            <file>./app/Config/Routes.php</file>
-        </exclude>
-    </source>
 </phpunit>

--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -10,7 +10,11 @@
     failOnRisky="true"
     failOnWarning="true"
     cacheDirectory="build/.phpunit.cache">
-    <coverage includeUncoveredFiles="true">
+    <coverage
+        includeUncoveredFiles="true"
+        pathCoverage="false"
+        ignoreDeprecatedCodeUnits="true"
+        disableCodeCoverageIgnore="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <html outputDirectory="build/logs/html"/>

--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -9,7 +9,7 @@
     stopOnIncomplete="false"
     stopOnSkipped="false"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-    cacheDirectory=".phpunit.cache">
+    cacheDirectory="build/.phpunit.cache">
     <coverage includeUncoveredFiles="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>

--- a/admin/framework/phpunit.xml.dist
+++ b/admin/framework/phpunit.xml.dist
@@ -43,6 +43,7 @@
     </source>
     <php>
         <server name="app.baseURL" value="http://example.com/"/>
+        <server name="CODEIGNITER_SCREAM_DEPRECATIONS" value="0"/>
         <!-- Directory containing phpunit.xml -->
         <const name="HOMEPATH" value="./"/>
         <!-- Directory containing the Paths config file -->

--- a/admin/starter/.gitignore
+++ b/admin/starter/.gitignore
@@ -124,5 +124,3 @@ nb-configuration.xml
 
 /results/
 /phpunit*.xml
-/.phpunit.*.cache
-

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -1,48 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php" backupGlobals="false" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
-  <coverage includeUncoveredFiles="true">
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/logs/html"/>
-      <php outputFile="build/logs/coverage.serialized"/>
-      <text outputFile="php://stdout" showUncoveredFiles="false"/>
-    </report>
-  </coverage>
-  <testsuites>
-    <testsuite name="App">
-      <directory>./tests</directory>
-    </testsuite>
-  </testsuites>
-  <logging>
-    <testdoxHtml outputFile="build/logs/testdox.html"/>
-    <testdoxText outputFile="build/logs/testdox.txt"/>
-    <junit outputFile="build/logs/logfile.xml"/>
-  </logging>
-  <php>
-    <server name="app.baseURL" value="http://example.com/"/>
-    <!-- Directory containing phpunit.xml -->
-    <const name="HOMEPATH" value="./"/>
-    <!-- Directory containing the Paths config file -->
-    <const name="CONFIGPATH" value="./app/Config/"/>
-    <!-- Directory containing the front controller (index.php) -->
-    <const name="PUBLICPATH" value="./public/"/>
-    <!-- Database configuration -->
-    <!-- Uncomment to provide your own database for testing
-        <env name="database.tests.hostname" value="localhost"/>
-        <env name="database.tests.database" value="tests"/>
-        <env name="database.tests.username" value="tests_user"/>
-        <env name="database.tests.password" value=""/>
-        <env name="database.tests.DBDriver" value="MySQLi"/>
-        <env name="database.tests.DBPrefix" value="tests_"/>
-        -->
-  </php>
-  <source>
-    <include>
-      <directory suffix=".php">./app</directory>
-    </include>
-    <exclude>
-      <directory suffix=".php">./app/Views</directory>
-      <file>./app/Config/Routes.php</file>
-    </exclude>
-  </source>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    cacheDirectory=".phpunit.cache">
+    <coverage includeUncoveredFiles="true">
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/logs/html"/>
+            <php outputFile="build/logs/coverage.serialized"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+        </report>
+    </coverage>
+    <testsuites>
+        <testsuite name="App">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <testdoxHtml outputFile="build/logs/testdox.html"/>
+        <testdoxText outputFile="build/logs/testdox.txt"/>
+        <junit outputFile="build/logs/logfile.xml"/>
+    </logging>
+    <php>
+        <server name="app.baseURL" value="http://example.com/"/>
+        <!-- Directory containing phpunit.xml -->
+        <const name="HOMEPATH" value="./"/>
+        <!-- Directory containing the Paths config file -->
+        <const name="CONFIGPATH" value="./app/Config/"/>
+        <!-- Directory containing the front controller (index.php) -->
+        <const name="PUBLICPATH" value="./public/"/>
+        <!-- Database configuration -->
+        <!-- Uncomment to provide your own database for testing
+            <env name="database.tests.hostname" value="localhost"/>
+            <env name="database.tests.database" value="tests"/>
+            <env name="database.tests.username" value="tests_user"/>
+            <env name="database.tests.password" value=""/>
+            <env name="database.tests.DBDriver" value="MySQLi"/>
+            <env name="database.tests.DBPrefix" value="tests_"/>
+            -->
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./app/Views</directory>
+            <file>./app/Config/Routes.php</file>
+        </exclude>
+    </source>
 </phpunit>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -32,6 +32,15 @@
         <testdoxText outputFile="build/logs/testdox.txt"/>
         <junit outputFile="build/logs/logfile.xml"/>
     </logging>
+    <source>
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./app/Views</directory>
+            <file>./app/Config/Routes.php</file>
+        </exclude>
+    </source>
     <php>
         <server name="app.baseURL" value="http://example.com/"/>
         <!-- Directory containing phpunit.xml -->
@@ -50,13 +59,4 @@
             <env name="database.tests.DBPrefix" value="tests_"/>
             -->
     </php>
-    <source>
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">./app/Views</directory>
-            <file>./app/Config/Routes.php</file>
-        </exclude>
-    </source>
 </phpunit>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -10,7 +10,11 @@
     failOnRisky="true"
     failOnWarning="true"
     cacheDirectory="build/.phpunit.cache">
-    <coverage includeUncoveredFiles="true">
+    <coverage
+        includeUncoveredFiles="true"
+        pathCoverage="false"
+        ignoreDeprecatedCodeUnits="true"
+        disableCodeCoverageIgnore="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <html outputDirectory="build/logs/html"/>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
-    backupGlobals="false"
-    colors="true"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    bootstrap="system/Test/bootstrap.php"
+    backupGlobals="false"
+    beStrictAboutOutputDuringTests="true"
+    colors="true"
+    columns="max"
+    failOnRisky="true"
+    failOnWarning="true"
     cacheDirectory="build/.phpunit.cache">
     <coverage includeUncoveredFiles="true">
         <report>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -9,7 +9,7 @@
     stopOnIncomplete="false"
     stopOnSkipped="false"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-    cacheDirectory=".phpunit.cache">
+    cacheDirectory="build/.phpunit.cache">
     <coverage includeUncoveredFiles="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>

--- a/admin/starter/phpunit.xml.dist
+++ b/admin/starter/phpunit.xml.dist
@@ -43,6 +43,7 @@
     </source>
     <php>
         <server name="app.baseURL" value="http://example.com/"/>
+        <server name="CODEIGNITER_SCREAM_DEPRECATIONS" value="0"/>
         <!-- Directory containing phpunit.xml -->
         <const name="HOMEPATH" value="./"/>
         <!-- Directory containing the Paths config file -->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
-         bootstrap="system/Test/bootstrap.php" backupGlobals="false"
-         beStrictAboutOutputDuringTests="true" colors="true" columns="max"
-         failOnRisky="true" failOnWarning="true"
-         cacheDirectory="build/.phpunit.cache">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+    bootstrap="system/Test/bootstrap.php"
+    backupGlobals="false"
+    beStrictAboutOutputDuringTests="true"
+    colors="true"
+    columns="max"
+    failOnRisky="true"
+    failOnWarning="true"
+    cacheDirectory="build/.phpunit.cache">
     <coverage ignoreDeprecatedCodeUnits="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
          bootstrap="system/Test/bootstrap.php" backupGlobals="false"
          beStrictAboutOutputDuringTests="true" colors="true" columns="max"
          failOnRisky="true" failOnWarning="true"
-         cacheDirectory=".phpunit.cache">
+         cacheDirectory="build/.phpunit.cache">
     <coverage ignoreDeprecatedCodeUnits="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,11 @@
     failOnRisky="true"
     failOnWarning="true"
     cacheDirectory="build/.phpunit.cache">
-    <coverage ignoreDeprecatedCodeUnits="true">
+    <coverage
+        includeUncoveredFiles="true"
+        pathCoverage="false"
+        ignoreDeprecatedCodeUnits="true"
+        disableCodeCoverageIgnore="true">
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <html outputDirectory="build/coverage/html" highLowerBound="80"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     bootstrap="system/Test/bootstrap.php"
     backupGlobals="false"
     beStrictAboutOutputDuringTests="true"


### PR DESCRIPTION
**Description**
- move PHPUnit cache to build/
- update phpunit.xml.dist for framework and appstarter
- update gitignore

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
