### PR TITLE
fix: Time loses microseconds

### DIFF
--- a/system/DataCaster/Cast/DatetimeCast.php
+++ b/system/DataCaster/Cast/DatetimeCast.php
@@ -43,12 +43,7 @@ class DatetimeCast extends BaseCast
         /**
          * @see https://www.php.net/manual/en/datetimeimmutable.createfromformat.php#datetimeimmutable.createfromformat.parameters
          */
-        $format = match ($params[0] ?? '') {
-            ''      => $helper->dateFormat['datetime'],
-            'ms'    => $helper->dateFormat['datetime-ms'],
-            'us'    => $helper->dateFormat['datetime-us'],
-            default => throw new InvalidArgumentException('Invalid parameter: ' . $params[0]),
-        };
+        $format = self::getDateTimeFormat($params, $helper);
 
         return Time::createFromFormat($format, $value);
     }
@@ -68,13 +63,23 @@ class DatetimeCast extends BaseCast
             throw new InvalidArgumentException($message);
         }
 
-        $format = match ($params[0] ?? '') {
-            ''      => $helper->dateFormat['datetime'],
-            'ms'    => $helper->dateFormat['datetime-ms'],
-            'us'    => $helper->dateFormat['datetime-us'],
-            default => throw new InvalidArgumentException('Invalid parameter: ' . $params[0]),
-        };
+        $format = self::getDateTimeFormat($params, $helper);
 
         return $value->format($format);
+    }
+
+    /**
+     * Gets DateTime format from the DB connection.
+     *
+     * @param list<string> $params Additional param
+     */
+    protected static function getDateTimeFormat(array $params, BaseConnection $db): string
+    {
+        return match ($params[0] ?? '') {
+            ''      => $db->dateFormat['datetime'],
+            'ms'    => $db->dateFormat['datetime-ms'],
+            'us'    => $db->dateFormat['datetime-us'],
+            default => throw new InvalidArgumentException('Invalid parameter: ' . $params[0]),
+        };
     }
 }

--- a/system/DataCaster/Cast/DatetimeCast.php
+++ b/system/DataCaster/Cast/DatetimeCast.php
@@ -62,6 +62,19 @@ class DatetimeCast extends BaseCast
             self::invalidTypeValueError($value);
         }
 
-        return (string) $value;
+        if (! $helper instanceof BaseConnection) {
+            $message = 'The parameter $helper must be BaseConnection.';
+
+            throw new InvalidArgumentException($message);
+        }
+
+        $format = match ($params[0] ?? '') {
+            ''      => $helper->dateFormat['datetime'],
+            'ms'    => $helper->dateFormat['datetime-ms'],
+            'us'    => $helper->dateFormat['datetime-us'],
+            default => throw new InvalidArgumentException('Invalid parameter: ' . $params[0]),
+        };
+
+        return $value->format($format);
     }
 }

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -314,10 +314,11 @@ trait TimeTrait
      */
     public function toDateTime()
     {
-        $dateTime = new DateTime('', $this->getTimezone());
-        $dateTime->setTimestamp(parent::getTimestamp());
-
-        return $dateTime;
+        return DateTime::createFromFormat(
+            'Y-m-d H:i:s.u',
+            $this->format('Y-m-d H:i:s.u'),
+            $this->getTimezone()
+        );
     }
 
     // --------------------------------------------------------------------

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -81,10 +81,10 @@ trait TimeTrait
         if ($time === '' && static::$testNow instanceof self) {
             if ($timezone !== null) {
                 $testNow = static::$testNow->setTimezone($timezone);
-                $time    = $testNow->format('Y-m-d H:i:s');
+                $time    = $testNow->format('Y-m-d H:i:s.u');
             } else {
                 $timezone = static::$testNow->getTimezone();
-                $time     = static::$testNow->format('Y-m-d H:i:s');
+                $time     = static::$testNow->format('Y-m-d H:i:s.u');
             }
         }
 
@@ -97,7 +97,7 @@ trait TimeTrait
         if ($time !== '' && static::hasRelativeKeywords($time)) {
             $instance = new DateTime('now', $this->timezone);
             $instance->modify($time);
-            $time = $instance->format('Y-m-d H:i:s');
+            $time = $instance->format('Y-m-d H:i:s.u');
         }
 
         parent::__construct($time, $this->timezone);
@@ -253,7 +253,7 @@ trait TimeTrait
             throw I18nException::forInvalidFormat($format);
         }
 
-        return new self($date->format('Y-m-d H:i:s'), $timezone);
+        return new self($date->format('Y-m-d H:i:s.u'), $timezone);
     }
 
     /**
@@ -283,7 +283,7 @@ trait TimeTrait
      */
     public static function createFromInstance(DateTimeInterface $dateTime, ?string $locale = null)
     {
-        $date     = $dateTime->format('Y-m-d H:i:s');
+        $date     = $dateTime->format('Y-m-d H:i:s.u');
         $timezone = $dateTime->getTimezone();
 
         return new self($date, $timezone, $locale);
@@ -348,7 +348,7 @@ trait TimeTrait
         if (is_string($datetime)) {
             $datetime = new self($datetime, $timezone, $locale);
         } elseif ($datetime instanceof DateTimeInterface && ! $datetime instanceof self) {
-            $datetime = new self($datetime->format('Y-m-d H:i:s'), $timezone);
+            $datetime = new self($datetime->format('Y-m-d H:i:s.u'), $timezone);
         }
 
         static::$testNow = $datetime;
@@ -941,9 +941,9 @@ trait TimeTrait
 
         $ourTime = $this->toDateTime()
             ->setTimezone(new DateTimeZone('UTC'))
-            ->format('Y-m-d H:i:s');
+            ->format('Y-m-d H:i:s.u');
 
-        return $testTime->format('Y-m-d H:i:s') === $ourTime;
+        return $testTime->format('Y-m-d H:i:s.u') === $ourTime;
     }
 
     /**
@@ -956,15 +956,15 @@ trait TimeTrait
     public function sameAs($testTime, ?string $timezone = null): bool
     {
         if ($testTime instanceof DateTimeInterface) {
-            $testTime = $testTime->format('Y-m-d H:i:s');
+            $testTime = $testTime->format('Y-m-d H:i:s.u O');
         } elseif (is_string($testTime)) {
             $timezone = $timezone ?: $this->timezone;
             $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
             $testTime = new DateTime($testTime, $timezone);
-            $testTime = $testTime->format('Y-m-d H:i:s');
+            $testTime = $testTime->format('Y-m-d H:i:s.u O');
         }
 
-        $ourTime = $this->toDateTimeString();
+        $ourTime = $this->format('Y-m-d H:i:s.u O');
 
         return $testTime === $ourTime;
     }

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -980,10 +980,16 @@ trait TimeTrait
      */
     public function isBefore($testTime, ?string $timezone = null): bool
     {
-        $testTime = $this->getUTCObject($testTime, $timezone)->getTimestamp();
-        $ourTime  = $this->getTimestamp();
+        $testTime = $this->getUTCObject($testTime, $timezone);
 
-        return $ourTime < $testTime;
+        $testTimestamp = $testTime->getTimestamp();
+        $ourTimestamp  = $this->getTimestamp();
+
+        if ($ourTimestamp === $testTimestamp) {
+            return $this->format('u') < $testTime->format('u');
+        }
+
+        return $ourTimestamp < $testTimestamp;
     }
 
     /**
@@ -996,10 +1002,16 @@ trait TimeTrait
      */
     public function isAfter($testTime, ?string $timezone = null): bool
     {
-        $testTime = $this->getUTCObject($testTime, $timezone)->getTimestamp();
-        $ourTime  = $this->getTimestamp();
+        $testTime = $this->getUTCObject($testTime, $timezone);
 
-        return $ourTime > $testTime;
+        $testTimestamp = $testTime->getTimestamp();
+        $ourTimestamp  = $this->getTimestamp();
+
+        if ($ourTimestamp === $testTimestamp) {
+            return $this->format('u') > $testTime->format('u');
+        }
+
+        return $ourTimestamp > $testTimestamp;
     }
 
     // --------------------------------------------------------------------

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -368,7 +368,7 @@ final class DataConverterTest extends CIUnitTestCase
             'id'   => 'int',
             'date' => 'datetime',
         ];
-        $converter = $this->createDataConverter($types);
+        $converter = $this->createDataConverter($types, [], db_connect());
 
         $phpData = [
             'id'   => '1',
@@ -620,7 +620,7 @@ final class DataConverterTest extends CIUnitTestCase
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
         ];
-        $converter = $this->createDataConverter($types);
+        $converter = $this->createDataConverter($types, [], db_connect());
 
         $phpData = [
             'id'         => 1,
@@ -652,7 +652,7 @@ final class DataConverterTest extends CIUnitTestCase
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
         ];
-        $converter = $this->createDataConverter($types, [], null, 'toRawArray');
+        $converter = $this->createDataConverter($types, [], db_connect(), 'toRawArray');
 
         $phpData = [
             'id'         => 1,

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -379,6 +379,23 @@ final class DataConverterTest extends CIUnitTestCase
         $this->assertSame('2023-11-18 14:18:18', $data['date']);
     }
 
+    public function testDateTimeConvertDataToDBWithFormat(): void
+    {
+        $types = [
+            'id'   => 'int',
+            'date' => 'datetime[us]',
+        ];
+        $converter = $this->createDataConverter($types, [], db_connect());
+
+        $phpData = [
+            'id'   => '1',
+            'date' => Time::parse('2009-02-15 00:00:01.123456'),
+        ];
+        $data = $converter->toDataSource($phpData);
+
+        $this->assertSame('2009-02-15 00:00:01.123456', $data['date']);
+    }
+
     public function testTimestampConvertDataFromDB(): void
     {
         $types = [

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -889,6 +889,14 @@ final class TimeTest extends CIUnitTestCase
         $this->assertTrue($time1->equals('January 10, 2017 21:50:00'));
     }
 
+    public function testEqualWithDifferentMicroseconds(): void
+    {
+        $time1 = new Time('2024-01-01 12:00:00.654321');
+        $time2 = new Time('2024-01-01 12:00:00');
+
+        $this->assertFalse($time1->equals($time2));
+    }
+
     public function testSameSuccess(): void
     {
         $time1 = Time::parse('January 10, 2017 21:50:00', 'America/Chicago');

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -875,7 +875,7 @@ final class TimeTest extends CIUnitTestCase
         $this->assertTrue($time1->equals('January 11, 2017 03:50:00', 'Europe/London'));
     }
 
-    public function testEqualWithStringAndNotimezone(): void
+    public function testEqualWithStringAndNoTimezone(): void
     {
         $time1 = Time::parse('January 10, 2017 21:50:00', 'America/Chicago');
 

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -936,6 +936,15 @@ final class TimeTest extends CIUnitTestCase
         $this->assertFalse($time2->isBefore($time1));
     }
 
+    public function testBeforeSameTime(): void
+    {
+        $time1 = new Time('2024-01-01 12:00:00.000000');
+        $time2 = new Time('2024-01-01 12:00:00.000000');
+
+        $this->assertFalse($time1->isBefore($time2));
+        $this->assertFalse($time2->isBefore($time1));
+    }
+
     public function testBeforeWithMicroseconds(): void
     {
         $time1 = new Time('2024-01-01 12:00:00.000000');
@@ -952,6 +961,15 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertFalse($time1->isAfter($time2));
         $this->assertTrue($time2->isAfter($time1));
+    }
+
+    public function testAfterSameTime(): void
+    {
+        $time1 = new Time('2024-01-01 12:00:00.000000');
+        $time2 = new Time('2024-01-01 12:00:00.000000');
+
+        $this->assertFalse($time1->isAfter($time2));
+        $this->assertFalse($time2->isAfter($time1));
     }
 
     public function testAfterWithMicroseconds(): void

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -61,7 +61,7 @@ final class TimeTest extends CIUnitTestCase
             'en_US',
             IntlDateFormatter::SHORT,
             IntlDateFormatter::SHORT,
-            'America/Chicago', // Default for CodeIgniter
+            'America/Chicago',
             IntlDateFormatter::GREGORIAN,
             'yyyy-MM-dd HH:mm:ss'
         );
@@ -76,7 +76,7 @@ final class TimeTest extends CIUnitTestCase
             'en_US',
             IntlDateFormatter::SHORT,
             IntlDateFormatter::SHORT,
-            'Europe/London', // Default for CodeIgniter
+            'Europe/London',
             IntlDateFormatter::GREGORIAN,
             'yyyy-MM-dd HH:mm:ss'
         );
@@ -92,7 +92,7 @@ final class TimeTest extends CIUnitTestCase
             'fr_FR',
             IntlDateFormatter::SHORT,
             IntlDateFormatter::SHORT,
-            'Europe/London', // Default for CodeIgniter
+            'Europe/London',
             IntlDateFormatter::GREGORIAN,
             'yyyy-MM-dd HH:mm:ss'
         );

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -234,6 +234,13 @@ final class TimeTest extends CIUnitTestCase
         $this->assertCloseEnoughString(date('2017-01-15 H:i:s', $now->getTimestamp()), $time->toDateTimeString());
     }
 
+    public function testCreateFromFormatWithMicroseconds(): void
+    {
+        $time = Time::createFromFormat('Y-m-d H:i:s.u', '2024-07-09 09:13:34.654321');
+
+        $this->assertSame('2024-07-09 09:13:34.654321', $time->format('Y-m-d H:i:s.u'));
+    }
+
     public function testCreateFromFormatWithTimezoneString(): void
     {
         $time = Time::createFromFormat('F j, Y', 'January 15, 2017', 'Europe/London');

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -936,6 +936,15 @@ final class TimeTest extends CIUnitTestCase
         $this->assertFalse($time2->isBefore($time1));
     }
 
+    public function testBeforeWithMicroseconds(): void
+    {
+        $time1 = new Time('2024-01-01 12:00:00.000000');
+        $time2 = new Time('2024-01-01 12:00:00.654321');
+
+        $this->assertTrue($time1->isBefore($time2));
+        $this->assertFalse($time2->isBefore($time1));
+    }
+
     public function testAfter(): void
     {
         $time1 = Time::parse('January 10, 2017 21:50:00', 'America/Chicago');
@@ -943,6 +952,15 @@ final class TimeTest extends CIUnitTestCase
 
         $this->assertFalse($time1->isAfter($time2));
         $this->assertTrue($time2->isAfter($time1));
+    }
+
+    public function testAfterWithMicroseconds(): void
+    {
+        $time1 = new Time('2024-01-01 12:00:00.654321');
+        $time2 = new Time('2024-01-01 12:00:00.000000');
+
+        $this->assertTrue($time1->isAfter($time2));
+        $this->assertFalse($time2->isAfter($time1));
     }
 
     public function testHumanizeYearsSingle(): void

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -59,6 +59,12 @@ executed twice, an exception will be thrown. See
 
 .. _v460-interface-changes:
 
+Time with Microseconds
+----------------------
+
+Fixed bugs that some methods in ``Time`` to lose microseconds have been fixed.
+See :ref:`Upgrading Guide <upgrade-460-time-keeps-microseconds>` for details.
+
 Interface Changes
 =================
 

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -29,6 +29,42 @@ See :ref:`ChangeLog <v460-behavior-changes-exceptions>` for details.
 
 If you have code that catches these exceptions, change the exception classes.
 
+.. _upgrade-460-time-keeps-microseconds:
+
+Time keeps Microseconds
+=======================
+
+In previous versions, :doc:`Time <../libraries/time>` lost microseconds in some
+cases. But the bugs have been fixed.
+
+The results of the ``Time`` comparison may differ due to these fixes:
+
+.. literalinclude:: upgrade_460/006.php
+   :lines: 2-
+
+In a such case, you need to remove the microseconds:
+
+.. literalinclude:: upgrade_460/007.php
+   :lines: 2-
+
+The following cases now keeps microseconds:
+
+.. literalinclude:: upgrade_460/002.php
+   :lines: 2-
+
+.. literalinclude:: upgrade_460/003.php
+   :lines: 2-
+
+Note that ``Time`` with the current time has been holding microseconds since before.
+
+.. literalinclude:: upgrade_460/004.php
+   :lines: 2-
+
+Also, methods that returns an ``int`` still lose the microseconds.
+
+.. literalinclude:: upgrade_460/005.php
+   :lines: 2-
+
 .. _upgrade-460-registrars-with-dirty-hack:
 
 Registrars with Dirty Hack

--- a/user_guide_src/source/installation/upgrade_460/002.php
+++ b/user_guide_src/source/installation/upgrade_460/002.php
@@ -1,0 +1,8 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time = Time::createFromFormat('Y-m-d H:i:s.u', '2024-07-09 09:13:34.654321');
+echo $time->format('Y-m-d H:i:s.u');
+// Before: 2024-07-09 09:13:34.000000
+//  After: 2024-07-09 09:13:34.654321

--- a/user_guide_src/source/installation/upgrade_460/003.php
+++ b/user_guide_src/source/installation/upgrade_460/003.php
@@ -1,0 +1,8 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time = new Time('1 hour ago');
+echo $time->format('Y-m-d H:i:s.u');
+// Before: 2024-07-26 21:05:57.000000
+//  After: 2024-07-26 21:05:57.857235

--- a/user_guide_src/source/installation/upgrade_460/004.php
+++ b/user_guide_src/source/installation/upgrade_460/004.php
@@ -1,0 +1,8 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time = Time::now();
+echo $time->format('Y-m-d H:i:s.u');
+// Before: 2024-07-26 21:39:32.249072
+//  After: 2024-07-26 21:39:32.249072

--- a/user_guide_src/source/installation/upgrade_460/005.php
+++ b/user_guide_src/source/installation/upgrade_460/005.php
@@ -1,0 +1,9 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time1 = new Time('2024-01-01 12:00:00');
+echo $time1->getTimestamp(); // 1704110400
+
+$time2 = new Time('2024-01-01 12:00:00.654321');
+echo $time2->getTimestamp(); // 1704110400

--- a/user_guide_src/source/installation/upgrade_460/006.php
+++ b/user_guide_src/source/installation/upgrade_460/006.php
@@ -1,0 +1,10 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time1 = new Time('2024-01-01 12:00:00.654321');
+$time2 = new Time('2024-01-01 12:00:00');
+
+$time1->equals($time2);
+// Before: true
+//  After: false

--- a/user_guide_src/source/installation/upgrade_460/007.php
+++ b/user_guide_src/source/installation/upgrade_460/007.php
@@ -1,0 +1,17 @@
+<?php
+
+use CodeIgniter\I18n\Time;
+
+$time1 = new Time('2024-01-01 12:00:00.654321');
+$time2 = new Time('2024-01-01 12:00:00');
+
+// Removes the microseconds.
+$time1 = Time::createFromFormat(
+    'Y-m-d H:i:s',
+    $time1->format('Y-m-d H:i:s'),
+    $time1->getTimezone()
+);
+
+$time1->equals($time2);
+// Before: true
+//  After: true

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -395,6 +395,18 @@ The datetime format is set in the ``dateFormat`` array of the
 :ref:`database configuration <database-config-explanation-of-values>` in the
 **app/Config/Database.php** file.
 
+.. note::
+    When you set ``ms`` or ``us`` as a parameter, **Model** takes care of second's
+    fractional part of the Time. But **Query Builder** does not. So you still need
+    to use the ``format()`` method when you pass the Time to Query Builder's methods
+    like ``where()``:
+
+    .. literalinclude:: model/063.php
+        :lines: 2-
+
+.. note:: Prior to v4.6.0, you cannot use ``ms`` or ``us`` as a parameter.
+    Because the second's fractional part of Time was lost due to bugs.
+
 Custom Casting
 ==============
 

--- a/user_guide_src/source/models/model/063.php
+++ b/user_guide_src/source/models/model/063.php
@@ -1,0 +1,13 @@
+<?php
+
+$model = model('SomeModel');
+
+$now = \CodeIgniter\I18n\Time::now();
+
+// The following code passes the microseconds to Query Builder.
+$model->where('my_dt_field', $now->format('Y-m-d H:i:s.u'))->findAll();
+// Generates: SELECT * FROM `my_table` WHERE `my_dt_field` = '2024-07-28 18:57:58.900326'
+
+// But the following code loses the microseconds.
+$model->where('my_dt_field', $now)->findAll();
+// Generates: SELECT * FROM `my_table` WHERE `my_dt_field` = '2024-07-28 18:57:58'


### PR DESCRIPTION
**Description**
Fixes #9079

Since PHP 7.1, DateTime constructor incorporates microseconds.
See https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds
and `Time` constructor also holds microseconds in most cases.
But some methods below in `Time` lost microseconds.

- `__construct()` ... not all cases
- `createFromFormat()`
- `createFromInstance()`
- `toDateTime()`
- `setTestNow()`
- `equals()`
- `sameAs()`
- `isBefore()`
- `isAfter()`

Also fixes:
- `DatetimeCast::set()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
