### PR TITLE
docs: fix Postgre DSN sample

### DIFF
--- a/user_guide_src/source/database/configuration/010.php
+++ b/user_guide_src/source/database/configuration/010.php
@@ -10,7 +10,7 @@ class Database extends Config
 
     // Postgre
     public array $default = [
-        'DSN' => 'Postgre://username:password@hostname:5432/database?charset=utf8&connect_timeout=5&sslmode=1',
+        'DSN' => 'Postgre://username:password@hostname:5432/database?charset=utf8&connect_timeout=5&sslmode=require',
         // ...
     ];
 


### PR DESCRIPTION
**Description**
See #8771

The following setting 

```
'DSN' => 'Postgre://postgres:postgres@localhost:5432/test?charset=utf8&connect_timeout=5&sslmode=1',    
```

causes the error:

>CodeIgniter\Database\Exceptions\DatabaseException: Unable to connect to the database.
Main connection [Postgre]: pg_connect(): Unable to connect to PostgreSQL server: invalid sslmode value: "1"



See "Table 33.1. SSL Mode Descriptions"
in https://www.postgresql.org/docs/12/libpq-ssl.html#LIBPQ-SSL-PROTECTION

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
