### PR TITLE
test: fix PHPStan errors in CommandTest

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -10387,17 +10387,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Commands/CommandGeneratorTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Commands\\\\CommandTest\\:\\:getBuffer\\(\\) has no return type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Commands/CommandTest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\CommandTest\\:\\:provideCommandParsesArgsCorrectly\\(\\) return type has no value type specified in iterable type iterable\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Commands/CommandTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method CodeIgniter\\\\Commands\\\\CommandTest\\:\\:testCommandParsesArgsCorrectly\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Commands/CommandTest.php',
 ];

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -43,7 +43,7 @@ final class CommandTest extends CIUnitTestCase
         $this->commands = Services::commands();
     }
 
-    protected function getBuffer()
+    protected function getBuffer(): string
     {
         return $this->getStreamFilterBuffer();
     }
@@ -130,6 +130,9 @@ final class CommandTest extends CIUnitTestCase
         $this->assertStringContainsString(':clear', $this->getBuffer());
     }
 
+    /**
+     * @param list<string> $expected
+     */
     #[DataProvider('provideCommandParsesArgsCorrectly')]
     public function testCommandParsesArgsCorrectly(string $input, array $expected): void
     {


### PR DESCRIPTION
**Description**
- fix PHPStan errors

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
