### PR TITLE
refactor: remove deprecated failValidationError() in API\ResponseTrait

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -10782,42 +10782,42 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:__construct\\(\\) has parameter \\$request with no type specified\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:__construct\\(\\) has parameter \\$request with no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:__construct\\(\\) has parameter \\$response with no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:fail\\(\\) has parameter \\$messages with no value type specified in iterable type array\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:fail\\(\\) has parameter \\$messages with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:format\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:format\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:respond\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:respond\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:respondCreated\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:respondCreated\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:respondDeleted\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:respondDeleted\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:respondUpdated\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
+	'message' => '#^Method class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:respondUpdated\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
@@ -10867,17 +10867,17 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:\\$format \\(\'html\'\\|\'json\'\\|\'xml\'\\|null\\) does not accept \'txt\'\\.$#',
+	'message' => '#^Property class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:\\$format \\(\'html\'\\|\'json\'\\|\'xml\'\\|null\\) does not accept \'txt\'\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:\\$request has no type specified\\.$#',
+	'message' => '#^Property class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:\\$request has no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:639\\:\\:\\$response has no type specified\\.$#',
+	'message' => '#^Property class@anonymous/tests/system/API/ResponseTraitTest\\.php\\:621\\:\\:\\$response has no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/API/ResponseTraitTest.php',
 ];

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -225,18 +225,6 @@ trait ResponseTrait
     }
 
     /**
-     * Used when the data provided by the client cannot be validated.
-     *
-     * @return ResponseInterface
-     *
-     * @deprecated Use failValidationErrors instead
-     */
-    protected function failValidationError(string $description = 'Bad Request', ?string $code = null, string $message = '')
-    {
-        return $this->fail($description, $this->codes['invalid_data'], $code, $message);
-    }
-
-    /**
      * Used when the data provided by the client cannot be validated on one or more fields.
      *
      * @param list<string>|string $errors

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -447,24 +447,6 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->assertSame($this->formatter->format($expected), $this->response->getBody());
     }
 
-    public function testValidationError(): void
-    {
-        $controller = $this->makeController();
-
-        $this->invoke($controller, 'failValidationError', ['Nope', 'FAT CHANCE', 'A Custom Reason']);
-
-        $expected = [
-            'status'   => 400,
-            'error'    => 'FAT CHANCE',
-            'messages' => [
-                'error' => 'Nope',
-            ],
-        ];
-        $this->assertSame('A Custom Reason', $this->response->getReasonPhrase());
-        $this->assertSame(400, $this->response->getStatusCode());
-        $this->assertSame($this->formatter->format($expected), $this->response->getBody());
-    }
-
     public function testValidationErrors(): void
     {
         $controller = $this->makeController();

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -29,6 +29,14 @@ Interface Changes
 Method Signature Changes
 ========================
 
+.. _v460-removed-deprecated-items:
+
+Removed Deprecated Items
+========================
+
+- **API:** The deprecated ``failValidationError()`` method in ``CodeIgniter\API\ResponseTrait``
+  has been removed. Use ``failValidationErrors()`` instead.
+
 ************
 Enhancements
 ************

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -20,6 +20,13 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+Removed Deprecated Items
+========================
+
+Some deprecated items have been removed. If you are still using these items, or
+extending these classes, upgrade your code.
+See :ref:`ChangeLog <v460-removed-deprecated-items>` for details.
+
 *********************
 Breaking Enhancements
 *********************

--- a/user_guide_src/source/outgoing/api_responses/002.php
+++ b/user_guide_src/source/outgoing/api_responses/002.php
@@ -25,7 +25,7 @@ $this->failForbidden($description);
 $this->failNotFound($description);
 
 // Data did not validate
-$this->failValidationError($description);
+$this->failValidationErrors($description);
 
 // Resource already exists
 $this->failResourceExists($description);


### PR DESCRIPTION
**Description**
- remove deprecated method. It was deprecated in v4.1.2 https://github.com/codeigniter4/CodeIgniter4/pull/4609/commits/3af7080d809863e6d81eb205220b4f633a4421be

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
