### PR TITLE
fix: CLI::promptByMultipleKeys() and prompt()

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -378,7 +378,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
-	'count' => 5,
+	'count' => 2,
 	'path' => __DIR__ . '/system/CLI/CLI.php',
 ];
 $ignoreErrors[] = [

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -343,9 +343,9 @@ class CLI
             // find max from input
             $maxInput = max($inputToArray);
 
-            // return the prompt again if $input contain(s) non-numeric charachter, except a comma.
-            // And if max from $options less than max from input
-            // it is mean user tried to access null value in $options
+            // return the prompt again if $input contain(s) non-numeric character, except a comma.
+            // And if max from $options less than max from input,
+            // it means user tried to access null value in $options
             if (! $pattern || $maxOptions < $maxInput) {
                 static::error('Please select correctly.');
                 CLI::newLine();

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -258,7 +258,8 @@ class CLI
         static::fwrite(STDOUT, $field . (trim($field) !== '' ? ' ' : '') . $extraOutput . ': ');
 
         // Read the input from keyboard.
-        $input = trim(static::$io->input()) ?: (string) $default;
+        $input = trim(static::$io->input());
+        $input = ($input === '') ? (string) $default : $input;
 
         if ($validation !== []) {
             while (! static::validate('"' . trim($field) . '"', $input, $validation)) {

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -330,7 +330,9 @@ class CLI
         CLI::write($text);
         CLI::printKeysAndValues($options);
         CLI::newLine();
-        $input = static::prompt($extraOutput) ?: 0; // 0 is default
+
+        $input = static::prompt($extraOutput);
+        $input = ($input === '') ? '0' : $input; // 0 is default
 
         // validation
         while (true) {
@@ -349,7 +351,9 @@ class CLI
             if (! $pattern || $maxOptions < $maxInput) {
                 static::error('Please select correctly.');
                 CLI::newLine();
-                $input = static::prompt($extraOutput) ?: 0;
+
+                $input = static::prompt($extraOutput);
+                $input = ($input === '') ? '0' : $input;
             } else {
                 break;
             }

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -76,9 +76,9 @@ final class CLITest extends CIUnitTestCase
         $time = time();
         CLI::wait(0);
 
-        $this->assertCloseEnough(0, time() - $time);
-
         PhpStreamWrapper::restore();
+
+        $this->assertCloseEnough(0, time() - $time);
     }
 
     public function testPrompt(): void
@@ -90,9 +90,9 @@ final class CLITest extends CIUnitTestCase
 
         $output = CLI::prompt('What is your favorite color?');
 
-        $this->assertSame($expected, $output);
-
         PhpStreamWrapper::restore();
+
+        $this->assertSame($expected, $output);
     }
 
     public function testPromptByMultipleKeys(): void
@@ -105,14 +105,13 @@ final class CLITest extends CIUnitTestCase
         $options = ['Playing game', 'Sleep', 'Badminton'];
         $output  = CLI::promptByMultipleKeys('Select your hobbies:', $options);
 
+        PhpStreamWrapper::restore();
+
         $expected = [
             0 => 'Playing game',
             1 => 'Sleep',
         ];
-
         $this->assertSame($expected, $output);
-
-        PhpStreamWrapper::restore();
     }
 
     public function testNewLine(): void

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -95,6 +95,80 @@ final class CLITest extends CIUnitTestCase
         $this->assertSame($expected, $output);
     }
 
+    public function testPromptInputNothing(): void
+    {
+        PhpStreamWrapper::register();
+
+        $input = '';
+        PhpStreamWrapper::setContent($input);
+
+        $output = CLI::prompt('What is your favorite color?', 'red');
+
+        PhpStreamWrapper::restore();
+
+        $this->assertSame('red', $output);
+    }
+
+    public function testPromptInputZero(): void
+    {
+        PhpStreamWrapper::register();
+
+        $input = '0';
+        PhpStreamWrapper::setContent($input);
+
+        $output = CLI::prompt('What is your favorite number?', '7');
+
+        PhpStreamWrapper::restore();
+
+        $this->assertSame('0', $output);
+    }
+
+    public function testPromptByKey(): void
+    {
+        PhpStreamWrapper::register();
+
+        $input = '1';
+        PhpStreamWrapper::setContent($input);
+
+        $options = ['Playing game', 'Sleep', 'Badminton'];
+        $output  = CLI::promptByKey('Select your hobbies:', $options);
+
+        PhpStreamWrapper::restore();
+
+        $this->assertSame($input, $output);
+    }
+
+    public function testPromptByKeyInputNothing(): void
+    {
+        PhpStreamWrapper::register();
+
+        $input = ''; // This is when you press the Enter key.
+        PhpStreamWrapper::setContent($input);
+
+        $options = ['Playing game', 'Sleep', 'Badminton'];
+        $output  = CLI::promptByKey('Select your hobbies:', $options);
+
+        PhpStreamWrapper::restore();
+
+        $expected = '0';
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPromptByKeyInputZero(): void
+    {
+        PhpStreamWrapper::register();
+
+        $input = '0';
+        PhpStreamWrapper::setContent($input);
+
+        $options = ['Playing game', 'Sleep', 'Badminton'];
+        $output  = CLI::promptByKey('Select your hobbies:', $options);
+
+        PhpStreamWrapper::restore();
+
+        $this->assertSame($input, $output);
+    }
+
     public function testPromptByMultipleKeys(): void
     {
         PhpStreamWrapper::register();
@@ -110,6 +184,42 @@ final class CLITest extends CIUnitTestCase
         $expected = [
             0 => 'Playing game',
             1 => 'Sleep',
+        ];
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPromptByMultipleKeysInputNothing(): void
+    {
+        PhpStreamWrapper::register();
+
+        $input = ''; // This is when you press the Enter key.
+        PhpStreamWrapper::setContent($input);
+
+        $options = ['Playing game', 'Sleep', 'Badminton'];
+        $output  = CLI::promptByMultipleKeys('Select your hobbies:', $options);
+
+        PhpStreamWrapper::restore();
+
+        $expected = [
+            0 => 'Playing game',
+        ];
+        $this->assertSame($expected, $output);
+    }
+
+    public function testPromptByMultipleKeysInputZero(): void
+    {
+        PhpStreamWrapper::register();
+
+        $input = '0';
+        PhpStreamWrapper::setContent($input);
+
+        $options = ['Playing game', 'Sleep', 'Badminton'];
+        $output  = CLI::promptByMultipleKeys('Select your hobbies:', $options);
+
+        PhpStreamWrapper::restore();
+
+        $expected = [
+            0 => 'Playing game',
         ];
         $this->assertSame($expected, $output);
     }


### PR DESCRIPTION
**Description**
Fixes #8861

- fix CLI::promptByMultipleKeys() TypeError
- fix bug that CLI::prompt() may incorrectly return default value

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
