### PR TITLE
feat: Increase visibility of printKeysAndValues() method

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -390,7 +390,7 @@ class CLI
     /**
      * Print each key and value one by one
      */
-    private static function printKeysAndValues(array $options): void
+    public static function printKeysAndValues(array $options): void
     {
         // +2 for the square brackets around the key
         $keyMaxLength = max(array_map(mb_strwidth(...), array_keys($options))) + 2;

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -665,4 +665,21 @@ final class CLITest extends CIUnitTestCase
         $this->assertSame(7, CLI::strlen(CLI::color('success', 'green')));
         $this->assertSame(0, CLI::strlen(null));
     }
+
+    public function testPrintKeysAndValues(): void
+    {
+        $options = [
+            'c' => 'Enable only config caching.',
+            'l' => 'Enable only locator caching.',
+            'd' => 'Disable config and locator caching.',
+        ];
+
+        $output = CLI::printKeysAndValues($options);
+
+        $expected = "  [-c]  Enable only config caching." . PHP_EOL;
+        $expected .= "  [-l]  Enable only locator caching." . PHP_EOL;
+        $expected .= "  [-d]  Disable config and locator caching." . PHP_EOL;
+
+        $this->assertSame($expected, $output);
+    }
 }

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -676,9 +676,9 @@ final class CLITest extends CIUnitTestCase
 
         $output = CLI::printKeysAndValues($options);
 
-        $expected = "  [-c]  Enable only config caching." . PHP_EOL;
-        $expected .= "  [-l]  Enable only locator caching." . PHP_EOL;
-        $expected .= "  [-d]  Disable config and locator caching." . PHP_EOL;
+        $expected = '  [-c]  Enable only config caching.' . PHP_EOL;
+        $expected .= '  [-l]  Enable only locator caching.' . PHP_EOL;
+        $expected .= '  [-d]  Disable config and locator caching.' . PHP_EOL;
 
         $this->assertSame($expected, $output);
     }

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -674,12 +674,12 @@ final class CLITest extends CIUnitTestCase
             'd' => 'Disable config and locator caching.',
         ];
 
-        $output = CLI::printKeysAndValues($options);
+        CLI::printKeysAndValues($options);
 
         $expected = '  [-c]  Enable only config caching.' . PHP_EOL;
         $expected .= '  [-l]  Enable only locator caching.' . PHP_EOL;
         $expected .= '  [-d]  Disable config and locator caching.' . PHP_EOL;
 
-        $this->assertSame($expected, $output);
+        $this->assertSame($this->getStreamFilterBuffer(), $expected);
     }
 }

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -676,9 +676,9 @@ final class CLITest extends CIUnitTestCase
 
         CLI::printKeysAndValues($options);
 
-        $expected = '  [-c]  Enable only config caching.' . PHP_EOL;
-        $expected .= '  [-l]  Enable only locator caching.' . PHP_EOL;
-        $expected .= '  [-d]  Disable config and locator caching.' . PHP_EOL;
+        $expected = '  [c]  Enable only config caching.' . PHP_EOL;
+        $expected .= '  [l]  Enable only locator caching.' . PHP_EOL;
+        $expected .= '  [d]  Disable config and locator caching.' . PHP_EOL;
 
         $this->assertSame($this->getStreamFilterBuffer(), $expected);
     }

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -119,6 +119,11 @@ The following new Exception interfaces have been added:
 - ``CodeIgniter\HTTP\Exceptions\ExceptionInterface``
 - ``CodeIgniter\Router\Exceptions\ExceptionInterface``
 
+CLI
+===
+
+- The ``printKeysAndValues()`` method has been changed from ``private`` to ``public``
+
 Commands
 ========
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

This PR makes `printKeysAndValues()` public so we can use it anywhere.

Why this needs to be changed: 

I have a use case where I need to display the contents of the `$options` property in a command file.
It's easier to reuse the existing `printKeysAndValues()` than make a new function with similar behavior. This will help us show more details in our commands. 

For example: if you type `spark optimize -h` or just some random stuff like `spark optimize asdf`, it'll either show you all the possible options or tell you there's a problem and then show you all the options anyway.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
