### PR TITLE
docs: replace deprecated failValidationError()

### DIFF
--- a/user_guide_src/source/changelogs/v4.1.2.rst
+++ b/user_guide_src/source/changelogs/v4.1.2.rst
@@ -59,7 +59,7 @@ Deprecations
 - Consolidated and deprecated ``ControllerResponse`` and ``FeatureResponse`` in favor of ``TestResponse``.
 - Deprecated ``Time::instance()``, use ``Time::createFromInstance()`` instead (now accepts ``DateTimeInterface``).
 - Deprecated ``IncomingRequest::removeRelativeDirectory()``, use ``URI::removeDotSegments()`` instead
-- Deprecated ``\API\ResponseTrait::failValidationError`` to use ``\API\ResponseTrait::failValidationErrors`` instead
+- Deprecated ``\API\ResponseTrait::failValidationError()`` to use ``\API\ResponseTrait::failValidationErrors()`` instead
 
 Bugs Fixed
 ----------

--- a/user_guide_src/source/outgoing/api_responses/002.php
+++ b/user_guide_src/source/outgoing/api_responses/002.php
@@ -24,8 +24,8 @@ $this->failForbidden($description);
 // Resource Not Found
 $this->failNotFound($description);
 
-// Data did not validate
-$this->failValidationError($description);
+// Data was not validated
+$this->failValidationErrors($errors);
 
 // Resource already exists
 $this->failResourceExists($description);


### PR DESCRIPTION
**Description**
- update sample code

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
