### PR TITLE
feat: Adding BaseService::updateServicesCache. Adds ablity to update Services Cache at runtime.

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -42,3 +42,6 @@ parameters:
 		booleansInConditions: true
 		disallowedConstructs: true
 		matchingInheritedMethodNames: true
+	codeigniter:
+		additionalServices:
+			- AfterAutoloadModule\Config\Services

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -413,4 +413,35 @@ class BaseService
             static::$discovered = true;
         }
     }
+
+    /**
+     * Update the services cache.
+     */
+    public static function updateServicesCache(): void
+    {
+        if ((new Modules())->shouldDiscover('services')) {
+            $locator = static::locator();
+            $files   = $locator->search('Config/Services');
+
+            $systemPath = static::autoloader()->getNamespace('CodeIgniter')[0];
+
+            // Get instances of all service classes and cache them locally.
+            foreach ($files as $file) {
+                // Does not search `CodeIgniter` namespace to prevent from loading twice.
+                if (str_starts_with($file, $systemPath)) {
+                    continue;
+                }
+
+                $classname = $locator->findQualifiedNameFromPath($file);
+
+                if ($classname === false) {
+                    continue;
+                }
+
+                if ($classname !== Services::class && ! in_array($classname, self::$serviceNames, true)) {
+                    self::$serviceNames[] = $classname;
+                }
+            }
+        }
+    }
 }

--- a/tests/_support/Test/AfterAutoloadModule/Config/Services.php
+++ b/tests/_support/Test/AfterAutoloadModule/Config/Services.php
@@ -16,8 +16,16 @@ namespace AfterAutoloadModule\Config;
 use AfterAutoloadModule\Test;
 use CodeIgniter\Config\BaseService;
 
+/**
+ * Services for testing BaseService::updateServicesCache()
+ *
+ * This class should not be discovered by the autoloader until the test adds this namespace to the autoloader.
+ */
 class Services extends BaseService
 {
+    /**
+     * Return a shared instance of the Test class for testing
+     */
     public static function test(bool $getShared = true): Test
     {
         if ($getShared) {

--- a/tests/_support/Test/AfterAutoloadModule/Config/Services.php
+++ b/tests/_support/Test/AfterAutoloadModule/Config/Services.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace AfterAutoloadModule\Config;
+
+use AfterAutoloadModule\Test;
+use CodeIgniter\Config\BaseService;
+
+class Services extends BaseService
+{
+    public static function test(bool $getShared = true): Test
+    {
+        if ($getShared) {
+            return static::getSharedInstance('test');
+        }
+
+        return new Test();
+    }
+}

--- a/tests/_support/Test/AfterAutoloadModule/Test.php
+++ b/tests/_support/Test/AfterAutoloadModule/Test.php
@@ -13,6 +13,11 @@ declare(strict_types=1);
 
 namespace AfterAutoloadModule;
 
+/**
+ * A simple class for testing BaseService::updateServicesCache()
+ *
+ * This class should not be discovered by the autoloader until the test adds this namespace to the autoloader.
+ */
 class Test
 {
 }

--- a/tests/_support/Test/AfterAutoloadModule/Test.php
+++ b/tests/_support/Test/AfterAutoloadModule/Test.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace AfterAutoloadModule;
+
+class Test
+{
+}

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -111,6 +111,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
             'reset',
             'resetSingle',
             'injectMock',
+            'updateServicesCache',
             'encrypter', // Encrypter needs a starter key
             'session', // Headers already sent
         ];

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -75,6 +75,9 @@ Helpers and Functions
 
 Others
 ======
+- **Services:** Added ``BaseService::updateServicesCache`` method to allow
+  updating the services cache file post autoloading. This will only look for
+  new services and add them to the class name cache.
 
 ***************
 Message Changes

--- a/user_guide_src/source/concepts/services.rst
+++ b/user_guide_src/source/concepts/services.rst
@@ -171,3 +171,6 @@ would simply use the framework's ``Config\Services`` class to grab your service:
 .. literalinclude:: services/012.php
 
 .. note:: If multiple Services files have the same method name, the first one found will be the instance returned.
+
+There may be times when you need to have Service Discovery refresh it's cache after the inital autoload proccess. This can be done by running :php:meth:`Config\\Services::updateServicesCache()`.
+This will force the service discovery to re-scan the directories for any new services files.


### PR DESCRIPTION
**Description**
Supersedes #8894

I need a different method to load Modules. I wanted to set it up so it was more database driven for enabling or disabling a module. This lead to problems with Services not being auto discovered by the buildServicesCache() function. As the autoloader doesn't know those files exist at the point it time it is called. Which results in any static calls to the any services class or service function would return null. So added a function that will update the service cache with and new Classes discovered since initial build. 

Apologizes for previous PR. This contains the code, documentation, change log, code comments, and tests. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
