### PR TITLE
docs: add note for View Cells typed properties

### DIFF
--- a/user_guide_src/source/outgoing/view_cells.rst
+++ b/user_guide_src/source/outgoing/view_cells.rst
@@ -101,6 +101,10 @@ Implementing the AlertMessage from above as a Controlled Cell would look like th
 
 .. literalinclude:: view_cells/010.php
 
+.. note:: If you use typed properties, you must set the initial values:
+
+    .. literalinclude:: view_cells/023.php
+
 .. _generating-cell-via-command:
 
 Generating Cell via Command

--- a/user_guide_src/source/outgoing/view_cells/023.php
+++ b/user_guide_src/source/outgoing/view_cells/023.php
@@ -1,0 +1,13 @@
+<?php
+
+// app/Cells/AlertMessageCell.php
+
+namespace App\Cells;
+
+use CodeIgniter\View\Cells\Cell;
+
+class AlertMessageCell extends Cell
+{
+    public string $type    = '';
+    public string $message = '';
+}


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=90967&pid=419195#pid419195

This is due to the behavior of get_object_vars().
See https://www.php.net/manual/ja/function.get-object-vars.php#127940

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
