### PR TITLE
feat: [FileCollection] add function to retain multiple patterns

### DIFF
--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -27,7 +27,7 @@ use IteratorAggregate;
  * filtering, and ordering them.
  *
  * @template-implements IteratorAggregate<int, File>
- * @see \CodeIgniter\Files\FileCollectionTest
+ * @see FileCollectionTest
  */
 class FileCollection implements Countable, IteratorAggregate
 {
@@ -344,8 +344,8 @@ class FileCollection implements Countable, IteratorAggregate
      * Keeps only the files from the list that match multiple patterns
      * (within the optional scope).
      *
-     * @param array<string>       $patterns Array of regex or pseudo-regex strings
-     * @param string|null $scope    A directory to limit the scope
+     * @param list<string> $patterns Array of regex or pseudo-regex strings
+     * @param string|null  $scope    A directory to limit the scope
      *
      * @return $this
      */

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -340,6 +340,44 @@ class FileCollection implements Countable, IteratorAggregate
         return $this->removeFiles(array_diff($files, self::matchFiles($files, $pattern)));
     }
 
+    /**
+     * Keeps only the files from the list that match multiple patterns
+     * (within the optional scope).
+     *
+     * @param array       $patterns Array of regex or pseudo-regex strings
+     * @param string|null $scope    A directory to limit the scope
+     *
+     * @return $this
+     */
+    public function retainMultiplePatterns(array $patterns, ?string $scope = null)
+    {
+        if (count($patterns) === 0) {
+            return $this;
+        }
+
+        if (count($patterns) === 1 && $patterns[0] === '') {
+            return $this;
+        }
+
+        // Start with all files or those in scope
+        $files = $scope === null ? $this->files : self::filterFiles($this->files, $scope);
+
+        // Add files to retain to array
+        $filesToRetain = [];
+
+        foreach ($patterns as $pattern) {
+            if ($pattern === '') {
+                continue;
+            }
+
+            // Matches the pattern within the scoped files
+            $filesToRetain = array_merge($filesToRetain, self::matchFIles($files, $pattern));
+        }
+
+        // Remove the inverse of files to retain
+        return $this->removeFiles(array_diff($files, $filesToRetain));
+    }
+
     // --------------------------------------------------------------------
     // Interface Methods
     // --------------------------------------------------------------------

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -371,7 +371,7 @@ class FileCollection implements Countable, IteratorAggregate
             }
 
             // Matches the pattern within the scoped files
-            $filesToRetain = array_merge($filesToRetain, self::matchFIles($files, $pattern));
+            $filesToRetain = array_merge($filesToRetain, self::matchFiles($files, $pattern));
         }
 
         // Remove the inverse of files to retain

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -27,7 +27,7 @@ use IteratorAggregate;
  * filtering, and ordering them.
  *
  * @template-implements IteratorAggregate<int, File>
- * @see FileCollectionTest
+ * @see \CodeIgniter\Files\FileCollectionTest
  */
 class FileCollection implements Countable, IteratorAggregate
 {

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -344,14 +344,14 @@ class FileCollection implements Countable, IteratorAggregate
      * Keeps only the files from the list that match multiple patterns
      * (within the optional scope).
      *
-     * @param array       $patterns Array of regex or pseudo-regex strings
+     * @param array<string>       $patterns Array of regex or pseudo-regex strings
      * @param string|null $scope    A directory to limit the scope
      *
      * @return $this
      */
     public function retainMultiplePatterns(array $patterns, ?string $scope = null)
     {
-        if (count($patterns) === 0) {
+        if ($patterns === []) {
             return $this;
         }
 

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -557,6 +557,76 @@ final class FileCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $collection->get());
     }
 
+    public function testRetainMultiplePatternsEmptyArray(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $files = $collection->get();
+
+        $collection->retainMultiplePatterns([]);
+
+        $this->assertSame($files, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsEmptyString(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $files = $collection->get();
+
+        $collection->retainMultiplePatterns(['']);
+
+        $this->assertSame($files, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsRegex(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $expected = [
+            SUPPORTPATH . 'Files/able/apple.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+        ];
+
+        $collection->retainMultiplePatterns(['#(apple).*#', '#(banana).*#']);
+
+        $this->assertSame($expected, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsPseudo(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $expected = [
+            SUPPORTPATH . 'Files/able/apple.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+        ];
+
+        $collection->retainMultiplePatterns(['apple*', 'banana*']);
+
+        $this->assertSame($expected, $collection->get());
+    }
+
+    public function testRetainMultiplePatternsScope(): void
+    {
+        $collection = new FileCollection();
+        $collection->addDirectory(SUPPORTPATH . 'Files', true);
+
+        $expected = [
+            $this->directory . 'fig_3.php',
+            SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+        ];
+
+        $collection->retainMultiplePatterns(['*_?.php'], $this->directory);
+
+        $this->assertSame($expected, $collection->get());
+    }
+
     public function testCount(): void
     {
         $collection = new FileCollection();

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -66,9 +66,6 @@ Removed Deprecated Items
 Enhancements
 ************
 
-- Added `retainMultiplePatterns()` to `FileCollection` class.
-
-
 Exceptions
 ==========
 
@@ -110,6 +107,8 @@ Model
 
 Libraries
 =========
+
+- Added `retainMultiplePatterns()` to `FileCollection` class.
 
 Helpers and Functions
 =====================

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -66,6 +66,9 @@ Removed Deprecated Items
 Enhancements
 ************
 
+- Added `retainMultiplePatterns()` to `FileCollection` class.
+
+
 Exceptions
 ==========
 

--- a/user_guide_src/source/libraries/file_collections.rst
+++ b/user_guide_src/source/libraries/file_collections.rst
@@ -118,6 +118,15 @@ Examples:
 
 .. literalinclude:: files/015.php
 
+retainMultiplePatterns(array $pattern, string $scope = null)
+============================================================
+
+Provides the same functionality as ``retainPattern()`` but accepts an array of patterns to retain files from all patterns.
+
+Example:
+
+.. literalinclude:: files/016.php
+
 ****************
 Retrieving Files
 ****************

--- a/user_guide_src/source/libraries/files/016.php
+++ b/user_guide_src/source/libraries/files/016.php
@@ -1,0 +1,3 @@
+<?php
+
+$files->retainMultiplePatterns(['*.css*', '*.js']); // Would keep only *.css and *.js files


### PR DESCRIPTION
**Description**
Supersedes #8940

Add a method to ``FileCollection`` that accepts an array of strings to retain multiple patterns in the file collection.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
