### PR TITLE
docs: Prevent text-wrap for span.pre in user guide citheme.css

### DIFF
--- a/user_guide_src/source/_static/css/citheme.css
+++ b/user_guide_src/source/_static/css/citheme.css
@@ -245,7 +245,8 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
     background-color: #fffff0;
 }
 
-span.std {
+span.std,
+span.pre {
     text-wrap: nowrap;
 }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Add span.pre to span.std to prevent text-wrap in user guide citheme.css

<img width="1203" alt="Screenshot 2024-05-29 at 09 21 13" src="https://github.com/codeigniter4/CodeIgniter4/assets/1913076/730a6e21-568d-4397-a07d-a2b940a72d46">
<img width="1202" alt="Screenshot 2024-05-29 at 09 21 31" src="https://github.com/codeigniter4/CodeIgniter4/assets/1913076/830fdf0d-f4c5-4ab1-97a3-7a4289f2cabe">


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
