### PR TITLE
docs: fix incorrect description for route group filter

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -584,12 +584,14 @@ It is possible to nest groups within groups for finer organization if you need i
 
 This would handle the URL at **admin/users/list**.
 
-**Filter** option passed to the outer ``group()`` are merged with the inner
+The ``filter`` option passed to the outer ``group()`` are merged with the inner
 ``group()`` filter option.
-The above code runs ``myfilter:config`` for the route ``admin``, and ``myfilter:config``
-and ``myfilter:region`` for the route ``admin/users/list``.
+The above code runs ``myfilter1:config`` for the route ``admin``, and ``myfilter1:config``
+and ``myfilter2:region`` for the route ``admin/users/list``.
 
-Any other overlapping options passed to the inner `group()` will overwrite their values.
+.. note:: The same filter cannot be run multiple times with different arguments.
+
+Any other overlapping options passed to the inner ``group()`` will overwrite their values.
 
 .. note:: Prior to v4.5.0, due to a bug, options passed to the outer ``group()``
     are not merged with the inner ``group()`` options.

--- a/user_guide_src/source/incoming/routing/026.php
+++ b/user_guide_src/source/incoming/routing/026.php
@@ -1,9 +1,9 @@
 <?php
 
-$routes->group('admin', ['filter' => 'myfilter:config'], static function ($routes) {
+$routes->group('admin', ['filter' => 'myfilter1:config'], static function ($routes) {
     $routes->get('/', 'Admin\Admin::index');
 
-    $routes->group('users', ['filter' => 'myfilter:region'], static function ($routes) {
+    $routes->group('users', ['filter' => 'myfilter2:region'], static function ($routes) {
         $routes->get('list', 'Admin\Users::list');
     });
 });


### PR DESCRIPTION
**Description**
See  #8973

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
