### PR TITLE
fix: [ErrorException] Undefined array key in `spark phpini:check`

### DIFF
--- a/system/Security/CheckPhpIni.php
+++ b/system/Security/CheckPhpIni.php
@@ -142,8 +142,8 @@ class CheckPhpIni
 
         foreach ($items as $key => $values) {
             $output[$key] = [
-                'global'      => $ini[$key]['global_value'],
-                'current'     => $ini[$key]['local_value'],
+                'global'      => array_key_exists($key, $ini) ? $ini[$key]['global_value'] : 'disabled',
+                'current'     => array_key_exists($key, $ini) ? $ini[$key]['local_value'] : 'disabled',
                 'recommended' => $values['recommended'] ?? '',
                 'remark'      => $values['remark'] ?? '',
             ];

--- a/system/Security/CheckPhpIni.php
+++ b/system/Security/CheckPhpIni.php
@@ -141,9 +141,10 @@ class CheckPhpIni
         $ini    = ini_get_all();
 
         foreach ($items as $key => $values) {
+            $hasKeyInIni  = array_key_exists($key, $ini);
             $output[$key] = [
-                'global'      => array_key_exists($key, $ini) ? $ini[$key]['global_value'] : 'disabled',
-                'current'     => array_key_exists($key, $ini) ? $ini[$key]['local_value'] : 'disabled',
+                'global'      => $hasKeyInIni ? $ini[$key]['global_value'] : 'disabled',
+                'current'     => $hasKeyInIni ? $ini[$key]['local_value'] : 'disabled',
                 'recommended' => $values['recommended'] ?? '',
                 'remark'      => $values['remark'] ?? '',
             ];


### PR DESCRIPTION
**Description**
Fixes #8803

```console
$ ./spark phpini:check

CodeIgniter v4.5.1 Command Line Tool - Server Time: 2024-04-19 00:01:44 UTC+00:00

+-------------------------+----------+----------+-------------+-----------------------+
| Directive               | Global   | Current  | Recommended | Remark                |
+-------------------------+----------+----------+-------------+-----------------------+
| error_reporting         | 32767    | 32767    | 5111        |                       |
| display_errors          | 1        | 1        | 0           |                       |
| display_startup_errors  | 1        | 1        | 0           |                       |
| log_errors              | 1        | 1        |             |                       |
| error_log               |          |          |             |                       |
| default_charset         | UTF-8    | UTF-8    | UTF-8       |                       |
| memory_limit            | 1G       | 1G       |             | > post_max_size       |
| post_max_size           | 8M       | 8M       |             | > upload_max_filesize |
| upload_max_filesize     | 2M       | 2M       |             | < post_max_size       |
| request_order           | GP       | GP       | GP          |                       |
| variables_order         | GPCS     | GPCS     | GPCS        |                       |
| date.timezone           | UTC      | UTC      | UTC         |                       |
| mbstring.language       | neutral  | neutral  | neutral     |                       |
| opcache.enable          | disabled | disabled | 1           |                       |
| opcache.enable_cli      | disabled | disabled |             |                       |
| opcache.jit             | disabled | disabled |             |                       |
| opcache.jit_buffer_size | disabled | disabled |             |                       |
+-------------------------+----------+----------+-------------+-----------------------+
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
