### PR TITLE
fix: FileCollection pseudo-regex

### DIFF
--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -105,7 +105,7 @@ class FileCollection implements Countable, IteratorAggregate
                 ['\#', '\.', '.*', '.'],
                 $pattern
             );
-            $pattern = "#{$pattern}#";
+            $pattern = "#\\A{$pattern}\\z#";
         }
 
         return array_filter($files, static fn ($value) => (bool) preg_match($pattern, basename($value)));

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -175,6 +175,7 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $files->add(SUPPORTPATH . 'Files');
@@ -227,6 +228,7 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
             SUPPORTPATH . 'Log/Handlers/TestHandler.php',
         ];
 
@@ -392,6 +394,7 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $collection->addDirectory(SUPPORTPATH . 'Files', true);
@@ -407,6 +410,7 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $collection->addDirectories([
@@ -425,6 +429,7 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
             SUPPORTPATH . 'Log/Handlers/TestHandler.php',
         ];
 
@@ -471,6 +476,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $expected = [
             $this->directory . 'apple.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $collection->removePattern('*_*.php');
@@ -485,6 +491,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $expected = [
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $collection->removePattern('*.php', $this->directory);
@@ -512,6 +519,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $expected = [
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $collection->retainPattern('#[a-z]+_.*#');
@@ -541,6 +549,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $expected = [
             $this->directory . 'fig_3.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $collection->retainPattern('*_?.php', $this->directory);
@@ -553,7 +562,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new FileCollection();
         $collection->addDirectory(SUPPORTPATH . 'Files', true);
 
-        $this->assertCount(4, $collection);
+        $this->assertCount(5, $collection);
     }
 
     public function testIterable(): void
@@ -568,6 +577,6 @@ final class FileCollectionTest extends CIUnitTestCase
             $count++;
         }
 
-        $this->assertSame($count, 4);
+        $this->assertSame($count, 5);
     }
 }

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -451,7 +451,10 @@ final class FilesystemHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $this->assertSame($expected, get_dir_file_info(SUPPORTPATH . 'Files/baker'));
+        $result = get_dir_file_info(SUPPORTPATH . 'Files/baker');
+        ksort($result);
+
+        $this->assertSame($expected, $result);
     }
 
     public function testGetDirFileInfoNested(): void

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -429,15 +429,24 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
     public function testGetDirFileInfo(): void
     {
-        $file = SUPPORTPATH . 'Files/baker/banana.php';
-        $info = get_file_info($file);
+        $file1 = SUPPORTPATH . 'Files/baker/banana.php';
+        $info1 = get_file_info($file1);
+        $file2 = SUPPORTPATH . 'Files/baker/fig_3.php.txt';
+        $info2 = get_file_info($file2);
 
         $expected = [
             'banana.php' => [
                 'name'          => 'banana.php',
-                'server_path'   => $file,
-                'size'          => $info['size'],
-                'date'          => $info['date'],
+                'server_path'   => $file1,
+                'size'          => $info1['size'],
+                'date'          => $info1['date'],
+                'relative_path' => realpath(__DIR__ . '/../../_support/Files/baker'),
+            ],
+            'fig_3.php.txt' => [
+                'name'          => 'fig_3.php.txt',
+                'server_path'   => $file2,
+                'size'          => $info2['size'],
+                'date'          => $info2['date'],
                 'relative_path' => realpath(__DIR__ . '/../../_support/Files/baker'),
             ],
         ];

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -86,6 +86,7 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
         ];
 
         $publisher->addPath('Files');
@@ -121,6 +122,7 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
             SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
             SUPPORTPATH . 'Log/Handlers/TestHandler.php',
         ];
 

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -161,6 +161,7 @@ final class PublisherOutputTest extends CIUnitTestCase
             $this->root->url() . '/able/fig_3.php',
             $this->root->url() . '/able/prune_ripe.php',
             $this->root->url() . '/baker/banana.php',
+            $this->root->url() . '/baker/fig_3.php.txt',
         ];
 
         $this->assertFileDoesNotExist($this->root->url() . '/able/fig_3.php');
@@ -183,6 +184,7 @@ final class PublisherOutputTest extends CIUnitTestCase
             $this->root->url() . '/able/fig_3.php',
             $this->root->url() . '/able/prune_ripe.php',
             $this->root->url() . '/baker/banana.php',
+            $this->root->url() . '/baker/fig_3.php.txt',
         ];
 
         $result = $publisher->addPath('/')->merge(true);
@@ -200,6 +202,7 @@ final class PublisherOutputTest extends CIUnitTestCase
             $this->root->url() . '/able/apple.php',
             $this->root->url() . '/able/prune_ripe.php',
             $this->root->url() . '/baker/banana.php',
+            $this->root->url() . '/baker/fig_3.php.txt',
         ];
 
         mkdir($this->root->url() . '/able/fig_3.php');


### PR DESCRIPTION
**Description**
Fixes a bug that the pseudo-regex `'*_?.php'` matches `fig_3.php.txt`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
