### PR TITLE
chore: add composer scripts for phpstan

### DIFF
--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -85,4 +85,4 @@ jobs:
         run: composer update --ansi --no-interaction
 
       - name: Run static analysis
-        run: vendor/bin/phpstan analyse
+        run: composer phpstan:check

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
         ],
         "analyze": [
             "Composer\\Config::disableProcessTimeout",
-            "bash -c \"XDEBUG_MODE=off vendor/bin/phpstan analyse\"",
+            "@phpstan:check",
             "vendor/bin/rector process --dry-run"
         ],
         "cs": [
@@ -110,6 +110,8 @@
             "utils/vendor/bin/php-cs-fixer fix --ansi --verbose --diff"
         ],
         "metrics": "utils/vendor/bin/phpmetrics --config=phpmetrics.json",
+        "phpstan:baseline": "vendor/bin/phpstan analyse --ansi --generate-baseline=phpstan-baseline.php",
+        "phpstan:check": "vendor/bin/phpstan analyse --verbose --ansi",
         "sa": "@analyze",
         "style": "@cs-fix",
         "test": "phpunit"
@@ -119,6 +121,8 @@
         "cs": "Check the coding style",
         "cs-fix": "Fix the coding style",
         "metrics": "Run PhpMetrics",
+        "phpstan:baseline": "Run PHPStan then dump all errors to baseline",
+        "phpstan:check": "Run PHPStan with support for identifiers",
         "test": "Run unit tests"
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
- Add composer scripts for phpstan
- The `--verbose` flag adds identifiers to errors reported

Why `:` instead of `-` in the names? Because Composer uses Symfony Console, and the latter groups commands with `:` in their names. So, running `composer` in the terminal will give:
<img width="545" alt="image" src="https://github.com/user-attachments/assets/220ada1f-82f1-4c17-815d-feb6565f152c">

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
