### PR TITLE
fix issue #8810: Bug: Invalid date format for ORACLE database for created_at and updated_at

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1402,7 +1402,7 @@ abstract class BaseModel
     {
         return match ($this->dateFormat) {
             'int'      => $value,
-            'datetime' => date($this->db->dateFormat['datetime'], $value),
+            'datetime' => date($this->db->dateFormat[($this->db->getPlatform() === 'OCI8'?'datetime-oci8':'datetime')], $value),
             'date'     => date($this->db->dateFormat['date'], $value),
             default    => throw ModelException::forNoDateFormat(static::class),
         };

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -357,11 +357,12 @@ abstract class BaseConnection implements ConnectionInterface
      * @var array<string, string>
      */
     protected array $dateFormat = [
-        'date'        => 'Y-m-d',
-        'datetime'    => 'Y-m-d H:i:s',
-        'datetime-ms' => 'Y-m-d H:i:s.v',
-        'datetime-us' => 'Y-m-d H:i:s.u',
-        'time'        => 'H:i:s',
+        'date'          => 'Y-m-d',
+        'datetime'      => 'Y-m-d H:i:s',
+        'datetime-oci8' => 'd-M-y h.i.s.u A',
+        'datetime-ms'   => 'Y-m-d H:i:s.v',
+        'datetime-us'   => 'Y-m-d H:i:s.u',
+        'time'          => 'H:i:s',
     ];
 
     /**

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -632,7 +632,7 @@ class Connection extends BaseConnection
         }
 
         $isEasyConnectableHostName = $this->hostname !== '' && ! str_contains($this->hostname, '/') && ! str_contains($this->hostname, ':');
-        $easyConnectablePort       = ! empty($this->port) && ctype_digit($this->port) ? ':' . $this->port : '';
+        $easyConnectablePort       = ! empty($this->port) && ctype_digit((string)$this->port) ? ':' . $this->port : '';
         $easyConnectableDatabase   = $this->database !== '' ? '/' . ltrim($this->database, '/') : '';
 
         if ($isEasyConnectableHostName && ($easyConnectablePort !== '' || $easyConnectableDatabase !== '')) {


### PR DESCRIPTION
Added an new date format key for oracle (d-M-y h.i.s.u A) in BaseConnection then  use it incase the platform is OCI8 in BaseModel intToDate function