### PR TITLE
fix: remove unused undefined param $raw in MockCache::save()

### DIFF
--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -92,11 +92,10 @@ class MockCache extends BaseHandler implements CacheInterface
      * @param string $key   Cache item name
      * @param mixed  $value the data to save
      * @param int    $ttl   Time To Live, in seconds (default 60)
-     * @param bool   $raw   Whether to store the raw value.
      *
      * @return bool
      */
-    public function save(string $key, $value, int $ttl = 60, bool $raw = false)
+    public function save(string $key, $value, int $ttl = 60)
     {
         if ($this->bypass) {
             return false;


### PR DESCRIPTION
**Description**
It is not defined in the interface or other classes, and not used at all.
See also https://github.com/codeigniter4/CodeIgniter4/pull/8846#discussion_r1585689583

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
