### PR TITLE
fix: correct property default values in Email

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -151,7 +151,7 @@ class Email
      *
      * @var string
      */
-    public $charset = 'utf-8';
+    public $charset = 'UTF-8';
 
     /**
      * Alternative message (for HTML messages only)
@@ -182,7 +182,7 @@ class Email
      *
      * @var string "\r\n" or "\n"
      */
-    public $newline = "\n";
+    public $newline = "\r\n";
 
     /**
      * CRLF character sequence
@@ -197,7 +197,7 @@ class Email
      *
      * @var string
      */
-    public $CRLF = "\n";
+    public $CRLF = "\r\n";
 
     /**
      * Whether to use Delivery Status Notification.


### PR DESCRIPTION
**Description**
Make them the same as in the Config\Email.
Related #8851

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
