### PR TITLE
fix: DefinedRouteCollector to use RouteCollectionInterface

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -7197,34 +7197,9 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Router/Router.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getDefaultNamespace\\(\\)\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/system/Router/Router.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getFiltersForRoute\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Router/Router.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRegisteredControllers\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Router/Router.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRoutesOptions\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Router/Router.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:isFiltered\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Router/Router.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:setHTTPVerb\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Router/Router.php',
+    'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRegisteredControllers\\(\\)\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/system/Router/Router.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -7197,11 +7197,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/Router/Router.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to an undefined method CodeIgniter\\\\Router\\\\RouteCollectionInterface\\:\\:getRegisteredControllers\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/system/Router/Router.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 2,
 	'path' => __DIR__ . '/system/Router/Router.php',

--- a/system/Router/DefinedRouteCollector.php
+++ b/system/Router/DefinedRouteCollector.php
@@ -23,7 +23,7 @@ use Generator;
  */
 final class DefinedRouteCollector
 {
-    public function __construct(private readonly RouteCollection $routeCollection)
+    public function __construct(private readonly RouteCollectionInterface $routeCollection)
     {
     }
 

--- a/system/Router/RouteCollectionInterface.php
+++ b/system/Router/RouteCollectionInterface.php
@@ -22,9 +22,6 @@ use CodeIgniter\HTTP\ResponseInterface;
  * A Route Collection's sole job is to hold a series of routes. The required
  * number of methods is kept very small on purpose, but implementors may
  * add a number of additional methods to customize how the routes are defined.
- *
- * The RouteCollection provides the Router with the routes so that it can determine
- * which controller should be run.
  */
 interface RouteCollectionInterface
 {
@@ -63,10 +60,18 @@ interface RouteCollectionInterface
     public function setDefaultNamespace(string $value);
 
     /**
+     * Returns the default namespace.
+     */
+    public function getDefaultNamespace(): string;
+
+    /**
      * Sets the default controller to use when no other controller has been
      * specified.
      *
      * @return RouteCollectionInterface
+     *
+     * @TODO The default controller is only for auto-routing. So this should be
+     *      removed in the future.
      */
     public function setDefaultController(string $value);
 
@@ -86,6 +91,9 @@ interface RouteCollectionInterface
      * doesn't work well with PHP method names....
      *
      * @return RouteCollectionInterface
+     *
+     * @TODO This method is only for auto-routing. So this should be removed in
+     *      the future.
      */
     public function setTranslateURIDashes(bool $value);
 
@@ -96,6 +104,9 @@ interface RouteCollectionInterface
      * defined routes.
      *
      * If FALSE, will stop searching and do NO automatic routing.
+     *
+     * @TODO This method is only for auto-routing. So this should be removed in
+     *      the future.
      */
     public function setAutoRoute(bool $value): self;
 
@@ -107,6 +118,9 @@ interface RouteCollectionInterface
      * This setting is passed to the Router class and handled there.
      *
      * @param callable|null $callable
+     *
+     * @TODO This method is not related to the route collection. So this should
+     *      be removed in the future.
      */
     public function set404Override($callable = null): self;
 
@@ -115,6 +129,9 @@ interface RouteCollectionInterface
      * or the controller/string.
      *
      * @return (Closure(string): (ResponseInterface|string|void))|string|null
+     *
+     * @TODO This method is not related to the route collection. So this should
+     *      be removed in the future.
      */
     public function get404Override();
 
@@ -122,6 +139,9 @@ interface RouteCollectionInterface
      * Returns the name of the default controller. With Namespace.
      *
      * @return string
+     *
+     * @TODO The default controller is only for auto-routing. So this should be
+     *      removed in the future.
      */
     public function getDefaultController();
 
@@ -136,6 +156,9 @@ interface RouteCollectionInterface
      * Returns the current value of the translateURIDashes setting.
      *
      * @return bool
+     *
+     * @TODO This method is only for auto-routing. So this should be removed in
+     *      the future.
      */
     public function shouldTranslateURIDashes();
 
@@ -143,15 +166,38 @@ interface RouteCollectionInterface
      * Returns the flag that tells whether to autoRoute URI against Controllers.
      *
      * @return bool
+     *
+     * @TODO This method is only for auto-routing. So this should be removed in
+     *      the future.
      */
     public function shouldAutoRoute();
 
     /**
      * Returns the raw array of available routes.
      *
-     * @return array
+     * @param non-empty-string|null $verb            HTTP verb like `GET`,`POST` or `*` or `CLI`.
+     * @param bool                  $includeWildcard Whether to include '*' routes.
      */
-    public function getRoutes();
+    public function getRoutes(?string $verb = null, bool $includeWildcard = true): array;
+
+    /**
+     * Returns one or all routes options
+     *
+     * @param string|null $from The route path (with placeholders or regex)
+     * @param string|null $verb HTTP verb like `GET`,`POST` or `*` or `CLI`.
+     *
+     * @return array<string, int|string> [key => value]
+     */
+    public function getRoutesOptions(?string $from = null, ?string $verb = null): array;
+
+    /**
+     * Sets the current HTTP verb.
+     *
+     * @param string $verb HTTP verb
+     *
+     * @return $this
+     */
+    public function setHTTPVerb(string $verb);
 
     /**
      * Returns the current HTTP Verb being used.
@@ -194,4 +240,28 @@ interface RouteCollectionInterface
      * Get the flag that limit or not the routes with {locale} placeholder to App::$supportedLocales
      */
     public function shouldUseSupportedLocalesOnly(): bool;
+
+    /**
+     * Checks a route (using the "from") to see if it's filtered or not.
+     *
+     * @param string|null $verb HTTP verb like `GET`,`POST` or `*` or `CLI`.
+     */
+    public function isFiltered(string $search, ?string $verb = null): bool;
+
+    /**
+     * Returns the filters that should be applied for a single route, along
+     * with any parameters it might have. Parameters are found by splitting
+     * the parameter name on a colon to separate the filter name from the parameter list,
+     * and the splitting the result on commas. So:
+     *
+     *    'role:admin,manager'
+     *
+     * has a filter of "role", with parameters of ['admin', 'manager'].
+     *
+     * @param string      $search routeKey
+     * @param string|null $verb   HTTP verb like `GET`,`POST` or `*` or `CLI`.
+     *
+     * @return list<string> filter_name or filter_name:arguments like 'role:admin,manager'
+     */
+    public function getFiltersForRoute(string $search, ?string $verb = null): array;
 }

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -170,7 +170,7 @@ class Router implements RouterInterface
                 );
             } else {
                 $this->autoRouter = new AutoRouter(
-                    $this->collection->getRoutes('CLI', false), // @phpstan-ignore-line
+                    $this->collection->getRoutes('CLI', false),
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),
@@ -400,7 +400,6 @@ class Router implements RouterInterface
      */
     protected function checkRoutes(string $uri): bool
     {
-        // @phpstan-ignore-next-line
         $routes = $this->collection->getRoutes($this->collection->getHTTPVerb());
 
         // Don't waste any time

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -161,6 +161,8 @@ class Router implements RouterInterface
         if ($this->collection->shouldAutoRoute()) {
             $autoRoutesImproved = config(Feature::class)->autoRoutesImproved ?? false;
             if ($autoRoutesImproved) {
+                assert($this->collection instanceof RouteCollection);
+
                 $this->autoRouter = new AutoRouterImproved(
                     $this->collection->getRegisteredControllers('*'),
                     $this->collection->getDefaultNamespace(),

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -43,6 +43,8 @@ The following breaking changes have been made accordingly:
 - ``TestException`` now extends ``CodeIgniter\Exceptions\LogicException``
   instead of ``CodeIgniter\Exceptions\CriticalError``.
 
+.. _v460-interface-changes:
+
 Interface Changes
 =================
 
@@ -57,6 +59,8 @@ Interface Changes
     - ``setHTTPVerb()``
     - ``isFiltered()``
     - ``getFiltersForRoute()``
+
+.. _v460-method-signature-changes:
 
 Method Signature Changes
 ========================

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -46,8 +46,23 @@ The following breaking changes have been made accordingly:
 Interface Changes
 =================
 
+.. note:: As long as you have not extended the relevant CodeIgniter core classes
+    or implemented these interfaces, all these changes are backward compatible
+    and require no intervention.
+
+- **Router:** The following methods have been added in ``RouteCollectionInterface``:
+
+    - ``getDefaultNamespace()``
+    - ``getRoutesOptions()``
+    - ``setHTTPVerb()``
+    - ``isFiltered()``
+    - ``getFiltersForRoute()``
+
 Method Signature Changes
 ========================
+
+- **Router:** The constructor of the ``DefinedRouteCollector`` has been
+  changed. The ``RouteCollection`` typehint has been changed to ``RouteCollectionInterface``.
 
 .. _v460-removed-deprecated-items:
 

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -29,6 +29,20 @@ See :ref:`ChangeLog <v460-behavior-changes-exceptions>` for details.
 
 If you have code that catches these exceptions, change the exception classes.
 
+Interface Changes
+=================
+
+Some interface changes have been made. Classes that implement them should update
+their APIs to reflect the changes. See :ref:`ChangeLog <v460-interface-changes>`
+for details.
+
+Method Signature Changes
+========================
+
+Some method signature changes have been made. Classes that extend them should
+update their APIs to reflect the changes. See :ref:`ChangeLog <v460-method-signature-changes>`
+for details.
+
 Removed Deprecated Items
 ========================
 


### PR DESCRIPTION
**Description**
Supersedes #8206
See #6814

- fix RouteCollectionInterface
- DefinedRouteCollector uses RouteCollectionInterface instead of RouteCollection

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
