### PR TITLE
fix: [QueryBuilder] `select()` does not escape after `NULL`

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -425,7 +425,9 @@ class BaseBuilder
                  * @see https://github.com/codeigniter4/CodeIgniter4/issues/1169
                  */
                 if (mb_stripos(trim($val), 'NULL') === 0) {
-                    $escape = false;
+                    $this->QBNoEscape[] = false;
+
+                    continue;
                 }
 
                 $this->QBNoEscape[] = $escape;

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -424,7 +424,7 @@ class BaseBuilder
                  * This prevents NULL being escaped
                  * @see https://github.com/codeigniter4/CodeIgniter4/issues/1169
                  */
-                if (mb_stripos(trim($val), 'NULL') === 0) {
+                if (mb_stripos($val, 'NULL') === 0) {
                     $this->QBNoEscape[] = false;
 
                     continue;

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -100,6 +100,28 @@ final class SelectTest extends CIUnitTestCase
         $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    public function testSelectNullAsInString(): void
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $builder->select('NULL as field_alias, name');
+
+        $expected = 'SELECT NULL as field_alias, "name" FROM "users"';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    public function testSelectNullAsInArray(): void
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $builder->select(['NULL as field_alias', 'name']);
+
+        $expected = 'SELECT NULL as field_alias, "name" FROM "users"';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
     /**
      * @see https://github.com/codeigniter4/CodeIgniter4/issues/4355
      */


### PR DESCRIPTION
**Description**
Follow-up #1169

Fixes bug that `select()` does not escape items after `NULL`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
