### PR TITLE
feat: Increase visibility of `printKeysAndValues()` method

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -390,7 +390,7 @@ class CLI
     /**
      * Print each key and value one by one
      */
-    private static function printKeysAndValues(array $options): void
+    public static function printKeysAndValues(array $options): void
     {
         // +2 for the square brackets around the key
         $keyMaxLength = max(array_map(mb_strwidth(...), array_keys($options))) + 2;


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

This PR makes `printKeysAndValues()` public so we can use it anywhere.

Why this needs to be changed: 

I have a use case where I need to display the contents of the `$options` property in a command file.
It's easier to reuse the existing `printKeysAndValues()` than make a new function. This will help us show more details in our commands.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
