### PR TITLE
docs: update PHPDoc in ContentSecurityPolicy

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -5936,12 +5936,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/HTTP/ContentSecurityPolicy.php',
 ];
 $ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Property CodeIgniter\\\\HTTP\\\\ContentSecurityPolicy\\:\\:\\$validSources type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/HTTP/ContentSecurityPolicy.php',
-];
-$ignoreErrors[] = [
 	// identifier: codeigniter.superglobalAccess
 	'message' => '#^Accessing offset \'HTTP_USER_AGENT\' directly on \\$_SERVER is discouraged\\.$#',
 	'count' => 2,

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -31,7 +31,7 @@ class ContentSecurityPolicy
     /**
      * CSP directives
      *
-     * @var array<string, string>
+     * @var array<string, string> [name => property]
      */
     protected array $directives = [
         'base-uri'        => 'baseURI',
@@ -166,7 +166,8 @@ class ContentSecurityPolicy
     protected $sandbox = [];
 
     /**
-     * Used for security enforcement
+     * A set of endpoints to which csp violation reports will be sent when
+     * particular behaviors are prevented.
      *
      * @var string|null
      */
@@ -189,7 +190,7 @@ class ContentSecurityPolicy
     /**
      * Used for security enforcement
      *
-     * @var array
+     * @var list<string>
      */
     protected $validSources = [
         'self',
@@ -242,7 +243,7 @@ class ContentSecurityPolicy
 
     /**
      * An array of header info since we have
-     * to build ourself before passing to Response.
+     * to build ourselves before passing to Response.
      *
      * @var array
      */

--- a/system/HTTP/ContentSecurityPolicy.php
+++ b/system/HTTP/ContentSecurityPolicy.php
@@ -595,6 +595,9 @@ class ContentSecurityPolicy
      *
      * @see http://www.w3.org/TR/CSP/#directive-report-uri
      *
+     * @param string $uri URL to send reports. Set `''` if you want to remove
+     *                    this directive at runtime.
+     *
      * @return $this
      */
     public function setReportURI(string $uri)

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -381,6 +381,19 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
 
     #[PreserveGlobalState(false)]
     #[RunInSeparateProcess]
+    public function testRemoveReportURI(): void
+    {
+        $this->prepare();
+        $this->csp->reportOnly(false);
+        $this->csp->setReportURI('');
+        $this->work();
+
+        $result = $this->getHeaderEmitted('Content-Security-Policy');
+        $this->assertStringNotContainsString('report-uri ', $result);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testSandboxFlags(): void
     {
         $this->prepare();


### PR DESCRIPTION
**Description**
Closes #9091

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
