### PR TITLE
fix: [Model] casting causes TypeError when finding no record

### DIFF
--- a/system/Model.php
+++ b/system/Model.php
@@ -210,7 +210,7 @@ class Model extends BaseModel
             $row = $builder->get()->getResult($this->tempReturnType);
         }
 
-        if ($useCast) {
+        if ($useCast && $row !== null) {
             $row = $this->convertToReturnType($row, $returnType);
 
             $this->tempReturnType = $returnType;

--- a/system/Model.php
+++ b/system/Model.php
@@ -318,7 +318,7 @@ class Model extends BaseModel
 
         $row = $builder->limit(1, 0)->get()->getFirstRow($this->tempReturnType);
 
-        if ($useCast) {
+        if ($useCast && $row !== null) {
             $row = $this->convertToReturnType($row, $returnType);
 
             $this->tempReturnType = $returnType;

--- a/tests/system/Models/DataConverterModelTest.php
+++ b/tests/system/Models/DataConverterModelTest.php
@@ -43,6 +43,16 @@ final class DataConverterModelTest extends LiveModelTestCase
         $this->seeInDatabase('user', ['name' => 'Sm9obiBTbWl0aA==']);
     }
 
+    public function testFindAsArrayReturnsNull(): void
+    {
+        $this->createModel(UserCastsTimestampModel::class);
+        $this->db->table('user')->truncate();
+
+        $user = $this->model->find(1);
+
+        $this->assertNull($user);
+    }
+
     /**
      * @return int|string Insert ID
      */
@@ -100,6 +110,16 @@ final class DataConverterModelTest extends LiveModelTestCase
         $this->assertInstanceOf(Time::class, $users[0]['created_at']);
         $this->assertIsInt($users[1]['id']);
         $this->assertInstanceOf(Time::class, $users[1]['created_at']);
+    }
+
+    public function testFindAllAsArrayReturnsNull(): void
+    {
+        $this->createModel(UserCastsTimestampModel::class);
+        $this->db->table('user')->truncate();
+
+        $users = $this->model->findAll();
+
+        $this->assertSame([], $users);
     }
 
     private function prepareTwoRecords(): void
@@ -168,6 +188,16 @@ final class DataConverterModelTest extends LiveModelTestCase
 
         $this->assertIsInt($user['id']);
         $this->assertInstanceOf(Time::class, $user['created_at']);
+    }
+
+    public function testFirstAsArrayReturnsNull(): void
+    {
+        $this->createModel(UserCastsTimestampModel::class);
+        $this->db->table('user')->truncate();
+
+        $user = $this->model->first();
+
+        $this->assertNull($user);
     }
 
     public function testFirstAsObject(): void


### PR DESCRIPTION
**Description**
Supersedes #8807
Fixes #8806

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
