### PR TITLE
FileCollection: add function to retain multiple patterns

### DIFF
--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -355,6 +355,10 @@ class FileCollection implements Countable, IteratorAggregate
             return $this;
         }
 
+        if (count($patterns) == 1 && $patterns[0] === '') {
+            return $this;
+        }
+
         // Start with all files or those in scope
         $files = $scope === null ? $this->files : self::filterFiles($this->files, $scope);
 

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -340,6 +340,40 @@ class FileCollection implements Countable, IteratorAggregate
         return $this->removeFiles(array_diff($files, self::matchFiles($files, $pattern)));
     }
 
+    /**
+     * Keeps only the files from the list that match multiple patterns
+     * (within the optional scope).
+     *
+     * @param array      $patterns Array of regex or pseudo-regex strings
+     * @param string|null $scope   A directory to limit the scope
+     *
+     * @return $this
+     */
+    public function retainMultiplePatterns(array $patterns, ?string $scope = null)
+    {
+        if (count($patterns) == 0) {
+            return $this;
+        }
+
+        // Start with all files or those in scope
+        $files = $scope === null ? $this->files : self::filterFiles($this->files, $scope);
+
+        // Add files to retain to array
+        $filesToRetain = [];
+        foreach ($patterns as $pattern){
+            if ($pattern === '') {
+                continue;
+            }
+
+            // Matches the pattern within the scoped files
+            $filesToRetain = array_merge($filesToRetain, self::matchFIles($files, $pattern));
+            
+        }
+
+        // Remove the inverse of files to retain
+        return $this->removeFiles(array_diff($files, $filesToRetain));
+    }
+
     // --------------------------------------------------------------------
     // Interface Methods
     // --------------------------------------------------------------------

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -344,18 +344,18 @@ class FileCollection implements Countable, IteratorAggregate
      * Keeps only the files from the list that match multiple patterns
      * (within the optional scope).
      *
-     * @param array      $patterns Array of regex or pseudo-regex strings
-     * @param string|null $scope   A directory to limit the scope
+     * @param array       $patterns Array of regex or pseudo-regex strings
+     * @param string|null $scope    A directory to limit the scope
      *
      * @return $this
      */
     public function retainMultiplePatterns(array $patterns, ?string $scope = null)
     {
-        if (count($patterns) == 0) {
+        if (count($patterns) === 0) {
             return $this;
         }
 
-        if (count($patterns) == 1 && $patterns[0] === '') {
+        if (count($patterns) === 1 && $patterns[0] === '') {
             return $this;
         }
 
@@ -364,14 +364,14 @@ class FileCollection implements Countable, IteratorAggregate
 
         // Add files to retain to array
         $filesToRetain = [];
-        foreach ($patterns as $pattern){
+
+        foreach ($patterns as $pattern) {
             if ($pattern === '') {
                 continue;
             }
 
             // Matches the pattern within the scoped files
             $filesToRetain = array_merge($filesToRetain, self::matchFIles($files, $pattern));
-            
         }
 
         // Remove the inverse of files to retain

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -557,6 +557,76 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $collection->get());
     }
 
+    public function testRetainMultiplePatternsEmptyArray(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $files = $collection->get();
+
+        $collection->retainMultiplePatterns([]);
+
+        $this->assertSame($files, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsEmptyString(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $files = $collection->get();
+
+        $collection->retainMultiplePatterns(['']);
+
+        $this->assertSame($files, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsRegex(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $expected = [
+            SUPPORTPATH . 'Files/able/apple.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+        ];
+
+        $collection->retainMultiplePatterns(['#(apple).*#', '#(banana).*#']);
+
+        $this->assertSame($expected, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsPseudo(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $expected = [
+            SUPPORTPATH . 'Files/able/apple.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+        ];
+
+        $collection->retainMultiplePatterns(['apple*', 'banana*']);
+
+        $this->assertSame($expected, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsScope(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $expected = [
+            $this->directory . 'fig_3.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+        ];
+
+        $collection->retainMultiplePatterns(['*_?.php'], $this->directory);
+
+        $this->assertSame($expected, $collection->get());
+    }
+
     public function testCount(): void
     {
         $collection = new FileCollection();

--- a/user_guide_src/source/changelogs/v4.5.2.rst
+++ b/user_guide_src/source/changelogs/v4.5.2.rst
@@ -14,6 +14,12 @@ Release Date: Unreleased
 BREAKING
 ********
 
+************
+Enhancements
+************
+- Added `retainMultiplePatterns()` to `FileCollection` class.
+
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/libraries/file_collections.rst
+++ b/user_guide_src/source/libraries/file_collections.rst
@@ -121,7 +121,7 @@ Examples:
 retainMultiplePatterns(array $pattern, string $scope = null)
 ====================================================
 
-Provides the same functionality as ```retainPattern`` but accepts an array of patterns to retain files from all patterns.
+Provides the same functionality as ``retainPattern()`` but accepts an array of patterns to retain files from all patterns.
 
 Example:
 

--- a/user_guide_src/source/libraries/file_collections.rst
+++ b/user_guide_src/source/libraries/file_collections.rst
@@ -118,6 +118,15 @@ Examples:
 
 .. literalinclude:: files/015.php
 
+retainMultiplePatterns(array $pattern, string $scope = null)
+====================================================
+
+Provides the same functionality as ```retainPattern`` but accepts an array of patterns to retain files from all patterns.
+
+Example:
+
+.. literalinclude:: files/016.php
+
 ****************
 Retrieving Files
 ****************

--- a/user_guide_src/source/libraries/files/016.php
+++ b/user_guide_src/source/libraries/files/016.php
@@ -1,0 +1,3 @@
+<?php
+
+$files->retainMultiplePatterns(['*.css*', '*.js']); // Would keep only *.css and *.js files


### PR DESCRIPTION
**Description**
Added a function to ``FileCollection`` that accepts an array of strings to retain multiple patterns in the file collection.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
