### PR TITLE
docs: Prevent text-wrap in user guide

### DIFF
--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -245,6 +245,10 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
     background-color: #fffff0;
 }
 
+span.std {
+    text-wrap: nowrap;
+}
+
 /* Messages ----------------------------------------------------------------- */
 
 .rst-content .success {


### PR DESCRIPTION
**Description**
Prevent text-wrap in user guide. For example 
```
$this-
>validateData() should stay unwrapped ($this->validateData()).
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
