### PR TITLE
refactor: remove dependency on BaseConnection in TableName

### DIFF
--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -200,7 +200,7 @@ class ShowTableInfo extends BaseCommand
         CLI::newLine();
 
         $this->removeDBPrefix();
-        $thead = $this->db->getFieldNames(TableName::fromActualName($this->db, $tableName));
+        $thead = $this->db->getFieldNames(TableName::fromActualName($this->db->DBPrefix, $tableName));
         $this->restoreDBPrefix();
 
         // If there is a field named `id`, sort by it.
@@ -278,7 +278,7 @@ class ShowTableInfo extends BaseCommand
         $this->tbody = [];
 
         $this->removeDBPrefix();
-        $builder = $this->db->table(TableName::fromActualName($this->db, $tableName));
+        $builder = $this->db->table(TableName::fromActualName($this->db->DBPrefix, $tableName));
         $builder->limit($limitRows);
         if ($sortField !== null) {
             $builder->orderBy($sortField, $this->sortDesc ? 'DESC' : 'ASC');

--- a/system/Database/TableName.php
+++ b/system/Database/TableName.php
@@ -44,10 +44,10 @@ class TableName
      * @param string $table Table name (w/o DB prefix)
      * @param string $alias Alias name
      */
-    public static function create(BaseConnection $db, string $table, string $alias = ''): self
+    public static function create(string $dbPrefix, string $table, string $alias = ''): self
     {
         return new self(
-            $db->DBPrefix . $table,
+            $dbPrefix . $table,
             $table,
             '',
             '',
@@ -61,9 +61,9 @@ class TableName
      * @param string $actualTable Actual table name with DB prefix
      * @param string $alias       Alias name
      */
-    public static function fromActualName(BaseConnection $db, string $actualTable, string $alias = ''): self
+    public static function fromActualName(string $dbPrefix, string $actualTable, string $alias = ''): self
     {
-        $prefix       = $db->DBPrefix;
+        $prefix       = $dbPrefix;
         $logicalTable = '';
 
         if (str_starts_with($actualTable, $prefix)) {
@@ -87,14 +87,14 @@ class TableName
      * @param string $alias    Alias name
      */
     public static function fromFullName(
-        BaseConnection $db,
+        string $dbPrefix,
         string $table,
         string $schema = '',
         string $database = '',
         string $alias = ''
     ): self {
         return new self(
-            $db->DBPrefix . $table,
+            $dbPrefix . $table,
             $table,
             $schema,
             $database,

--- a/tests/system/Database/Builder/AliasTest.php
+++ b/tests/system/Database/Builder/AliasTest.php
@@ -44,7 +44,7 @@ final class AliasTest extends CIUnitTestCase
 
     public function testTableName(): void
     {
-        $tableName = TableName::create($this->db, 'jobs', 'j');
+        $tableName = TableName::create($this->db->DBPrefix, 'jobs', 'j');
         $builder   = $this->db->table($tableName);
 
         $expectedSQL = 'SELECT * FROM "jobs" "j"';

--- a/tests/system/Database/TableNameTest.php
+++ b/tests/system/Database/TableNameTest.php
@@ -38,7 +38,7 @@ final class TableNameTest extends CIUnitTestCase
     {
         $table = 'table';
 
-        $tableName = TableName::create($this->db, $table);
+        $tableName = TableName::create($this->db->DBPrefix, $table);
 
         $this->assertInstanceOf(TableName::class, $tableName);
     }
@@ -47,7 +47,7 @@ final class TableNameTest extends CIUnitTestCase
     {
         $table = 'table';
 
-        $tableName = TableName::create($this->db, $table);
+        $tableName = TableName::create($this->db->DBPrefix, $table);
 
         $this->assertSame($table, $tableName->getTableName());
         $this->assertSame('db_table', $tableName->getActualTableName());
@@ -57,7 +57,7 @@ final class TableNameTest extends CIUnitTestCase
     {
         $actualTable = 'db_table';
 
-        $tableName = TableName::fromActualName($this->db, $actualTable);
+        $tableName = TableName::fromActualName($this->db->DBPrefix, $actualTable);
 
         $this->assertSame('table', $tableName->getTableName());
         $this->assertSame($actualTable, $tableName->getActualTableName());
@@ -67,7 +67,7 @@ final class TableNameTest extends CIUnitTestCase
     {
         $actualTable = 'table';
 
-        $tableName = TableName::fromActualName($this->db, $actualTable);
+        $tableName = TableName::fromActualName($this->db->DBPrefix, $actualTable);
 
         $this->assertSame('', $tableName->getTableName());
         $this->assertSame($actualTable, $tableName->getActualTableName());
@@ -78,7 +78,7 @@ final class TableNameTest extends CIUnitTestCase
         $table = 'table';
         $alias = 't';
 
-        $tableName = TableName::create($this->db, $table, $alias);
+        $tableName = TableName::create($this->db->DBPrefix, $table, $alias);
 
         $this->assertSame($alias, $tableName->getAlias());
     }
@@ -89,7 +89,7 @@ final class TableNameTest extends CIUnitTestCase
         $schema   = 'dbo';
         $database = 'test';
 
-        $tableName = TableName::fromFullName($this->db, $table, $schema, $database);
+        $tableName = TableName::fromFullName($this->db->DBPrefix, $table, $schema, $database);
 
         $this->assertSame($schema, $tableName->getSchema());
     }
@@ -100,7 +100,7 @@ final class TableNameTest extends CIUnitTestCase
         $schema   = 'dbo';
         $database = 'test';
 
-        $tableName = TableName::fromFullName($this->db, $table, $schema, $database);
+        $tableName = TableName::fromFullName($this->db->DBPrefix, $table, $schema, $database);
 
         $this->assertSame($database, $tableName->getDatabase());
     }


### PR DESCRIPTION
**Description**
Follow-up #8748

`TableName` should not depend on DB Connection.
Because it may be a table name in another database. See #9085

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
