### PR TITLE
refactor: reduce_multiples() and fix user guide

### DIFF
--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -529,7 +529,7 @@ if (! function_exists('reduce_multiples')) {
         $pattern = '#' . preg_quote($character, '#') . '{2,}#';
         $str     = preg_replace($pattern, $character, $str);
 
-        return ($trim) ? trim($str, $character) : $str;
+        return $trim ? trim($str, $character) : $str;
     }
 }
 

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -526,7 +526,8 @@ if (! function_exists('reduce_multiples')) {
      */
     function reduce_multiples(string $str, string $character = ',', bool $trim = false): string
     {
-        $str = preg_replace('#' . preg_quote($character, '#') . '{2,}#', $character, $str);
+        $pattern = '#' . preg_quote($character, '#') . '{2,}#';
+        $str     = preg_replace($pattern, $character, $str);
 
         return ($trim) ? trim($str, $character) : $str;
     }

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -93,8 +93,9 @@ final class TextHelperTest extends CIUnitTestCase
     {
         yield from [
             // string, expected
-            'double commas'         => ['Fred, Bill,, Joe, Jimmy', 'Fred, Bill, Joe, Jimmy'],
-            'double commas at last' => ['Ringo, John, Paul,,', 'Ringo, John, Paul,'],
+            'double commas'            => ['Fred, Bill,, Joe, Jimmy', 'Fred, Bill, Joe, Jimmy'],
+            'double commas at last'    => ['Ringo, John, Paul,,', 'Ringo, John, Paul,'],
+            'commas at first and last' => [',Fred, Bill,, Joe, Jimmy,', ',Fred, Bill, Joe, Jimmy,'],
         ];
     }
 
@@ -108,8 +109,9 @@ final class TextHelperTest extends CIUnitTestCase
     {
         yield from [
             // string, expected
-            'double commas'         => ['Fred, Bill,, Joe, Jimmy', 'Fred, Bill, Joe, Jimmy'],
-            'double commas at last' => ['Ringo, John, Paul,,', 'Ringo, John, Paul'],
+            'double commas'            => ['Fred, Bill,, Joe, Jimmy', 'Fred, Bill, Joe, Jimmy'],
+            'double commas at last'    => ['Ringo, John, Paul,,', 'Ringo, John, Paul'],
+            'commas at first and last' => [',Fred, Bill,, Joe, Jimmy,', 'Fred, Bill, Joe, Jimmy'],
         ];
     }
 

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Helpers;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -82,24 +83,34 @@ final class TextHelperTest extends CIUnitTestCase
         }
     }
 
-    public function testReduceMultiples(): void
+    #[DataProvider('provideReduceMultiples')]
+    public function testReduceMultiples(string $str, string $expected): void
     {
-        $strs = [
-            'Fred, Bill,, Joe, Jimmy' => 'Fred, Bill, Joe, Jimmy',
-            'Ringo, John, Paul,,'     => 'Ringo, John, Paul,',
-        ];
+        $this->assertSame($expected, reduce_multiples($str));
+    }
 
-        foreach ($strs as $str => $expect) {
-            $this->assertSame($expect, reduce_multiples($str));
-        }
-        $strs = [
-            'Fred, Bill,, Joe, Jimmy' => 'Fred, Bill, Joe, Jimmy',
-            'Ringo, John, Paul,,'     => 'Ringo, John, Paul',
+    public static function provideReduceMultiples(): iterable
+    {
+        yield from [
+            // string, expected
+            'double commas'         => ['Fred, Bill,, Joe, Jimmy', 'Fred, Bill, Joe, Jimmy'],
+            'double commas at last' => ['Ringo, John, Paul,,', 'Ringo, John, Paul,'],
         ];
+    }
 
-        foreach ($strs as $str => $expect) {
-            $this->assertSame($expect, reduce_multiples($str, ',', true));
-        }
+    #[DataProvider('provideReduceMultiplesWithTrim')]
+    public function testReduceMultiplesWithTrim(string $str, string $expected): void
+    {
+        $this->assertSame($expected, reduce_multiples($str, ',', true));
+    }
+
+    public static function provideReduceMultiplesWithTrim(): iterable
+    {
+        yield from [
+            // string, expected
+            'double commas'         => ['Fred, Bill,, Joe, Jimmy', 'Fred, Bill, Joe, Jimmy'],
+            'double commas at last' => ['Ringo, John, Paul,,', 'Ringo, John, Paul'],
+        ];
     }
 
     public function testRandomString(): void

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -89,6 +89,9 @@ final class TextHelperTest extends CIUnitTestCase
         $this->assertSame($expected, reduce_multiples($str));
     }
 
+    /**
+     * @return iterable<string, list<string>>
+     */
     public static function provideReduceMultiples(): iterable
     {
         yield from [
@@ -105,6 +108,9 @@ final class TextHelperTest extends CIUnitTestCase
         $this->assertSame($expected, reduce_multiples($str, ',', true));
     }
 
+    /**
+     * @return iterable<string, list<string>>
+     */
     public static function provideReduceMultiplesWithTrim(): iterable
     {
         yield from [

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -140,7 +140,7 @@ The following functions are available:
 
     .. literalinclude:: text_helper/009.php
 
-    If the third parameter is set to true it will remove occurrences of the
+    If the third parameter is set to ``true``, it will remove occurrences of the
     character at the beginning and the end of the string. Example:
 
     .. literalinclude:: text_helper/010.php

--- a/user_guide_src/source/helpers/text_helper.rst
+++ b/user_guide_src/source/helpers/text_helper.rst
@@ -127,7 +127,7 @@ The following functions are available:
         and handle string inputs. This however makes it just an
         alias for ``stripslashes()``.
 
-.. php:function:: reduce_multiples($str[, $character = ''[, $trim = false]])
+.. php:function:: reduce_multiples($str[, $character = ','[, $trim = false]])
 
     :param    string    $str: Text to search in
     :param    string    $character: Character to reduce

--- a/user_guide_src/source/helpers/text_helper/009.php
+++ b/user_guide_src/source/helpers/text_helper/009.php
@@ -1,4 +1,4 @@
 <?php
 
 $string = 'Fred, Bill,, Joe, Jimmy';
-$string = reduce_multiples($string, ','); // results in "Fred, Bill, Joe, Jimmy"
+$string = reduce_multiples($string); // results in "Fred, Bill, Joe, Jimmy"

--- a/user_guide_src/source/helpers/text_helper/010.php
+++ b/user_guide_src/source/helpers/text_helper/010.php
@@ -1,4 +1,4 @@
 <?php
 
 $string = ',Fred, Bill,, Joe, Jimmy,';
-$string = reduce_multiples($string, ', ', true); // results in "Fred, Bill, Joe, Jimmy"
+$string = reduce_multiples($string, ',', true); // results in "Fred, Bill, Joe, Jimmy"


### PR DESCRIPTION
**Description**
- refactor to suppress PHPStan error (false positive)
- fix user guide
- refactor test code

```
 ------ ------------------------------------------------------------------- 
  Line   system/Helpers/text_helper.php                                     
 ------ ------------------------------------------------------------------- 
  529    Regex pattern is invalid: Compilation failed: quantifier does not  
         follow a repeatable item at offset 5 in pattern: #.*{2,}#          
         🪪  regexp.pattern                                                 
 ------ ------------------------------------------------------------------- 
```
https://github.com/codeigniter4/CodeIgniter4/actions/runs/10208178324/job/28244217081

But the pattern  is `#,{2,}#` by default:
https://github.com/codeigniter4/CodeIgniter4/blob/1d3336b7cc07349886178d14757ef5c5885c1da6/system/Helpers/text_helper.php#L527-L529
I sent a bug report: https://github.com/phpstan/phpstan/issues/11432

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
