### PR TITLE
fix: [Postgres] show missing error message

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -420,6 +420,7 @@ abstract class BaseConnection implements ConnectionInterface
             // Connect to the database and set the connection ID
             $this->connID = $this->connect($this->pConnect);
         } catch (Throwable $e) {
+            $this->connID       = false;
             $connectionErrors[] = sprintf('Main connection [%s]: %s', $this->DBDriver, $e->getMessage());
             log_message('error', 'Error connecting to the database: ' . $e);
         }

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -421,7 +421,11 @@ abstract class BaseConnection implements ConnectionInterface
             $this->connID = $this->connect($this->pConnect);
         } catch (Throwable $e) {
             $this->connID       = false;
-            $connectionErrors[] = sprintf('Main connection [%s]: %s', $this->DBDriver, $e->getMessage());
+            $connectionErrors[] = sprintf(
+                'Main connection [%s]: %s',
+                $this->DBDriver,
+                $e->getMessage()
+            );
             log_message('error', 'Error connecting to the database: ' . $e);
         }
 
@@ -442,7 +446,12 @@ abstract class BaseConnection implements ConnectionInterface
                         // Try to connect
                         $this->connID = $this->connect($this->pConnect);
                     } catch (Throwable $e) {
-                        $connectionErrors[] = sprintf('Failover #%d [%s]: %s', ++$index, $this->DBDriver, $e->getMessage());
+                        $connectionErrors[] = sprintf(
+                            'Failover #%d [%s]: %s',
+                            ++$index,
+                            $this->DBDriver,
+                            $e->getMessage()
+                        );
                         log_message('error', 'Error connecting to the database: ' . $e);
                     }
 

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -80,7 +80,9 @@ class Connection extends BaseConnection
         if ($this->connID !== false) {
             if ($persistent === true && pg_connection_status($this->connID) === PGSQL_CONNECTION_BAD && pg_ping($this->connID) === false
             ) {
-                return false;
+                $error = pg_last_error($this->connID);
+
+                throw new DatabaseException($error);
             }
 
             if (! empty($this->schema)) {
@@ -88,7 +90,9 @@ class Connection extends BaseConnection
             }
 
             if ($this->setClientEncoding($this->charset) === false) {
-                return false;
+                $error = pg_last_error($this->connID);
+
+                throw new DatabaseException($error);
             }
         }
 

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -78,7 +78,10 @@ class Connection extends BaseConnection
         $this->connID = $persistent === true ? pg_pconnect($this->DSN) : pg_connect($this->DSN);
 
         if ($this->connID !== false) {
-            if ($persistent === true && pg_connection_status($this->connID) === PGSQL_CONNECTION_BAD && pg_ping($this->connID) === false
+            if (
+                $persistent === true
+                && pg_connection_status($this->connID) === PGSQL_CONNECTION_BAD
+                && pg_ping($this->connID) === false
             ) {
                 $error = pg_last_error($this->connID);
 

--- a/tests/system/Database/Live/Postgre/ConnectTest.php
+++ b/tests/system/Database/Live/Postgre/ConnectTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live\Postgre;
+
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Test\CIUnitTestCase;
+use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class ConnectTest extends CIUnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->db = Database::connect($this->DBGroup);
+
+        if ($this->db->DBDriver !== 'Postgre') {
+            $this->markTestSkipped('This test is only for Postgre.');
+        }
+    }
+
+    public function testShowErrorMessageWhenSettingInvalidCharset(): void
+    {
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage(
+            'Unable to connect to the database.
+Main connection [Postgre]: ERROR:  invalid value for parameter "client_encoding": "utf8mb4"'
+        );
+
+        $config = config('Database');
+        $group  = $config->tests;
+        // Sets invalid charset.
+        $group['charset'] = 'utf8mb4';
+        $db               = Database::connect($group);
+
+        // Actually connect to DB.
+        $db->initialize();
+    }
+}


### PR DESCRIPTION
**Description**
See #8912

Shows PostgreSQL error message in Database Exception.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
