### PR TITLE
docs: missing BaseModel class property protectFields

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -122,9 +122,8 @@ abstract class BaseModel
     protected ?DataConverter $converter = null;
 
     /**
-     * If this model should use "softDeletes" and
-     * simply set a date when rows are deleted, or
-     * do hard deletes.
+     * If false, then user can perform
+     * mass assignment.
      *
      * @var bool
      */

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -153,13 +153,19 @@ configured to any name of your choice by using `$deletedField`_ property.
 
 .. _model-allowed-fields:
 
+$protectFields
+--------------
+
+If false, then the field names inside ``$allowedFields = []`` array doesn't matter anymore.
+It allows you to mass assigning records in the table.
+
 $allowedFields
 --------------
 
 This array should be updated with the field names that can be set during ``save()``, ``insert()``, or
 ``update()`` methods. Any field names other than these will be discarded. This helps to protect
 against just taking input from a form and throwing it all at the model, resulting in
-potential mass assignment vulnerabilities.
+potential mass assignment vulnerabilities. This only work when ``$protectFields = true``.
 
 .. note:: The `$primaryKey`_ field should never be an allowed field.
 

--- a/user_guide_src/source/models/model/005.php
+++ b/user_guide_src/source/models/model/005.php
@@ -14,6 +14,7 @@ class UserModel extends Model
     protected $returnType     = 'array';
     protected $useSoftDeletes = true;
 
+    protected $protectFields = true;
     protected $allowedFields = ['name', 'email'];
 
     protected bool $allowEmptyInserts = false;


### PR DESCRIPTION
Documentation for BaseModel class property protectFields.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
