### PR TITLE
fix: add missing method __set_state()

### DIFF
--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -157,6 +157,7 @@ class AutoloadConfig
      * Restores the state of the object
      *
      * @param array<string, mixed> $array An array containingthe properties and their values.
+     *
      * @return static Returns an instance of the called class.
      */
     public static function __set_state(array $array): static

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -132,19 +132,6 @@ class AutoloadConfig
      */
     protected $coreFiles = [];
 
-    public static function __set_state(array $array)
-    {
-        $obj              = new static();
-
-        $properties = array_keys(get_object_vars($obj));
-
-        foreach ($properties as $property) {
-            $obj->{$property} = $array[$property];
-        }
-
-        return $obj;
-    }
-
     /**
      * Constructor.
      *
@@ -162,5 +149,24 @@ class AutoloadConfig
         $this->psr4     = array_merge($this->corePsr4, $this->psr4);
         $this->classmap = array_merge($this->coreClassmap, $this->classmap);
         $this->files    = [...$this->coreFiles, ...$this->files];
+    }
+    
+    /**
+     * Restores the state of the object
+     *
+     * @param array<string, mixed> $array An array containingthe properties and their values.
+     * @return static Returns an instance of the called class.
+     */
+    public static function __set_state(array $array): static
+    {
+        $obj = new static();
+
+        $properties = array_keys(get_object_vars($obj));
+
+        foreach ($properties as $property) {
+            $obj->{$property} = $array[$property];
+        }
+
+        return $obj;
     }
 }

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -132,6 +132,19 @@ class AutoloadConfig
      */
     protected $coreFiles = [];
 
+    public static function __set_state(array $array)
+    {
+        $obj              = new static();
+
+        $properties = array_keys(get_object_vars($obj));
+
+        foreach ($properties as $property) {
+            $obj->{$property} = $array[$property];
+        }
+
+        return $obj;
+    }
+
     /**
      * Constructor.
      *

--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -31,6 +31,8 @@ use Psr\Log\NullLogger;
  *
  * This file defines the namespaces and class maps so the Autoloader
  * can find the files as needed.
+ *
+ * @phpstan-consistent-constructor
  */
 class AutoloadConfig
 {
@@ -150,7 +152,7 @@ class AutoloadConfig
         $this->classmap = array_merge($this->coreClassmap, $this->classmap);
         $this->files    = [...$this->coreFiles, ...$this->files];
     }
-    
+
     /**
      * Restores the state of the object
      *


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

```php
php spark optimize 
``` 
after run that command will cause an `Error Call to an undefined method`

***<img width="1454" alt="Screenshot 2024-07-20 at 12 57 42" src="https://github.com/user-attachments/assets/3dfc88dc-3b5d-4604-958f-a22a5d452c2b">***


so, add the missing `__set_state()` method in `\Codeigniter\Config\AutoloadConfig` will solve the problem.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
