### PR TITLE
fix / feat : Update protected function setBind  for permitting complex key binds

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3506,8 +3506,9 @@ class BaseBuilder
      *
      * @param mixed $value
      */
-    protected function setBind(string $key, $value = null, bool $escape = true): string
+    protected function setBind(string $origKey, $value = null, bool $escape = true): string
     {
+        $key = md5($origKey);
         if (! array_key_exists($key, $this->binds)) {
             $this->binds[$key] = [
                 $value,


### PR DESCRIPTION
fix : Anonymize bind key for complex query  like `CONCAT(field1, ' ', field2 ) LIKE '%value%'`

the bind `:CONCAT(field1, ' ', field2 )`  does not work

**Description**
on a query sample : `CONCAT(field1, ' ', field2 ) LIKE '%value%'`
the bind `:CONCAT(field1, ' ', field2 )`  does not work 
the key on setBind is now an md5 of original.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
