### PR TITLE
chore: fix mssql-server 2022 failing to start

### DIFF
--- a/.github/workflows/reusable-phpunit-test.yml
+++ b/.github/workflows/reusable-phpunit-test.yml
@@ -95,13 +95,13 @@ jobs:
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
         env:
-          SA_PASSWORD: 1Secure*Password1
+          MSSQL_SA_PASSWORD: 1Secure*Password1
           ACCEPT_EULA: Y
           MSSQL_PID: Developer
         ports:
           - 1433:1433
         options: >-
-          --health-cmd="/opt/mssql-tools/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'"
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3

--- a/.github/workflows/reusable-phpunit-test.yml
+++ b/.github/workflows/reusable-phpunit-test.yml
@@ -101,7 +101,7 @@ jobs:
         ports:
           - 1433:1433
         options: >-
-          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'"
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -C -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q 'SELECT @@VERSION'"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3


### PR DESCRIPTION
**Description**
Trying to fix the latest GitHub Actions failure for MSSQL.

See
- https://github.com/codeigniter4/CodeIgniter4/pull/9068#discussion_r1690620653
- https://github.com/microsoft/mssql-docker/issues/892#issuecomment-2248045546
- https://github.com/microsoft/mssql-docker/issues/892#issuecomment-2249029917

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
