### PR TITLE
refactor!: remove depreacted ResponseInterface::getReason()

### DIFF
--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -206,21 +206,6 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * Gets the response response phrase associated with the status code.
-     *
-     * @see http://tools.ietf.org/html/rfc7231#section-6
-     * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     *
-     * @deprecated Use getReasonPhrase()
-     *
-     * @codeCoverageIgnore
-     */
-    public function getReason(): string
-    {
-        return $this->getReasonPhrase();
-    }
-
-    /**
      * Gets the response reason phrase associated with the status code.
      *
      * Because a reason phrase is not a required element in a response

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -136,16 +136,6 @@ interface ResponseInterface extends MessageInterface
     public function setStatusCode(int $code, string $reason = '');
 
     /**
-     * Gets the response phrase associated with the status code.
-     *
-     * @see http://tools.ietf.org/html/rfc7231#section-6
-     * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-     *
-     * @deprecated Use getReasonPhrase()
-     */
-    public function getReason(): string;
-
-    /**
      * Gets the response reason phrase associated with the status code.
      *
      * Because a reason phrase is not a required element in a response

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -36,6 +36,8 @@ Removed Deprecated Items
 
 - **API:** The deprecated ``failValidationError()`` method in ``CodeIgniter\API\ResponseTrait``
   has been removed. Use ``failValidationErrors()`` instead.
+- **HTTP:** The deprecated ``getReason()`` method in ``CodeIgniter\HTTP\Response``
+  and ``ResponseInterface`` has been removed. Use ``getReasonPhrase()`` instead.
 
 ************
 Enhancements


### PR DESCRIPTION
**Description**
See https://codeigniter4.github.io/CodeIgniter4/installation/upgrade_405.html#message-getheader-s
- remove deprecated ResponseInterface::getReason()

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
