### PR TITLE
feat: [Entity] add changedValues() function

### DIFF
--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -271,6 +271,37 @@ class Entity implements JsonSerializable
     }
 
     /**
+     * Return an array containing the original and changed value of new attributes
+     * and attributes that have changed only
+    */
+    public function changedValues(): array
+    {
+        $changed = [];
+
+        // Add new attributes to changed array
+        foreach ($this->attributes as $key => $value) {
+            if (! array_key_exists($key, $this->original)) {
+                $changed[$key] = [
+                    'original' => null,
+                    'changed'  => $this->attributes[$key],
+                ];
+
+                continue;
+            }
+
+            // Add changed attributes to changed array
+            if ($this->original[$key] !== $this->attributes[$key]) {
+                $changed[$key] = [
+                    'original' => $this->original[$key],
+                    'changed'  => $this->attributes[$key],
+                ];
+            }
+        }
+
+        return $changed;
+    }
+
+    /**
      * Checks a property to see if it has changed since the entity
      * was created. Or, without a parameter, checks if any
      * properties have changed.


### PR DESCRIPTION
**Description**
Suggesting to introduce a function `Entity::changedValues()` that returns an array of original and changed values of new or changed attributes only. I use this for my project logging capability where I desire to only log changed values.

I have implemented this function in my own `EntityBase` class and have been using it in my live project. Code is not yet optimized and tested but can do if given the go ahead.

Would this be a welcome function to implement in the `Entity` class?

Sample output

```
name =>
   original => 'Peter'
   changed => 'John'
date_birth =>
   original => null,
   changed => '2024-08-01'
```


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
