### PR TITLE
chore: add missing `/` at the end in `starter/composer.json`

### DIFF
--- a/admin/starter/composer.json
+++ b/admin/starter/composer.json
@@ -21,7 +21,7 @@
     "autoload": {
         "psr-4": {
             "App\\": "app/",
-            "Config\\": "app/Config"
+            "Config\\": "app/Config/"
         },
         "exclude-from-classmap": [
             "**/Database/Migrations/**"


### PR DESCRIPTION
**Description**
It seems better to put `/` at the end of directories. 
See https://getcomposer.org/doc/04-schema.md#psr-4

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
