### PR TITLE
fix: [DBForge] addForeignKey() Table prefix issue while using with database

### DIFF
--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -1190,7 +1190,7 @@ abstract class BaseConnection implements ConnectionInterface
                 $parts[$i] = preg_replace('/^' . $this->swapPre . '(\S+?)/', $this->DBPrefix . '\\1', $parts[$i]);
             }
             // We only add the table prefix if it does not already exist
-            elseif (! str_starts_with($parts[$i], $this->DBPrefix)) {
+            elseif (! str_starts_with($parts[$i], $this->DBPrefix) && !stripos($parts[$i], $this->DBPrefix)) {
                 $parts[$i] = $this->DBPrefix . $parts[$i];
             }
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1226,9 +1226,9 @@ class Forge
 
             $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTable = explode('.',$fkey['referenceTable']);
+            $referenceTable = explode('.', $fkey['referenceTable']);
             $referenceTable[array_key_last($referenceTable)] = $this->db->DBPrefix . $referenceTable[array_key_last($referenceTable)];
-            $referenceTableFilled = $this->db->escapeIdentifiers(implode('.',$referenceTable));
+            $referenceTableFilled = $this->db->escapeIdentifiers(implode('.', $referenceTable));
             $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
             if ($asQuery === true) {

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1226,7 +1226,7 @@ class Forge
 
             $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTable = explode('.', $fkey['referenceTable']);
+            $referenceTable = explode('.', (string)$fkey['referenceTable']);
             $referenceTable[array_key_last($referenceTable)] = $this->db->DBPrefix . $referenceTable[array_key_last($referenceTable)];
             $referenceTableFilled = $this->db->escapeIdentifiers(implode('.', $referenceTable));
             $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1220,16 +1220,14 @@ class Forge
                 $sqls[$index] = '';
             }
 
-            $nameIndex = $fkey['fkName'] !== '' ?
-            $fkey['fkName'] :
-            $table . '_' . implode('_', $fkey['field']) . ($this->db->DBDriver === 'OCI8' ? '_fk' : '_foreign');
-
-            $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
-            $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTable = explode('.', (string)$fkey['referenceTable']);
-            $referenceTable[array_key_last($referenceTable)] = $this->db->DBPrefix . $referenceTable[array_key_last($referenceTable)];
-            $referenceTableFilled = $this->db->escapeIdentifiers(implode('.', $referenceTable));
-            $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
+            $nameIndex                  = $fkey['fkName'] !== '' ? $fkey['fkName'] : $table . '_' . implode('_', $fkey['field']) . ($this->db->DBDriver === 'OCI8' ? '_fk' : '_foreign');
+            $nameIndexFilled            = $this->db->escapeIdentifiers($nameIndex);
+            $foreignKeyFilled           = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
+            $referenceTable             = explode('.', (string)$fkey['referenceTable']);
+            $lastKey                    = array_key_last($referenceTable);
+            $referenceTable[$lastKey]   = $this->db->DBPrefix . $referenceTable[$lastKey];
+            $referenceTableFilled       = $this->db->escapeIdentifiers(implode('.', $referenceTable));
+            $referenceFieldFilled       = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
             if ($asQuery === true) {
                 $sqls[$index] .= 'ALTER TABLE ' . $this->db->escapeIdentifiers($this->db->DBPrefix . $table) . ' ADD ';

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -1226,7 +1226,9 @@ class Forge
 
             $nameIndexFilled      = $this->db->escapeIdentifiers($nameIndex);
             $foreignKeyFilled     = implode(', ', $this->db->escapeIdentifiers($fkey['field']));
-            $referenceTableFilled = $this->db->escapeIdentifiers($this->db->DBPrefix . $fkey['referenceTable']);
+            $referenceTable = explode('.',$fkey['referenceTable']);
+            $referenceTable[array_key_last($referenceTable)] = $this->db->DBPrefix . $referenceTable[array_key_last($referenceTable)];
+            $referenceTableFilled = $this->db->escapeIdentifiers(implode('.',$referenceTable));
             $referenceFieldFilled = implode(', ', $this->db->escapeIdentifiers($fkey['referenceField']));
 
             if ($asQuery === true) {


### PR DESCRIPTION
While adding a foreign key to any external table, it was getting miss formatted if we defined the DB prefix like `db2.table_name` is being formatted like `prefix_db2.tablename` and the query was ended up in malformed constraint error.

This fix will add prefix to the table name only.

**Description**
I have changed the logic of adding prefix for foreign tables and now prefix will only prepend with table name only (last index)

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
