### PR TITLE
feat: [Filters] enables a filter to run more than once with different arguments

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -14014,7 +14014,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: codeigniter.superglobalAccessAssign
 	'message' => '#^Assigning \'GET\' directly on offset \'REQUEST_METHOD\' of \\$_SERVER is discouraged\\.$#',
-	'count' => 36,
+	'count' => 38,
 	'path' => __DIR__ . '/tests/system/Filters/FiltersTest.php',
 ];
 $ignoreErrors[] = [

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -5325,18 +5325,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:getFilters\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:getFiltersClass\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:getRequiredFilters\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',
@@ -5344,12 +5332,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:pathApplies\\(\\) has parameter \\$paths with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:registerArguments\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];
@@ -5374,18 +5356,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: booleanNot.exprNotBoolean
 	'message' => '#^Only booleans are allowed in a negated boolean, array\\<string, array\\<string, array\\<int, string\\>\\>\\> given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Property CodeIgniter\\\\Filters\\\\Filters\\:\\:\\$filters type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Property CodeIgniter\\\\Filters\\\\Filters\\:\\:\\$filtersClass type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',
 ];

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -5337,18 +5337,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:runAfter\\(\\) has parameter \\$filterClasses with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:runBefore\\(\\) has parameter \\$filterClasses with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:setToolbarToLast\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -220,11 +220,13 @@ class Filters
     }
 
     /**
+     * @param list<array{0: class-string, 1: list<string>}> $filterClassList [[classname, arguments], ...]
+     *
      * @return RequestInterface|ResponseInterface|string
      */
-    private function runBefore(array $filterClasses)
+    private function runBefore(array $filterClassList)
     {
-        foreach ($filterClasses as $filterClassInfo) {
+        foreach ($filterClassList as $filterClassInfo) {
             $className = $filterClassInfo[0];
             $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
 
@@ -260,9 +262,12 @@ class Filters
         return $this->request;
     }
 
-    private function runAfter(array $filterClasses): ResponseInterface
+    /**
+     * @param list<array{0: class-string, 1: list<string>}> $filterClassList [[classname, arguments], ...]
+     */
+    private function runAfter(array $filterClassList): ResponseInterface
     {
-        foreach ($filterClasses as $filterClassInfo) {
+        foreach ($filterClassList as $filterClassInfo) {
             $className = $filterClassInfo[0];
             $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
 

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -119,6 +119,13 @@ class Filters
     ];
 
     /**
+     * List of filter class instances.
+     *
+     * @var array<class-string, FilterInterface> [classname => instance]
+     */
+    protected array $filterClassInstances = [];
+
+    /**
      * Any arguments to be passed to filters.
      *
      * @var array<string, list<string>|null> [name => params]
@@ -230,7 +237,17 @@ class Filters
             $className = $filterClassInfo[0];
             $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
 
-            $class = new $className();
+            if (isset($this->filterClassInstances[$className])) {
+                $class = $this->filterClassInstances[$className];
+            } else {
+                $class = new $className();
+
+                if (! $class instanceof FilterInterface) {
+                    throw FilterException::forIncorrectInterface($class::class);
+                }
+
+                $this->filterClassInstances[$className] = $class;
+            }
 
             if (! $class instanceof FilterInterface) {
                 throw FilterException::forIncorrectInterface($class::class);
@@ -271,10 +288,16 @@ class Filters
             $className = $filterClassInfo[0];
             $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
 
-            $class = new $className();
+            if (isset($this->filterClassInstances[$className])) {
+                $class = $this->filterClassInstances[$className];
+            } else {
+                $class = new $className();
 
-            if (! $class instanceof FilterInterface) {
-                throw FilterException::forIncorrectInterface($class::class);
+                if (! $class instanceof FilterInterface) {
+                    throw FilterException::forIncorrectInterface($class::class);
+                }
+
+                $this->filterClassInstances[$className] = $class;
             }
 
             $result = $class->after($this->request, $this->response, $arguments);

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -562,11 +562,7 @@ class Filters
     {
         // Normalize the arguments.
         [$alias, $arguments] = $this->getCleanName($name);
-        if ($arguments === []) {
-            $filter = $alias;
-        } else {
-            $filter = $alias . ':' . implode(',', $arguments);
-        }
+        $filter              = ($arguments === []) ? $alias : $alias . ':' . implode(',', $arguments);
 
         if (class_exists($alias)) {
             $this->config->aliases[$alias] = $alias;

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Config\Filters as BaseFiltersConfig;
-use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -66,12 +65,28 @@ class Filters
     protected $initialized = false;
 
     /**
-     * The processed filters that will
-     * be used to check against.
+     * The filter list to execute for the current request (URI path).
      *
+     * This property is for display. Use $filtersClass to execute filters.
      * This does not include "Required Filters".
      *
-     * @var array<string, array>
+     * [
+     *     'before' => [
+     *         'alias',
+     *         'alias:arg1',
+     *         'alias:arg1,arg2',
+     *     ],
+     *     'after'  => [
+     *         'alias',
+     *         'alias:arg1',
+     *         'alias:arg1,arg2',
+     *     ],
+     * ]
+     *
+     * @var array{
+     *     before: list<string>,
+     *     after: list<string>
+     * }
      */
     protected $filters = [
         'before' => [],
@@ -79,12 +94,24 @@ class Filters
     ];
 
     /**
-     * The collection of filters' class names that will
-     * be used to execute in each position.
+     * The collection of filters' class names to execute for the current request
+     * (URI path).
      *
      * This does not include "Required Filters".
      *
-     * @var array<string, array>
+     * [
+     *     'before' => [
+     *         [classname, arguments],
+     *     ],
+     *     'after'  => [
+     *         [classname, arguments],
+     *     ],
+     * ]
+     *
+     * @var array{
+     *     before: list<array{0: class-string, 1: list<string>}>,
+     *     after: list<array{0: class-string, 1: list<string>}>
+     * }
      */
     protected $filtersClass = [
         'before' => [],
@@ -95,6 +122,8 @@ class Filters
      * Any arguments to be passed to filters.
      *
      * @var array<string, list<string>|null> [name => params]
+     *
+     * @deprecated 4.6.0 No longer used.
      */
     protected $arguments = [];
 
@@ -102,6 +131,8 @@ class Filters
      * Any arguments to be passed to filtersClass.
      *
      * @var array<class-string, list<string>|null> [classname => arguments]
+     *
+     * @deprecated 4.6.0 No longer used.
      */
     protected $argumentsClass = [];
 
@@ -193,17 +224,17 @@ class Filters
      */
     private function runBefore(array $filterClasses)
     {
-        foreach ($filterClasses as $className) {
+        foreach ($filterClasses as $filterClassInfo) {
+            $className = $filterClassInfo[0];
+            $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
+
             $class = new $className();
 
             if (! $class instanceof FilterInterface) {
                 throw FilterException::forIncorrectInterface($class::class);
             }
 
-            $result = $class->before(
-                $this->request,
-                $this->argumentsClass[$className] ?? null
-            );
+            $result = $class->before($this->request, $arguments);
 
             if ($result instanceof RequestInterface) {
                 $this->request = $result;
@@ -231,18 +262,17 @@ class Filters
 
     private function runAfter(array $filterClasses): ResponseInterface
     {
-        foreach ($filterClasses as $className) {
+        foreach ($filterClasses as $filterClassInfo) {
+            $className = $filterClassInfo[0];
+            $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
+
             $class = new $className();
 
             if (! $class instanceof FilterInterface) {
                 throw FilterException::forIncorrectInterface($class::class);
             }
 
-            $result = $class->after(
-                $this->request,
-                $this->response,
-                $this->argumentsClass[$className] ?? null
-            );
+            $result = $class->after($this->request, $this->response, $arguments);
 
             if ($result instanceof ResponseInterface) {
                 $this->response = $result;
@@ -277,9 +307,11 @@ class Filters
 
         foreach ($filters as $alias) {
             if (is_array($aliases[$alias])) {
-                $filterClasses[$position] = array_merge($filterClasses[$position], $aliases[$alias]);
+                foreach ($this->config->aliases[$alias] as $class) {
+                    $filterClasses[$position][] = [$class, []];
+                }
             } else {
-                $filterClasses[$position][] = $aliases[$alias];
+                $filterClasses[$position][] = [$aliases[$alias], []];
             }
         }
 
@@ -406,6 +438,11 @@ class Filters
         // Set the toolbar filter to the last position to be executed
         $this->filters['after'] = $this->setToolbarToLast($this->filters['after']);
 
+        // Since some filters like rate limiters rely on being executed once a request,
+        // we filter em here.
+        $this->filters['before'] = array_unique($this->filters['before']);
+        $this->filters['after']  = array_unique($this->filters['after']);
+
         $this->processAliasesToClass('before');
         $this->processAliasesToClass('after');
 
@@ -436,6 +473,11 @@ class Filters
     /**
      * Returns the processed filters array.
      * This does not include "Required Filters".
+     *
+     * @return array{
+     *      before: list<string>,
+     *      after: list<string>
+     *  }
      */
     public function getFilters(): array
     {
@@ -445,6 +487,11 @@ class Filters
     /**
      * Returns the filtersClass array.
      * This does not include "Required Filters".
+     *
+     * @return array{
+     *      before: list<array{0: class-string, 1: list<string>}>,
+     *      after: list<array{0: class-string, 1: list<string>}>
+     *  }
      */
     public function getFiltersClass(): array
     {
@@ -485,29 +532,31 @@ class Filters
      * are passed to the filter when executed.
      *
      * @param string $name filter_name or filter_name:arguments like 'role:admin,manager'
+     *                     or filter classname.
      */
     private function enableFilter(string $name, string $when = 'before'): void
     {
-        // Get arguments and clean name
-        [$name, $arguments]     = $this->getCleanName($name);
-        $this->arguments[$name] = ($arguments !== []) ? $arguments : null;
-
-        if (class_exists($name)) {
-            $this->config->aliases[$name] = $name;
-        } elseif (! array_key_exists($name, $this->config->aliases)) {
-            throw FilterException::forNoAlias($name);
+        // Normalize the arguments.
+        [$alias, $arguments] = $this->getCleanName($name);
+        if ($arguments === []) {
+            $filter = $alias;
+        } else {
+            $filter = $alias . ':' . implode(',', $arguments);
         }
 
-        $classNames = (array) $this->config->aliases[$name];
-
-        foreach ($classNames as $className) {
-            $this->argumentsClass[$className] = $this->arguments[$name] ?? null;
+        if (class_exists($alias)) {
+            $this->config->aliases[$alias] = $alias;
+        } elseif (! array_key_exists($alias, $this->config->aliases)) {
+            throw FilterException::forNoAlias($alias);
         }
 
-        if (! isset($this->filters[$when][$name])) {
-            $this->filters[$when][]    = $name;
-            $this->filtersClass[$when] = array_merge($this->filtersClass[$when], $classNames);
+        if (! isset($this->filters[$when][$filter])) {
+            $this->filters[$when][] = $filter;
         }
+
+        // Since some filters like rate limiters rely on being executed once a request,
+        // we filter em here.
+        $this->filters[$when] = array_unique($this->filters[$when]);
     }
 
     /**
@@ -557,6 +606,8 @@ class Filters
      * Returns the arguments for a specified key, or all.
      *
      * @return array<string, string>|string
+     *
+     * @deprecated 4.6.0 Already does not work.
      */
     public function getArguments(?string $key = null)
     {
@@ -692,12 +743,7 @@ class Filters
                 $path = $settings['before'];
 
                 if ($this->pathApplies($uri, $path)) {
-                    // Get arguments and clean name
-                    [$name, $arguments] = $this->getCleanName($alias);
-
-                    $filters['before'][] = $name;
-
-                    $this->registerArguments($name, $arguments);
+                    $filters['before'][] = $alias;
                 }
             }
 
@@ -705,14 +751,7 @@ class Filters
                 $path = $settings['after'];
 
                 if ($this->pathApplies($uri, $path)) {
-                    // Get arguments and clean name
-                    [$name, $arguments] = $this->getCleanName($alias);
-
-                    $filters['after'][] = $name;
-
-                    // The arguments may have already been registered in the before filter.
-                    // So disable check.
-                    $this->registerArguments($name, $arguments, false);
+                    $filters['after'][] = $alias;
                 }
             }
         }
@@ -737,31 +776,6 @@ class Filters
     }
 
     /**
-     * @param string $name      filter alias
-     * @param array  $arguments filter arguments
-     * @param bool   $check     if true, check if already defined
-     */
-    private function registerArguments(string $name, array $arguments, bool $check = true): void
-    {
-        if ($arguments !== []) {
-            if ($check && array_key_exists($name, $this->arguments)) {
-                throw new ConfigException(
-                    '"' . $name . '" already has arguments: '
-                    . (($this->arguments[$name] === null) ? 'null' : implode(',', $this->arguments[$name]))
-                );
-            }
-
-            $this->arguments[$name] = $arguments;
-        }
-
-        $classNames = (array) $this->config->aliases[$name];
-
-        foreach ($classNames as $className) {
-            $this->argumentsClass[$className] = $this->arguments[$name] ?? null;
-        }
-    }
-
-    /**
      * Maps filter aliases to the equivalent filter classes
      *
      * @return void
@@ -772,32 +786,28 @@ class Filters
     {
         $filterClasses = [];
 
-        foreach ($this->filters[$position] as $alias => $rules) {
-            if (is_numeric($alias) && is_string($rules)) {
-                $alias = $rules;
-            }
+        foreach ($this->filters[$position] as $filter) {
+            // Get arguments and clean alias
+            [$alias, $arguments] = $this->getCleanName($filter);
 
             if (! array_key_exists($alias, $this->config->aliases)) {
                 throw FilterException::forNoAlias($alias);
             }
 
             if (is_array($this->config->aliases[$alias])) {
-                $filterClasses = [...$filterClasses, ...$this->config->aliases[$alias]];
+                foreach ($this->config->aliases[$alias] as $class) {
+                    $filterClasses[] = [$class, $arguments];
+                }
             } else {
-                $filterClasses[] = $this->config->aliases[$alias];
+                $filterClasses[] = [$this->config->aliases[$alias], $arguments];
             }
         }
 
-        // when using enableFilter() we already write the class name in $filterClasses as well as the
-        // alias in $filters. This leads to duplicates when using route filters.
         if ($position === 'before') {
             $this->filtersClass[$position] = array_merge($filterClasses, $this->filtersClass[$position]);
         } else {
             $this->filtersClass[$position] = array_merge($this->filtersClass[$position], $filterClasses);
         }
-
-        // Since some filters like rate limiters rely on being executed once a request we filter em here.
-        $this->filtersClass[$position] = array_values(array_unique($this->filtersClass[$position]));
     }
 
     /**

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -237,23 +237,9 @@ class Filters
             $className = $filterClassInfo[0];
             $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
 
-            if (isset($this->filterClassInstances[$className])) {
-                $class = $this->filterClassInstances[$className];
-            } else {
-                $class = new $className();
+            $instance = $this->createFilter($className);
 
-                if (! $class instanceof FilterInterface) {
-                    throw FilterException::forIncorrectInterface($class::class);
-                }
-
-                $this->filterClassInstances[$className] = $class;
-            }
-
-            if (! $class instanceof FilterInterface) {
-                throw FilterException::forIncorrectInterface($class::class);
-            }
-
-            $result = $class->before($this->request, $arguments);
+            $result = $instance->before($this->request, $arguments);
 
             if ($result instanceof RequestInterface) {
                 $this->request = $result;
@@ -288,19 +274,9 @@ class Filters
             $className = $filterClassInfo[0];
             $arguments = ($filterClassInfo[1] === []) ? null : $filterClassInfo[1];
 
-            if (isset($this->filterClassInstances[$className])) {
-                $class = $this->filterClassInstances[$className];
-            } else {
-                $class = new $className();
+            $instance = $this->createFilter($className);
 
-                if (! $class instanceof FilterInterface) {
-                    throw FilterException::forIncorrectInterface($class::class);
-                }
-
-                $this->filterClassInstances[$className] = $class;
-            }
-
-            $result = $class->after($this->request, $this->response, $arguments);
+            $result = $instance->after($this->request, $this->response, $arguments);
 
             if ($result instanceof ResponseInterface) {
                 $this->response = $result;
@@ -310,6 +286,26 @@ class Filters
         }
 
         return $this->response;
+    }
+
+    /**
+     * @param class-string $className
+     */
+    private function createFilter(string $className): FilterInterface
+    {
+        if (isset($this->filterClassInstances[$className])) {
+            return $this->filterClassInstances[$className];
+        }
+
+        $instance = new $className();
+
+        if (! $instance instanceof FilterInterface) {
+            throw FilterException::forIncorrectInterface($instance::class);
+        }
+
+        $this->filterClassInstances[$className] = $instance;
+
+        return $instance;
     }
 
     /**

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -379,6 +379,9 @@ class Filters
      * @TODO We don't need to accept null as $uri.
      *
      * @return Filters
+     *
+     * @testTag Only for test code. The run() calls this, so you don't need to
+     *          call this in your app.
      */
     public function initialize(?string $uri = null)
     {

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -94,8 +94,8 @@ class Filters
     ];
 
     /**
-     * The collection of filters' class names to execute for the current request
-     * (URI path).
+     * The collection of filter class names and its arguments to execute for the
+     * current request (URI path).
      *
      * This does not include "Required Filters".
      *

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter;
 use App\Controllers\Home;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Debug\Timer;
-use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Response;
@@ -313,9 +312,6 @@ final class CodeIgniterTest extends CIUnitTestCase
 
     public function testRegisterSameFilterTwiceWithDifferentArgument(): void
     {
-        $this->expectException(ConfigException::class);
-        $this->expectExceptionMessage('"test-customfilter" already has arguments: null');
-
         $_SERVER['argv'] = ['index.php', 'pages/about'];
         $_SERVER['argc'] = 2;
 
@@ -343,7 +339,11 @@ final class CodeIgniterTest extends CIUnitTestCase
         ];
         Services::filters($filterConfig);
 
+        ob_start();
         $this->codeigniter->run();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('http://hellowworld.comhttp://hellowworld.com', $output);
 
         $this->resetServices();
     }

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -833,8 +833,8 @@ final class FiltersTest extends CIUnitTestCase
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
         $filters       = $this->createFilters($filtersConfig);
 
-        $filters = $filters->initialize('admin/foo/bar');
         $filters->enableFilters(['google'], 'before');
+        $filters = $filters->initialize('admin/foo/bar');
         $filters = $filters->getFilters();
 
         $this->assertContains('google', $filters['before']);
@@ -997,8 +997,8 @@ final class FiltersTest extends CIUnitTestCase
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
         $filters       = $this->createFilters($filtersConfig);
 
-        $filters = $filters->initialize('admin/foo/bar');
         $filters->enableFilters(['goggle'], 'before');
+        $filters = $filters->initialize('admin/foo/bar');
     }
 
     /**

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -998,7 +998,7 @@ final class FiltersTest extends CIUnitTestCase
         $filters       = $this->createFilters($filtersConfig);
 
         $filters->enableFilters(['goggle'], 'before');
-        $filters = $filters->initialize('admin/foo/bar');
+        $filters->initialize('admin/foo/bar');
     }
 
     /**

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Filters;
 
 use CodeIgniter\Config\Services;
-use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\Filters\fixtures\GoogleCurious;
 use CodeIgniter\Filters\fixtures\GoogleEmpty;
@@ -75,7 +74,7 @@ final class FiltersTest extends CIUnitTestCase
 
     private function createFilters(FiltersConfig $config, $request = null): Filters
     {
-        $request ??= Services::request();
+        $request ??= Services::incomingrequest();
 
         return new Filters($config, $request, $this->response);
     }
@@ -862,9 +861,7 @@ final class FiltersTest extends CIUnitTestCase
         $filters = $filters->initialize('admin/foo/bar');
         $found   = $filters->getFilters();
 
-        $this->assertContains('role', $found['before']);
-        $this->assertSame(['admin', 'super'], $filters->getArguments('role'));
-        $this->assertSame(['role' => ['admin', 'super']], $filters->getArguments());
+        $this->assertContains('role:admin,super', $found['before']);
 
         $response = $filters->run('admin/foo/bar', 'before');
 
@@ -875,11 +872,8 @@ final class FiltersTest extends CIUnitTestCase
         $this->assertSame('admin;super', $response->getBody());
     }
 
-    public function testFilterWithArgumentsIsDefined(): void
+    public function testFilterWithDiffernetArguments(): void
     {
-        $this->expectException(ConfigException::class);
-        $this->expectExceptionMessage('"role" already has arguments: admin,super');
-
         $_SERVER['REQUEST_METHOD'] = 'GET';
 
         $config = [
@@ -898,6 +892,10 @@ final class FiltersTest extends CIUnitTestCase
         $filters       = $this->createFilters($filtersConfig);
 
         $filters->initialize('admin/user/bar');
+        $found = $filters->getFilters();
+
+        $this->assertContains('role:admin,super', $found['before']);
+        $this->assertContains('role:super', $found['before']);
     }
 
     public function testFilterWithoutArgumentsIsDefined(): void
@@ -923,8 +921,6 @@ final class FiltersTest extends CIUnitTestCase
         $found   = $filters->getFilters();
 
         $this->assertContains('role', $found['before']);
-        $this->assertSame(['super'], $filters->getArguments('role'));
-        $this->assertSame(['role' => ['super']], $filters->getArguments());
     }
 
     public function testEnableFilterWithArguments(): void
@@ -941,14 +937,11 @@ final class FiltersTest extends CIUnitTestCase
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
         $filters       = $this->createFilters($filtersConfig);
 
-        $filters = $filters->initialize('admin/foo/bar');
         $filters->enableFilters(['role:admin , super'], 'before');
         $filters->enableFilters(['role:admin , super'], 'after');
         $found = $filters->getFilters();
 
-        $this->assertContains('role', $found['before']);
-        $this->assertSame(['admin', 'super'], $filters->getArguments('role'));
-        $this->assertSame(['role' => ['admin', 'super']], $filters->getArguments());
+        $this->assertContains('role:admin,super', $found['before']);
 
         $response = $filters->run('admin/foo/bar', 'before');
 
@@ -973,7 +966,6 @@ final class FiltersTest extends CIUnitTestCase
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
         $filters       = $this->createFilters($filtersConfig);
 
-        $filters = $filters->initialize('admin/foo/bar');
         $filters->enableFilters(['role'], 'before');
         $filters->enableFilters(['role'], 'after');
         $found = $filters->getFilters();
@@ -1323,8 +1315,8 @@ final class FiltersTest extends CIUnitTestCase
         $expected = [
             'before' => [],
             'after'  => [
-                Multiple1::class,
-                Multiple2::class,
+                [Multiple1::class, []],
+                [Multiple2::class, []],
             ],
         ];
         $this->assertSame($expected, $filters->getFiltersClass());

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -1352,4 +1352,42 @@ final class FiltersTest extends CIUnitTestCase
         $this->assertSame(['foo'], $filters->initialize($uri)->getFilters()['before']);
         $this->assertSame([], $filters->reset()->getFilters()['before']);
     }
+
+    public function testRunRequiredDoesBefore(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $config = [
+            'aliases'  => ['google' => GoogleMe::class],
+            'required' => [
+                'before' => ['google'],
+                'after'  => [],
+            ],
+        ];
+        $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
+        $filters       = $this->createFilters($filtersConfig);
+
+        $request = $filters->runRequired('before');
+
+        $this->assertSame('http://google.com', $request->getBody());
+    }
+
+    public function testRunRequiredDoesAfter(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $config = [
+            'aliases'  => ['google' => GoogleMe::class],
+            'required' => [
+                'before' => [],
+                'after'  => ['google'],
+            ],
+        ];
+        $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
+        $filters       = $this->createFilters($filtersConfig);
+
+        $response = $filters->runRequired('after');
+
+        $this->assertSame('http://google.com', $response->getBody());
+    }
 }

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -43,6 +43,13 @@ The following breaking changes have been made accordingly:
 - ``TestException`` now extends ``CodeIgniter\Exceptions\LogicException``
   instead of ``CodeIgniter\Exceptions\CriticalError``.
 
+Filters Changes
+---------------
+
+The ``Filters`` class has been changed to allow multiple runs of the same filter
+with different arguments in before or after. See
+:ref:`Upgrading Guide <upgrade-460-filters-changes>` for details.
+
 .. _v460-interface-changes:
 
 Interface Changes
@@ -106,6 +113,9 @@ The following new Exception interfaces have been added:
 Commands
 ========
 
+- The ``spark routes`` and ``spark filter:check`` commands now display filter
+  arguments.
+
 Testing
 =======
 
@@ -137,6 +147,9 @@ Helpers and Functions
 
 Others
 ======
+
+- **Filters:** Now you can execute a filter more than once with the different
+  arguments in before or after.
 
 ***************
 Message Changes
@@ -175,6 +188,11 @@ The following changes have been made accordingly:
 ************
 Deprecations
 ************
+
+- **Filters:**
+    - The properties ``$arguments`` and ``$argumentsClass`` of ``Filters`` have
+      been deprecated. No longer used.
+    - The ``Filters::getArguments()`` method has been deprecated. No longer used.
 
 **********
 Bugs Fixed

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -226,6 +226,9 @@ will be passed in ``$arguments`` to the ``group`` filter's ``before()`` methods.
 When the URI matches ``admin/users/*'``, the array ``['users.manage']``
 will be passed in ``$arguments`` to the ``permission`` filter's ``before()`` methods.
 
+.. note:: Prior to v4.6.0, the same filter cannot be run multiple times with
+    different arguments.
+
 .. _filter-execution-order:
 
 Filter Execution Order

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -589,7 +589,8 @@ The ``filter`` option passed to the outer ``group()`` are merged with the inner
 The above code runs ``myfilter1:config`` for the route ``admin``, and ``myfilter1:config``
 and ``myfilter2:region`` for the route ``admin/users/list``.
 
-.. note:: The same filter cannot be run multiple times with different arguments.
+.. note:: Prior to v4.6.0, the same filter cannot be run multiple times with
+    different arguments.
 
 Any other overlapping options passed to the inner ``group()`` will overwrite their values.
 

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -54,6 +54,24 @@ See :ref:`ChangeLog <v460-removed-deprecated-items>` for details.
 Breaking Enhancements
 *********************
 
+.. _upgrade-460-filters-changes:
+
+Filters Changes
+===============
+
+The ``Filters`` class has been changed to allow multiple runs of the same filter
+with different arguments in before or after.
+
+If you are extending ``Filters``, you will need to modify it to conform to the
+following changes:
+
+- The structure of the array properties ``$filters`` and ``$filtersClasses`` have
+  been changed.
+- The properties ``$arguments`` and ``$argumentsClass`` are no longer used.
+- ``Filters`` has been changed so that the same filter class is not instantiated
+  multiple times. If a filter class is used both before and after, the same instance
+  is used.
+
 *************
 Project Files
 *************


### PR DESCRIPTION
**Description**
Fixes #8973

- enables a filter to run more than once with the different arguments
- changes array structure of `Filters::$filters` and `$filtersClasses`
- `Filters::$arguments` and `$argumentsClass` are no longer used
- does not instantiate the same filter class more than once
- `spark routes` and `filter:check` show filter arguments

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
