### PR TITLE
fix: recursive call makes duplicate entries in registrar

### DIFF
--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -230,6 +230,9 @@ class BaseConfig
         }
 
         if (! static::$didDiscovery) {
+            // It's done once, don't do it again recursively
+            static::$didDiscovery = true;
+            
             $locator         = service('locator');
             $registrarsFiles = $locator->search('Config/Registrar.php');
 
@@ -239,11 +242,10 @@ class BaseConfig
                 if ($className === false) {
                     continue;
                 }
-
+                
+                // this will make a recursive call
                 static::$registrars[] = new $className();
             }
-
-            static::$didDiscovery = true;
         }
 
         $shortName = (new ReflectionClass($this))->getShortName();


### PR DESCRIPTION
When assigning new class to registrar the class initialization makes a recursive call.

By setting the didDiscovery variable to true before the assignment will prevent entry duplication in the registrar.

<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
