### PR TITLE
docs: [File Instance] RunTimeException if file does not exist

### DIFF
--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -60,7 +60,7 @@ class File extends SplFileInfo
      * Implementations SHOULD return the value stored in the "size" key of
      * the file in the $_FILES array if available, as PHP calculates this based
      * on the actual size transmitted. A RuntimeException will be thrown if the file
-     * does not exist or an error occurs. 
+     * does not exist or an error occurs.
      *
      * @return false|int The file size in bytes, or false on failure
      */

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -59,7 +59,8 @@ class File extends SplFileInfo
      *
      * Implementations SHOULD return the value stored in the "size" key of
      * the file in the $_FILES array if available, as PHP calculates this based
-     * on the actual size transmitted.
+     * on the actual size transmitted. A RuntimeException will be thrown if the file
+     * does not exist or an error occurs. 
      *
      * @return false|int The file size in bytes, or false on failure
      */

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -46,7 +46,7 @@ Returns the size of the uploaded file in bytes:
 
 .. literalinclude:: files/004.php
 
-A RuntimeException will be thrown if the file does not exist or an error occurs.
+A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
 getSizeByUnit()
 ===============
@@ -56,7 +56,7 @@ the results in kilobytes or megabytes, respectively:
 
 .. literalinclude:: files/005.php
 
-A RuntimeException will be thrown if the file does not exist or an error occurs.
+A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
 getMimeType()
 =============

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -46,6 +46,8 @@ Returns the size of the uploaded file in bytes:
 
 .. literalinclude:: files/004.php
 
+A RuntimeException will be thrown if the file does not exist or an error occurs.
+
 getSizeByUnit()
 ===============
 
@@ -53,6 +55,8 @@ Returns the size of the uploaded file default in bytes. You can pass in either '
 the results in kilobytes or megabytes, respectively:
 
 .. literalinclude:: files/005.php
+
+A RuntimeException will be thrown if the file does not exist or an error occurs.
 
 getMimeType()
 =============


### PR DESCRIPTION
**Description**
`File::getSize` and `File::getSizeByUnit()` may cause a `RunTimeException` if the file does not exist or an error occurs. From the original docblock my expectation was that the functions would return `false` on an error (e.g. file does not exist), but the called `SplFileInfo::getSize()` throws a runtime error if the file does not exist.

From [the PHP docs](https://www.php.net/manual/en/splfileinfo.getsize.php)
> The filesize in bytes on success, or [false](https://www.php.net/manual/en/reserved.constants.php#constant.false) on failure.
> A RuntimeException will be thrown if the file does not exist or an error occurs.

From the PHP docs it is not quite clear to me when to expect an exception and when to expect `false`.

If return of `false` on any error is desired, I am happy to submit a PR to catch the exception.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [X] User guide updated
- [ ] Conforms to style guide
