### PR TITLE
[4.6] fix: add validation message for min_dims

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -74,4 +74,5 @@ return [
     'mime_in'  => '{field} does not have a valid mime type.',
     'ext_in'   => '{field} does not have a valid file extension.',
     'max_dims' => '{field} is either not an image, or it is too wide or tall.',
+    'min_dims' => '{field} is either not an image, or it is not wide or tall enough.',
 ];

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -141,6 +141,7 @@ Others
 ***************
 Message Changes
 ***************
+- Added `Validation.min_dims` message
 
 *******
 Changes

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -141,7 +141,8 @@ Others
 ***************
 Message Changes
 ***************
-- Added `Validation.min_dims` message
+
+- Added ``Validation.min_dims`` message
 
 *******
 Changes


### PR DESCRIPTION
**Description**
Add missing validation message for `min_dims` validation rule introduced in #8966 

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide
