### PR TITLE
feat: add `foundRows` option for MySQLi config

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -43,6 +43,7 @@ class Database extends Config
         'failover'     => [],
         'port'         => 3306,
         'numberNative' => false,
+        'foundRows'    => false,
         'dateFormat'   => [
             'date'     => 'Y-m-d',
             'datetime' => 'Y-m-d H:i:s',

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -13460,6 +13460,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Database/Live/MySQLi/NumberNativeTest.php',
 ];
 $ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property CodeIgniter\\\\Database\\\\BaseConnection\\:\\:\\$foundRows\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/tests/system/Database/Live/MySQLi/FoundRowsTest.php',
+];
+$ignoreErrors[] = [
 	// identifier: missingType.property
 	'message' => '#^Property CodeIgniter\\\\Database\\\\Live\\\\MySQLi\\\\NumberNativeTest\\:\\:\\$tests has no type specified\\.$#',
 	'count' => 1,

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -35,6 +35,7 @@ use Throwable;
  * @property-read string     $DSN
  * @property-read array|bool $encrypt
  * @property-read array      $failover
+ * @property-read bool       $foundRows
  * @property-read string     $hostname
  * @property-read Query      $lastQuery
  * @property-read string     $password

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -35,7 +35,6 @@ use Throwable;
  * @property-read string     $DSN
  * @property-read array|bool $encrypt
  * @property-read array      $failover
- * @property-read bool       $foundRows
  * @property-read string     $hostname
  * @property-read Query      $lastQuery
  * @property-read string     $password

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -82,6 +82,16 @@ class Connection extends BaseConnection
     public $numberNative = false;
 
     /**
+     * Use MYSQLI_CLIENT_FOUND_ROWS
+     *
+     * Whether affected_rows should return number of rows found,
+     * or number of rows changed, after an UPDATE query.
+     *
+     * @var bool
+     */
+    public $foundRows = false;
+
+    /**
      * Connect to the database.
      *
      * @return false|mysqli
@@ -180,6 +190,10 @@ class Connection extends BaseConnection
             }
 
             $clientFlags += MYSQLI_CLIENT_SSL;
+        }
+
+        if ($this->foundRows) {
+            $clientFlags += MYSQLI_CLIENT_FOUND_ROWS;
         }
 
         try {

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -84,7 +84,7 @@ class Connection extends BaseConnection
     /**
      * Use MYSQLI_CLIENT_FOUND_ROWS
      *
-     * Whether affected_rows should return number of rows found,
+     * Whether affectedRows() should return number of rows found,
      * or number of rows changed, after an UPDATE query.
      *
      * @var bool

--- a/tests/system/Database/Live/MySQLi/FoundRowsTest.php
+++ b/tests/system/Database/Live/MySQLi/FoundRowsTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live\MySQLi;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\Database\Seeds\CITestSeeder;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class FoundRowsTest extends CIUnitTestCase
+{
+    use DatabaseTestTrait;
+
+    /**
+     * @var array<string,mixed>
+     */
+    private $tests;
+
+    protected $refresh = true;
+    protected $seed    = CITestSeeder::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = config('Database');
+
+        $this->tests = $config->tests;
+    }
+
+    public function testEnableFoundRows(): void
+    {
+        $this->tests['foundRows'] = true;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $this->assertTrue($db1->foundRows);
+    }
+
+    public function testDisableFoundRows(): void
+    {
+        $this->tests['foundRows'] = false;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $this->assertFalse($db1->foundRows);
+    }
+
+    public function testAffectedRowsAfterEnableFoundRowsWithNoChange(): void
+    {
+        $this->tests['foundRows'] = true;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $db1->table('db_user')
+            ->set('country', 'US')
+            ->where('country', 'US')
+            ->update();
+
+        $affectedRows = $db1->affectedRows();
+
+        $this->assertSame($affectedRows, 2);
+    }
+
+    public function testAffectedRowsAfterDisableFoundRowsWithNoChange(): void
+    {
+        $this->tests['foundRows'] = false;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $db1->table('db_user')
+            ->set('country', 'US')
+            ->where('country', 'US')
+            ->update();
+
+        $affectedRows = $db1->affectedRows();
+
+        $this->assertSame($affectedRows, 0);
+    }
+
+    public function testAffectedRowsAfterEnableFoundRowsWithChange(): void
+    {
+        $this->tests['foundRows'] = true;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $db1->table('db_user')
+            ->set('country', 'NZ')
+            ->where('country', 'US')
+            ->update();
+
+        $affectedRows = $db1->affectedRows();
+
+        $this->assertSame($affectedRows, 2);
+    }
+
+    public function testAffectedRowsAfterDisableFoundRowsWithChange(): void
+    {
+        $this->tests['foundRows'] = false;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $db1->table('db_user')
+            ->set('country', 'NZ')
+            ->where('country', 'US')
+            ->update();
+
+        $affectedRows = $db1->affectedRows();
+
+        $this->assertSame($affectedRows, 2);
+    }
+
+    public function testAffectedRowsAfterEnableFoundRowsWithPartialChange(): void
+    {
+        $this->tests['foundRows'] = true;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $db1->table('db_user')
+            ->set('name', 'Derek Jones')
+            ->where('country', 'US')
+            ->update();
+
+        $affectedRows = $db1->affectedRows();
+
+        $this->assertSame($affectedRows, 2);
+    }
+
+    public function testAffectedRowsAfterDisableFoundRowsWithPartialChange(): void
+    {
+        $this->tests['foundRows'] = false;
+
+        $db1 = Database::connect($this->tests);
+
+        if ($db1->DBDriver !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
+
+        $db1->table('db_user')
+            ->set('name', 'Derek Jones')
+            ->where('country', 'US')
+            ->update();
+
+        $affectedRows = $db1->affectedRows();
+
+        $this->assertSame($affectedRows, 1);
+    }
+}

--- a/tests/system/Database/Live/MySQLi/FoundRowsTest.php
+++ b/tests/system/Database/Live/MySQLi/FoundRowsTest.php
@@ -28,7 +28,9 @@ final class FoundRowsTest extends CIUnitTestCase
     use DatabaseTestTrait;
 
     /**
-     * @var array<string,mixed>
+     * Database config for tests
+     *
+     * @var array<string, mixed>
      */
     private $tests;
 
@@ -37,8 +39,6 @@ final class FoundRowsTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $config = config('Database');
 
         $this->tests = $config->tests;
@@ -46,6 +46,8 @@ final class FoundRowsTest extends CIUnitTestCase
         if ($this->tests['DBDriver'] !== 'MySQLi') {
             $this->markTestSkipped('Only MySQLi can complete this test.');
         }
+
+        parent::setUp();
     }
 
     public function testEnableFoundRows(): void

--- a/tests/system/Database/Live/MySQLi/FoundRowsTest.php
+++ b/tests/system/Database/Live/MySQLi/FoundRowsTest.php
@@ -42,6 +42,10 @@ final class FoundRowsTest extends CIUnitTestCase
         $config = config('Database');
 
         $this->tests = $config->tests;
+
+        if ($this->tests['DBDriver'] !== 'MySQLi') {
+            $this->markTestSkipped('Only MySQLi can complete this test.');
+        }
     }
 
     public function testEnableFoundRows(): void
@@ -49,10 +53,6 @@ final class FoundRowsTest extends CIUnitTestCase
         $this->tests['foundRows'] = true;
 
         $db1 = Database::connect($this->tests);
-
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
 
         $this->assertTrue($db1->foundRows);
     }
@@ -63,10 +63,6 @@ final class FoundRowsTest extends CIUnitTestCase
 
         $db1 = Database::connect($this->tests);
 
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
-
         $this->assertFalse($db1->foundRows);
     }
 
@@ -75,10 +71,6 @@ final class FoundRowsTest extends CIUnitTestCase
         $this->tests['foundRows'] = true;
 
         $db1 = Database::connect($this->tests);
-
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
 
         $db1->table('db_user')
             ->set('country', 'US')
@@ -96,10 +88,6 @@ final class FoundRowsTest extends CIUnitTestCase
 
         $db1 = Database::connect($this->tests);
 
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
-
         $db1->table('db_user')
             ->set('country', 'US')
             ->where('country', 'US')
@@ -115,10 +103,6 @@ final class FoundRowsTest extends CIUnitTestCase
         $this->tests['foundRows'] = true;
 
         $db1 = Database::connect($this->tests);
-
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
 
         $db1->table('db_user')
             ->set('country', 'NZ')
@@ -136,10 +120,6 @@ final class FoundRowsTest extends CIUnitTestCase
 
         $db1 = Database::connect($this->tests);
 
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
-
         $db1->table('db_user')
             ->set('country', 'NZ')
             ->where('country', 'US')
@@ -156,10 +136,6 @@ final class FoundRowsTest extends CIUnitTestCase
 
         $db1 = Database::connect($this->tests);
 
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
-
         $db1->table('db_user')
             ->set('name', 'Derek Jones')
             ->where('country', 'US')
@@ -175,10 +151,6 @@ final class FoundRowsTest extends CIUnitTestCase
         $this->tests['foundRows'] = false;
 
         $db1 = Database::connect($this->tests);
-
-        if ($db1->DBDriver !== 'MySQLi') {
-            $this->markTestSkipped('Only MySQLi can complete this test.');
-        }
 
         $db1->table('db_user')
             ->set('name', 'Derek Jones')

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -121,7 +121,7 @@ Forge
 Others
 ------
 
-- Added a new configuration `foundRows` for MySQLi to use `MYSQLI_CLIENT_FOUND_ROWS`.
+- Added a new configuration ``foundRows`` for MySQLi to use ``MYSQLI_CLIENT_FOUND_ROWS``.
 
 Model
 =====

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -121,6 +121,8 @@ Forge
 Others
 ------
 
+- Added a new configuration `foundRows` for MySQLi to use `MYSQLI_CLIENT_FOUND_ROWS`.
+
 Model
 =====
 

--- a/user_guide_src/source/database/configuration.rst
+++ b/user_guide_src/source/database/configuration.rst
@@ -179,6 +179,7 @@ Description of Values
                      To enforce Foreign Key constraint, set this config item to true.
 **busyTimeout**  (``SQLite3`` only) milliseconds (int) - Sleeps for a specified amount of time when a table is locked.
 **numberNative** (``MySQLi`` only) true/false (boolean) - Whether to enable MYSQLI_OPT_INT_AND_FLOAT_NATIVE.
+**foundRows**    (``MySQLi`` only) true/false (boolean) - Whether to enable MYSQLI_CLIENT_FOUND_ROWS.
 **dateFormat**   The default date/time formats as PHP's `DateTime format`_.
                  * ``date``        - date format
                  * ``datetime``    - date and time format


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Added a new database config `foundRows` for MySQLi. Enabling this adds the flag `MYSQLI_CLIENT_FOUND_ROWS` when connecting to a MySQL database.

The flag changes the behaviour of `affectedRows()` for `UPDATE` or `INSERT ... ON DUPLICATE KEY UPDATE`, where the number of rows updated to the same value will also be returned. By default, it only returns the number rows with a value changed.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
