### PR TITLE
feat: Add `isMethod` for consistent request method checking

### DIFF
--- a/system/HTTP/OutgoingRequest.php
+++ b/system/HTTP/OutgoingRequest.php
@@ -79,13 +79,12 @@ class OutgoingRequest extends Message implements OutgoingRequestInterface
 
     /**
      * Check if the request method is of specified type.
-     * 
+     *
      * @param string $method
-     * @return bool
      */
     public function isMethod($method): bool
     {
-        return $this->getMethod(true) === strtoupper($method);
+        return $this->getMethod() === strtoupper($method);
     }
 
     /**

--- a/system/HTTP/OutgoingRequest.php
+++ b/system/HTTP/OutgoingRequest.php
@@ -78,6 +78,17 @@ class OutgoingRequest extends Message implements OutgoingRequestInterface
     }
 
     /**
+     * Check if the request method is of specified type.
+     * 
+     * @param string $method
+     * @return bool
+     */
+    public function isMethod($method): bool
+    {
+        return $this->getMethod(true) === strtoupper($method);
+    }
+
+    /**
      * Sets the request method. Used when spoofing the request.
      *
      * @return $this

--- a/system/HTTP/OutgoingRequestInterface.php
+++ b/system/HTTP/OutgoingRequestInterface.php
@@ -30,6 +30,14 @@ interface OutgoingRequestInterface extends MessageInterface
     public function getMethod(): string;
 
     /**
+     * Check if the request method is of specified type.
+     * 
+     * @param string $method
+     * @return bool
+     */
+    public function isMethod($method): bool;
+
+    /**
      * Return an instance with the provided HTTP method.
      *
      * While HTTP method names are typically all uppercase characters, HTTP

--- a/system/HTTP/OutgoingRequestInterface.php
+++ b/system/HTTP/OutgoingRequestInterface.php
@@ -31,9 +31,8 @@ interface OutgoingRequestInterface extends MessageInterface
 
     /**
      * Check if the request method is of specified type.
-     * 
+     *
      * @param string $method
-     * @return bool
      */
     public function isMethod($method): bool;
 

--- a/tests/system/HTTP/OutgoingRequestTest.php
+++ b/tests/system/HTTP/OutgoingRequestTest.php
@@ -113,7 +113,7 @@ final class OutgoingRequestTest extends CIUnitTestCase
 
     public function testIsMethod(): void
     {
-        $uri = new URI('https://example.com/');
+        $uri     = new URI('https://example.com/');
         $request = new OutgoingRequest('POST', $uri);
 
         $this->assertTrue($request->isMethod('POST'));

--- a/tests/system/HTTP/OutgoingRequestTest.php
+++ b/tests/system/HTTP/OutgoingRequestTest.php
@@ -110,4 +110,14 @@ final class OutgoingRequestTest extends CIUnitTestCase
 
         $this->assertSame('example.com', $newRequest->header('Host')->getValue());
     }
+
+    public function testIsMethod(): void
+    {
+        $uri = new URI('https://example.com/');
+        $request = new OutgoingRequest('POST', $uri);
+
+        $this->assertTrue($request->isMethod('POST'));
+        $this->assertTrue($request->isMethod('post'));
+        $this->assertFalse($request->isMethod('GET'));
+    }
 }


### PR DESCRIPTION
**Description**
To check the request method, we currently use `$this->request->getMethod() === 'post'`. However, since `getMethod()` can return the method in both uppercase and lowercase, this can be confusing for users.

This pull request adds the `isMethod` function, which simplifies method checking by allowing you to use `$this->request->isMethod('POST')` or `$this->request->isMethod('post')`, both of which will work consistently.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
