### PR TITLE
fix: run `outputBufferingStart()` before `runRequiredBeforeFilters()`

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -330,9 +330,10 @@ class CodeIgniter
         }
 
         $this->pageCache->setTtl(0);
-        $this->bufferLevel = ob_get_level();
 
         $this->startBenchmark();
+
+        $this->outputBufferingStart();
 
         $this->getRequestObject();
         $this->getResponseObject();
@@ -828,8 +829,6 @@ class CodeIgniter
 
         // $uri is URL-encoded.
         $uri = $this->request->getPath();
-
-        $this->outputBufferingStart();
 
         $this->controller = $this->router->handle($uri);
         $this->method     = $this->router->methodName();


### PR DESCRIPTION
**Description**
The output buffering should be started as early as possible.

This is bad practice, but if a dev `echo` something in a required filter, the order seems weird.

Before:
`App\Filters\TestFilter::before App\Filters\TestFilter::after App\Controllers\Home::index `

After:
`App\Filters\TestFilter::before App\Controllers\Home::index App\Filters\TestFilter::after `

```php
<?php

namespace App\Filters;

use CodeIgniter\Filters\FilterInterface;
use CodeIgniter\HTTP\RequestInterface;
use CodeIgniter\HTTP\ResponseInterface;

class TestFilter implements FilterInterface
{
    public function before(RequestInterface $request, $arguments = null)
    {
        echo __METHOD__ . ' ';
    }

    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
    {
        echo __METHOD__ . ' ';
    }
}
```
```diff
diff --git a/app/Config/Filters.php b/app/Config/Filters.php
index eb46a1d7ce..531f668825 100644
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -2,6 +2,7 @@
 
 namespace Config;
 
+use App\Filters\TestFilter;
 use CodeIgniter\Config\Filters as BaseFilters;
 use CodeIgniter\Filters\Cors;
 use CodeIgniter\Filters\CSRF;
@@ -34,6 +35,7 @@ class Filters extends BaseFilters
         'forcehttps'    => ForceHTTPS::class,
         'pagecache'     => PageCache::class,
         'performance'   => PerformanceMetrics::class,
+        'test'          => TestFilter::class,
     ];
 
     /**
@@ -53,11 +55,13 @@ class Filters extends BaseFilters
         'before' => [
             'forcehttps', // Force Global Secure Requests
             'pagecache',  // Web Page Caching
+            'test',
         ],
         'after' => [
             'pagecache',   // Web Page Caching
             'performance', // Performance Metrics
             'toolbar',     // Debug Toolbar
+            'test',
         ],
     ];
 
diff --git a/app/Controllers/Home.php b/app/Controllers/Home.php
index 5934333309..09959a095e 100644
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -4,8 +4,8 @@ namespace App\Controllers;
 
 class Home extends BaseController
 {
-    public function index(): string
+    public function index()
     {
-        return view('welcome_message');
+        echo __METHOD__ . ' ';
     }
 }
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
