### PR TITLE
test: fix coding style and test-coding-standards.yml

### DIFF
--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         php-version:
           - '8.1'
-          - '8.2'
+          - '8.3'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -60,8 +60,11 @@ jobs:
       - name: Run lint on `app/`, `admin/`, `public/`
         run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.php-cs-fixer.no-header.php --using-cache=no --diff
 
-      - name: Run lint on `system/`, `tests`, `utils/`, and root PHP files
+      - name: Run lint on `system/`, `utils/`, and root PHP files
         run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --using-cache=no --diff
+
+      - name: Run lint on `tests`
+        run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.php-cs-fixer.tests.php --using-cache=no --diff
 
       - name: Run lint on `user_guide_src/source/`
         run: vendor/bin/php-cs-fixer fix --verbose --ansi --dry-run --config=.php-cs-fixer.user-guide.php --using-cache=no --diff

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\API;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\Format\JSONFormatter;
@@ -25,6 +24,7 @@ use CodeIgniter\Test\Mock\MockIncomingRequest;
 use CodeIgniter\Test\Mock\MockResponse;
 use Config\App;
 use Config\Cookie;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/AutoReview/ComposerJsonTest.php
+++ b/tests/system/AutoReview/ComposerJsonTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\AutoReview;
 
-use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\Group;
 use InvalidArgumentException;
 use JsonException;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/system/AutoReview/FrameworkCodeTest.php
+++ b/tests/system/AutoReview/FrameworkCodeTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\AutoReview;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use FilesystemIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Autoloader;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use App\Controllers\Home;
 use Closure;
 use CodeIgniter\Exceptions\ConfigException;
@@ -25,6 +22,9 @@ use Config\Autoload;
 use Config\Modules;
 use Config\Services;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use RuntimeException;
 use UnnamespacedClass;
 

--- a/tests/system/Autoloader/FileLocatorCachedTest.php
+++ b/tests/system/Autoloader/FileLocatorCachedTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Autoloader;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Cache\FactoriesCache\FileVarExportHandler;
 use Config\Autoload;
 use Config\Modules;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Autoloader;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\Header;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Autoload;
 use Config\Modules;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\CLI;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\PhpStreamWrapper;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionProperty;
 use RuntimeException;
 

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\CLI;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\DotEnv;
 use CodeIgniter\Events\Events;
@@ -21,6 +20,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCLIConfig;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/CacheFactoryTest.php
+++ b/tests/system/Cache/CacheFactoryTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\Cache\Handlers\DummyHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Cache;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/CacheMockTest.php
+++ b/tests/system/Cache/CacheMockTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Cache\Handlers\BaseHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCache;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/FactoriesCacheFileHandlerTest.php
+++ b/tests/system/Cache/FactoriesCacheFileHandlerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache;
 
-use PHPUnit\Framework\Attributes\Group;
 use Config\Cache as CacheConfig;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/FactoriesCacheFileVarExportHandlerTest.php
+++ b/tests/system/Cache/FactoriesCacheFileVarExportHandlerTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Cache\FactoriesCache\FileVarExportHandler;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/Handlers/BaseHandlerTest.php
+++ b/tests/system/Cache/Handlers/BaseHandlerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Cache\RestrictiveHandler;
 

--- a/tests/system/Cache/Handlers/DummyHandlerTest.php
+++ b/tests/system/Cache/Handlers/DummyHandlerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Cache\Exceptions\CacheException;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
 /**
  * @internal

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
 use Exception;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/Handlers/PredisHandlerTest.php
+++ b/tests/system/Cache/Handlers/PredisHandlerTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cache/ResponseCacheTest.php
+++ b/tests/system/Cache/ResponseCacheTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
@@ -26,6 +24,8 @@ use Config\App as AppConfig;
 use Config\Cache as CacheConfig;
 use ErrorException;
 use Exception;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -13,10 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use App\Controllers\Home;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Debug\Timer;
@@ -34,6 +30,10 @@ use Config\Cache;
 use Config\Filters as FiltersConfig;
 use Config\Modules;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\Filters\Customfilter;
 use Tests\Support\Filters\RedirectFilter;
 

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Commands\AppInfo;
 
 /**

--- a/tests/system/Commands/CellGeneratorTest.php
+++ b/tests/system/Commands/CellGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ClearCacheTest.php
+++ b/tests/system/Commands/ClearCacheTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ClearDebugbarTest.php
+++ b/tests/system/Commands/ClearDebugbarTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ClearLogsTest.php
+++ b/tests/system/Commands/ClearLogsTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/CommandGeneratorTest.php
+++ b/tests/system/Commands/CommandGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\CLI\Commands;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Commands\ParamsReveal;
 
 /**

--- a/tests/system/Commands/ConfigGeneratorTest.php
+++ b/tests/system/Commands/ConfigGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ConfigurableSortImportsTest.php
+++ b/tests/system/Commands/ConfigurableSortImportsTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ControllerGeneratorTest.php
+++ b/tests/system/Commands/ControllerGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/CreateDatabaseTest.php
+++ b/tests/system/Commands/CreateDatabaseTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Database as DatabaseFactory;
 use CodeIgniter\Database\OCI8\Connection as OCI8Connection;
@@ -21,6 +20,7 @@ use CodeIgniter\Database\SQLite3\Connection as SQLite3Connection;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoMockIOTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Mock\MockInputOutput;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Database/ShowTableInfoTest.php
+++ b/tests/system/Commands/Database/ShowTableInfoTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Commands/DatabaseCommandsTest.php
+++ b/tests/system/Commands/DatabaseCommandsTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/EntityGeneratorTest.php
+++ b/tests/system/Commands/EntityGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/EnvironmentCommandTest.php
+++ b/tests/system/Commands/EnvironmentCommandTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/FilterCheckTest.php
+++ b/tests/system/Commands/FilterCheckTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/FilterGeneratorTest.php
+++ b/tests/system/Commands/FilterGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/Commands/GeneratorsTest.php
+++ b/tests/system/Commands/GeneratorsTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/HelpCommandTest.php
+++ b/tests/system/Commands/HelpCommandTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/InfoCacheTest.php
+++ b/tests/system/Commands/InfoCacheTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/MigrationGeneratorTest.php
+++ b/tests/system/Commands/MigrationGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ModelGeneratorTest.php
+++ b/tests/system/Commands/ModelGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/PublishCommandTest.php
+++ b/tests/system/Commands/PublishCommandTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Publishers\TestPublisher;
 
 /**

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/ScaffoldGeneratorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Autoload;
 use Config\Modules;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/SeederGeneratorTest.php
+++ b/tests/system/Commands/SeederGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/TestGeneratorTest.php
+++ b/tests/system/Commands/TestGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Translation/LocalizationFinderTest.php
+++ b/tests/system/Commands/Translation/LocalizationFinderTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Translation;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\App;
 use Config\Services;
 use Locale;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Utilities/ConfigCheckTest.php
+++ b/tests/system/Commands/Utilities/ConfigCheckTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\App;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Utilities/NamespacesTest.php
+++ b/tests/system/Commands/Utilities/NamespacesTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Utilities/Routes/AutoRouteCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouteCollectorTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Filters;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Dash_folder\Dash_controller;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\Home;
 use CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers\SubDir\BlogController;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Controllers\Newautorouting;
 use Tests\Support\Controllers\Remap;
 

--- a/tests/system/Commands/Utilities/Routes/ControllerFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/ControllerFinderTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Controllers\Hello;
 
 /**

--- a/tests/system/Commands/Utilities/Routes/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/ControllerMethodReaderTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Controllers\Popcorn;
 use Tests\Support\Controllers\Remap;
 

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\CSRF;
 use CodeIgniter\Filters\DebugToolbar;
@@ -30,6 +29,7 @@ use Config\Feature;
 use Config\Filters as FiltersConfig;
 use Config\Modules;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Commands/ValidationGeneratorTest.php
+++ b/tests/system/Commands/ValidationGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/CommonFunctionsSendTest.php
+++ b/tests/system/CommonFunctionsSendTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -13,11 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\BaseService;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\CLIRequest;
@@ -46,6 +41,11 @@ use Config\Services;
 use Config\Session as SessionConfig;
 use Exception;
 use Kint;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use RuntimeException;
 use stdClass;
 use Tests\Support\Models\JobModel;

--- a/tests/system/CommonHelperTest.php
+++ b/tests/system/CommonHelperTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\CoversFunction;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use RuntimeException;
 use Tests\Support\Autoloader\FatalLocator;

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockSecurity;
 use Config\Security as SecurityConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionClass;
 use ReflectionMethod;
 

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Config;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Encryption;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\MockObject\MockObject;
 use RegistrarConfig;
 use RuntimeException;

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Config;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use TypeError;
 
 /**

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Config;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\Depends;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\Database;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionClass;
 use stdClass;
 use Tests\Support\Config\TestRegistrar;

--- a/tests/system/Config/MimesTest.php
+++ b/tests/system/Config/MimesTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Config;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Mimes;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Config;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Autoloader\Autoloader;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Database\MigrationRunner;
@@ -49,6 +46,9 @@ use CodeIgniter\View\Parser;
 use Config\App;
 use Config\Exceptions;
 use Config\Security as SecurityConfig;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use RuntimeException;
 use Tests\Support\Config\Services;
 

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -27,6 +25,8 @@ use CodeIgniter\Validation\Exceptions\ValidationException;
 use Config\App;
 use Config\Services;
 use Config\Validation as ValidationConfig;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/tests/system/Cookie/CookieStoreTest.php
+++ b/tests/system/Cookie/CookieStoreTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cookie;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\Test\CIUnitTestCase;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cookie;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Cookie as CookieConfig;
 use DateTimeImmutable;
 use DateTimeZone;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\DataConverter;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Closure;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Entity\CustomUser;
 use Tests\Support\Entity\User;
 

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Throwable;
 
 /**

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/BaseTest.php
+++ b/tests/system/Database/Builder/BaseTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/CountTest.php
+++ b/tests/system/Database/Builder/CountTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/DeleteTest.php
+++ b/tests/system/Database/Builder/DeleteTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/DistinctTest.php
+++ b/tests/system/Database/Builder/DistinctTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/EmptyTest.php
+++ b/tests/system/Database/Builder/EmptyTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/FromTest.php
+++ b/tests/system/Database/Builder/FromTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/GetTest.php
+++ b/tests/system/Database/Builder/GetTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use Config\Feature;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/GroupTest.php
+++ b/tests/system/Database/Builder/GroupTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Postgre\Builder as PostgreBuilder;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/LikeTest.php
+++ b/tests/system/Database/Builder/LikeTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/LimitTest.php
+++ b/tests/system/Database/Builder/LimitTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/OrderTest.php
+++ b/tests/system/Database/Builder/OrderTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/PrefixTest.php
+++ b/tests/system/Database/Builder/PrefixTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/ReplaceTest.php
+++ b/tests/system/Database/Builder/ReplaceTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Database\SQLSRV\Builder as SQLSRVBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/TruncateTest.php
+++ b/tests/system/Database/Builder/TruncateTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/UnionTest.php
+++ b/tests/system/Database/Builder/UnionTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\SQLSRV\Connection as SQLSRVConnection;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/UpdateTest.php
+++ b/tests/system/Database/Builder/UpdateTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
 use CodeIgniter\Test\Mock\MockQuery;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/WhenTest.php
+++ b/tests/system/Database/Builder/WhenTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Builder/WhereTest.php
+++ b/tests/system/Database/Builder/WhereTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Builder;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -22,6 +20,8 @@ use CodeIgniter\Test\Mock\MockConnection;
 use DateTime;
 use Error;
 use ErrorException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/DatabaseSeederTest.php
+++ b/tests/system/Database/DatabaseSeederTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Database;
 use Faker\Generator;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\DatabaseTestCase;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * DatabaseTestCaseMigrationOnce1Test and DatabaseTestCaseMigrationOnce2Test

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\DatabaseTestCase;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * DatabaseTestCaseMigrationOnce1Test and DatabaseTestCaseMigrationOnce2Test

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\AnotherSeeder;
 use Tests\Support\Database\Seeds\CITestSeeder;
 

--- a/tests/system/Database/Forge/CreateTableTest.php
+++ b/tests/system/Database/Forge/CreateTableTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Forge;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Forge/DropForeignKeyTest.php
+++ b/tests/system/Database/Forge/DropForeignKeyTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Forge;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/AliasTest.php
+++ b/tests/system/Database/Live/AliasTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/BadQueryTest.php
+++ b/tests/system/Database/Live/BadQueryTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Database\SQLite3\Connection;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/CountTest.php
+++ b/tests/system/Database/Live/CountTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
+++ b/tests/system/Database/Live/DatabaseTestTraitCaseTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/DbDebugTest.php
+++ b/tests/system/Database/Live/DbDebugTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Database;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/EmptyTest.php
+++ b/tests/system/Database/Live/EmptyTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/EscapeTest.php
+++ b/tests/system/Database/Live/EscapeTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/FabricatorLiveTest.php
+++ b/tests/system/Database/Live/FabricatorLiveTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Fabricator;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\UserModel;
 use Tests\Support\Models\ValidModel;
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use LogicException;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 use stdClass;
 use Tests\Support\Database\Seeds\CITestSeeder;

--- a/tests/system/Database/Live/FromTest.php
+++ b/tests/system/Database/Live/FromTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/GetNumRowsTest.php
+++ b/tests/system/Database/Live/GetNumRowsTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Feature;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/GetVersionTest.php
+++ b/tests/system/Database/Live/GetVersionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/GroupTest.php
+++ b/tests/system/Database/Live/GroupTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/IncrementTest.php
+++ b/tests/system/Database/Live/IncrementTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/JoinTest.php
+++ b/tests/system/Database/Live/JoinTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/LimitTest.php
+++ b/tests/system/Database/Live/LimitTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/MySQLi/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/MySQLi/GetFieldDataTestCase.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\MySQLi;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/MySQLi/NumberNativeTest.php
+++ b/tests/system/Database/Live/MySQLi/NumberNativeTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\MySQLi;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/MySQLi/RawSqlTest.php
+++ b/tests/system/Database/Live/MySQLi/RawSqlTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\MySQLi;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use stdclass;
 use Tests\Support\Database\Seeds\CITestSeeder;
 

--- a/tests/system/Database/Live/OCI8/CallStoredProcedureTest.php
+++ b/tests/system/Database/Live/OCI8/CallStoredProcedureTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\OCI8;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/OCI8/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/OCI8/GetFieldDataTestCase.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\OCI8;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
 use LogicException;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/Database/Live/OCI8/LastInsertIDTest.php
+++ b/tests/system/Database/Live/OCI8/LastInsertIDTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\OCI8;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/OrderTest.php
+++ b/tests/system/Database/Live/OrderTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/Postgre/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/Postgre/GetFieldDataTestCase.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\Postgre;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/PreparedQueryTest.php
+++ b/tests/system/Database/Live/PreparedQueryTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use BadMethodCallException;
 use CodeIgniter\Database\BasePreparedQuery;
 use CodeIgniter\Database\Exceptions\DatabaseException;
@@ -21,6 +20,7 @@ use CodeIgniter\Database\Query;
 use CodeIgniter\Database\ResultInterface;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/PretendTest.php
+++ b/tests/system/Database/Live/PretendTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/SQLSRV/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/SQLSRV/GetFieldDataTestCase.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\SQLSRV;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/SQLite3/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite3/AlterTableTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\SQLite3;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Database\SQLite3\Forge;
 use CodeIgniter\Database\SQLite3\Table;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * @internal

--- a/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
+++ b/tests/system/Database/Live/SQLite3/ForgeModifyColumnTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\SQLite3;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/SQLite3/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/SQLite3/GetFieldDataTestCase.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\SQLite3;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Live\AbstractGetFieldDataTestCase;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/Live/SQLite3/GetIndexDataTest.php
+++ b/tests/system/Database/Live/SQLite3/GetIndexDataTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live\SQLite3;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\SQLite3\Connection;
 use CodeIgniter\Database\SQLite3\Forge;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/Database/Live/SelectTest.php
+++ b/tests/system/Database/Live/SelectTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/TransactionDBDebugFalseTest.php
+++ b/tests/system/Database/Live/TransactionDBDebugFalseTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database\Live;
 
 use PHPUnit\Framework\Attributes\Group;
+
 /**
  * @internal
  */

--- a/tests/system/Database/Live/TransactionDBDebugTrueTest.php
+++ b/tests/system/Database/Live/TransactionDBDebugTrueTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/UnionTest.php
+++ b/tests/system/Database/Live/UnionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/UpsertTest.php
+++ b/tests/system/Database/Live/UpsertTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use stdclass;
 use Tests\Support\Database\Seeds\CITestSeeder;
 

--- a/tests/system/Database/Live/WhereTest.php
+++ b/tests/system/Database/Live/WhereTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Live/WriteTypeQueryTest.php
+++ b/tests/system/Database/Live/WriteTypeQueryTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseBuilder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
 /**

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Migrations;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Events\Events;
@@ -25,6 +24,7 @@ use Config\Migrations;
 use Config\Services;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\MigrationTestMigrations\Database\Migrations\Migration_another_migration;
 use Tests\Support\MigrationTestMigrations\Database\Migrations\Migration_some_migration;
 

--- a/tests/system/Database/Migrations/MigrationTest.php
+++ b/tests/system/Database/Migrations/MigrationTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Migrations;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Migration;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Database/RawSqlTest.php
+++ b/tests/system/Database/RawSqlTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Debug;
 
-use PHPUnit\Framework\Attributes\Group;
 use App\Controllers\Home;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -21,6 +20,7 @@ use CodeIgniter\Test\IniTestTrait;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -11,8 +11,6 @@
 
 namespace CodeIgniter\Debug;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RequiresPhp;
 use App\Controllers\Home;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Entity\Exceptions\CastException;
@@ -22,6 +20,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
 use Config\Exceptions as ExceptionsConfig;
 use ErrorException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use RuntimeException;
 
 /**

--- a/tests/system/Debug/TimerTest.php
+++ b/tests/system/Debug/TimerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Debug;
 
-use PHPUnit\Framework\Attributes\Group;
 use ArgumentCountError;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**

--- a/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Query;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**

--- a/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use DateTime;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/DebugTraceableTraitTest.php
+++ b/tests/system/DebugTraceableTraitTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\CoversClass;
 use CodeIgniter\Exceptions\DebugTraceableTrait;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Email;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockEmail;
 use ErrorException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Encryption/EncryptionTest.php
+++ b/tests/system/Encryption/EncryptionTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Encryption;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Encryption\Exceptions\EncryptionException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Encryption as EncryptionConfig;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
+++ b/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Encryption\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Encryption\Encryption;
 use CodeIgniter\Encryption\Exceptions\EncryptionException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Encryption as EncryptionConfig;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Encryption/Handlers/SodiumHandlerTest.php
+++ b/tests/system/Encryption/Handlers/SodiumHandlerTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Encryption\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Encryption\Encryption;
 use CodeIgniter\Encryption\Exceptions\EncryptionException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Encryption as EncryptionConfig;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Entity;
 
-use PHPUnit\Framework\Attributes\Group;
 use Closure;
 use CodeIgniter\Entity\Exceptions\CastException;
 use CodeIgniter\HTTP\URI;
@@ -22,6 +21,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
 use DateTime;
 use DateTimeInterface;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionException;
 use Tests\Support\Entity\Cast\CastBase64;
 use Tests\Support\Entity\Cast\CastPassParameters;

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Events;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockEvents;
 use Config\Modules;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Files;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Files\Exceptions\FileException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Files;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use ZipArchive;
 
 /**

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Files;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Filters/CorsTest.php
+++ b/tests/system/Filters/CorsTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -24,6 +23,7 @@ use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * This test case is based on:

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Filters as FilterConfig;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Filters\Exceptions\FilterException;
@@ -34,6 +31,9 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ConfigFromArrayTrait;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use Config\Filters as FiltersConfig;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 require_once __DIR__ . '/fixtures/GoogleMe.php';
 require_once __DIR__ . '/fixtures/GoogleYou.php';

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -13,10 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\CLIRequest;
@@ -24,6 +20,10 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Honeypot;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/Filters/InvalidCharsTest.php
+++ b/tests/system/Filters/InvalidCharsTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\SiteURI;
@@ -23,6 +20,9 @@ use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Filters/SecureHeadersTest.php
+++ b/tests/system/Filters/SecureHeadersTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Format/FormatTest.php
+++ b/tests/system/Format/FormatTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Format;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Format\Exceptions\FormatException;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Format/JSONFormatterTest.php
+++ b/tests/system/Format/JSONFormatterTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Format;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**

--- a/tests/system/Format/XMLFormatterTest.php
+++ b/tests/system/Format/XMLFormatterTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Format;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use DOMDocument;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/CLIRequestTest.php
+++ b/tests/system/HTTP/CLIRequestTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * This should be the same as RequestTest,

--- a/tests/system/HTTP/CURLRequestShareOptionsTest.php
+++ b/tests/system/HTTP/CURLRequestShareOptionsTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\Mock\MockCURLRequest;
 use Config\App;
 use Config\CURLRequest as ConfigCURLRequest;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * This test case is for the case where shareOptions is true.

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\BackupGlobals;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
@@ -23,6 +21,8 @@ use CodeIgniter\Test\Mock\MockCURLRequest;
 use Config\App;
 use Config\CURLRequest as ConfigCURLRequest;
 use CURLFile;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\TestResponse;
 use Config\App;
 use Config\ContentSecurityPolicy as CSPConfig;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * Test the CSP policy directive creation.

--- a/tests/system/HTTP/CorsTest.php
+++ b/tests/system/HTTP/CorsTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/DownloadResponseTest.php
+++ b/tests/system/HTTP/DownloadResponseTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Exceptions\DownloadException;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP\Files;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Mimes;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP\Files;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Error;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/HTTP/IncomingRequestDetectingTest.php
+++ b/tests/system/HTTP/IncomingRequestDetectingTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -13,11 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
@@ -26,6 +21,11 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use InvalidArgumentException;
 use JsonException;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use TypeError;
 
 /**

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/OutgoingRequestTest.php
+++ b/tests/system/HTTP/OutgoingRequestTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/RedirectExceptionTest.php
+++ b/tests/system/HTTP/RedirectExceptionTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use Config\Services;
 use LogicException;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\Log\Handlers\TestHandler;
 

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Router\RouteCollection;
@@ -26,6 +23,9 @@ use Config\App;
 use Config\Modules;
 use Config\Routing;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/ResponseCookieTest.php
+++ b/tests/system/HTTP/ResponseCookieTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\Cookie\CookieStore;
@@ -21,6 +20,7 @@ use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\Cookie as CookieConfig;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Security\Exceptions\SecurityException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * This test suite has been created separately from

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -23,6 +21,8 @@ use Config\App;
 use Config\Services;
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
+++ b/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/SiteURITest.php
+++ b/tests/system/HTTP/SiteURITest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use BadMethodCallException;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HTTP/UserAgentTest.php
+++ b/tests/system/HTTP/UserAgentTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HTTP;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/Array/ArrayHelperDotKeyExistsTest.php
+++ b/tests/system/Helpers/Array/ArrayHelperDotKeyExistsTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\Array;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/Array/ArrayHelperRecursiveDiffTest.php
+++ b/tests/system/Helpers/Array/ArrayHelperRecursiveDiffTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\Array;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/Array/ArrayHelperSortValuesByNaturalTest.php
+++ b/tests/system/Helpers/Array/ArrayHelperSortValuesByNaturalTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\Array;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/ArrayHelperTest.php
+++ b/tests/system/Helpers/ArrayHelperTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use ValueError;
 
 /**

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -26,6 +25,7 @@ use Config\App;
 use Config\Cookie;
 use Config\Cookie as CookieConfig;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Test\CIUnitTestCase;
 use DateTimeZone;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\DocTypes;
 use Config\Filters;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\DocTypes;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/InflectorHelperTest.php
+++ b/tests/system/Helpers/InflectorHelperTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/NumberHelperTest.php
+++ b/tests/system/Helpers/NumberHelperTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/SecurityHelperTest.php
+++ b/tests/system/Helpers/SecurityHelperTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockSecurity;
 use Config\Security as SecurityConfig;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Config\Services;
 
 /**

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\URLHelper;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -25,6 +22,9 @@ use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test cases for all URL Helper functions

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -13,11 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\URLHelper;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -28,6 +23,11 @@ use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/Helpers/URLHelper/SiteUrlCliTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlCliTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\URLHelper;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Since base_url() only slightly modifies

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers\URLHelper;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -24,6 +21,9 @@ use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Since base_url() only slightly modifies

--- a/tests/system/Helpers/XMLHelperTest.php
+++ b/tests/system/Helpers/XMLHelperTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Helpers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HomeTest.php
+++ b/tests/system/HomeTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\FeatureTestTrait;
 use CodeIgniter\Test\TestResponse;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Honeypot;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\Filters;
@@ -25,6 +23,8 @@ use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\Honeypot as HoneypotConfig;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/HotReloader/DirectoryHasherTest.php
+++ b/tests/system/HotReloader/DirectoryHasherTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\HotReloader;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/I18n/TimeDifferenceTest.php
+++ b/tests/system/I18n/TimeDifferenceTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\I18n;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Locale;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/I18n/TimeLegacyTest.php
+++ b/tests/system/I18n/TimeLegacyTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\I18n;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\I18n\Exceptions\I18nException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -23,6 +21,8 @@ use DateTime;
 use DateTimeZone;
 use IntlDateFormatter;
 use Locale;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\I18n;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\I18n\Exceptions\I18nException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -23,6 +21,8 @@ use DateTime;
 use DateTimeZone;
 use IntlDateFormatter;
 use Locale;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Images;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Images\Exceptions\ImageException;
@@ -21,6 +20,7 @@ use CodeIgniter\Images\Handlers\BaseHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test the common image processing functionality.

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Images;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Images\Handlers\BaseHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Unit testing for the GD image handler.

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Images;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RequiresPhpExtension;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Images\Handlers\BaseHandler;
@@ -23,6 +20,9 @@ use CodeIgniter\Images\Handlers\ImageMagickHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Images;
 use Imagick;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * Unit testing for the ImageMagick image handler.

--- a/tests/system/Images/ImageTest.php
+++ b/tests/system/Images/ImageTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Images;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Language;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLanguage;
 use Config\Services;
 use MessageFormatter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Language\SecondMockLanguage;
 
 /**

--- a/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Log\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use CodeIgniter\Test\Mock\MockResponse;
 use Config\App;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/Log/Handlers/ErrorlogHandlerTest.php
+++ b/tests/system/Log/Handlers/ErrorlogHandlerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Log\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Log\Exceptions\LogException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**

--- a/tests/system/Log/Handlers/FileHandlerTest.php
+++ b/tests/system/Log/Handlers/FileHandlerTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Log\Handlers;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockFileLogger;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Log\Handlers\TestHandler;
 
 /**

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Log;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Log\Exceptions\LogException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use Exception;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Log\Handlers\TestHandler;
 use TypeError;
 

--- a/tests/system/Models/DataConverterModelTest.php
+++ b/tests/system/Models/DataConverterModelTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\I18n\Time;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Entity\CustomUser;
 use Tests\Support\Entity\User;
 use Tests\Support\Models\UserCastsTimestampModel;

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Exceptions\ModelException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\StringifyPkeyModel;
 use Tests\Support\Models\UserModel;

--- a/tests/system/Models/EventsModelTest.php
+++ b/tests/system/Models/EventsModelTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DataException;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\EventModel;
 
 /**

--- a/tests/system/Models/FindModelTest.php
+++ b/tests/system/Models/FindModelTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Exceptions\ModelException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Entity\UserWithCasts;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SecondaryModel;

--- a/tests/system/Models/GeneralModelTest.php
+++ b/tests/system/Models/GeneralModelTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use BadMethodCallException;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Model;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\UserModel;
 

--- a/tests/system/Models/GetCompiledModelTest.php
+++ b/tests/system/Models/GetCompiledModelTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Exceptions\ModelException;
 use CodeIgniter\Model;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\UserObjModel;
 
 /**

--- a/tests/system/Models/InsertModelTest.php
+++ b/tests/system/Models/InsertModelTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Model;
 use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Entity\User;
 use Tests\Support\Models\JobModel;

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\I18n\Time;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\EntityModel;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SimpleEntity;

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Model;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Models\EntityModel;
 use Tests\Support\Models\JobModel;

--- a/tests/system/Models/TimestampModelTest.php
+++ b/tests/system/Models/TimestampModelTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\I18n\Time;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Entity\User;
 use Tests\Support\Models\UserTimestampModel;
 

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Entity\Entity;
 use Config\Database;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Entity\User;
 use Tests\Support\Entity\UUID;

--- a/tests/system/Models/ValidationModelRuleGroupTest.php
+++ b/tests/system/Models/ValidationModelRuleGroupTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Model;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Config\Validation;
 use Tests\Support\Models\JobModel;

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Models;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Model;
 use Config\Validation;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Models\JobModel;
 use Tests\Support\Models\SimpleEntity;

--- a/tests/system/Pager/PagerRendererTest.php
+++ b/tests/system/Pager/PagerRendererTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Pager;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\URI;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Pager;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\SiteURI;
@@ -25,6 +23,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\Pager as PagerConfig;
 use Config\Services;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Publisher/ContentReplacerTest.php
+++ b/tests/system/Publisher/ContentReplacerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Publisher;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Publisher/PublisherContentReplaceTest.php
+++ b/tests/system/Publisher/PublisherContentReplaceTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Publisher;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Publisher;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Publisher;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Publisher/PublisherRestrictionsTest.php
+++ b/tests/system/Publisher/PublisherRestrictionsTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Publisher;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Publisher\Exceptions\PublisherException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Publisher Restrictions Test

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Publisher;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Publisher\Exceptions\PublisherException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Publishers\TestPublisher;
 
 /**

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\RESTful;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Format\JSONFormatter;
@@ -30,6 +27,9 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Test\Mock\MockResourceController;
 use Config\App;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\Log\NullLogger;
 use Tests\Support\Models\UserModel;
 use Tests\Support\RESTful\Worker;

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\RESTful;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Model;
@@ -24,6 +21,9 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use CodeIgniter\Test\Mock\MockResourcePresenter;
 use Config\App;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\Models\EntityModel;
 use Tests\Support\Models\UserModel;
 use Tests\Support\RESTful\Worker2;

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
@@ -27,6 +25,8 @@ use CodeIgniter\Router\Controllers\Mycontroller;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Router\Exceptions\RouterException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use App\Controllers\Product;
 use CodeIgniter\Config\Services;
 use CodeIgniter\controller;
@@ -23,6 +21,8 @@ use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Controllers\Hello;
 
 /**

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
@@ -27,6 +25,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
 use Config\Modules;
 use Config\Routing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Filters\Customfilter;
 
 /**

--- a/tests/system/Security/CheckPhpIniTest.php
+++ b/tests/system/Security/CheckPhpIniTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Security;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockInputOutput;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Security;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Cookie;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -23,6 +22,7 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use CodeIgniter\Test\Mock\MockSecurity;
 use Config\Security as SecurityConfig;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Security;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -35,6 +32,9 @@ use Config\Cookie;
 use Config\Logger as LoggerConfig;
 use Config\Security as SecurityConfig;
 use Config\Session as SessionConfig;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
 /**

--- a/tests/system/Security/SecurityCSRFSessionTest.php
+++ b/tests/system/Security/SecurityCSRFSessionTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Security;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -34,6 +31,9 @@ use Config\Cookie;
 use Config\Logger as LoggerConfig;
 use Config\Security as SecurityConfig;
 use Config\Session as SessionConfig;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * @internal

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Security;
 
-use PHPUnit\Framework\Attributes\BackupGlobals;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;
@@ -26,6 +24,8 @@ use CodeIgniter\Test\Mock\MockAppConfig;
 use CodeIgniter\Test\Mock\MockSecurity;
 use Config\Security as SecurityConfig;
 use Config\Services;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Session/Handlers/Database/MySQLiHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/MySQLiHandlerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session\Handlers\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use Config\Database as DatabaseConfig;
 use Config\Session as SessionConfig;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Session/Handlers/Database/PostgreHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/PostgreHandlerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session\Handlers\Database;
 
-use PHPUnit\Framework\Attributes\Group;
 use Config\Database as DatabaseConfig;
 use Config\Session as SessionConfig;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Session/Handlers/Database/RedisHandlerTest.php
+++ b/tests/system/Session/Handlers/Database/RedisHandlerTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session\Handlers\Database;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RequiresPhpExtension;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Session\Handlers\RedisHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Session as SessionConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
 /**
  * @internal

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Session;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use CodeIgniter\Session\Handlers\FileHandler;
@@ -25,6 +22,9 @@ use CodeIgniter\Test\TestLogger;
 use Config\Cookie as CookieConfig;
 use Config\Logger as LoggerConfig;
 use Config\Session as SessionConfig;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * @internal

--- a/tests/system/SparkTest.php
+++ b/tests/system/SparkTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/SuperglobalsTest.php
+++ b/tests/system/SuperglobalsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Test;
 
 use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Class BootstrapFCPATHTest
  *

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\Group;
 use App\Controllers\Home;
 use App\Controllers\NeverHeardOfIt;
 use CodeIgniter\Controller;
@@ -24,6 +21,9 @@ use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use Config\App;
 use Config\Services;
 use Exception;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Tests\Support\Controllers\Newautorouting;
 use Tests\Support\Controllers\Popcorn;
 

--- a/tests/system/Test/DOMParserTest.php
+++ b/tests/system/Test/DOMParserTest.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * @internal
  */

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Model;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Models\EntityModel;
 use Tests\Support\Models\EventModel;
 use Tests\Support\Models\FabricatorModel;

--- a/tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
+++ b/tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Events\Events;
 use Config\Feature;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\PageNotFoundException;
@@ -24,6 +22,8 @@ use CodeIgniter\Test\Mock\MockCodeIgniter;
 use Config\App;
 use Config\Routing;
 use Config\Services;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\RequestInterface;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Filters\Customfilter;
 
 /**

--- a/tests/system/Test/TestCaseEmissionsTest.php
+++ b/tests/system/Test/TestCaseEmissionsTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\HTTP\Response;
 use Config\App;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * This test suite has been created separately from

--- a/tests/system/Test/TestCaseTest.php
+++ b/tests/system/Test/TestCaseTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\Events\Events;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Test\TestForReflectionHelper;
 
 /**

--- a/tests/system/Test/TestLoggerTest.php
+++ b/tests/system/Test/TestLoggerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Config\Logger;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
 use Config\App;
 use Config\Services;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Throttle/ThrottleTest.php
+++ b/tests/system/Throttle/ThrottleTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Throttle;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Typography/TypographyTest.php
+++ b/tests/system/Typography/TypographyTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Typography;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/DatabaseRelatedRulesTest.php
+++ b/tests/system/Validation/DatabaseRelatedRulesTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Validation\StrictRules\DatabaseRelatedRulesTest as StrictDatabaseRelatedRulesTest;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/DotArrayFilterTest.php
+++ b/tests/system/Validation/DotArrayFilterTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Validation\TestRules;
 

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation\StrictRules;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Validation;
 use Config\Services;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
+++ b/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation\StrictRules;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Validation\Validation;
@@ -21,6 +20,7 @@ use Config\Database;
 use Config\Services;
 use InvalidArgumentException;
 use LogicException;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation\StrictRules;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Validation;
 use Config\Services;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/StrictRules/FormatRulesTest.php
+++ b/tests/system/Validation/StrictRules/FormatRulesTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation\StrictRules;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Validation\FormatRulesTest as TraditionalFormatRulesTest;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation\StrictRules;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Validation\RulesTest as TraditionalRulesTest;
 use CodeIgniter\Validation\Validation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/StrictRules/ValidationTest.php
+++ b/tests/system/Validation/StrictRules/ValidationTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation\StrictRules;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Validation\ValidationTest as TraditionalValidationTest;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
 
 /**

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Validation;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\SiteURI;
@@ -23,6 +21,8 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use Config\App;
 use Config\Services;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Support\Validation\TestRules;
 use Throwable;

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockCache;
 use CodeIgniter\View\Exceptions\ViewException;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/View/ControlledCellTest.php
+++ b/tests/system/View/ControlledCellTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
 use LogicException;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\View\Cells\AdditionCell;
 use Tests\Support\View\Cells\AwesomeCell;
 use Tests\Support\View\Cells\BadCell;

--- a/tests/system/View/DecoratorsTest.php
+++ b/tests/system/View/DecoratorsTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\View\BadDecorator;
 use Tests\Support\View\WorldDecorator;
 

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\View;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Validation;
 use Config\Services;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @internal

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
 use Config\Services;
 use Config\View as ViewConfig;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/View/TableTest.php
+++ b/tests/system/View/TableTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\Attributes\DataProvider;
 use CodeIgniter\Database\MySQLi\Result;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockTable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace CodeIgniter\View;
 
-use PHPUnit\Framework\Attributes\Group;
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
 use Config;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**


### PR DESCRIPTION
**Description**
Follow-up #8746 and #8821

- update `test-coding-standards.yml`
- fix coding style for test classes

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
