### PR TITLE
chore: add autoload.exclude-from-classmap to suppress Composer 2.7.7 warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,9 @@
             "CodeIgniter\\": "system/"
         },
         "exclude-from-classmap": [
-            "**/Database/Migrations/**"
+            "**/Database/Migrations/**",
+            "system/ThirdParty/**",
+            "tests/system/Config/fixtures/**"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/8951#issuecomment-2164052589

E.g.,
> Class Laminas\Escaper\Escaper located in ./system/ThirdParty/Escaper/Escaper.php does not comply with psr-4 autoloading standard (rule: CodeIgniter\ => ./system). Skipping.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
