### PR TITLE
fix: allow string as parameter to CURLRequest version

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -651,11 +651,11 @@ class CURLRequest extends OutgoingRequest
 
         // version
         if (! empty($config['version'])) {
-            if ($config['version'] === 1.0) {
+            if ($config['version'] === 1.0 || $config['version'] === "1.0") {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
-            } elseif ($config['version'] === 1.1) {
+            } elseif ($config['version'] === 1.1 || $config['version'] === "1.1") {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
-            } elseif ($config['version'] === 2.0) {
+            } elseif ($config['version'] === 2.0 || $config['version'] === "2.0") {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
             }
         }

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -651,7 +651,7 @@ class CURLRequest extends OutgoingRequest
 
         // version
         if (! empty($config['version'])) {
-            $version = sprintf('%.1f', $config['version']);
+            $version = sprintf('%.1F', $config['version']);
             if ($version === '1.0') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
             } elseif ($version === '1.1') {

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -651,11 +651,11 @@ class CURLRequest extends OutgoingRequest
 
         // version
         if (! empty($config['version'])) {
-            if ($config['version'] === 1.0 || $config['version'] === "1.0") {
+            if ($config['version'] === 1.0 || $config['version'] === '1.0') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
-            } elseif ($config['version'] === 1.1 || $config['version'] === "1.1") {
+            } elseif ($config['version'] === 1.1 || $config['version'] === '1.1') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
-            } elseif ($config['version'] === 2.0 || $config['version'] === "2.0") {
+            } elseif ($config['version'] === 2.0 || $config['version'] === '2.0') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
             }
         }

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -651,11 +651,12 @@ class CURLRequest extends OutgoingRequest
 
         // version
         if (! empty($config['version'])) {
-            if ($config['version'] === 1.0 || $config['version'] === '1.0') {
+            $version = sprintf('%.1f', $config['version']);
+            if ($version === '1.0') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
-            } elseif ($config['version'] === 1.1 || $config['version'] === '1.1') {
+            } elseif ($version === '1.1') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
-            } elseif ($config['version'] === 2.0 || $config['version'] === '2.0') {
+            } elseif ($version === '2.0') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
             }
         }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1256,6 +1256,5 @@ alt-svc: h3=":443"; ma=86400' . "\x0d\x0a\x0d\x0aResponse Body";
 
         $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
         $this->assertSame(CURL_HTTP_VERSION_2_0, $options[CURLOPT_HTTP_VERSION]);
-
     }
 }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1227,4 +1227,35 @@ alt-svc: h3=":443"; ma=86400' . "\x0d\x0a\x0d\x0aResponse Body";
 
         $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
     }
+
+    public function testHTTPversionAsString(): void
+    {
+        $this->request->request('POST', '/post', [
+            'version' => '1.0',
+        ]);
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
+        $this->assertSame(CURL_HTTP_VERSION_1_0, $options[CURLOPT_HTTP_VERSION]);
+
+        $this->request->request('POST', '/post', [
+            'version' => '1.1',
+        ]);
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
+        $this->assertSame(CURL_HTTP_VERSION_1_1, $options[CURLOPT_HTTP_VERSION]);
+
+        $this->request->request('POST', '/post', [
+            'version' => '2.0',
+        ]);
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
+        $this->assertSame(CURL_HTTP_VERSION_2_0, $options[CURLOPT_HTTP_VERSION]);
+
+    }
 }

--- a/user_guide_src/source/changelogs/v4.5.4.rst
+++ b/user_guide_src/source/changelogs/v4.5.4.rst
@@ -30,6 +30,9 @@ Deprecations
 Bugs Fixed
 **********
 
+- **CURLRequest:** Fixed a bug preventing the use of strings for ``version`` in the config array
+  when making requests.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
The [docs](https://codeigniter4.github.io/userguide/libraries/curlrequest.html#version) (as of 4.5.3) specifies *"To set the HTTP protocol to use, you can pass a string or float with the version number"*. However, the code in the library does a strict comparison with `=== 2.0` so a string value **will not work**.

Adding a strict comparison with `'1.0'`, `'1.1'` and `'2.0'` since this seems to be the coding style used in the library. (A `==` comparison would work, but casting could introduce some issues?)

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
