### PR TITLE
fix: TypeError in DefinedRouteCollector::collect()

### DIFF
--- a/system/Router/DefinedRouteCollector.php
+++ b/system/Router/DefinedRouteCollector.php
@@ -38,6 +38,10 @@ final class DefinedRouteCollector
             $routes = $this->routeCollection->getRoutes($method);
 
             foreach ($routes as $route => $handler) {
+                // The route key should be a string, but it is stored as an array key,
+                // it might be an integer.
+                $route = (string) $route;
+
                 if (is_string($handler) || $handler instanceof Closure) {
                     if ($handler instanceof Closure) {
                         $view = $this->routeCollection->getRoutesOptions($route, $method)['view'] ?? false;

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -50,8 +50,10 @@ final class DefinedRouteCollectorTest extends CIUnitTestCase
     {
         $routes = $this->createRouteCollection();
         $routes->get('journals', 'Blogs');
+        $routes->get('100', 'Home::index');
         $routes->get('product/(:num)', 'Catalog::productLookupByID/$1');
         $routes->get('feed', static fn () => 'A Closure route.');
+        $routes->get('200', static fn () => 'A Closure route.');
         $routes->view('about', 'pages/about');
 
         $collector = new DefinedRouteCollector($routes);
@@ -71,6 +73,12 @@ final class DefinedRouteCollectorTest extends CIUnitTestCase
             ],
             [
                 'method'  => 'GET',
+                'route'   => '100',
+                'name'    => '100',
+                'handler' => '\App\Controllers\Home::index',
+            ],
+            [
+                'method'  => 'GET',
                 'route'   => 'product/([0-9]+)',
                 'name'    => 'product/([0-9]+)',
                 'handler' => '\App\Controllers\Catalog::productLookupByID/$1',
@@ -79,6 +87,12 @@ final class DefinedRouteCollectorTest extends CIUnitTestCase
                 'method'  => 'GET',
                 'route'   => 'feed',
                 'name'    => 'feed',
+                'handler' => '(Closure)',
+            ],
+            [
+                'method'  => 'GET',
+                'route'   => '200',
+                'name'    => '200',
                 'handler' => '(Closure)',
             ],
             [


### PR DESCRIPTION
**Description**
Fixes #8954

```
1) CodeIgniter\Router\DefinedRouteCollectorTest::testCollect
TypeError: CodeIgniter\Router\RouteCollection::getRoutesOptions(): Argument #1 ($from) must be of type ?string, int given, called in .../CodeIgniter4/system/Router/DefinedRouteCollector.php on line 48
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
