### PR TITLE
Prep for 4.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [v4.5.4](https://github.com/codeigniter4/CodeIgniter4/tree/v4.5.3) (2024-07-27)
+[Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.5.3...v4.5.4)
+
+### Fixed Bugs
+
+* fix: [OCI8] Easy Connect string validation by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/9006
+* fix: [QueryBuilder] select() with RawSql may cause TypeError by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/9009
+* fix: [QueryBuilder] `select()` does not escape after `NULL` by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/9010
+* fix: allow string as parameter to CURLRequest version by @tangix in https://github.com/codeigniter4/CodeIgniter4/pull/9021
+* fix: `spark phpini:check` may cause TypeError by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/9026
+* fix: Prevent invalid session handlers by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/9036
+* fix: DebugBar CSS for daisyUI by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/9046
+* docs: `referrer` is undefined by @totoprayogo1916 in https://github.com/codeigniter4/CodeIgniter4/pull/9059
+* fix: filters passed to the ``$routes->group()`` are not merged into the filters passed to the inner routes by @kenjis in https://github.com/codeigniter4/CodeIgniter4/pull/9064
+
+### Refactoring
+
+* refactor: use first class callable on function call by @samsonasik in https://github.com/codeigniter4/CodeIgniter4/pull/9004
+* refactor: enable AddClosureVoidReturnTypeWhereNoReturnRector to add void return on closure by @samsonasik in https://github.com/codeigniter4/CodeIgniter4/pull/9008
+* refactor: enable AddFunctionVoidReturnTypeWhereNoReturnRector to add void to functions by @samsonasik in https://github.com/codeigniter4/CodeIgniter4/pull/9014
+* refactor: Enable phpunit 10 attribute Rector rules by @samsonasik in https://github.com/codeigniter4/CodeIgniter4/pull/9015
+* refactor: fix `Throttler::check()` $tokens by @paulbalandan in https://github.com/codeigniter4/CodeIgniter4/pull/9067
+
 ## [v4.5.3](https://github.com/codeigniter4/CodeIgniter4/tree/v4.5.3) (2024-06-25)
 [Full Changelog](https://github.com/codeigniter4/CodeIgniter4/compare/v4.5.2...v4.5.3)
 

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -10,7 +10,7 @@
         <output>api/build/</output>
         <cache>api/cache/</cache>
     </paths>
-    <version number="4.5.3">
+    <version number="4.5.4">
         <api format="php">
             <source dsn=".">
                 <path>system</path>

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -56,7 +56,7 @@ class CodeIgniter
     /**
      * The current version of CodeIgniter Framework
      */
-    public const CI_VERSION = '4.5.3';
+    public const CI_VERSION = '4.5.4';
 
     /**
      * App startup time.

--- a/user_guide_src/source/changelogs/v4.5.4.rst
+++ b/user_guide_src/source/changelogs/v4.5.4.rst
@@ -2,29 +2,13 @@
 Version 4.5.4
 #############
 
-Release Date: Unreleased
+Release Date: July 27, 2024
 
 **4.5.4 release of CodeIgniter4**
 
 .. contents::
     :local:
     :depth: 3
-
-********
-BREAKING
-********
-
-***************
-Message Changes
-***************
-
-*******
-Changes
-*******
-
-************
-Deprecations
-************
 
 **********
 Bugs Fixed

--- a/user_guide_src/source/conf.py
+++ b/user_guide_src/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2019-' + str(year_now) + ' CodeIgniter Foundation'
 version = '4.5'
 
 # The full version, including alpha/beta/rc tags.
-release = '4.5.3'
+release = '4.5.4'
 
 # -- General configuration ---------------------------------------------------
 

--- a/user_guide_src/source/installation/upgrade_454.rst
+++ b/user_guide_src/source/installation/upgrade_454.rst
@@ -12,18 +12,6 @@ Please refer to the upgrade instructions corresponding to your installation meth
     :local:
     :depth: 2
 
-**********************
-Mandatory File Changes
-**********************
-
-****************
-Breaking Changes
-****************
-
-*********************
-Breaking Enhancements
-*********************
-
 *************
 Project Files
 *************
@@ -35,21 +23,11 @@ these files being outside of the **system** scope they will not be changed witho
     with merging changes to the project space:
     `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
 
-Content Changes
-===============
-
-The following files received significant changes (including deprecations or visual adjustments)
-and it is recommended that you merge the updated versions with your application:
-
-Config
-------
-
-- @TODO
-
 All Changes
 ===========
 
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
+- app/Config/Events.php
+- composer.json


### PR DESCRIPTION
**Description**
Updates changelog and version references for 4.5.4.

Previous version: #8996
Release Code: TODO
New Changelog: TODO

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
