### PR TITLE
fix: [Validation] `if_exist` does not work with array data

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -29,10 +29,6 @@ class FormatRules
      */
     public function alpha($str = null): bool
     {
-        if (is_array($str)) {
-            return false;
-        }
-
         if (! is_string($str)) {
             $str = (string) $str;
         }

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -29,6 +29,10 @@ class FormatRules
      */
     public function alpha($str = null): bool
     {
+        if (is_array($str)) {
+            return false;
+        }
+
         if (! is_string($str)) {
             $str = (string) $str;
         }

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -399,8 +399,10 @@ class Validation implements ValidationInterface
                         break;
                     }
                 }
-            } else {
+            } elseif (str_contains($field, '.')) {
                 $dataIsExisting = array_key_exists($ifExistField, $flattenedData);
+            } else {
+                $dataIsExisting = array_key_exists($ifExistField, $data);
             }
 
             if (! $dataIsExisting) {

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -100,6 +100,12 @@ class RulesTest extends CIUnitTestCase
                 ['foo' => ''],
                 false,
             ],
+            // Invalid array input
+            [
+                ['foo' => 'if_exist|alpha'],
+                ['foo' => ['bar' => '12345']],
+                false,
+            ],
             // Input data does not exist then the other rules will be ignored
             [
                 ['foo' => 'if_exist|required'],

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
+use ErrorException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
@@ -100,12 +101,6 @@ class RulesTest extends CIUnitTestCase
                 ['foo' => ''],
                 false,
             ],
-            // Invalid array input
-            [
-                ['foo' => 'if_exist|alpha'],
-                ['foo' => ['bar' => '12345']],
-                false,
-            ],
             // Input data does not exist then the other rules will be ignored
             [
                 ['foo' => 'if_exist|required'],
@@ -130,6 +125,19 @@ class RulesTest extends CIUnitTestCase
                 true,
             ],
         ];
+    }
+
+    public function testIfExistArray(): void
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Array to string conversion');
+
+        $rules = ['foo' => 'if_exist|alpha'];
+        // Invalid array input
+        $data = ['foo' => ['bar' => '12345']];
+
+        $this->validation->setRules($rules);
+        $this->validation->run($data);
     }
 
     #[DataProvider('providePermitEmpty')]

--- a/tests/system/Validation/StrictRules/RulesTest.php
+++ b/tests/system/Validation/StrictRules/RulesTest.php
@@ -244,4 +244,14 @@ final class RulesTest extends TraditionalRulesTest
             'foo bar bool match'       => [['foo' => true, 'bar' => true], false],
         ];
     }
+
+    public function testIfExistArray(): void
+    {
+        $rules = ['foo' => 'if_exist|alpha'];
+        // Invalid array input
+        $data = ['foo' => ['bar' => '12345']];
+
+        $this->validation->setRules($rules);
+        $this->assertFalse($this->validation->run($data));
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #8956

Fixed the bug that If an array is passed, Validation with `if_exist` rule always returns `true`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
