### PR TITLE
feat: [Helpers] retrieve the query string in `current_url()`

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -76,7 +76,7 @@ if (! function_exists('current_url')) {
         /** @var CLIRequest|IncomingRequest $request */
         $uri = $request->getUri();
 
-        return $returnObject ? $uri : URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath());
+        return $returnObject ? $uri : URI::createURIString($uri->getScheme(), $uri->getAuthority(), $uri->getPath(), $uri->getQuery());
     }
 }
 

--- a/tests/system/Helpers/URLHelper/CurrentUrlTest.php
+++ b/tests/system/Helpers/URLHelper/CurrentUrlTest.php
@@ -74,6 +74,18 @@ final class CurrentUrlTest extends CIUnitTestCase
         $this->assertSame('http://example.com/public/index.php/', current_url());
     }
 
+    public function testCurrentURLReturnsBasicURLWithQuery(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/public/';
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php?foo=bar';
+
+        $this->config->baseURL = 'http://example.com/public/';
+
+        $this->createRequest($this->config);
+
+        $this->assertSame('http://example.com/public/index.php?foo=bar', current_url());
+    }
+
     public function testCurrentURLReturnsAllowedHostname(): void
     {
         $_SERVER['HTTP_HOST']   = 'www.example.jp';


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

I'm using **CodeIgniter Shield**. When accessing a link like` http://localhost:8080/product?page=4` while not logged in, that URL is recorded in the session called `beforeLoginUrl`, but the query parameter `page=4` is missing. 

After investigation, I found that Shield uses the `current_url()` helper. See https://github.com/codeigniter4/shield/blob/7a118f32243452a68b43aa8b910490345d8ac7a4/src/Filters/SessionAuth.php#L86-L91

To capture the complete link, I added `$this->getQuery()` to retrieve the query string.



**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
