### PR TITLE
chore: add `Config` namespace to appstarter autoload.psr4

### DIFF
--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
+            "App\\": "app/",
+            "Config\\": "app/Config"
         },
         "exclude-from-classmap": [
             "**/Database/Migrations/**"

--- a/user_guide_src/source/concepts/autoloader.rst
+++ b/user_guide_src/source/concepts/autoloader.rst
@@ -93,6 +93,9 @@ Config files are namespaced in the ``Config`` namespace, not in ``App\Config`` a
 expect. This allows the core system files to always be able to locate them, even when the application
 namespace has changed.
 
+.. note:: Since v4.5.3 appstarter, the ``Config\\`` namespace has been added to
+    **composer.json**'s ``autoload.psr-4``.
+
 Changing App Namespace
 ----------------------
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/8951#issuecomment-2164059098

To suppress Composer's warning like this:
> Class Config\Email located in ./app/Config/Email.php does not comply with psr-4 autoloading standard (rule: App\ => ./app). Skipping.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
