### PR TITLE
fix: Redis cache handler  deleteMatching() not working when a prefix is being used

### DIFF
--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -180,7 +180,7 @@ class RedisHandler extends BaseHandler
 
         do {
             // Scan for some keys
-            $keys = $this->redis->scan($iterator, $pattern);
+            $keys = $this->redis->scan($iterator, $this->prefix.$pattern);
 
             // Redis may return empty results, so protect against that
             if ($keys !== false) {


### PR DESCRIPTION
deleteMatching wasn't working for Redis cache when a prefix was being used.  adding prefix here fixed the issue.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide