### PR TITLE
feat: [Validation] add date validation rules

### DIFF
--- a/system/Language/en/Validation.php
+++ b/system/Language/en/Validation.php
@@ -27,6 +27,7 @@ return [
     'alpha_numeric_punct'   => 'The {field} field may contain only alphanumeric characters, spaces, and  ~ ! # $ % & * - _ + = | : . characters.',
     'alpha_numeric_space'   => 'The {field} field may only contain alphanumeric and space characters.',
     'alpha_space'           => 'The {field} field may only contain alphabetical characters and spaces.',
+    'date_after'            => 'The {field} field must be after a date in another field',
     'decimal'               => 'The {field} field must contain a decimal number.',
     'differs'               => 'The {field} field must differ from the {param} field.',
     'equals'                => 'The {field} field must be exactly: {param}.',

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Validation;
 use CodeIgniter\Exceptions\InvalidArgumentException;
 use CodeIgniter\Helpers\Array\ArrayHelper;
 use Config\Database;
+use DateTime;
 
 /**
  * Validation Rules.
@@ -24,6 +25,58 @@ use Config\Database;
  */
 class Rules
 {
+    /**
+     * The value is a date after another field in $data
+     *
+     * Example usage:
+     *      date_after[date_arrival,Y-m-d]
+     *
+     * @param string $str
+     * @param array  $data Other field/value pairs
+     */
+    public function date_after($str, string $params, array $data): bool
+    {
+        // Split params, return false if field is not set
+        $params = explode(',', $params);
+        $field  = (string) $params[0] ?? null;
+        $format = (string) $params[1] ?? null;
+
+        // Return false if value is not a non-empty string
+        if (! is_string($str)) {
+            $str = (string) $str;
+        }
+
+        if ($str === '') {
+            return false;
+        }
+
+        // Return false if field name is empty or does not exits in $data
+        if ($field === '') {
+            return false;
+        }
+        $fieldData = (string) dot_array_search($field, $data);
+
+        if ($fieldData === '') {
+            return false;
+        }
+
+        // Create DateTime objects
+        if ($format === null || $format === '') {
+            $valueDate = new DateTime($str);
+            $fieldDate = new DateTime($fieldData);
+        } else {
+            $valueDate = DateTime::createFromFormat($format, $str);
+            $fieldDate = DateTime::createFromFormat($format, $fieldData);
+        }
+
+        // Return false if either DateTime object is false
+        if ($valueDate === false || $fieldDate === false) {
+            return false;
+        }
+
+        return $valueDate->getTimestamp() > $fieldDate->getTimestamp();
+    }
+
     /**
      * The value does not match another field in $data.
      *

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -38,8 +38,8 @@ class Rules
     {
         // Split params, return false if field is not set
         $params = explode(',', $params);
-        $field  = (string) $params[0] ?? null;
-        $format = (string) $params[1] ?? null;
+        $field  = (string) $params[0] ?? '';
+        $format = (string) $params[1] ?? '';
 
         // Return false if value is not a non-empty string
         if (! is_string($str)) {
@@ -61,7 +61,7 @@ class Rules
         }
 
         // Create DateTime objects
-        if ($format === null || $format === '') {
+        if ($format === '') {
             $valueDate = new DateTime($str);
             $fieldDate = new DateTime($fieldData);
         } else {
@@ -70,7 +70,7 @@ class Rules
         }
 
         // Return false if either DateTime object is false
-        if ($valueDate === false || $fieldDate === false) {
+        if ($fieldDate === false) {
             return false;
         }
 

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -38,8 +38,8 @@ class Rules
     {
         // Split params, return false if field is not set
         $params = explode(',', $params);
-        $field  = (string) $params[0] ?? '';
-        $format = (string) $params[1] ?? '';
+        $field  = (string) $params[0];
+        $format = (string) $params[1];
 
         // Return false if value is not a non-empty string
         if (! is_string($str)) {

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -32,6 +32,25 @@ class Rules
     }
 
     /**
+     * The value is a date after another field in $data
+     *
+     * Example usage:
+     *      date_after[date_arrival,Y-m-d]
+     *
+     * @param string $str
+     * @param string $format
+     * @param array  $data Other field/value pairs
+     */
+    public function date_after($str, string $params, array $data): bool
+    {
+        if (! is_string($str)) {
+            return false;
+        }
+
+        return $this->nonStrictRules->date_after($str, $params, $data);
+    }
+
+    /**
      * The value does not match another field in $data.
      *
      * @param array|bool|float|int|object|string|null $str

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -37,9 +37,9 @@ class Rules
      * Example usage:
      *      date_after[date_arrival,Y-m-d]
      *
-     * @param string $str
-     * @param string $format
-     * @param array  $data Other field/value pairs
+     * @param array|bool|float|int|object|string|null $str
+     * @param string                                  $params
+     * @param array                                   $data Other field/value pairs
      */
     public function date_after($str, string $params, array $data): bool
     {


### PR DESCRIPTION
**Description**
Add date validation rules: `date_after`,  `date_on_or_after`, `date_before`, `date_on_or_before`

Example:
```php
$data = [
            'start_date'    => '2024-06-01',
            'end_date'      => '2024-06-10',
            'after_pass'    => '2024-06-02',
            'after_fail'    => '2024-06-01'
        ];

$rules = [
      'after_pass' => 'valid_date|date_after[start_date,Y-m-d]',
      'after_fail' => 'valid_date|date_after[start_date,Y-m-d]',
      ];

$this->validateData($data, $rules);
```
If you want me to go ahead with this, I will add `date_on_or_after`, `date_before`, `date_on_or_before` based on any changes proposed to `date_after` and write tests and documentation.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
