### PR TITLE
refactor: fix `Throttler::check()` $tokens

### DIFF
--- a/system/Throttle/Throttler.php
+++ b/system/Throttle/Throttler.php
@@ -102,8 +102,11 @@ class Throttler implements ThrottlerInterface
         // Number of seconds to get one token
         $refresh = 1 / $rate;
 
+        /** @var float|int|null $tokens */
+        $tokens = $this->cache->get($tokenName);
+
         // Check to see if the bucket has even been created yet.
-        if (($tokens = $this->cache->get($tokenName)) === null) {
+        if ($tokens === null) {
             // If it hasn't been created, then we'll set it to the maximum
             // capacity - 1, and save it to the cache.
             $tokens = $capacity - $cost;
@@ -124,7 +127,7 @@ class Throttler implements ThrottlerInterface
         // should be refilled, then checked against capacity
         // to be sure the bucket didn't overflow.
         $tokens += $rate * $elapsed;
-        $tokens = $tokens > $capacity ? $capacity : $tokens;
+        $tokens = min($tokens, $capacity);
 
         // If $tokens >= 1, then we are safe to perform the action, but
         // we need to decrement the number of available tokens.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Fix for PHPStan v1.11.8
```
------ ------------------------------------------------------------------------------------------------------- 
  Line   system/Throttle/Throttler.php                                                                          
 ------ ------------------------------------------------------------------------------------------------------- 
  :126   Binary operation "+=" between array|bool|float|int|object|string and (float|int) results in an error.  
         🪪  assignOp.invalid                                                                                   
         ✏️  system/Throttle/Throttler.php:126                                                                  
 ------ ------------------------------------------------------------------------------------------------------- 
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
