### PR TITLE
fix: Cannot declare class CodeIgniter\Config\Services, because the name is already in use

### DIFF
--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -265,14 +265,22 @@ class FileLocator implements FileLocatorInterface
     }
 
     /**
-     * Find the qualified name of a file according to
-     * the namespace of the first matched namespace path.
+     * Find the qualified name of a file according to the namespace of the first
+     * matched namespace path.
+     *
+     * This does not find files in `CodeIgniter` namespace.
      *
      * @return false|string The qualified name or false if the path is not found
      */
     public function findQualifiedNameFromPath(string $path)
     {
         $path = realpath($path) ?: $path;
+
+        // Does not search `CodeIgniter` namespace to prevent from loading twice.
+        $systemPath = $this->autoloader->getNamespace('CodeIgniter')[0];
+        if (str_starts_with($path, $systemPath)) {
+            return false;
+        }
 
         if (! is_file($path)) {
             return false;


### PR DESCRIPTION
**Description**
Follow-up #8745

See https://github.com/codeigniter4/CodeIgniter4/pull/8745#issuecomment-2052569997
In this case, `CodeIgniter\Config\Services` was already loaded in the `Boot` class.
In auto-discovery, checking `vendor/codeigniter4/codeigniter4/system/Config/Services.php` first time (`Translations\vendor\codeigniter4\codeigniter4\system\Config\Services`) causes a Fatal error.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
