### PR TITLE
docs: update deprecated method in sample code in CURLRequest

### DIFF
--- a/user_guide_src/source/libraries/curlrequest/009.php
+++ b/user_guide_src/source/libraries/curlrequest/009.php
@@ -1,4 +1,4 @@
 <?php
 
-$code   = $response->getStatusCode(); // 200
-$reason = $response->getReason(); // OK
+$code   = $response->getStatusCode();   // 200
+$reason = $response->getReasonPhrase(); // OK


### PR DESCRIPTION
**Description**
The `getReason()` method is deprecated. See https://codeigniter4.github.io/CodeIgniter4/installation/upgrade_405.html#message-getheader-s

- update deprecated method in sample code

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
