### PR TITLE
test: suppress psalm error

### DIFF
--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -126,6 +126,9 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->assertStringContainsString('You want to see "about" page.', $output);
     }
 
+    /**
+     * @psalm-suppress UndefinedClass
+     */
     public function testRun404Override(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';


### PR DESCRIPTION
**Description**
> Error: tests/system/CodeIgniterTest.php:138:33: UndefinedClass: Class, interface or enum named Tests\Support\Errors does not exist (see https://psalm.dev/019)
https://github.com/codeigniter4/CodeIgniter4/actions/runs/10103403558/job/27940714508

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
