### PR TITLE
refactor: remove unused path parameter on PhpStreamWrapper::stream_open()

### DIFF
--- a/system/Test/PhpStreamWrapper.php
+++ b/system/Test/PhpStreamWrapper.php
@@ -46,7 +46,7 @@ final class PhpStreamWrapper
         stream_wrapper_restore('php');
     }
 
-    public function stream_open(string $path): bool
+    public function stream_open(): bool
     {
         return true;
     }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

Detected by latest rector rule: `RemoveUnusedPublicMethodParameterRector` 

- https://github.com/rectorphp/rector-src/pull/5925

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
