### PR TITLE
feat: [Validation] add `min_dims` rule in FileRules

### DIFF
--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -260,4 +260,51 @@ class FileRules
 
         return true;
     }
+
+    /**
+     * Checks an uploaded file to verify that the dimensions are greater than
+     * a specified dimension.
+     */
+    public function min_dims(?string $blank, string $params): bool
+    {
+        // Grab the file name off the top of the $params
+        // after we split it.
+        $params = explode(',', $params);
+        $name   = array_shift($params);
+
+        if (! ($files = $this->request->getFileMultiple($name))) {
+            $files = [$this->request->getFile($name)];
+        }
+
+        foreach ($files as $file) {
+            if ($file === null) {
+                return false;
+            }
+
+            if ($file->getError() === UPLOAD_ERR_NO_FILE) {
+                return true;
+            }
+
+            // Get Parameter sizes
+            $minimumWidth  = $params[0] ?? 0;
+            $minimumHeight = $params[1] ?? 0;
+
+            // Get uploaded image size
+            $info = getimagesize($file->getTempName());
+
+            if ($info === false) {
+                // Cannot get the image size.
+                return false;
+            }
+
+            $fileWidth  = $info[0];
+            $fileHeight = $info[1];
+
+            if ($fileWidth < $minimumWidth || $fileHeight < $minimumHeight) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -272,7 +272,8 @@ class FileRules
         $params = explode(',', $params);
         $name   = array_shift($params);
 
-        if (! ($files = $this->request->getFileMultiple($name))) {
+        $files = $this->request->getFileMultiple($name);
+        if ($files === null) {
             $files = [$this->request->getFile($name)];
         }
 

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -230,6 +230,24 @@ final class FileRulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run([]));
     }
 
+    public function testMinDims(): void
+    {
+        $this->validation->setRules(['avatar' => 'min_dims[avatar,320,240]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testMinDimsFail(): void
+    {
+        $this->validation->setRules(['avatar' => 'min_dims[avatar,800,600]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMinDimsBad(): void
+    {
+        $this->validation->setRules(['avatar' => 'min_dims[unknown,640,480]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
     public function testIsImage(): void
     {
         $this->validation->setRules(['avatar' => 'is_image[avatar]']);

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -231,6 +231,24 @@ final class FileRulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run([]));
     }
 
+    public function testMinDims(): void
+    {
+        $this->validation->setRules(['avatar' => 'min_dims[avatar,320,240]']);
+        $this->assertTrue($this->validation->run([]));
+    }
+
+    public function testMinDimsFail(): void
+    {
+        $this->validation->setRules(['avatar' => 'min_dims[avatar,800,600]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
+    public function testMinDimsBad(): void
+    {
+        $this->validation->setRules(['avatar' => 'min_dims[unknown,640,480]']);
+        $this->assertFalse($this->validation->run([]));
+    }
+
     public function testIsImage(): void
     {
         $this->validation->setRules(['avatar' => 'is_image[avatar]']);

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -119,7 +119,7 @@ Forge
 -----
 
 Others
-------
+------ma
 
 Model
 =====
@@ -128,6 +128,7 @@ Libraries
 =========
 
 - Added `retainMultiplePatterns()` to `FileCollection` class. See :ref:`FileCollection::retainMultiplePatterns() <file-collections-retain-multiple-patterns>`.
+- Added `min_dims` validation rule to `FileRules` class. See :ref`Validation <rules-for-file-uploads>`. 
 
 Helpers and Functions
 =====================

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -1082,6 +1082,12 @@ max_dims                Yes         Fails if the maximum width and height of an 
                                     the width, and the third is the height. Will
                                     also fail if the file cannot be determined
                                     to be an image.
+min_dims                Yes         Fails if the maximum width and height of an  ``min_dims[field_name,300,150]``
+                                    uploaded image not meet values. The first
+                                    parameter is the field name. The second is
+                                    the width, and the third is the height. Will
+                                    also fail if the file cannot be determined
+                                    to be an image.
 mime_in                 Yes         Fails if the file's mime type is not one     ``mime_in[field_name,image/png,image/jpeg]``
                                     listed in the parameters.
 ext_in                  Yes         Fails if the file's extension is not one     ``ext_in[field_name,png,jpg,gif]``

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -1082,12 +1082,13 @@ max_dims                Yes         Fails if the maximum width and height of an 
                                     the width, and the third is the height. Will
                                     also fail if the file cannot be determined
                                     to be an image.
-min_dims                Yes         Fails if the maximum width and height of an  ``min_dims[field_name,300,150]``
+min_dims                Yes         Fails if the minimum width and height of an  ``min_dims[field_name,300,150]``
                                     uploaded image not meet values. The first
                                     parameter is the field name. The second is
                                     the width, and the third is the height. Will
                                     also fail if the file cannot be determined
-                                    to be an image.
+                                    to be an image. (This rule was added in 
+                                    v4.6.0.)
 mime_in                 Yes         Fails if the file's mime type is not one     ``mime_in[field_name,image/png,image/jpeg]``
                                     listed in the parameters.
 ext_in                  Yes         Fails if the file's extension is not one     ``ext_in[field_name,png,jpg,gif]``


### PR DESCRIPTION
**Description**
Add  `min_dims` validation rule to the `FileRules` class

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
