### PR TITLE
fix: DebugBar CSS for daisyUI

### DIFF
--- a/admin/css/debug-toolbar/toolbar.scss
+++ b/admin/css/debug-toolbar/toolbar.scss
@@ -95,6 +95,7 @@
     }
 
     h2 {
+        font-weight: bold;
         font-size: $base-size;
         margin: 0;
         padding: 5px 0 10px 0;
@@ -292,6 +293,8 @@
 
     // The tabs container
     .tab {
+        height: fit-content;
+        text-align: left;
         bottom: 35px;
         display: none;
         left: 0;
@@ -306,6 +309,8 @@
 
     // The "Timeline" tab
     .timeline {
+        position: static;
+        display: table;
         margin-left: 0;
         width: 100%;
 

--- a/system/Debug/Toolbar/Views/toolbar.css
+++ b/system/Debug/Toolbar/Views/toolbar.css
@@ -60,6 +60,7 @@
   margin-right: 5px;
 }
 #debug-bar h2 {
+  font-weight: bold;
   font-size: 16px;
   margin: 0;
   padding: 5px 0 10px 0;
@@ -213,6 +214,8 @@
   white-space: nowrap;
 }
 #debug-bar .tab {
+  height: fit-content;
+  text-align: left;
   bottom: 35px;
   display: none;
   left: 0;
@@ -225,6 +228,8 @@
   z-index: 9999;
 }
 #debug-bar .timeline {
+  position: static;
+  display: table;
   margin-left: 0;
   width: 100%;
 }


### PR DESCRIPTION
**Description**
Fixes #9041

How to Test:
```diff
--- a/app/Views/welcome_message.php
+++ b/app/Views/welcome_message.php
@@ -6,6 +6,8 @@
     <meta name="description" content="The small framework with powerful features">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" type="image/png" href="/favicon.ico">
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.10/dist/full.min.css" rel="stylesheet" type="text/css" />
+    <script src="https://cdn.tailwindcss.com"></script>
 
     <!-- STYLES -->
 
```

Before:
![Screenshot 2024-07-11 17 58 47](https://github.com/codeigniter4/CodeIgniter4/assets/87955/14ecb6c2-887b-4cbd-8ccd-daf5374968dd)

After:
![Screenshot 2024-07-11 17 58 27](https://github.com/codeigniter4/CodeIgniter4/assets/87955/572d3250-ea98-4f05-8295-14334529c8ba)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
