### PR TITLE
fix: Time::createFromTimestamp() change for PHP 8.4

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -7484,18 +7484,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/I18n/Time.php',
 ];
 $ignoreErrors[] = [
-	// identifier: method.childReturnType
-	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\Time\\) of method CodeIgniter\\\\I18n\\\\Time\\:\\:setTimestamp\\(\\) should be covariant with return type \\(static\\(DateTimeImmutable\\)\\) of method DateTimeImmutable\\:\\:setTimestamp\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/I18n/Time.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.childReturnType
-	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\Time\\) of method CodeIgniter\\\\I18n\\\\Time\\:\\:setTimezone\\(\\) should be covariant with return type \\(static\\(DateTimeImmutable\\)\\) of method DateTimeImmutable\\:\\:setTimezone\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/I18n/Time.php',
-];
-$ignoreErrors[] = [
 	// identifier: ternary.shortNotAllowed
 	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
 	'count' => 4,
@@ -7504,18 +7492,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\I18n\\\\TimeLegacy\\:\\:__get\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.childReturnType
-	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\TimeLegacy\\) of method CodeIgniter\\\\I18n\\\\TimeLegacy\\:\\:setTimestamp\\(\\) should be covariant with return type \\(static\\(DateTime\\)\\) of method DateTime\\:\\:setTimestamp\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.childReturnType
-	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\TimeLegacy\\) of method CodeIgniter\\\\I18n\\\\TimeLegacy\\:\\:setTimezone\\(\\) should be covariant with return type \\(static\\(DateTime\\)\\) of method DateTime\\:\\:setTimezone\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
 ];

--- a/system/DataCaster/Cast/TimestampCast.php
+++ b/system/DataCaster/Cast/TimestampCast.php
@@ -32,7 +32,7 @@ class TimestampCast extends BaseCast
             self::invalidTypeValueError($value);
         }
 
-        return Time::createFromTimestamp((int) $value);
+        return Time::createFromTimestamp((int) $value, date_default_timezone_get());
     }
 
     public static function set(

--- a/system/Entity/Cast/DatetimeCast.php
+++ b/system/Entity/Cast/DatetimeCast.php
@@ -40,7 +40,7 @@ class DatetimeCast extends BaseCast
         }
 
         if (is_numeric($value)) {
-            return Time::createFromTimestamp((int) $value);
+            return Time::createFromTimestamp((int) $value, date_default_timezone_get());
         }
 
         if (is_string($value)) {

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -39,6 +39,8 @@ use Stringable;
  * @property-read string $weekOfYear
  * @property-read string $year
  *
+ * @phpstan-consistent-constructor
+ *
  * @see \CodeIgniter\I18n\TimeTest
  */
 class Time extends DateTimeImmutable implements Stringable

--- a/system/I18n/TimeLegacy.php
+++ b/system/I18n/TimeLegacy.php
@@ -39,6 +39,8 @@ use DateTime;
  * @property string $weekOfYear  read-only
  * @property string $year        read-only
  *
+ * @phpstan-consistent-constructor
+ *
  * @deprecated Use Time instead.
  * @see \CodeIgniter\I18n\TimeLegacyTest
  */

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -261,11 +261,9 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
-     *
      * @throws Exception
      */
-    public static function createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null)
+    public static function createFromTimestamp(float|int $timestamp, $timezone = null, ?string $locale = null): static
     {
         $time = new self(gmdate('Y-m-d H:i:s', $timestamp), 'UTC', $locale);
 

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -265,7 +265,7 @@ trait TimeTrait
      */
     public static function createFromTimestamp(float|int $timestamp, $timezone = null, ?string $locale = null): static
     {
-        $time = new static('@' . $timestamp, 'UTC', $locale);
+        $time = new static(sprintf('@%.6f', $timestamp), 'UTC', $locale);
 
         $timezone ??= 'UTC';
 

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -269,7 +269,7 @@ trait TimeTrait
     {
         $time = new self(gmdate('Y-m-d H:i:s', $timestamp), 'UTC', $locale);
 
-        $timezone ??= date_default_timezone_get();
+        $timezone ??= 'UTC';
 
         return $time->setTimezone($timezone);
     }

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -265,7 +265,7 @@ trait TimeTrait
      */
     public static function createFromTimestamp(float|int $timestamp, $timezone = null, ?string $locale = null): static
     {
-        $time = new self(gmdate('Y-m-d H:i:s', $timestamp), 'UTC', $locale);
+        $time = new self('@' . $timestamp, 'UTC', $locale);
 
         $timezone ??= 'UTC';
 

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -78,7 +78,7 @@ trait TimeTrait
         $time ??= '';
 
         // If a test instance has been provided, use it instead.
-        if ($time === '' && static::$testNow instanceof self) {
+        if ($time === '' && static::$testNow instanceof static) {
             if ($timezone !== null) {
                 $testNow = static::$testNow->setTimezone($timezone);
                 $time    = $testNow->format('Y-m-d H:i:s.u');
@@ -108,13 +108,13 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
     public static function now($timezone = null, ?string $locale = null)
     {
-        return new self(null, $timezone, $locale);
+        return new static(null, $timezone, $locale);
     }
 
     /**
@@ -125,13 +125,13 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
     public static function parse(string $datetime, $timezone = null, ?string $locale = null)
     {
-        return new self($datetime, $timezone, $locale);
+        return new static($datetime, $timezone, $locale);
     }
 
     /**
@@ -139,13 +139,13 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
     public static function today($timezone = null, ?string $locale = null)
     {
-        return new self(date('Y-m-d 00:00:00'), $timezone, $locale);
+        return new static(date('Y-m-d 00:00:00'), $timezone, $locale);
     }
 
     /**
@@ -153,13 +153,13 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
     public static function yesterday($timezone = null, ?string $locale = null)
     {
-        return new self(date('Y-m-d 00:00:00', strtotime('-1 day')), $timezone, $locale);
+        return new static(date('Y-m-d 00:00:00', strtotime('-1 day')), $timezone, $locale);
     }
 
     /**
@@ -167,13 +167,13 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
     public static function tomorrow($timezone = null, ?string $locale = null)
     {
-        return new self(date('Y-m-d 00:00:00', strtotime('+1 day')), $timezone, $locale);
+        return new static(date('Y-m-d 00:00:00', strtotime('+1 day')), $timezone, $locale);
     }
 
     /**
@@ -182,7 +182,7 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -196,7 +196,7 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -210,7 +210,7 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -231,7 +231,7 @@ trait TimeTrait
         $minutes ??= 0;
         $seconds ??= 0;
 
-        return new self(date('Y-m-d H:i:s', strtotime("{$year}-{$month}-{$day} {$hour}:{$minutes}:{$seconds}")), $timezone, $locale);
+        return new static(date('Y-m-d H:i:s', strtotime("{$year}-{$month}-{$day} {$hour}:{$minutes}:{$seconds}")), $timezone, $locale);
     }
 
     /**
@@ -242,7 +242,7 @@ trait TimeTrait
      * @param string                   $datetime
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -253,7 +253,7 @@ trait TimeTrait
             throw I18nException::forInvalidFormat($format);
         }
 
-        return new self($date->format('Y-m-d H:i:s.u'), $timezone);
+        return new static($date->format('Y-m-d H:i:s.u'), $timezone);
     }
 
     /**
@@ -265,7 +265,7 @@ trait TimeTrait
      */
     public static function createFromTimestamp(float|int $timestamp, $timezone = null, ?string $locale = null): static
     {
-        $time = new self('@' . $timestamp, 'UTC', $locale);
+        $time = new static('@' . $timestamp, 'UTC', $locale);
 
         $timezone ??= 'UTC';
 
@@ -275,7 +275,7 @@ trait TimeTrait
     /**
      * Takes an instance of DateTimeInterface and returns an instance of Time with it's same values.
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -284,13 +284,13 @@ trait TimeTrait
         $date     = $dateTime->format('Y-m-d H:i:s.u');
         $timezone = $dateTime->getTimezone();
 
-        return new self($date, $timezone, $locale);
+        return new static($date, $timezone, $locale);
     }
 
     /**
      * Takes an instance of DateTime and returns an instance of Time with it's same values.
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      *
@@ -300,7 +300,7 @@ trait TimeTrait
      */
     public static function instance(DateTime $dateTime, ?string $locale = null)
     {
-        return self::createFromInstance($dateTime, $locale);
+        return static::createFromInstance($dateTime, $locale);
     }
 
     /**
@@ -345,9 +345,9 @@ trait TimeTrait
 
         // Convert to a Time instance
         if (is_string($datetime)) {
-            $datetime = new self($datetime, $timezone, $locale);
-        } elseif ($datetime instanceof DateTimeInterface && ! $datetime instanceof self) {
-            $datetime = new self($datetime->format('Y-m-d H:i:s.u'), $timezone);
+            $datetime = new static($datetime, $timezone, $locale);
+        } elseif ($datetime instanceof DateTimeInterface && ! $datetime instanceof static) {
+            $datetime = new static($datetime->format('Y-m-d H:i:s.u'), $timezone);
         }
 
         static::$testNow = $datetime;
@@ -475,7 +475,7 @@ trait TimeTrait
     public function getAge()
     {
         // future dates have no age
-        return max(0, $this->difference(self::now())->getYears());
+        return max(0, $this->difference(static::now())->getYears());
     }
 
     /**
@@ -532,7 +532,7 @@ trait TimeTrait
      *
      * @param int|string $value
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -546,7 +546,7 @@ trait TimeTrait
      *
      * @param int|string $value
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -568,7 +568,7 @@ trait TimeTrait
      *
      * @param int|string $value
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -592,7 +592,7 @@ trait TimeTrait
      *
      * @param int|string $value
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -610,7 +610,7 @@ trait TimeTrait
      *
      * @param int|string $value
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -628,7 +628,7 @@ trait TimeTrait
      *
      * @param int|string $value
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -646,7 +646,7 @@ trait TimeTrait
      *
      * @param int $value
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -656,7 +656,7 @@ trait TimeTrait
 
         ${$name} = $value;
 
-        return self::create(
+        return static::create(
             (int) $year,
             (int) $month,
             (int) $day,
@@ -673,7 +673,7 @@ trait TimeTrait
      *
      * @param DateTimeZone|string $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -682,7 +682,7 @@ trait TimeTrait
     {
         $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
 
-        return self::createFromInstance($this->toDateTime()->setTimezone($timezone), $this->locale);
+        return static::createFromInstance($this->toDateTime()->setTimezone($timezone), $this->locale);
     }
 
     /**
@@ -690,7 +690,7 @@ trait TimeTrait
      *
      * @param int $timestamp
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -699,7 +699,7 @@ trait TimeTrait
     {
         $time = date('Y-m-d H:i:s', $timestamp);
 
-        return self::parse($time, $this->timezone, $this->locale);
+        return static::parse($time, $this->timezone, $this->locale);
     }
 
     // --------------------------------------------------------------------
@@ -1085,7 +1085,7 @@ trait TimeTrait
         if (is_string($testTime)) {
             $timezone = ($timezone !== null) ? new DateTimeZone($timezone) : $this->timezone;
             $testTime = new DateTime($testTime, $timezone);
-        } elseif ($testTime instanceof self) {
+        } elseif ($testTime instanceof static) {
             $testTime = $testTime->toDateTime();
         }
 
@@ -1116,7 +1116,7 @@ trait TimeTrait
      */
     public function getUTCObject($time, ?string $timezone = null)
     {
-        if ($time instanceof self) {
+        if ($time instanceof static) {
             $time = $time->toDateTime();
         } elseif (is_string($time)) {
             $timezone = $timezone ?: $this->timezone;

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -398,6 +398,12 @@ final class DataConverterTest extends CIUnitTestCase
 
     public function testTimestampConvertDataFromDB(): void
     {
+        // Save the current timezone.
+        $tz = date_default_timezone_get();
+
+        // Change the timezone other than UTC.
+        date_default_timezone_set('Asia/Tokyo'); // +09:00
+
         $types = [
             'id'   => 'int',
             'date' => 'timestamp',
@@ -412,10 +418,20 @@ final class DataConverterTest extends CIUnitTestCase
 
         $this->assertInstanceOf(Time::class, $data['date']);
         $this->assertSame(1_700_285_831, $data['date']->getTimestamp());
+        $this->assertSame('Asia/Tokyo', $data['date']->getTimezoneName());
+
+        // Restore timezone.
+        date_default_timezone_set($tz);
     }
 
     public function testTimestampConvertDataToDB(): void
     {
+        // Save the current timezone.
+        $tz = date_default_timezone_get();
+
+        // Change the timezone other than UTC.
+        date_default_timezone_set('Asia/Tokyo'); // +09:00
+
         $types = [
             'id'   => 'int',
             'date' => 'timestamp',
@@ -429,6 +445,9 @@ final class DataConverterTest extends CIUnitTestCase
         $data = $converter->toDataSource($phpData);
 
         $this->assertSame(1_700_285_831, $data['date']);
+
+        // Restore timezone.
+        date_default_timezone_set($tz);
     }
 
     public function testURIConvertDataFromDB(): void

--- a/tests/system/Entity/EntityTest.php
+++ b/tests/system/Entity/EntityTest.php
@@ -460,6 +460,27 @@ final class EntityTest extends CIUnitTestCase
         $this->assertSame('2017-03-12', $entity->eighth->format('Y-m-d'));
     }
 
+    public function testCastDateTimeWithTimestampTimezone(): void
+    {
+        // Save the current timezone.
+        $tz = date_default_timezone_get();
+
+        // Change the timezone other than UTC.
+        date_default_timezone_set('Asia/Tokyo'); // +09:00
+
+        $entity = $this->getCastEntity();
+
+        $entity->eighth = 1722988800; // 2024-08-07 00:00:00 UTC
+
+        $this->assertInstanceOf(DateTimeInterface::class, $entity->eighth);
+        // The timezone is the default timezone, not UTC.
+        $this->assertSame('2024-08-07 09:00:00', $entity->eighth->format('Y-m-d H:i:s'));
+        $this->assertSame('Asia/Tokyo', $entity->eighth->getTimezoneName());
+
+        // Restore timezone.
+        date_default_timezone_set($tz);
+    }
+
     public function testCastTimestamp(): void
     {
         $entity = $this->getCastEntity();

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -287,15 +287,14 @@ final class TimeTest extends CIUnitTestCase
         date_default_timezone_set($tz);
     }
 
-    public function testCreateFromTimestampWithMicrotime(): void
+    public function testCreateFromTimestampWithMicroseconds(): void
     {
         $timestamp = 1489762800.654321;
 
         // The timezone will be UTC if you don't specify.
         $time = Time::createFromTimestamp($timestamp);
 
-        // float cannot handle the number precisely.
-        $this->assertSame('2017-03-17 15:00:00.654300', $time->format('Y-m-d H:i:s.u'));
+        $this->assertSame('2017-03-17 15:00:00.654321', $time->format('Y-m-d H:i:s.u'));
     }
 
     public function testCreateFromTimestampWithTimezone(): void

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -287,6 +287,17 @@ final class TimeTest extends CIUnitTestCase
         date_default_timezone_set($tz);
     }
 
+    public function testCreateFromTimestampWithMicrotime(): void
+    {
+        $timestamp = 1489762800.654321;
+
+        // The timezone will be UTC if you don't specify.
+        $time = Time::createFromTimestamp($timestamp);
+
+        // float cannot handle the number precisely.
+        $this->assertSame('2017-03-17 15:00:00.654300', $time->format('Y-m-d H:i:s.u'));
+    }
+
     public function testCreateFromTimestampWithTimezone(): void
     {
         // Set the timezone temporarily to UTC to make sure the test timestamp is correct

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -277,10 +277,11 @@ final class TimeTest extends CIUnitTestCase
 
         $timestamp = strtotime('2017-03-18 midnight');
 
+        // The timezone will be UTC if you don't specify.
         $time = Time::createFromTimestamp($timestamp);
 
-        $this->assertSame('Asia/Tokyo', $time->getTimezone()->getName());
-        $this->assertSame('2017-03-18 00:00:00', $time->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $time->getTimezone()->getName());
+        $this->assertSame('2017-03-17 15:00:00', $time->format('Y-m-d H:i:s'));
 
         // Restore timezone.
         date_default_timezone_set($tz);

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -57,13 +57,21 @@ Added check to prevent Auto-Discovery of Registrars from running twice. If it is
 executed twice, an exception will be thrown. See
 :ref:`upgrade-460-registrars-with-dirty-hack`.
 
-.. _v460-interface-changes:
+Time::createFromTimestamp()
+---------------------------
+
+``Time::createFromTimestamp()`` handles timezones differently. If ``$timezone``
+is not explicitly passed then the instance has timezone set to UTC unlike earlier
+where the currently set default timezone was used.
+See :ref:`Upgrading Guide <upgrade-460-time-create-from-timestamp>` for details.
 
 Time with Microseconds
 ----------------------
 
 Fixed bugs that some methods in ``Time`` to lose microseconds have been fixed.
 See :ref:`Upgrading Guide <upgrade-460-time-keeps-microseconds>` for details.
+
+.. _v460-interface-changes:
 
 Interface Changes
 =================

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -97,6 +97,9 @@ Method Signature Changes
   changed. The ``RouteCollection`` typehint has been changed to ``RouteCollectionInterface``.
 - **View:** The return type of the ``renderSection()`` method has been
   changed to ``string``, and now the method does not call ``echo``.
+- **Time:** The first parameter type of the ``createFromTimestamp()`` has been
+  changed from ``int`` to ``int|float``, and the return type ``static``` has been
+  added.
 
 Removed Type Definitions
 ------------------------

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -29,6 +29,26 @@ See :ref:`ChangeLog <v460-behavior-changes-exceptions>` for details.
 
 If you have code that catches these exceptions, change the exception classes.
 
+.. _upgrade-460-time-create-from-timestamp:
+
+Time::createFromTimestamp() Timezone Change
+===========================================
+
+When you do not explicitly pass a timezone, now
+:ref:`Time::createFromTimestamp() <time-createfromtimestamp>` returns a Time
+instance with **UTC**. In v4.4.6 to prior to v4.6.0, a Time instance with the
+currently set default timezone was returned.
+
+This behavior change normalizes behavior with changes in PHP 8.4 which adds a
+new ``DateTimeInterface::createFromTimestamp()`` method.
+
+If you want to keep the default timezone, you need to pass the timezone as the
+second parameter::
+
+    use CodeIgniter\I18n\Time;
+
+    $time = Time::createFromTimestamp(1501821586, date_default_timezone_get());
+
 .. _upgrade-460-time-keeps-microseconds:
 
 Time keeps Microseconds

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -126,8 +126,10 @@ This method takes a UNIX timestamp and, optionally, the timezone and locale, to 
 
 .. literalinclude:: time/012.php
 
-.. note:: Due to a bug, prior to v4.4.6, this method returned a Time instance
-    in timezone UTC when you do not specify a timezone.
+If you do not explicitly pass a timezone, it returns a Time instance with **UTC**.
+
+.. note:: In v4.4.6 to prior to v4.6.0, this method returned a Time instance
+    with the default timezone when you do not specify a timezone.
 
 createFromInstance()
 ====================

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -122,7 +122,8 @@ and returns a ``Time`` instance, instead of DateTimeImmutable:
 createFromTimestamp()
 =====================
 
-This method takes a UNIX timestamp and, optionally, the timezone and locale, to create a new Time instance:
+This method takes a UNIX timestamp and, optionally, the timezone and locale, to
+create a new Time instance:
 
 .. literalinclude:: time/012.php
 

--- a/user_guide_src/source/libraries/time.rst
+++ b/user_guide_src/source/libraries/time.rst
@@ -129,6 +129,9 @@ create a new Time instance:
 
 If you do not explicitly pass a timezone, it returns a Time instance with **UTC**.
 
+.. note:: We recommend to always call ``createFromTimestamp()`` with 2 parameters
+    (i.e. explicitly pass a timezone) unless using UTC as the default timezone.
+
 .. note:: In v4.4.6 to prior to v4.6.0, this method returned a Time instance
     with the default timezone when you do not specify a timezone.
 

--- a/user_guide_src/source/models/model.rst
+++ b/user_guide_src/source/models/model.rst
@@ -407,6 +407,12 @@ The datetime format is set in the ``dateFormat`` array of the
 .. note:: Prior to v4.6.0, you cannot use ``ms`` or ``us`` as a parameter.
     Because the second's fractional part of Time was lost due to bugs.
 
+timestamp
+---------
+
+The timezone of the ``Time`` instance created will be the default timezone
+(app's timezone), not UTC.
+
 Custom Casting
 ==============
 


### PR DESCRIPTION
~~Needs  #9107~~

**Description**
Follow-up #8544

- `Time::createFromTimestamp()` (without timezone specified) should return `Time` with the timezone UTC, because `DateTime(Immutable)::createFromTimestamp()` in PHP 8.4 returns an instance with the timezone `+00:00`.
- update the method signature for PHP 8.4.
- replace`self` with `static`.

PHP 8.4 introduces new `DateTime(Immutable)::createFromTimestamp()` method.
https://php.watch/versions/8.4/datetime-createFromTimestamp

```console
bash-3.2$ php -v
PHP 8.4.0-dev (cli) (built: Aug  5 2024 00:57:29) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.4.0-dev, Copyright (c) Zend Technologies
    with Zend OPcache v8.4.0-dev, Copyright (c), by Zend Technologies
```
```console
bash-3.2$ php -a
Interactive shell

php > $d = DateTimeImmutable::createFromTimeStamp(0);
php > var_dump($d);
object(DateTimeImmutable)#1 (3) {
  ["date"]=>
  string(26) "1970-01-01 00:00:00.000000"
  ["timezone_type"]=>
  int(1)
  ["timezone"]=>
  string(6) "+00:00"
}
```

Carbon and Chronos have changed the behaviors.

> createFromTimestamp UTC by default
Timezone for createFromTimestamp was previously date_default_timezone_get() in Carbon 2.
In Carbon 3, it's now "UTC" so to be consistent with DateTime behavior when doing new DateTime('@123').
https://carbon.nesbot.com/docs/#api-carbon-3

> Chronos::createFromTimestamp() handles timezones differently. If $timezone is not explicitly passed then the instance has timezone set to +00:00 unlike earlier where the currently set default timezone was used. This behavior change normalizes behavior with changes in PHP 8.4 which adds a new DateTimeInterface::createFromTimestamp() method.
https://github.com/cakephp/chronos/releases/tag/3.1.0

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
