### PR TITLE
fix: `migrate:rollback -b` does not work due to TypeError

### DIFF
--- a/system/Commands/Database/MigrateRollback.php
+++ b/system/Commands/Database/MigrateRollback.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Database;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Database\MigrationRunner;
 use Throwable;
 
 /**
@@ -78,10 +79,23 @@ class MigrateRollback extends BaseCommand
             // @codeCoverageIgnoreEnd
         }
 
+        /** @var MigrationRunner $runner */
         $runner = service('migrations');
 
         try {
             $batch = $params['b'] ?? CLI::getOption('b') ?? $runner->getLastBatch() - 1;
+
+            if (is_string($batch)) {
+                if (! ctype_digit($batch)) {
+                    CLI::error('Invalid batch number: ' . $batch, 'light_gray', 'red');
+                    CLI::newLine();
+
+                    return EXIT_ERROR;
+                }
+
+                $batch = (int) $batch;
+            }
+
             CLI::write(lang('Migrations.rollingBack') . ' ' . $batch, 'yellow');
 
             if (! $runner->regress($batch)) {

--- a/tests/system/Commands/DatabaseCommandsTest.php
+++ b/tests/system/Commands/DatabaseCommandsTest.php
@@ -53,6 +53,24 @@ final class DatabaseCommandsTest extends CIUnitTestCase
         $this->assertStringContainsString('Migrations complete.', $this->getBuffer());
     }
 
+    public function testMigrateRollbackValidBatchNumber(): void
+    {
+        command('migrate --all');
+        $this->clearBuffer();
+
+        command('migrate:rollback -b 1');
+        $this->assertStringContainsString('Done rolling back migrations.', $this->getBuffer());
+    }
+
+    public function testMigrateRollbackInvalidBatchNumber(): void
+    {
+        command('migrate --all');
+        $this->clearBuffer();
+
+        command('migrate:rollback -b x');
+        $this->assertStringContainsString('Invalid batch number: x', $this->getBuffer());
+    }
+
     public function testMigrateRollback(): void
     {
         command('migrate --all -g tests');


### PR DESCRIPTION
**Description**
Fixes #8955

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
