### PR TITLE
chore: workaround for phpDocumentor error

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build API in source repo
         working-directory: source
         run: |
-          php tools/phpDocumentor run --ansi --verbose
+          php tools/phpDocumentor --ansi --verbose
           cp -R ${GITHUB_WORKSPACE}/source/api/build/* ${GITHUB_WORKSPACE}/api/docs
 
       - name: Deploy to API repo


### PR DESCRIPTION
**Description**
Closes #8949

See https://github.com/phpDocumentor/phpDocumentor/issues/3725#issuecomment-2145896103

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
