### PR TITLE
feat: Add ability to set route to multiple host

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1568,13 +1568,9 @@ class RouteCollection implements RouteCollectionInterface
         // Hostname has multiple hostname
         if(is_array($hostname)) 
         {
-            $hasMatch = false;
-            foreach ($hostname as $host) {
-                if (strtolower($this->httpHost) === strtolower($host)) {
-                    $hasMatch = true;
-                }
-            }
-            return $hasMatch;
+            $hostnameLower = array_map('strtolower', $hostname);
+
+            return in_array(strtolower($this->httpHost), $hostnameLower, true);
         }
         else {
             return strtolower($this->httpHost) === strtolower($hostname);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1565,7 +1565,20 @@ class RouteCollection implements RouteCollectionInterface
             return false;
         }
 
-        return strtolower($this->httpHost) === strtolower($hostname);
+        // Hostname has multiple hostname
+        if(is_array($hostname)) 
+        {
+            $hasMatch = false;
+            foreach ($hostname as $host) {
+                if (strtolower($this->httpHost) === strtolower($host)) {
+                    $hasMatch = true;
+                }
+            }
+            return $hasMatch;
+        }
+        else {
+            return strtolower($this->httpHost) === strtolower($hostname);
+        }
     }
 
     private function processArrayCallableSyntax(string $from, array $to): string


### PR DESCRIPTION
Example
```php
$routes->group('api', ['hostname' =>  ['api.website.com', 'api.website.net]], function ($routes) {
    $routes->get('/', 'Api::royplayer');
});
```

**Description**
in this way i can set route for multiple host instead of creating multiple route for each hostname

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
