### PR TITLE
refactor: using phpunit 10 assertObjectHasNotProperty() and assertObjectHasProperty()

### DIFF
--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -131,7 +131,7 @@ final class BaseConfigTest extends CIUnitTestCase
         // override config with shortPrefix ENV var
         $this->assertSame('hubbahubba', $config->delta);
         // incorrect env name should not inject property
-        $this->assertFalse(property_exists($config, 'notthere'));
+        $this->assertObjectNotHasProperty('notthere', $config);
         // empty ENV var should not affect config setting
         $this->assertSame('pineapple', $config->fruit);
         // non-empty ENV var should overrideconfig setting

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -413,7 +413,7 @@ final class FabricatorTest extends CIUnitTestCase
         $this->assertIsInt($result->created_at);
         $this->assertIsInt($result->updated_at);
 
-        $this->assertTrue(property_exists($result, 'deleted_at'));
+        $this->assertObjectHasProperty('deleted_at', $result);
         $this->assertNull($result->deleted_at);
     }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

using phpunit 10 assertObjectHasNotProperty() and assertObjectHasProperty(), detected by latest rector dev-main

 - https://github.com/rectorphp/rector-phpunit/pull/338
 - https://github.com/rectorphp/rector-phpunit/pull/340

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
