### PR TITLE
test: add `@var` for PHPStan

### DIFF
--- a/tests/system/Models/FindModelTest.php
+++ b/tests/system/Models/FindModelTest.php
@@ -45,6 +45,7 @@ final class FindModelTest extends LiveModelTestCase
         ]);
         $id = $this->model->insert($user, true);
 
+        /** @var UserWithCasts $user */
         $user = $this->model->find($id);
 
         $this->assertSame('John Smith', $user->name);


### PR DESCRIPTION
**Description**
Follow-up #8823

```
 ------ -----------------------------------------------------
  Line   tests/system/Models/FindModelTest.php
 ------ -----------------------------------------------------
  50     Cannot access property $name on array<int, array>.
  51     Cannot access property $email on array<int, array>.
 ------ -----------------------------------------------------
```

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
