### PR TITLE
fix: Cannot declare class CodeIgniter\Config\Services, because the name is already in use

### DIFF
--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -389,8 +389,15 @@ class BaseService
                 $locator = static::locator();
                 $files   = $locator->search('Config/Services');
 
+                $systemPath = static::autoloader()->getNamespace('CodeIgniter')[0];
+
                 // Get instances of all service classes and cache them locally.
                 foreach ($files as $file) {
+                    // Does not search `CodeIgniter` namespace to prevent from loading twice.
+                    if (str_starts_with($file, $systemPath)) {
+                        continue;
+                    }
+
                     $classname = $locator->findQualifiedNameFromPath($file);
 
                     if ($classname === false) {


### PR DESCRIPTION
**Description**
Follow-up #8745

See https://github.com/codeigniter4/CodeIgniter4/pull/8745#issuecomment-2052569997
In this case, `CodeIgniter\Config\Services` was already loaded in the `Boot` class.
In auto-discovery, checking `vendor/codeigniter4/codeigniter4/system/Config/Services.php` first time (`Translations\vendor\codeigniter4\codeigniter4\system\Config\Services`) causes a Fatal error.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
