### PR TITLE
feat: add directives to `phpini:check` command

### DIFF
--- a/system/Commands/Utilities/PhpIniCheck.php
+++ b/system/Commands/Utilities/PhpIniCheck.php
@@ -41,7 +41,7 @@ final class PhpIniCheck extends BaseCommand
      *
      * @var string
      */
-    protected $description = 'Check your php.ini values.';
+    protected $description = 'Check your php.ini values in production environment.';
 
     /**
      * The Command's usage

--- a/system/Security/CheckPhpIni.php
+++ b/system/Security/CheckPhpIni.php
@@ -124,9 +124,11 @@ class CheckPhpIni
             'log_errors'              => [],
             'error_log'               => [],
             'default_charset'         => ['recommended' => 'UTF-8'],
+            'max_execution_time'      => ['remark' => 'The default is 30.'],
             'memory_limit'            => ['remark' => '> post_max_size'],
             'post_max_size'           => ['remark' => '> upload_max_filesize'],
             'upload_max_filesize'     => ['remark' => '< post_max_size'],
+            'max_input_vars'          => ['remark' => 'The default is 1000.'],
             'request_order'           => ['recommended' => 'GP'],
             'variables_order'         => ['recommended' => 'GPCS'],
             'date.timezone'           => ['recommended' => 'UTC'],
@@ -135,6 +137,7 @@ class CheckPhpIni
             'opcache.enable_cli'      => [],
             'opcache.jit'             => [],
             'opcache.jit_buffer_size' => [],
+            'zend.assertions'         => ['recommended' => '-1'],
         ];
 
         $output = [];


### PR DESCRIPTION
**Description**
- add directives to `phpini:check`
   - max_execution_time
   - max_input_vars
   - zend.assertions

```
+-------------------------+---------+---------+-------------+-----------------------+
| Directive               | Global  | Current | Recommended | Remark                |
+-------------------------+---------+---------+-------------+-----------------------+
| error_reporting         | 32767   | 32767   | 5111        |                       |
| display_errors          | 1       | 1       | 0           |                       |
| display_startup_errors  | 1       | 1       | 0           |                       |
| log_errors              | 1       | 1       |             |                       |
| error_log               |         |         |             |                       |
| default_charset         | UTF-8   | UTF-8   | UTF-8       |                       |
| max_execution_time      | 0       | 0       |             | The default is 30.    |
| memory_limit            | 1G      | 1G      |             | > post_max_size       |
| post_max_size           | 8M      | 8M      |             | > upload_max_filesize |
| upload_max_filesize     | 2M      | 2M      |             | < post_max_size       |
| max_input_vars          | 1000    | 1000    |             | The default is 1000.  |
| request_order           | GP      | GP      | GP          |                       |
| variables_order         | GPCS    | GPCS    | GPCS        |                       |
| date.timezone           | UTC     | UTC     | UTC         |                       |
| mbstring.language       | neutral | neutral | neutral     |                       |
| opcache.enable          | 1       | 1       | 1           |                       |
| opcache.enable_cli      | 0       | 0       |             |                       |
| opcache.jit             | tracing | tracing |             |                       |
| opcache.jit_buffer_size | 0       | 0       |             |                       |
| zend.assertions         | 1       | 1       | -1          |                       |
+-------------------------+---------+---------+-------------+-----------------------+
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
