### PR TITLE
fix: `RedisHandler::deleteMatching()` not deleting matching keys if cache prefix is used

### DIFF
--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -176,6 +176,7 @@ class RedisHandler extends BaseHandler
     public function deleteMatching(string $pattern)
     {
         $matchedKeys = [];
+        $pattern     = static::validateKey($pattern, $this->prefix);
         $iterator    = null;
 
         do {

--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -175,19 +175,17 @@ class RedisHandler extends BaseHandler
      */
     public function deleteMatching(string $pattern)
     {
+        /** @var list<string> $matchedKeys */
         $matchedKeys = [];
         $pattern     = static::validateKey($pattern, $this->prefix);
         $iterator    = null;
 
         do {
-            // Scan for some keys
+            /** @var false|list<string>|Redis $keys */
             $keys = $this->redis->scan($iterator, $pattern);
 
-            // Redis may return empty results, so protect against that
-            if ($keys !== false) {
-                foreach ($keys as $key) {
-                    $matchedKeys[] = $key;
-                }
+            if (is_array($keys)) {
+                $matchedKeys = [...$matchedKeys, ...$keys];
             }
         } while ($iterator > 0);
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -151,7 +151,9 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         $this->assertIsArray($cacheInfo);
         $this->assertArrayHasKey('db0', $cacheInfo);
         $this->assertIsString($cacheInfo['db0']);
-        $this->assertSame(1, preg_match('/^keys=(?P<count>\d+)/', $cacheInfo['db0'], $matches));
+        $this->assertMatchesRegularExpression('/^keys=(?P<count>\d+)/', $cacheInfo['db0']);
+
+        preg_match('/^keys=(?P<count>\d+)/', $cacheInfo['db0'], $matches);
         $this->assertSame(101, (int) $matches['count']);
 
         $this->assertSame($expectedDeleteCount, $handler->deleteMatching($pattern));
@@ -160,7 +162,9 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         $this->assertIsArray($cacheInfo);
         $this->assertArrayHasKey('db0', $cacheInfo);
         $this->assertIsString($cacheInfo['db0']);
-        $this->assertSame(1, preg_match('/^keys=(?P<count>\d+)/', $cacheInfo['db0'], $matches));
+        $this->assertMatchesRegularExpression('/^keys=(?P<count>\d+)/', $cacheInfo['db0']);
+
+        preg_match('/^keys=(?P<count>\d+)/', $cacheInfo['db0'], $matches);
         $this->assertSame(101 - $expectedDeleteCount, (int) $matches['count']);
 
         $handler->deleteMatching('key_*');

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -179,7 +179,7 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         // key_1, key_10, key_11, key_12, key_13, key_14, key_15, key_16, key_17, key_18, key_19, key_100, key_101
         yield 'prefix' => ['key_1*', 13];
 
-        // Given the key "*1", deleteMatching() should delete 11 keys: 
+        // Given the key "*1", deleteMatching() should delete 11 keys:
         // key_1, key_11, key_21, key_31, key_41, key_51, key_61, key_71, key_81, key_91, key_101
         yield 'suffix' => ['*1', 11];
 

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -175,8 +175,12 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
      */
     public static function provideDeleteMatching(): iterable
     {
+        // Given the key "key_1*", deleteMatching() should delete 13 keys:
+        // key_1, key_10, key_11, key_12, key_13, key_14, key_15, key_16, key_17, key_18, key_19, key_100, key_101
         yield 'prefix' => ['key_1*', 13];
 
+        // Given the key "*1", deleteMatching() should delete 11 keys: 
+        // key_1, key_11, key_21, key_31, key_41, key_51, key_61, key_71, key_81, key_91, key_101
         yield 'suffix' => ['*1', 11];
 
         yield 'cache-prefix' => ['key_1*', 13, 'foo_'];

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cache\Handlers;
 
+use CodeIgniter\Cache\CacheFactory;
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\I18n\Time;
 use Config\Cache;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -129,44 +131,49 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         $this->assertFalse($this->handler->delete(self::$dummy));
     }
 
-    public function testDeleteMatchingPrefix(): void
+    #[DataProvider('provideDeleteMatching')]
+    public function testDeleteMatching(string $pattern, int $expectedDeleteCount, string $prefix = ''): void
     {
-        // Save 101 items to match on
-        for ($i = 1; $i <= 101; $i++) {
-            $this->handler->save('key_' . $i, 'value' . $i);
+        $cache = new Cache();
+
+        if ($prefix !== '') {
+            $cache->prefix = $prefix;
         }
 
-        // check that there are 101 items is cache store
-        $dbInfo = explode(',', $this->handler->getCacheInfo()['db0']);
-        $this->assertSame('keys=101', $dbInfo[0]);
+        /** @var RedisHandler $handler */
+        $handler = CacheFactory::getHandler($cache, 'redis');
 
-        // Checking that given the prefix "key_1", deleteMatching deletes 13 keys:
-        // (key_1, key_10, key_11, key_12, key_13, key_14, key_15, key_16, key_17, key_18, key_19, key_100, key_101)
-        $this->assertSame(13, $this->handler->deleteMatching('key_1*'));
+        for ($i = 1; $i <= 101; $i++) {
+            $handler->save('key_' . $i, 'value_' . $i);
+        }
 
-        // check that there remains (101 - 13) = 88 items is cache store
-        $dbInfo = explode(',', $this->handler->getCacheInfo()['db0']);
-        $this->assertSame('keys=88', $dbInfo[0]);
+        $cacheInfo = $handler->getCacheInfo();
+        $this->assertIsArray($cacheInfo);
+        $this->assertArrayHasKey('db0', $cacheInfo);
+        $this->assertIsString($cacheInfo['db0']);
+        $this->assertSame(1, preg_match('/^keys=(?P<count>\d+)/', $cacheInfo['db0'], $matches));
+        $this->assertSame(101, (int) $matches['count']);
+
+        $this->assertSame($expectedDeleteCount, $handler->deleteMatching($pattern));
+
+        $cacheInfo = $handler->getCacheInfo();
+        $this->assertIsArray($cacheInfo);
+        $this->assertArrayHasKey('db0', $cacheInfo);
+        $this->assertIsString($cacheInfo['db0']);
+        $this->assertSame(1, preg_match('/^keys=(?P<count>\d+)/', $cacheInfo['db0'], $matches));
+        $this->assertSame(101 - $expectedDeleteCount, (int) $matches['count']);
+
+        $handler->deleteMatching('key_*');
     }
 
-    public function testDeleteMatchingSuffix(): void
+    /**
+     * @return iterable<string, array{0: string, 1: int, 2?: string}>
+     */
+    public static function provideDeleteMatching(): iterable
     {
-        // Save 101 items to match on
-        for ($i = 1; $i <= 101; $i++) {
-            $this->handler->save('key_' . $i, 'value' . $i);
-        }
+        yield 'prefix' => ['key_1*', 13];
 
-        // check that there are 101 items is cache store
-        $dbInfo = explode(',', $this->handler->getCacheInfo()['db0']);
-        $this->assertSame('keys=101', $dbInfo[0]);
-
-        // Checking that given the suffix "1", deleteMatching deletes 11 keys:
-        // (key_1, key_11, key_21, key_31, key_41, key_51, key_61, key_71, key_81, key_91, key_101)
-        $this->assertSame(11, $this->handler->deleteMatching('*1'));
-
-        // check that there remains (101 - 13) = 88 items is cache store
-        $dbInfo = explode(',', $this->handler->getCacheInfo()['db0']);
-        $this->assertSame('keys=90', $dbInfo[0]);
+        yield 'suffix' => ['*1', 11];
     }
 
     public function testIncrementAndDecrement(): void

--- a/tests/system/Cache/Handlers/RedisHandlerTest.php
+++ b/tests/system/Cache/Handlers/RedisHandlerTest.php
@@ -174,6 +174,8 @@ final class RedisHandlerTest extends AbstractHandlerTestCase
         yield 'prefix' => ['key_1*', 13];
 
         yield 'suffix' => ['*1', 11];
+
+        yield 'cache-prefix' => ['key_1*', 13, 'foo_'];
     }
 
     public function testIncrementAndDecrement(): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Supersedes and closes #8878 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
