### PR TITLE
refactor: [BaseConnection] change `@property-read` annotations to just `@property`

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -21,35 +21,35 @@ use Stringable;
 use Throwable;
 
 /**
- * @property-read array      $aliasedTables
- * @property-read string     $charset
- * @property-read bool       $compress
- * @property-read float      $connectDuration
- * @property-read float      $connectTime
- * @property-read string     $database
- * @property-read array      $dateFormat
- * @property-read string     $DBCollat
- * @property-read bool       $DBDebug
- * @property-read string     $DBDriver
- * @property-read string     $DBPrefix
- * @property-read string     $DSN
- * @property-read array|bool $encrypt
- * @property-read array      $failover
- * @property-read string     $hostname
- * @property-read Query      $lastQuery
- * @property-read string     $password
- * @property-read bool       $pConnect
- * @property-read int|string $port
- * @property-read bool       $pretend
- * @property-read string     $queryClass
- * @property-read array      $reservedIdentifiers
- * @property-read bool       $strictOn
- * @property-read string     $subdriver
- * @property-read string     $swapPre
- * @property-read int        $transDepth
- * @property-read bool       $transFailure
- * @property-read bool       $transStatus
- * @property-read string     $username
+ * @property array      $aliasedTables
+ * @property string     $charset
+ * @property bool       $compress
+ * @property float      $connectDuration
+ * @property float      $connectTime
+ * @property string     $database
+ * @property array      $dateFormat
+ * @property string     $DBCollat
+ * @property bool       $DBDebug
+ * @property string     $DBDriver
+ * @property string     $DBPrefix
+ * @property string     $DSN
+ * @property array|bool $encrypt
+ * @property array      $failover
+ * @property string     $hostname
+ * @property Query      $lastQuery
+ * @property string     $password
+ * @property bool       $pConnect
+ * @property int|string $port
+ * @property bool       $pretend
+ * @property string     $queryClass
+ * @property array      $reservedIdentifiers
+ * @property bool       $strictOn
+ * @property string     $subdriver
+ * @property string     $swapPre
+ * @property int        $transDepth
+ * @property bool       $transFailure
+ * @property bool       $transStatus
+ * @property string     $username
  *
  * @template TConnection
  * @template TResult


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
I'm not sure what's the intention of putting these `@property-read` annotations. Please enlighten me. However, these means the properties are "readonly by annotation", hence they cannot be reassigned later on. But we reassign them in several places across the database connection so I think the intention does not meet the actual practice. Found this because intelephense is complaining of "Cannot modify readonly property ...".

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
