### PR TITLE
fix: [Auto Routing Improved] Default Method Fallback does not work with `$translateUriToCamelCase`

### DIFF
--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -519,13 +519,15 @@ final class AutoRouterImproved implements AutoRouterInterface
             return;
         }
 
-        // If `getSomeMethod()` exists, only `controller/some-method` should be
-        // accessible. But if a visitor navigates to `controller/somemethod`,
-        // `getSomemethod()` will be checked, and method_exists() will return true.
         if (
+            // For example, if `getSomeMethod()` exists in the controller, only
+            // the URI `controller/some-method` should be accessible. But if a
+            // visitor navigates to the URI `controller/somemethod`, `getSomemethod()`
+            // will be checked, and `method_exists()` will return true because
+            // method names in PHP are case-insensitive.
             method_exists($this->controller, $method)
-            // We do not permit `controller/somemethod`, so check the exact method
-            // name.
+            // But we do not permit `controller/somemethod`, so check the exact
+            // method name.
             && ! in_array($method, get_class_methods($this->controller), true)
         ) {
             throw new PageNotFoundException(

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -162,7 +162,7 @@ final class AutoRouterImproved implements AutoRouterInterface
             $segment = array_shift($segments);
             $controllerPos++;
 
-            $class = $this->translateURIDashes($segment);
+            $class = $this->translateURI($segment);
 
             // as soon as we encounter any segment that is not PSR-4 compliant, stop searching
             if (! $this->isValidSegment($class)) {
@@ -209,7 +209,7 @@ final class AutoRouterImproved implements AutoRouterInterface
             }
 
             $namespaces = array_map(
-                fn ($segment) => $this->translateURIDashes($segment),
+                fn ($segment) => $this->translateURI($segment),
                 $segments
             );
 
@@ -307,7 +307,7 @@ final class AutoRouterImproved implements AutoRouterInterface
 
         $method = '';
         if ($methodParam !== null) {
-            $method = $httpVerb . $this->translateURIDashes($methodParam);
+            $method = $httpVerb . $this->translateURI($methodParam);
 
             $this->checkUriForMethod($method);
         }
@@ -544,7 +544,10 @@ final class AutoRouterImproved implements AutoRouterInterface
         return (bool) preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $segment);
     }
 
-    private function translateURIDashes(string $segment): string
+    /**
+     * Translates URI segment to CamelCase or replaces `-` with `_`.
+     */
+    private function translateURI(string $segment): string
     {
         if ($this->translateUriToCamelCase) {
             if (strtolower($segment) !== $segment) {

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -519,7 +519,15 @@ final class AutoRouterImproved implements AutoRouterInterface
             return;
         }
 
-        if (! in_array($method, get_class_methods($this->controller), true)) {
+        // If `getSomeMethod()` exists, only `controller/some-method` should be
+        // accessible. But if a visitor navigates to `controller/somemethod`,
+        // `getSomemethod()` will be checked, and method_exists() will return true.
+        if (
+            method_exists($this->controller, $method)
+            // We do not permit `controller/somemethod`, so check the exact method
+            // name.
+            && ! in_array($method, get_class_methods($this->controller), true)
+        ) {
             throw new PageNotFoundException(
                 '"' . $this->controller . '::' . $method . '()" is not found.'
             );

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -277,6 +277,28 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         ], $router->getPos());
     }
 
+    public function testAutoRouteFallbackToDefaultMethodWithTranslateUriToCamelCase(): void
+    {
+        $config                          = config(Routing::class);
+        $config->translateUriToCamelCase = true;
+        Factories::injectMock('config', Routing::class, $config);
+
+        $router = $this->createNewAutoRouter();
+
+        [$directory, $controller, $method, $params]
+            = $router->getRoute('index/15', Method::GET);
+
+        $this->assertNull($directory);
+        $this->assertSame('\\' . Index::class, $controller);
+        $this->assertSame('getIndex', $method);
+        $this->assertSame(['15'], $params);
+        $this->assertSame([
+            'controller' => 0,
+            'method'     => null,
+            'params'     => 1,
+        ], $router->getPos());
+    }
+
     public function testAutoRouteFallbackToDefaultControllerOneParam(): void
     {
         $router = $this->createNewAutoRouter();


### PR DESCRIPTION
**Description**
- fix bug that [Default Method Fallback](https://codeigniter4.github.io/CodeIgniter4/incoming/controllers.html#default-method-fallback) does not work with `$translateUriToCamelCase`

Navigate to `http://localhost:8080/product/15/edit`.
Before:
```
404
"\App\Controllers\Product::get15()" is not found.
```

After:
```
$id string (2) "15"
$action string (4) "edit"
⧉ Called from .../app/Controllers/Product.php:12 [dd()]
```

```php
<?php

namespace App\Controllers;

use App\Controllers\BaseController;
use CodeIgniter\HTTP\ResponseInterface;

class Product extends BaseController
{
    public function getIndex($id = null, $action = '')
    {
        dd($id, $action);
    }
}
```

```diff
diff --git a/app/Config/Feature.php b/app/Config/Feature.php
index efd4a0b20a..3e9e009657 100644
--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -12,7 +12,7 @@ class Feature extends BaseConfig
     /**
      * Use improved new auto routing instead of the default legacy version.
      */
-    public bool $autoRoutesImproved = false;
+    public bool $autoRoutesImproved = true;
 
     /**
      * Use filter execution order in 4.4 or before.
diff --git a/app/Config/Routing.php b/app/Config/Routing.php
index 7abadc7b76..63d4ca2290 100644
--- a/app/Config/Routing.php
+++ b/app/Config/Routing.php
@@ -94,7 +94,7 @@ class Routing extends BaseRouting
      *
      * If FALSE, will stop searching and do NO automatic routing.
      */
-    public bool $autoRoute = false;
+    public bool $autoRoute = true;
 
     /**
      * For Defined Routes.
@@ -136,5 +136,5 @@ class Routing extends BaseRouting
      *
      * Default: false
      */
-    public bool $translateUriToCamelCase = false;
+    public bool $translateUriToCamelCase = true;
 }
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
