### PR TITLE
fix: incorrect Security exception message

### DIFF
--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -670,7 +670,7 @@ trait ResponseTrait
 
         foreach ($this->cookieStore->display() as $cookie) {
             if ($cookie->isSecure() && ! $request->isSecure()) {
-                throw SecurityException::forDisallowedAction();
+                throw SecurityException::forInsecureCookie();
             }
 
             $name    = $cookie->getPrefixedName();

--- a/system/Language/en/Security.php
+++ b/system/Language/en/Security.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 // Security language settings
 return [
     'disallowedAction' => 'The action you requested is not allowed.',
+    'insecureCookie'   => 'Attempted to send a secure cookie over a non-secure connection.',
 
     // @deprecated
     'invalidSameSite' => 'The SameSite value must be None, Lax, Strict, or a blank string. Given: "{0}"',

--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -20,12 +20,22 @@ class SecurityException extends FrameworkException implements HTTPExceptionInter
 {
     /**
      * Throws when some specific action is not allowed.
+     * This is used for CSRF protection.
      *
      * @return static
      */
     public static function forDisallowedAction()
     {
         return new static(lang('Security.disallowedAction'), 403);
+    }
+
+    /**
+     * Throws if a secure cookie is dispatched when the current connection is not
+     * secure.
+     */
+    public static function forInsecureCookie(): static
+    {
+        return new static(lang('Security.insecureCookie'));
     }
 
     /**

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -162,14 +162,11 @@ final class ResponseSendTest extends CIUnitTestCase
 
     /**
      * Make sure secure cookies are not sent with HTTP request
-     *
-     * @ runInSeparateProcess
-     * @ preserveGlobalState  disabled
      */
     public function testDoNotSendUnSecureCookie(): void
     {
         $this->expectException(SecurityException::class);
-        $this->expectExceptionMessage('The action you requested is not allowed');
+        $this->expectExceptionMessage('Attempted to send a secure cookie over a non-secure connection.');
 
         $request = $this->createMock(IncomingRequest::class);
         $request->method('isSecure')->willReturn(false);

--- a/user_guide_src/source/changelogs/v4.5.2.rst
+++ b/user_guide_src/source/changelogs/v4.5.2.rst
@@ -18,6 +18,8 @@ BREAKING
 Message Changes
 ***************
 
+- Added ``Security.insecureCookie`` message.
+
 *******
 Changes
 *******


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=90653&pid=418015#pid418015

This is a server side misconfiguration, not a client error.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
