### PR TITLE
feat: `spark filter:check` shows filter classnames

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -879,18 +879,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Commands\\\\Utilities\\\\FilterCheck\\:\\:addRequiredFilters\\(\\) has parameter \\$filters with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Utilities/FilterCheck.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Commands\\\\Utilities\\\\FilterCheck\\:\\:addRequiredFilters\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Commands/Utilities/FilterCheck.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Commands\\\\Utilities\\\\Namespaces\\:\\:outputAllNamespaces\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Commands/Utilities/Namespaces.php',

--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -125,6 +125,28 @@ class FilterCheck extends BaseCommand
 
         CLI::table($tbody, $thead);
 
+        // Show filter classes
+        $requiredFilterClasses = $filterCollector->getRequiredFilterClasses();
+        $filterClasses         = $filterCollector->getClasses($method, $route);
+
+        foreach ($requiredFilterClasses as $position => $classes) {
+            foreach ($classes as $class) {
+                $class = CLI::color($class, 'yellow');
+
+                $coloredRequiredFilterClasses[$position][] = $class;
+            }
+        }
+
+        $classList = [
+            'before' => array_merge($coloredRequiredFilterClasses['before'], $filterClasses['before']),
+            'after'  => array_merge($filterClasses['after'], $coloredRequiredFilterClasses['after']),
+        ];
+
+        foreach ($classList as $position => $classes) {
+            CLI::write(ucfirst($position) . ' Filter Classes:', 'cyan');
+            CLI::write(implode(' → ', $classes));
+        }
+
         return EXIT_SUCCESS;
     }
 

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -43,7 +43,7 @@ final class FilterCollector
      * @param string $method HTTP verb like `GET`,`POST` or `CLI`.
      * @param string $uri    URI path to find filters for
      *
-     * @return array{before: list<string>, after: list<string>} array of filter alias or classname
+     * @return array{before: list<string>, after: list<string>} array of alias/classname:args
      */
     public function get(string $method, string $uri): array
     {
@@ -80,9 +80,51 @@ final class FilterCollector
     }
 
     /**
+     * Returns filter classes for the URI
+     *
+     * @param string $method HTTP verb like `GET`,`POST` or `CLI`.
+     * @param string $uri    URI path to find filters for
+     *
+     * @return array{before: list<string>, after: list<string>} array of classname:args
+     */
+    public function getClasses(string $method, string $uri): array
+    {
+        if ($method === strtolower($method)) {
+            @trigger_error(
+                'Passing lowercase HTTP method "' . $method . '" is deprecated.'
+                . ' Use uppercase HTTP method like "' . strtoupper($method) . '".',
+                E_USER_DEPRECATED
+            );
+        }
+
+        /**
+         * @deprecated 4.5.0
+         * @TODO Remove this in the future.
+         */
+        $method = strtoupper($method);
+
+        if ($method === 'CLI') {
+            return [
+                'before' => [],
+                'after'  => [],
+            ];
+        }
+
+        $request = Services::incomingrequest(null, false);
+        $request->setMethod($method);
+
+        $router  = $this->createRouter($request);
+        $filters = $this->createFilters($request);
+
+        $finder = new FilterFinder($router, $filters);
+
+        return $finder->findClasses($uri);
+    }
+
+    /**
      * Returns Required Filters
      *
-     * @return array{before: list<string>, after: list<string>} array of filter alias or classname
+     * @return array{before: list<string>, after: list<string>} array of aliases
      */
     public function getRequiredFilters(): array
     {
@@ -95,6 +137,24 @@ final class FilterCollector
         $finder = new FilterFinder($router, $filters);
 
         return $finder->getRequiredFilters();
+    }
+
+    /**
+     * Returns Required Filter class list
+     *
+     * @return array{before: list<string>, after: list<string>} array of classnames
+     */
+    public function getRequiredFilterClasses(): array
+    {
+        $request = Services::incomingrequest(null, false);
+        $request->setMethod(Method::GET);
+
+        $router  = $this->createRouter($request);
+        $filters = $this->createFilters($request);
+
+        $finder = new FilterFinder($router, $filters);
+
+        return $finder->getRequiredFilterClasses();
     }
 
     private function createRouter(Request $request): Router

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -160,6 +160,9 @@ final class FilterFinder
         $before = $this->filters->getRequiredClasses('before');
         $after  = $this->filters->getRequiredClasses('after');
 
+        $requiredBefore = [];
+        $requiredAfter  = [];
+
         foreach ($before as $classInfo) {
             $requiredBefore[] = $classInfo[0];
         }

--- a/system/Commands/Utilities/Routes/FilterFinder.php
+++ b/system/Commands/Utilities/Routes/FilterFinder.php
@@ -46,23 +46,20 @@ final class FilterFinder
     /**
      * @param string $uri URI path to find filters for
      *
-     * @return array{before: list<string>, after: list<string>} array of filter alias or classname
+     * @return array{before: list<string>, after: list<string>} array of alias/classname:args
      */
     public function find(string $uri): array
     {
         $this->filters->reset();
 
-        // Add route filters
         try {
+            // Add route filters
             $routeFilters = $this->getRouteFilters($uri);
-
             $this->filters->enableFilters($routeFilters, 'before');
-
             $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
             if (! $oldFilterOrder) {
                 $routeFilters = array_reverse($routeFilters);
             }
-
             $this->filters->enableFilters($routeFilters, 'after');
 
             $this->filters->initialize($uri);
@@ -82,14 +79,94 @@ final class FilterFinder
     }
 
     /**
+     * @param string $uri URI path to find filters for
+     *
+     * @return array{before: list<string>, after: list<string>} array of classname:args
+     */
+    public function findClasses(string $uri): array
+    {
+        $this->filters->reset();
+
+        try {
+            // Add route filters
+            $routeFilters = $this->getRouteFilters($uri);
+            $this->filters->enableFilters($routeFilters, 'before');
+            $oldFilterOrder = config(Feature::class)->oldFilterOrder ?? false;
+            if (! $oldFilterOrder) {
+                $routeFilters = array_reverse($routeFilters);
+            }
+            $this->filters->enableFilters($routeFilters, 'after');
+
+            $this->filters->initialize($uri);
+
+            $filterClassList = $this->filters->getFiltersClass();
+
+            $filterClasses = [
+                'before' => [],
+                'after'  => [],
+            ];
+
+            foreach ($filterClassList['before'] as $classInfo) {
+                $classWithArguments = ($classInfo[1] === []) ? $classInfo[0]
+                    : $classInfo[0] . ':' . implode(',', $classInfo[1]);
+
+                $filterClasses['before'][] = $classWithArguments;
+            }
+
+            foreach ($filterClassList['after'] as $classInfo) {
+                $classWithArguments = ($classInfo[1] === []) ? $classInfo[0]
+                    : $classInfo[0] . ':' . implode(',', $classInfo[1]);
+
+                $filterClasses['after'][] = $classWithArguments;
+            }
+
+            return $filterClasses;
+        } catch (RedirectException) {
+            return [
+                'before' => [],
+                'after'  => [],
+            ];
+        } catch (BadRequestException|PageNotFoundException) {
+            return [
+                'before' => ['<unknown>'],
+                'after'  => ['<unknown>'],
+            ];
+        }
+    }
+
+    /**
      * Returns Required Filters
      *
-     * @return array{before: list<string>, after:list<string>}
+     * @return array{before: list<string>, after:list<string>} array of aliases
      */
     public function getRequiredFilters(): array
     {
         [$requiredBefore] = $this->filters->getRequiredFilters('before');
         [$requiredAfter]  = $this->filters->getRequiredFilters('after');
+
+        return [
+            'before' => $requiredBefore,
+            'after'  => $requiredAfter,
+        ];
+    }
+
+    /**
+     * Returns Required Filter classes
+     *
+     * @return array{before: list<string>, after:list<string>}
+     */
+    public function getRequiredFilterClasses(): array
+    {
+        $before = $this->filters->getRequiredClasses('before');
+        $after  = $this->filters->getRequiredClasses('after');
+
+        foreach ($before as $classInfo) {
+            $requiredBefore[] = $classInfo[0];
+        }
+
+        foreach ($after as $classInfo) {
+            $requiredAfter[] = $classInfo[0];
+        }
 
         return [
             'before' => $requiredBefore,

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -545,9 +545,11 @@ class Filters
      * MUST be called prior to initialize();
      * Intended for use within routes files.
      *
+     * @phpstan-param 'before'|'after' $position
+     *
      * @return $this
      */
-    public function addFilter(string $class, ?string $alias = null, string $when = 'before', string $section = 'globals')
+    public function addFilter(string $class, ?string $alias = null, string $position = 'before', string $section = 'globals')
     {
         $alias ??= md5($class);
 
@@ -555,13 +557,13 @@ class Filters
             $this->config->{$section} = [];
         }
 
-        if (! isset($this->config->{$section}[$when])) {
-            $this->config->{$section}[$when] = [];
+        if (! isset($this->config->{$section}[$position])) {
+            $this->config->{$section}[$position] = [];
         }
 
         $this->config->aliases[$alias] = $class;
 
-        $this->config->{$section}[$when][] = $alias;
+        $this->config->{$section}[$position][] = $alias;
 
         return $this;
     }
@@ -573,10 +575,11 @@ class Filters
      * after the filter name, followed by a comma-separated list of arguments that
      * are passed to the filter when executed.
      *
-     * @param string $name filter_name or filter_name:arguments like 'role:admin,manager'
-     *                     or filter classname.
+     * @param         string           $name     filter_name or filter_name:arguments like 'role:admin,manager'
+     *                                           or filter classname.
+     * @phpstan-param 'before'|'after' $position
      */
-    private function enableFilter(string $name, string $when = 'before'): void
+    private function enableFilter(string $name, string $position = 'before'): void
     {
         // Normalize the arguments.
         [$alias, $arguments] = $this->getCleanName($name);
@@ -588,13 +591,13 @@ class Filters
             throw FilterException::forNoAlias($alias);
         }
 
-        if (! isset($this->filters[$when][$filter])) {
-            $this->filters[$when][] = $filter;
+        if (! isset($this->filters[$position][$filter])) {
+            $this->filters[$position][] = $filter;
         }
 
         // Since some filters like rate limiters rely on being executed once a request,
         // we filter em here.
-        $this->filters[$when] = array_unique($this->filters[$when]);
+        $this->filters[$position] = array_unique($this->filters[$position]);
     }
 
     /**
@@ -815,6 +818,8 @@ class Filters
 
     /**
      * Maps filter aliases to the equivalent filter classes
+     *
+     * @phpstan-param 'before'|'after' $position
      *
      * @return void
      *

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -29,7 +29,7 @@ use Config\Modules;
 class Filters
 {
     /**
-     * The original config file
+     * The Config\Filters instance
      *
      * @var FiltersConfig
      */
@@ -50,15 +50,14 @@ class Filters
     protected $response;
 
     /**
-     * Handle to the modules config.
+     * The Config\Modules instance
      *
      * @var Modules
      */
     protected $modules;
 
     /**
-     * Whether we've done initial processing
-     * on the filter lists.
+     * Whether we've done initial processing on the filter lists.
      *
      * @var bool
      */
@@ -94,8 +93,8 @@ class Filters
     ];
 
     /**
-     * The collection of filter class names and its arguments to execute for the
-     * current request (URI path).
+     * The collection of filter classnames and their arguments to execute for
+     * the current request (URI path).
      *
      * This does not include "Required Filters".
      *
@@ -163,10 +162,10 @@ class Filters
 
     /**
      * If discoverFilters is enabled in Config then system will try to
-     * auto-discover custom filters files in Namespaces and allow access to
-     * the config object via the variable $filters as with the routes file
+     * auto-discover custom filters files in namespaces and allow access to
+     * the config object via the variable $filters as with the routes file.
      *
-     * Sample :
+     * Sample:
      * $filters->aliases['custom-auth'] = \Acme\Blob\Filters\BlobAuth::class;
      *
      * @deprecated 4.4.2 Use Registrar instead.
@@ -204,8 +203,8 @@ class Filters
     }
 
     /**
-     * Runs through all of the filters for the specified
-     * uri and position.
+     * Runs through all the filters (except "Required Filters") for the specified
+     * URI and position.
      *
      * @param         string           $uri      URI path relative to baseURL
      * @phpstan-param 'before'|'after' $position

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -322,19 +322,19 @@ class Filters
             return [];
         }
 
-        $filterClasses = [];
+        $filterClassList = [];
 
         foreach ($filters as $alias) {
             if (is_array($aliases[$alias])) {
                 foreach ($this->config->aliases[$alias] as $class) {
-                    $filterClasses[] = [$class, []];
+                    $filterClassList[] = [$class, []];
                 }
             } else {
-                $filterClasses[] = [$aliases[$alias], []];
+                $filterClassList[] = [$aliases[$alias], []];
             }
         }
 
-        return $filterClasses;
+        return $filterClassList;
     }
 
     /**
@@ -350,18 +350,18 @@ class Filters
      */
     public function runRequired(string $position = 'before')
     {
-        $filterClasses = $this->getRequiredClasses($position);
+        $filterClassList = $this->getRequiredClasses($position);
 
-        if ($filterClasses === []) {
+        if ($filterClassList === []) {
             return $position === 'before' ? $this->request : $this->response;
         }
 
         if ($position === 'before') {
-            return $this->runBefore($filterClasses);
+            return $this->runBefore($filterClassList);
         }
 
         // After
-        return $this->runAfter($filterClasses);
+        return $this->runAfter($filterClassList);
     }
 
     /**
@@ -826,7 +826,7 @@ class Filters
      */
     protected function processAliasesToClass(string $position)
     {
-        $filterClasses = [];
+        $filterClassList = [];
 
         foreach ($this->filters[$position] as $filter) {
             // Get arguments and clean alias
@@ -838,17 +838,17 @@ class Filters
 
             if (is_array($this->config->aliases[$alias])) {
                 foreach ($this->config->aliases[$alias] as $class) {
-                    $filterClasses[] = [$class, $arguments];
+                    $filterClassList[] = [$class, $arguments];
                 }
             } else {
-                $filterClasses[] = [$this->config->aliases[$alias], $arguments];
+                $filterClassList[] = [$this->config->aliases[$alias], $arguments];
             }
         }
 
         if ($position === 'before') {
-            $this->filtersClass[$position] = array_merge($filterClasses, $this->filtersClass[$position]);
+            $this->filtersClass[$position] = array_merge($filterClassList, $this->filtersClass[$position]);
         } else {
-            $this->filtersClass[$position] = array_merge($this->filtersClass[$position], $filterClasses);
+            $this->filtersClass[$position] = array_merge($this->filtersClass[$position], $filterClassList);
         }
     }
 

--- a/tests/system/Commands/FilterCheckTest.php
+++ b/tests/system/Commands/FilterCheckTest.php
@@ -50,6 +50,13 @@ final class FilterCheckTest extends CIUnitTestCase
             '| GET    | /     | forcehttps pagecache | pagecache performance toolbar |',
             preg_replace('/\033\[.+?m/u', '', $this->getBuffer())
         );
+        $this->assertStringContainsString(
+            'Before Filter Classes:
+CodeIgniter\Filters\ForceHTTPS → CodeIgniter\Filters\PageCache
+After Filter Classes:
+CodeIgniter\Filters\PageCache → CodeIgniter\Filters\PerformanceMetrics → CodeIgniter\Filters\DebugToolbar',
+            preg_replace('/\033\[.+?m/u', '', $this->getBuffer())
+        );
     }
 
     public function testFilterCheckInvalidRoute(): void

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -154,6 +154,42 @@ final class FilterFinderTest extends CIUnitTestCase
         $this->assertSame($expected, $filters);
     }
 
+    public function testFindGlobalsAndRouteFiltersWithArguments(): void
+    {
+        $collection = $this->createRouteCollection();
+        $collection->get('admin', ' AdminController::index', ['filter' => 'honeypot:arg1,arg2']);
+        $router  = $this->createRouter($collection);
+        $filters = $this->createFilters();
+
+        $finder = new FilterFinder($router, $filters);
+
+        $filters = $finder->find('admin');
+
+        $expected = [
+            'before' => ['csrf', 'honeypot:arg1,arg2'],
+            'after'  => ['honeypot:arg1,arg2', 'toolbar'],
+        ];
+        $this->assertSame($expected, $filters);
+    }
+
+    public function testFindClassesGlobalsAndRouteFiltersWithArguments(): void
+    {
+        $collection = $this->createRouteCollection();
+        $collection->get('admin', ' AdminController::index', ['filter' => 'honeypot:arg1,arg2']);
+        $router  = $this->createRouter($collection);
+        $filters = $this->createFilters();
+
+        $finder = new FilterFinder($router, $filters);
+
+        $filters = $finder->findClasses('admin');
+
+        $expected = [
+            'before' => [CSRF::class, Honeypot::class . ':arg1,arg2'],
+            'after'  => [Honeypot::class . ':arg1,arg2', DebugToolbar::class],
+        ];
+        $this->assertSame($expected, $filters);
+    }
+
     public function testFindGlobalsAndRouteClassnameFilters(): void
     {
         $collection = $this->createRouteCollection();

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -117,6 +117,7 @@ Commands
 
 - The ``spark routes`` and ``spark filter:check`` commands now display filter
   arguments.
+- The ``spark filter:check`` command now displays filter classnames.
 
 Testing
 =======

--- a/user_guide_src/source/incoming/filters.rst
+++ b/user_guide_src/source/incoming/filters.rst
@@ -274,11 +274,19 @@ The output is like the following:
 
 .. code-block:: none
 
-    +--------+-------+----------------+---------------+
-    | Method | Route | Before Filters | After Filters |
-    +--------+-------+----------------+---------------+
-    | GET    | /     |                | toolbar       |
-    +--------+-------+----------------+---------------+
+    +--------+-------+----------------------+-------------------------------+
+    | Method | Route | Before Filters       | After Filters                 |
+    +--------+-------+----------------------+-------------------------------+
+    | GET    | /     | forcehttps pagecache | pagecache performance toolbar |
+    +--------+-------+----------------------+-------------------------------+
+
+    Before Filter Classes:
+    CodeIgniter\Filters\ForceHTTPS → CodeIgniter\Filters\PageCache
+    After Filter Classes:
+    CodeIgniter\Filters\PageCache → CodeIgniter\Filters\PerformanceMetrics → CodeIgniter\Filters\DebugToolbar
+
+.. note:: Since v4.6.0, filter arguments have been displayed in the output table.
+    Also, the actual filter classnames have been displayed in the end.
 
 You can also see the routes and filters by the ``spark routes`` command,
 but it might not show accurate filters when you use regular expressions for routes.


### PR DESCRIPTION
Needs #8977

**Description**
Before:
```console
$ ./spark filter:check GET admin/users/list

CodeIgniter v4.5.2 Command Line Tool - Server Time: 2024-06-24 00:57:28 UTC+00:00

+--------+------------------+----------------------------------------------+-------------------------------------------------------+
| Method | Route            | Before Filters                               | After Filters                                         |
+--------+------------------+----------------------------------------------+-------------------------------------------------------+
| GET    | admin/users/list | forcehttps pagecache csrf:config csrf:region | csrf:region csrf:config pagecache performance toolbar |
+--------+------------------+----------------------------------------------+-------------------------------------------------------+
```
After:
```console
$ ./spark filter:check GET admin/users/list

CodeIgniter v4.5.2 Command Line Tool - Server Time: 2024-06-22 02:52:05 UTC+00:00

+--------+------------------+----------------------------------------------+-------------------------------------------------------+
| Method | Route            | Before Filters                               | After Filters                                         |
+--------+------------------+----------------------------------------------+-------------------------------------------------------+
| GET    | admin/users/list | forcehttps pagecache csrf:config csrf:region | csrf:region csrf:config pagecache performance toolbar |
+--------+------------------+----------------------------------------------+-------------------------------------------------------+

Before Filter Classes:
CodeIgniter\Filters\ForceHTTPS → CodeIgniter\Filters\PageCache → CodeIgniter\Filters\CSRF:config → CodeIgniter\Filters\CSRF:region
After Filter Classes:
CodeIgniter\Filters\CSRF:region → CodeIgniter\Filters\CSRF:config → CodeIgniter\Filters\PageCache → CodeIgniter\Filters\PerformanceMetrics → CodeIgniter\Filters\DebugToolbar
```

```diff
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -6,3 +6,11 @@ use CodeIgniter\Router\RouteCollection;
  * @var RouteCollection $routes
  */
 $routes->get('/', 'Home::index');
+
+$routes->group('admin', ['filter' => 'csrf:config'], static function ($routes) {
+    $routes->get('/', 'Admin\Admin::index');
+
+    $routes->group('users', ['filter' => 'csrf:region'], static function ($routes) {
+        $routes->get('list', 'Admin\Users::list');
+    });
+});
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
