### PR TITLE
fix: [OCI8] Bug: Argument #1 ($value) must be of type ?int, string given

### DIFF
--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -632,7 +632,7 @@ class Connection extends BaseConnection
         }
 
         $isEasyConnectableHostName = $this->hostname !== '' && ! str_contains($this->hostname, '/') && ! str_contains($this->hostname, ':');
-        $easyConnectablePort       = ! empty($this->port) && ctype_digit($this->port) ? ':' . $this->port : '';
+        $easyConnectablePort       = ! empty($this->port) && ctype_digit((string)$this->port) ? ':' . $this->port : '';
         $easyConnectableDatabase   = $this->database !== '' ? '/' . ltrim($this->database, '/') : '';
 
         if ($isEasyConnectableHostName && ($easyConnectablePort !== '' || $easyConnectableDatabase !== '')) {


### PR DESCRIPTION
cast $this->port to string on ctype_digit of OCI8 Connection

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide