### PR TITLE
fix: Validation rule `differs`/`matches` with dot array

### DIFF
--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -48,11 +48,15 @@ class Rules
             return $str !== dot_array_search($otherField, $data);
         }
 
-        if (! array_key_exists($field, $data)) {
+        if (! array_key_exists($otherField, $data)) {
             return false;
         }
 
-        if (! array_key_exists($otherField, $data)) {
+        if (str_contains($field, '.')) {
+            if (! ArrayHelper::dotKeyExists($field, $data)) {
+                return false;
+            }
+        } elseif (! array_key_exists($field, $data)) {
             return false;
         }
 
@@ -281,11 +285,15 @@ class Rules
             return $str === dot_array_search($otherField, $data);
         }
 
-        if (! array_key_exists($field, $data)) {
+        if (! array_key_exists($otherField, $data)) {
             return false;
         }
 
-        if (! array_key_exists($otherField, $data)) {
+        if (str_contains($field, '.')) {
+            if (! ArrayHelper::dotKeyExists($field, $data)) {
+                return false;
+            }
+        } elseif (! array_key_exists($field, $data)) {
             return false;
         }
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -336,6 +336,50 @@ class RulesTest extends CIUnitTestCase
         $this->assertSame($expected, $this->validation->run($data));
     }
 
+    public function testMatchesWithDotArrayPass(): void
+    {
+        $rules = [
+            'name'         => 'permit_empty',
+            'emailAddress' => 'permit_empty|valid_email',
+            'alias.*'      => 'permit_empty|matches[name]',
+        ];
+        $this->validation->setRules($rules);
+
+        $data = [
+            'name'         => 'Princess Peach',
+            'emailAddress' => 'valid@example.com',
+            'alias'        => [
+                'Princess Peach',
+                'Princess Peach',
+            ],
+        ];
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testMatchesWithDotArrayFail(): void
+    {
+        $rules = [
+            'name'         => 'permit_empty',
+            'emailAddress' => 'permit_empty|valid_email',
+            'alias.*'      => 'permit_empty|matches[name]',
+        ];
+        $this->validation->setRules($rules);
+
+        $data = [
+            'name'         => 'Princess Peach',
+            'emailAddress' => 'valid@example.com',
+            'alias'        => [
+                'Princess ',
+                'Princess Peach',
+            ],
+        ];
+        $this->assertFalse($this->validation->run($data));
+        $this->assertSame(
+            ['alias.0' => 'The alias.* field does not match the name field.'],
+            $this->validation->getErrors()
+        );
+    }
+
     public static function provideMatchesNestedCases(): iterable
     {
         yield from [
@@ -371,6 +415,50 @@ class RulesTest extends CIUnitTestCase
     {
         $this->validation->setRules(['nested.foo' => 'differs[nested.bar]']);
         $this->assertSame(! $expected, $this->validation->run($data));
+    }
+
+    public function testDiffersWithDotArrayPass(): void
+    {
+        $rules = [
+            'name'         => 'permit_empty',
+            'emailAddress' => 'permit_empty|valid_email',
+            'alias.*'      => 'permit_empty|differs[name]',
+        ];
+        $this->validation->setRules($rules);
+
+        $data = [
+            'name'         => 'Princess Peach',
+            'emailAddress' => 'valid@example.com',
+            'alias'        => [
+                'Princess Toadstool',
+                'Peach',
+            ],
+        ];
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testDiffersWithDotArrayFail(): void
+    {
+        $rules = [
+            'name'         => 'permit_empty',
+            'emailAddress' => 'permit_empty|valid_email',
+            'alias.*'      => 'permit_empty|differs[name]',
+        ];
+        $this->validation->setRules($rules);
+
+        $data = [
+            'name'         => 'Princess Peach',
+            'emailAddress' => 'valid@example.com',
+            'alias'        => [
+                'Princess Toadstool',
+                'Princess Peach',
+            ],
+        ];
+        $this->assertFalse($this->validation->run($data));
+        $this->assertSame(
+            ['alias.1' => 'The alias.* field must differ from the name field.'],
+            $this->validation->getErrors()
+        );
     }
 
     #[DataProvider('provideEquals')]


### PR DESCRIPTION
**Description**
Fixes #9101

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
