### PR TITLE
fix: `spark phpini:check` may cause TypeError

### DIFF
--- a/system/Security/CheckPhpIni.php
+++ b/system/Security/CheckPhpIni.php
@@ -50,17 +50,17 @@ class CheckPhpIni
     private static function outputForCli(array $output, array $thead, array $tbody): void
     {
         foreach ($output as $directive => $values) {
-            $current        = $values['current'];
+            $current        = $values['current'] ?? '';
             $notRecommended = false;
 
             if ($values['recommended'] !== '') {
-                if ($values['recommended'] !== $values['current']) {
+                if ($values['recommended'] !== $current) {
                     $notRecommended = true;
                 }
 
                 $current = $notRecommended
-                    ? CLI::color($values['current'] === '' ? 'n/a' : $values['current'], 'red')
-                    : $values['current'];
+                    ? CLI::color($current === '' ? 'n/a' : $current, 'red')
+                    : $current;
             }
 
             $directive = $notRecommended ? CLI::color($directive, 'red') : $directive;


### PR DESCRIPTION
**Description**
Fixes #9025

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
