### PR TITLE
docs: fix `@return` type in BaseModel

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -105,12 +105,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\BaseModel\\:\\:doErrors\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/BaseModel.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\BaseModel\\:\\:doFind\\(\\) has parameter \\$id with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/BaseModel.php',

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -541,7 +541,7 @@ abstract class BaseModel
      * Grabs the last error(s) that occurred from the Database connection.
      * This method works only with dbCalls.
      *
-     * @return array|null
+     * @return array<string, string>
      */
     abstract protected function doErrors();
 
@@ -1242,7 +1242,7 @@ abstract class BaseModel
      *
      * @param bool $forceDB Always grab the db error, not validation
      *
-     * @return array<string,string>
+     * @return array<string, string>
      */
     public function errors(bool $forceDB = false)
     {


### PR DESCRIPTION
**Description**
See #8732

- fix PHPDoc type

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
