### PR TITLE
docs: fix typo in errors.rst

### DIFF
--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -19,8 +19,8 @@ Using Exceptions
 
 This section is a quick overview for newer programmers, or for developers who are not experienced with using exceptions.
 
-What is Exceptions
-------------------
+What are Exceptions
+-------------------
 
 Exceptions are simply events that happen when the exception is "thrown". This halts the current flow of the script, and
 execution is then sent to the error handler which displays the appropriate error page:


### PR DESCRIPTION
**Description**
Supersedes #8907

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
