### PR TITLE
fix: update `preload.php` for 4.5

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -36,6 +36,7 @@ $finder = Finder::create()
         __DIR__ . '/.php-cs-fixer.no-header.php',
         __DIR__ . '/.php-cs-fixer.tests.php',
         __DIR__ . '/.php-cs-fixer.user-guide.php',
+        __DIR__ . '/preload.php',
         __DIR__ . '/rector.php',
         __DIR__ . '/spark',
     ]);

--- a/preload.php
+++ b/preload.php
@@ -29,19 +29,6 @@ require __DIR__ . '/app/Config/Paths.php';
 // Path to the front controller
 define('FCPATH', __DIR__ . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR);
 
-/**
- * See https://www.php.net/manual/en/function.str-contains.php#126277
- */
-if (! function_exists('str_contains')) {
-    /**
-     * Polyfill of str_contains()
-     */
-    function str_contains(string $haystack, string $needle): bool
-    {
-        return empty($needle) || strpos($haystack, $needle) !== false;
-    }
-}
-
 class preload
 {
     /**
@@ -51,6 +38,7 @@ class preload
         [
             'include' => __DIR__ . '/vendor/codeigniter4/framework/system', // Change this path if using manual installation
             'exclude' => [
+                '/system/bootstrap.php',
                 // Not needed if you don't use them.
                 '/system/Database/OCI8/',
                 '/system/Database/Postgre/',
@@ -77,16 +65,18 @@ class preload
         $this->loadAutoloader();
     }
 
-    private function loadAutoloader()
+    private function loadAutoloader(): void
     {
         $paths = new Config\Paths();
-        require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'bootstrap.php';
+        require rtrim($paths->systemDirectory, '\\/ ') . DIRECTORY_SEPARATOR . 'Boot.php';
+
+        CodeIgniter\Boot::preload($paths);
     }
 
     /**
      * Load PHP files.
      */
-    public function load()
+    public function load(): void
     {
         foreach ($this->paths as $path) {
             $directory = new RecursiveDirectoryIterator($path['include']);

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -123,6 +123,19 @@ class Boot
     }
 
     /**
+     * Used by `preload.php`
+     */
+    public static function preload(Paths $paths): void
+    {
+        static::definePathConstants($paths);
+        static::loadConstants();
+        static::defineEnvironment();
+        static::loadEnvironmentBootstrap($paths, false);
+
+        static::loadAutoloader();
+    }
+
+    /**
      * Load environment settings from .env files into $_SERVER and $_ENV
      */
     protected static function loadDotEnv(Paths $paths): void


### PR DESCRIPTION
**Description**
Fixes #8801

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
