### PR TITLE
fix: Forge::dropColumn() seems to always return false.

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2679,12 +2679,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Database\\\\Forge\\:\\:dropColumn\\(\\) has parameter \\$columnNames with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Database/Forge.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Forge\\:\\:modifyColumn\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Database/Forge.php',

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -796,6 +796,11 @@ class Forge
             return false;
         }
 
+        // If _alterTable() return execute result instead of sql string, return.
+        if ((bool) $sql === true) {
+            return true;
+        }
+
         return $this->db->query($sql);
     }
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -796,11 +796,6 @@ class Forge
             return false;
         }
 
-        // If _alterTable() return execute result instead of sql string, return.
-        if ((bool) $sql === true) {
-            return true;
-        }
-
         return $this->db->query($sql);
     }
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -778,7 +778,7 @@ class Forge
     }
 
     /**
-     * @param array|string $columnNames column names to DROP
+     * @param list<string>|string $columnNames column names to DROP
      *
      * @return bool
      *

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -126,11 +126,12 @@ class Forge extends BaseForge
 
                 $sqlTable = new Table($this->db, $this);
 
-                $sqlTable->fromTable($table)
+                $sqlExecuteResult = $sqlTable->fromTable($table)
                     ->dropColumn($columnNamesToDrop)
                     ->run();
 
-                return ''; // Why empty string?
+                // Return the execute result with string type.
+                return '' . $sqlExecuteResult;
 
             case 'CHANGE':
                 $fieldsToModify = [];

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -175,6 +175,8 @@ class Forge extends BaseForge
                 'Failed to drop column. Table: "' . $table
                 . '", Column: "' . $columns . '"'
             );
+
+            return false;
         }
 
         return $sqlExecuteResult;

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -154,7 +154,7 @@ class Forge extends BaseForge
     }
 
     /**
-     * @param array|string $columnNames column names to DROP
+     * @param list<string>|string $columnNames column names to DROP
      *
      * @return bool
      *

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -175,8 +175,6 @@ class Forge extends BaseForge
                 'Failed to drop column. Table: "' . $table
                 . '", Column: "' . $columns . '"'
             );
-
-            return false;
         }
 
         return $sqlExecuteResult;

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -169,9 +169,12 @@ class Forge extends BaseForge
             ->run();
 
         if ($sqlExecuteResult === false) {
-            if ($this->db->DBDebug) {
-                throw new DatabaseException('This feature is not available for the database you are using.');
-            }
+            $columns = is_array($columnNames) ? implode(',', $columnNames) : $columnNames;
+
+            throw new DatabaseException(
+                'Failed to drop column. Table: "' . $table
+                . '", Column: "' . $columns . '"'
+            );
 
             return false;
         }

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1317,7 +1317,8 @@ final class ForgeTest extends CIUnitTestCase
 
         $this->assertTrue($this->db->fieldExists('name', 'forge_test_two'));
 
-        $this->forge->dropColumn('forge_test_two', 'name');
+        $result = $this->forge->dropColumn('forge_test_two', 'name');
+        $this->assertTrue($result);
 
         $this->db->resetDataCache();
 


### PR DESCRIPTION
**Description**
Fixes #8849
I think return sql execute result directly is a simplest way to fix this issue.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
