### PR TITLE
fix: precedence of command classes with the same `$name`

### DIFF
--- a/system/CLI/Commands.php
+++ b/system/CLI/Commands.php
@@ -125,7 +125,7 @@ class Commands
                 /** @var BaseCommand $class */
                 $class = new $className($this->logger, $this);
 
-                if (isset($class->group)) {
+                if (isset($class->group) && ! isset($this->commands[$class->name])) {
                     $this->commands[$class->name] = [
                         'class'       => $className,
                         'file'        => $file,

--- a/tests/_support/_command/ListCommands.php
+++ b/tests/_support/_command/ListCommands.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace App\Commands;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\Commands\ListCommands as BaseListCommands;
+
+class ListCommands extends BaseListCommands
+{
+    /**
+     * The group the command is lumped under
+     * when listing commands.
+     *
+     * @var string
+     */
+    protected $group = 'App';
+
+    /**
+     * The Command's name
+     *
+     * @var string
+     */
+    protected $name = 'list';
+
+    /**
+     * the Command's short description
+     *
+     * @var string
+     */
+    protected $description = 'This is testing to override `list` command.';
+
+    /**
+     * the Command's usage
+     *
+     * @var string
+     */
+    protected $usage = 'list';
+
+    /**
+     * Displays the help for the spark cli script itself.
+     */
+    public function run(array $params)
+    {
+        CLI::write('This is ' . self::class);
+
+        return EXIT_SUCCESS;
+    }
+}

--- a/tests/system/Commands/CommandOverrideTest.php
+++ b/tests/system/Commands/CommandOverrideTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\StreamFilterTrait;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('Others')]
+final class CommandOverrideTest extends CIUnitTestCase
+{
+    use StreamFilterTrait;
+
+    protected function setUp(): void
+    {
+        $this->resetServices();
+
+        parent::setUp();
+    }
+
+    protected function getBuffer(): string
+    {
+        return $this->getStreamFilterBuffer();
+    }
+
+    public function testOverrideListCommands(): void
+    {
+        $this->copyListCommands();
+
+        command('list');
+
+        $this->assertStringContainsString('This is App\Commands\ListCommands', $this->getBuffer());
+        $this->assertStringNotContainsString('Displays basic usage information.', $this->getBuffer());
+
+        $this->deleteListCommands();
+    }
+
+    private function copyListCommands(): void
+    {
+        if (! is_dir(APPPATH . 'Commands')) {
+            mkdir(APPPATH . 'Commands');
+        }
+        copy(SUPPORTPATH . '_command/ListCommands.php', APPPATH . 'Commands/ListCommands.php');
+    }
+
+    private function deleteListCommands(): void
+    {
+        unlink(APPPATH . 'Commands/ListCommands.php');
+    }
+}


### PR DESCRIPTION
**Description**
This PR allows users to override commands in the framework with commands in `App\Commands`,
and prevents other packages from overriding commands in the framework.

This PR changes to use the first command class discovered.
In the current implementation, the last class discovered is executed. 
However, for CI4's behavior, if there is a command class in `App\Commands`, it should take precedence.

See also https://forum.codeigniter.com/showthread.php?tid=90877&pid=418854#pid418854

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
