### PR TITLE
fix: `spark routes` may show BadRequestException when a route has a regexp

### DIFF
--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Filters\Filters;
+use CodeIgniter\HTTP\Exceptions\BadRequestException;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
 use CodeIgniter\Router\Router;
 use Config\Feature;
@@ -72,7 +73,7 @@ final class FilterFinder
                 'before' => [],
                 'after'  => [],
             ];
-        } catch (PageNotFoundException) {
+        } catch (BadRequestException|PageNotFoundException) {
             return [
                 'before' => ['<unknown>'],
                 'after'  => ['<unknown>'],

--- a/system/Config/BaseService.php
+++ b/system/Config/BaseService.php
@@ -346,6 +346,8 @@ class BaseService
      * Reset shared instances and mocks for testing.
      *
      * @return void
+     *
+     * @testTag only available to test code
      */
     public static function reset(bool $initAutoloader = true)
     {
@@ -362,6 +364,8 @@ class BaseService
      * Resets any mock and shared instances for a single service.
      *
      * @return void
+     *
+     * @testTag only available to test code
      */
     public static function resetSingle(string $name)
     {
@@ -375,6 +379,8 @@ class BaseService
      * @param object $mock
      *
      * @return void
+     *
+     * @testTag only available to test code
      */
     public static function injectMock(string $name, $mock)
     {

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -187,6 +187,7 @@ class Router implements RouterInterface
      *
      * @return (Closure(mixed...): (ResponseInterface|string|void))|string Controller classname or Closure
      *
+     * @throws BadRequestException
      * @throws PageNotFoundException
      * @throws RedirectException
      */

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -240,4 +240,18 @@ final class RoutesTest extends CIUnitTestCase
             EOL;
         $this->assertStringContainsString($expected, $this->getBuffer());
     }
+
+    public function testRoutesCommandRouteWithRegexp(): void
+    {
+        $routes = Services::routes();
+        $routes->resetRoutes();
+        $routes->options('picker/(.+)', 'Options::index');
+
+        command('routes');
+
+        $expected = <<<'EOL'
+            | OPTIONS | picker/(.+) | »             | \App\Controllers\Options::index        | <unknown>      | <unknown>     |
+            EOL;
+        $this->assertStringContainsString($expected, $this->getBuffer());
+    }
 }


### PR DESCRIPTION
**Description**
Fixes #8972

```diff
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -6,3 +6,4 @@ use CodeIgniter\Router\RouteCollection;
  * @var RouteCollection $routes
  */
 $routes->get('/', 'Home::index');
+$routes->options('picker/(.+)', 'Options::index');
```

Before:
```console
$ ./spark routes

CodeIgniter v4.5.2 Command Line Tool - Server Time: 2024-06-19 03:40:45 UTC+00:00

[CodeIgniter\HTTP\Exceptions\BadRequestException]
The URI you submitted has disallowed characters: "(. )"
at SYSTEMPATH/Router/Router.php:736

Backtrace:
  1    SYSTEMPATH/Router/Router.php:203
       CodeIgniter\Router\Router()->checkDisallowedChars('picker/(. )')
...
```

After:
```console
$ ./spark routes

CodeIgniter v4.5.2 Command Line Tool - Server Time: 2024-06-19 03:41:40 UTC+00:00

+---------+-------------+------+---------------------------------+----------------+---------------+
| Method  | Route       | Name | Handler                         | Before Filters | After Filters |
+---------+-------------+------+---------------------------------+----------------+---------------+
| GET     | /           | »    | \App\Controllers\Home::index    |                |               |
| OPTIONS | picker/(.+) | »    | \App\Controllers\Options::index | <unknown>      | <unknown>     |
+---------+-------------+------+---------------------------------+----------------+---------------+

Required Before Filters: forcehttps, pagecache
 Required After Filters: pagecache, performance, toolbar
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
