### PR TITLE
fix: `command()` may execute `rewrite.php`

### DIFF
--- a/system/Commands/Server/Serve.php
+++ b/system/Commands/Server/Serve.php
@@ -103,7 +103,7 @@ class Serve extends BaseCommand
         $docroot = escapeshellarg(FCPATH);
 
         // Mimic Apache's mod_rewrite functionality with user settings.
-        $rewrite = escapeshellarg(__DIR__ . '/rewrite.php');
+        $rewrite = escapeshellarg(SYSTEMPATH . 'rewrite.php');
 
         // Call PHP's built-in webserver, making sure to set our
         // base path to the public folder, and to use the rewrite file

--- a/system/rewrite.php
+++ b/system/rewrite.php
@@ -21,11 +21,6 @@ declare(strict_types=1);
  */
 
 // @codeCoverageIgnoreStart
-// Avoid this file run when listing commands
-if (PHP_SAPI === 'cli') {
-    return;
-}
-
 $uri = urldecode(
     parse_url('https://codeigniter.com' . $_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
 );


### PR DESCRIPTION
**Description**
From https://forum.codeigniter.com/showthread.php?tid=91137&pid=419751#pid419751

- move `rewrite.php` to `system/rewrite.php`

To avoid `CodeIgniter\CLI\Commands->discoverCommands()` loads `rewrite.php`.

`FileLocator::findQualifiedNameFromPath()` tries to generate classname from the path, and calls `class_exists()`, then it loads `rewrite.php`. If PHP_SAPI is `apache2handler`, it will be executed.

Before:
```diff
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -6,6 +6,6 @@ class Home extends BaseController
 {
     public function index(): string
     {
-        return view('welcome_message');
+        return command('list');
     }
 }
diff --git a/system/Commands/Server/rewrite.php b/system/Commands/Server/rewrite.php
index f936cd63f0..6912b23834 100644
--- a/system/Commands/Server/rewrite.php
+++ b/system/Commands/Server/rewrite.php
@@ -20,6 +20,9 @@ declare(strict_types=1);
  * functionality so the site will operate as normal.
  */
 
+debug_print_backtrace();
+exit(PHP_SAPI);
+
 // @codeCoverageIgnoreStart
 // Avoid this file run when listing commands
 if (PHP_SAPI === 'cli') {
```

Navigate to `http://localhost/CodeIgniter4/` (Apache mod_php):
```
#0 /.../CodeIgniter4/vendor/composer/ClassLoader.php(576): include()
#1 /.../CodeIgniter4/vendor/composer/ClassLoader.php(427): Composer\Autoload\{closure}('/Users/kenji/wo...')
#2 [internal function]: Composer\Autoload\ClassLoader->loadClass('CodeIgniter\\Com...')
#3 /.../CodeIgniter4/system/Autoloader/FileLocator.php(306): class_exists('CodeIgniter\\Com...')
#4 /.../CodeIgniter4/system/CLI/Commands.php(112): CodeIgniter\Autoloader\FileLocator->findQualifiedNameFromPath('/Users/kenji/wo...')
#5 /.../CodeIgniter4/system/CLI/Commands.php(49): CodeIgniter\CLI\Commands->discoverCommands()
#6 /.../CodeIgniter4/system/Config/Services.php(176): CodeIgniter\CLI\Commands->__construct()
#7 /.../CodeIgniter4/system/Config/BaseService.php(311): CodeIgniter\Config\Services::commands(false)
#8 /.../CodeIgniter4/system/Config/BaseService.php(250): CodeIgniter\Config\BaseService::__callStatic('commands', Array)
#9 /.../CodeIgniter4/system/Config/Services.php(173): CodeIgniter\Config\BaseService::getSharedInstance('commands')
#10 /.../CodeIgniter4/system/Config/BaseService.php(320): CodeIgniter\Config\Services::commands()
#11 /.../CodeIgniter4/system/Config/BaseService.php(201): CodeIgniter\Config\BaseService::__callStatic('commands', Array)
#12 /.../CodeIgniter4/system/Common.php(998): CodeIgniter\Config\BaseService::get('commands')
#13 /.../CodeIgniter4/system/Common.php(124): service('commands')
#14 /.../CodeIgniter4/app/Controllers/Home.php(9): command('list')
#15 /.../CodeIgniter4/system/CodeIgniter.php(933): App\Controllers\Home->index()
#16 /.../CodeIgniter4/system/CodeIgniter.php(509): CodeIgniter\CodeIgniter->runController(Object(App\Controllers\Home))
#17 /.../CodeIgniter4/system/CodeIgniter.php(355): CodeIgniter\CodeIgniter->handleRequest(NULL, Object(Config\Cache), false)
#18 /.../CodeIgniter4/system/Boot.php(325): CodeIgniter\CodeIgniter->run()
#19 /.../CodeIgniter4/system/Boot.php(67): CodeIgniter\Boot::runCodeIgniter(Object(CodeIgniter\CodeIgniter))
#20 /.../CodeIgniter4/public/index.php(56): CodeIgniter\Boot::bootWeb(Object(Config\Paths))
apache2handler
```

After:
```diff
--- a/system/rewrite.php
+++ b/system/rewrite.php
@@ -20,6 +20,9 @@ declare(strict_types=1);
  * functionality so the site will operate as normal.
  */
 
+debug_print_backtrace();
+exit(PHP_SAPI);
+
 // @codeCoverageIgnoreStart
 $uri = urldecode(
     parse_url('https://codeigniter.com' . $_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
```

Navigate to `http://localhost/CodeIgniter4/` (Apache mod_php):
```
Cache
  cache:clear       Clears the current system caches.
  cache:info        Shows file cache information in the current system.

...
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
