### PR TITLE
fix: filters passed to the ``$routes->group()`` are not merged into the filters passed to the inner routes

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1456,6 +1456,12 @@ class RouteCollection implements RouteCollectionInterface
             $to = $this->processArrayCallableSyntax($from, $to);
         }
 
+        // Merge group filters.
+        if (isset($options['filter'])) {
+            $currentFilter     = (array) ($this->currentOptions['filter'] ?? []);
+            $options['filter'] = array_merge($currentFilter, (array) $options['filter']);
+        }
+
         $options = array_merge($this->currentOptions ?? [], $options ?? []);
 
         // Route priority detect

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -440,6 +440,22 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutesOptions());
     }
 
+    public function testGroupFilterAndRouteFilter(): void
+    {
+        $routes = $this->getCollector();
+
+        $routes->group('admin', ['filter' => ['csrf']], static function ($routes): void {
+            $routes->get('profile', 'Admin\Profile::index', ['filter' => ['honeypot']]);
+        });
+
+        $expected = [
+            'admin/profile' => [
+                'filter' => ['csrf', 'honeypot'],
+            ],
+        ];
+        $this->assertSame($expected, $routes->getRoutesOptions());
+    }
+
     public function testGroupingWorksWithEmptyStringPrefix(): void
     {
         $routes = $this->getCollector();

--- a/user_guide_src/source/changelogs/v4.5.4.rst
+++ b/user_guide_src/source/changelogs/v4.5.4.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Routing:** Fixed a bug that filters passed to ``$routes->group()`` were not
+  merged into filters passed to the inner routes.
 - **CURLRequest:** Fixed a bug preventing the use of strings for ``version`` in the config array
   when making requests.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -564,6 +564,9 @@ run the filter before or after the controller. This is especially handy during a
 
 The value for the filter must match one of the aliases defined within **app/Config/Filters.php**.
 
+.. note:: Prior to v4.5.4, due to a bug, filters passed to the ``group()`` were
+    not merged into the filters passed to the inner routes.
+
 Setting Other Options
 =====================
 


### PR DESCRIPTION
**Description**
Fixes #9063

```php
$routes->group('', ['filter' => ['csrf']], static function ($routes) {
    $routes->get('getuserinfo', 'Mmeber::getUserInfo', ['filter' => ['honeypot']]);
});
```
Before:
```
+--------+-------------+------+--------------------------------------+----------------+---------------+
| Method | Route       | Name | Handler                              | Before Filters | After Filters |
+--------+-------------+------+--------------------------------------+----------------+---------------+
| GET    | getuserinfo | »    | \App\Controllers\Mmeber::getUserInfo | honeypot       | honeypot      |
+--------+-------------+------+--------------------------------------+----------------+---------------+
```
After:
```
+--------+-------------+------+--------------------------------------+----------------+---------------+
| Method | Route       | Name | Handler                              | Before Filters | After Filters |
+--------+-------------+------+--------------------------------------+----------------+---------------+
| GET    | getuserinfo | »    | \App\Controllers\Mmeber::getUserInfo | csrf honeypot  | honeypot csrf |
+--------+-------------+------+--------------------------------------+----------------+---------------+
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
