### PR TITLE
fix: [Filters] normalize `$filters` arguments

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -5259,12 +5259,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:enableFilters\\(\\) has parameter \\$names with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/Filters/Filters.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Filters\\\\Filters\\:\\:getRequiredFilters\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/Filters/Filters.php',

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -778,6 +778,10 @@ class Filters
         $filters = [];
 
         foreach ($this->config->filters as $alias => $settings) {
+            // Normalize the arguments.
+            [$alias, $arguments] = $this->getCleanName($alias);
+            $alias               = ($arguments === []) ? $alias : $alias . ':' . implode(',', $arguments);
+
             // Look for inclusion rules
             if (isset($settings['before'])) {
                 $path = $settings['before'];

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -610,18 +610,18 @@ class Filters
     {
         $arguments = [];
 
-        if (str_contains($filter, ':')) {
-            [$alias, $arguments] = explode(':', $filter);
-
-            $arguments = explode(',', $arguments);
-            array_walk($arguments, static function (&$item) {
-                $item = trim($item);
-            });
-
-            return [$alias, $arguments];
+        if (! str_contains($filter, ':')) {
+            return [$filter, $arguments];
         }
 
-        return [$filter, $arguments];
+        [$alias, $arguments] = explode(':', $filter);
+
+        $arguments = explode(',', $arguments);
+        array_walk($arguments, static function (&$item) {
+            $item = trim($item);
+        });
+
+        return [$alias, $arguments];
     }
 
     /**

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -574,14 +574,14 @@ class Filters
      * after the filter name, followed by a comma-separated list of arguments that
      * are passed to the filter when executed.
      *
-     * @param         string           $name     filter_name or filter_name:arguments like 'role:admin,manager'
+     * @param         string           $filter   filter_name or filter_name:arguments like 'role:admin,manager'
      *                                           or filter classname.
      * @phpstan-param 'before'|'after' $position
      */
-    private function enableFilter(string $name, string $position = 'before'): void
+    private function enableFilter(string $filter, string $position = 'before'): void
     {
         // Normalize the arguments.
-        [$alias, $arguments] = $this->getCleanName($name);
+        [$alias, $arguments] = $this->getCleanName($filter);
         $filter              = ($arguments === []) ? $alias : $alias . ':' . implode(',', $arguments);
 
         if (class_exists($alias)) {
@@ -602,24 +602,26 @@ class Filters
     /**
      * Get clean name and arguments
      *
-     * @param string $name filter_name or filter_name:arguments like 'role:admin,manager'
+     * @param string $filter filter_name or filter_name:arguments like 'role:admin,manager'
      *
      * @return array{0: string, 1: list<string>} [name, arguments]
      */
-    private function getCleanName(string $name): array
+    private function getCleanName(string $filter): array
     {
         $arguments = [];
 
-        if (str_contains($name, ':')) {
-            [$name, $arguments] = explode(':', $name);
+        if (str_contains($filter, ':')) {
+            [$alias, $arguments] = explode(':', $filter);
 
             $arguments = explode(',', $arguments);
             array_walk($arguments, static function (&$item) {
                 $item = trim($item);
             });
+
+            return [$alias, $arguments];
         }
 
-        return [$name, $arguments];
+        return [$filter, $arguments];
     }
 
     /**
@@ -629,13 +631,13 @@ class Filters
      * after the filter name, followed by a comma-separated list of arguments that
      * are passed to the filter when executed.
      *
-     * @params array<string> $names filter_name or filter_name:arguments like 'role:admin,manager'
+     * @param list<string> $filters filter_name or filter_name:arguments like 'role:admin,manager'
      *
      * @return Filters
      */
-    public function enableFilters(array $names, string $when = 'before')
+    public function enableFilters(array $filters, string $when = 'before')
     {
-        foreach ($names as $filter) {
+        foreach ($filters as $filter) {
             $this->enableFilter($filter, $when);
         }
 
@@ -777,17 +779,17 @@ class Filters
         // Add any filters that apply to this URI
         $filters = [];
 
-        foreach ($this->config->filters as $alias => $settings) {
+        foreach ($this->config->filters as $filter => $settings) {
             // Normalize the arguments.
-            [$alias, $arguments] = $this->getCleanName($alias);
-            $alias               = ($arguments === []) ? $alias : $alias . ':' . implode(',', $arguments);
+            [$alias, $arguments] = $this->getCleanName($filter);
+            $filter              = ($arguments === []) ? $alias : $alias . ':' . implode(',', $arguments);
 
             // Look for inclusion rules
             if (isset($settings['before'])) {
                 $path = $settings['before'];
 
                 if ($this->pathApplies($uri, $path)) {
-                    $filters['before'][] = $alias;
+                    $filters['before'][] = $filter;
                 }
             }
 
@@ -795,7 +797,7 @@ class Filters
                 $path = $settings['after'];
 
                 if ($this->pathApplies($uri, $path)) {
-                    $filters['after'][] = $alias;
+                    $filters['after'][] = $filter;
                 }
             }
         }

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -282,6 +282,10 @@ final class FiltersTest extends CIUnitTestCase
                     'before' => ['admin/*'],
                     'after'  => ['/users/*'],
                 ],
+                'bar: arg1, arg2' => [
+                    'before' => ['admin/*'],
+                    'after'  => ['/users/*'],
+                ],
             ],
         ];
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
@@ -289,7 +293,7 @@ final class FiltersTest extends CIUnitTestCase
 
         $uri      = 'admin/foo/bar';
         $expected = [
-            'before' => ['foo'],
+            'before' => ['foo', 'bar:arg1,arg2'],
             'after'  => [],
         ];
         $this->assertSame($expected, $filters->initialize($uri)->getFilters());
@@ -311,6 +315,10 @@ final class FiltersTest extends CIUnitTestCase
                     'before' => ['admin/*'],
                     'after'  => ['/users/*'],
                 ],
+                'bar: arg1, arg2' => [
+                    'before' => ['admin/*'],
+                    'after'  => ['/users/*'],
+                ],
             ],
         ];
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
@@ -319,9 +327,7 @@ final class FiltersTest extends CIUnitTestCase
         $uri      = 'users/foo/bar';
         $expected = [
             'before' => [],
-            'after'  => [
-                'foo',
-            ],
+            'after'  => ['bar:arg1,arg2', 'foo'],
         ];
         $this->assertSame($expected, $filters->initialize($uri)->getFilters());
     }


### PR DESCRIPTION
**Description**
This PR normalizes `$filters` arguments.
Because Route filter's arguments are already normalized (trimmed). 
https://github.com/codeigniter4/CodeIgniter4/blob/ab64aeb36ff9bb72da8459e4f73321b925c2c498/system/Filters/Filters.php#L489
https://github.com/codeigniter4/CodeIgniter4/blob/ab64aeb36ff9bb72da8459e4f73321b925c2c498/system/Filters/Filters.php#L517-L531

- normalize `$filters` arguments
- refactor

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
