### PR TITLE
fix: Tests that failing on Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,10 @@
         "phpstan:check": "vendor/bin/phpstan analyse --verbose --ansi",
         "sa": "@analyze",
         "style": "@cs-fix",
-        "test": "phpunit"
+        "test": [
+            "Composer\\Config::disableProcessTimeout",
+            "phpunit"
+        ]
     },
     "scripts-descriptions": {
         "analyze": "Run static analysis",

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -200,16 +200,19 @@ class Autoloader
 
                 if (is_array($namespacedPath)) {
                     foreach ($namespacedPath as $dir) {
-                        $this->prefixes[$prefix][] = rtrim($dir, '\\/') . DIRECTORY_SEPARATOR;
+                        $dir                       = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $dir);
+                        $this->prefixes[$prefix][] = rtrim($dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
                     }
 
                     continue;
                 }
 
-                $this->prefixes[$prefix][] = rtrim($namespacedPath, '\\/') . DIRECTORY_SEPARATOR;
+                $namespacedPath            = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $namespacedPath);
+                $this->prefixes[$prefix][] = rtrim($namespacedPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
             }
         } else {
-            $this->prefixes[trim($namespace, '\\')][] = rtrim($path, '\\/') . DIRECTORY_SEPARATOR;
+            $path                                     = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
+            $this->prefixes[trim($namespace, '\\')][] = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         }
 
         return $this;

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -61,7 +61,7 @@ class FileLocator implements FileLocatorInterface
 
         // Clears the folder name if it is at the beginning of the filename
         if ($folder !== null && str_starts_with($file, $folder)) {
-            $file = substr($file, strlen($folder . '/'));
+            $file = substr($file, strlen($folder . DIRECTORY_SEPARATOR));
         }
 
         // Is not namespaced? Try the application folder.
@@ -93,7 +93,10 @@ class FileLocator implements FileLocatorInterface
                 // There may be sub-namespaces of the same vendor,
                 // so overwrite them with namespaces found later.
                 $paths    = $namespaces[$namespace];
-                $filename = ltrim(str_replace('\\', '/', $fileWithoutNamespace), '/');
+                $filename = ltrim(
+                    str_replace('\\', DIRECTORY_SEPARATOR, $fileWithoutNamespace),
+                    DIRECTORY_SEPARATOR
+                );
             }
         }
 
@@ -104,14 +107,14 @@ class FileLocator implements FileLocatorInterface
 
         // Check each path in the namespace
         foreach ($paths as $path) {
-            // Ensure trailing slash
-            $path = rtrim($path, '/') . '/';
+            // Ensure trailing directory separator
+            $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
             // If we have a folder name, then the calling function
             // expects this file to be within that folder, like 'Views',
             // or 'libraries'.
-            if ($folder !== null && ! str_contains($path . $filename, '/' . $folder . '/')) {
-                $path .= trim($folder, '/') . '/';
+            if ($folder !== null && ! str_contains($path . $filename, DIRECTORY_SEPARATOR . $folder . DIRECTORY_SEPARATOR)) {
+                $path .= trim($folder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
             }
 
             $path .= $filename;

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -351,8 +351,12 @@ class UploadedFile extends File implements UploadedFileInterface
         $folderName = rtrim($folderName ?? date('Ymd'), '/') . '/';
         $fileName ??= $this->getRandomName();
 
+        if (! str_contains($folderName, 'vfs://')) {
+            $folderName = WRITEPATH . 'uploads/' . $folderName;
+        }
+
         // Move the uploaded file to a new location.
-        $this->move(WRITEPATH . 'uploads/' . $folderName, $fileName);
+        $this->move($folderName, $fileName);
 
         return $folderName . $this->name;
     }

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -101,13 +101,13 @@ final class AutoloaderTest extends CIUnitTestCase
 
         $ns = $loader->getNamespace();
         $this->assertCount(1, $ns['App']);
-        $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
+        $this->assertSame('ROOTPATH' . DIRECTORY_SEPARATOR . 'app', clean_path($ns['App'][0]));
 
         $loader->initialize(new Autoload(), new Modules());
 
         $ns = $loader->getNamespace();
         $this->assertCount(1, $ns['App']);
-        $this->assertSame('ROOTPATH/app', clean_path($ns['App'][0]));
+        $this->assertSame('ROOTPATH' . DIRECTORY_SEPARATOR . 'app', clean_path($ns['App'][0]));
     }
 
     public function testServiceAutoLoaderFromShareInstances(): void
@@ -288,7 +288,11 @@ final class AutoloaderTest extends CIUnitTestCase
     {
         $config       = new Autoload();
         $config->psr4 = [
-            'Psr\Log' => '/Config/Autoload/Psr/Log/',
+            'Psr\Log' => DIRECTORY_SEPARATOR . 'Config'
+                . DIRECTORY_SEPARATOR . 'Autoload'
+                . DIRECTORY_SEPARATOR . 'Psr'
+                . DIRECTORY_SEPARATOR . 'Log'
+                . DIRECTORY_SEPARATOR,
         ];
         $modules                     = new Modules();
         $modules->discoverInComposer = true;
@@ -297,7 +301,7 @@ final class AutoloaderTest extends CIUnitTestCase
         $loader->initialize($config, $modules);
 
         $namespaces = $loader->getNamespace();
-        $this->assertSame('/Config/Autoload/Psr/Log/', $namespaces['Psr\Log'][0]);
+        $this->assertSame($config->psr4['Psr\Log'], $namespaces['Psr\Log'][0]);
         $this->assertStringContainsString(VENDORPATH, $namespaces['Psr\Log'][1]);
     }
 

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -59,7 +59,7 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Controllers/Home'; // not namespaced
 
-        $expected = APPPATH . 'Controllers/Home.php';
+        $expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
 
         $this->assertSame($expected, $this->locator->locateFile($file));
     }
@@ -75,7 +75,7 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'welcome_message'; // not namespaced
 
-        $expected = APPPATH . 'Views/welcome_message.php';
+        $expected = APPPATH . 'Views' . DIRECTORY_SEPARATOR . 'welcome_message.php';
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
@@ -93,7 +93,7 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Controllers/Home'; // not namespaced
 
-        $expected = APPPATH . 'Controllers/Home.php';
+        $expected = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Home.php';
 
         // This works because $file contains `Controllers`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Controllers'));
@@ -103,7 +103,10 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\App\Views/errors/html/error_404.php';
 
-        $expected = APPPATH . 'Views/errors/html/error_404.php';
+        $expected = APPPATH . 'Views'
+            . DIRECTORY_SEPARATOR . 'errors'
+            . DIRECTORY_SEPARATOR . 'html'
+            . DIRECTORY_SEPARATOR . 'error_404.php';
 
         // This works because $file contains `Views`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
@@ -113,7 +116,7 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Views/welcome_message.php'; // not namespaced
 
-        $expected = APPPATH . 'Views/welcome_message.php';
+        $expected = APPPATH . 'Views' . DIRECTORY_SEPARATOR . 'welcome_message.php';
 
         // This works because $file contains `Views`.
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
@@ -123,7 +126,10 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\Errors\error_404';
 
-        $expected = APPPATH . 'Views/errors/html/error_404.php';
+        $expected = APPPATH . 'Views'
+            . DIRECTORY_SEPARATOR . 'errors'
+            . DIRECTORY_SEPARATOR . 'html'
+            . DIRECTORY_SEPARATOR . 'error_404.php';
 
         // The namespace `Errors` (APPPATH . 'Views/errors') + the folder (`html`) + `error_404`
         $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
@@ -133,7 +139,10 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\Errors\html/error_404';
 
-        $expected = APPPATH . 'Views/errors/html/error_404.php';
+        $expected = APPPATH . 'Views'
+            . DIRECTORY_SEPARATOR . 'errors'
+            . DIRECTORY_SEPARATOR . 'html'
+            . DIRECTORY_SEPARATOR . 'error_404.php';
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'html'));
     }
@@ -142,7 +151,11 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = '\CodeIgniter\Devkit\View\Views/simple';
 
-        $expected = ROOTPATH . 'tests/_support/View/Views/simple.php';
+        $expected = ROOTPATH . 'tests'
+            . DIRECTORY_SEPARATOR . '_support'
+            . DIRECTORY_SEPARATOR . 'View'
+            . DIRECTORY_SEPARATOR . 'Views'
+            . DIRECTORY_SEPARATOR . 'simple.php';
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
@@ -165,14 +178,18 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $file = 'Acme\SampleProject\View\Views\simple';
 
-        $expected = ROOTPATH . 'tests/_support/View/Views/simple.php';
+        $expected = ROOTPATH . 'tests'
+            . DIRECTORY_SEPARATOR . '_support'
+            . DIRECTORY_SEPARATOR . 'View'
+            . DIRECTORY_SEPARATOR . 'Views'
+            . DIRECTORY_SEPARATOR . 'simple.php';
 
         $this->assertSame($expected, $this->locator->locateFile($file, 'Views'));
     }
 
     public function testSearchSimple(): void
     {
-        $expected = APPPATH . 'Config/App.php';
+        $expected = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'App.php';
 
         $foundFiles = $this->locator->search('Config/App.php');
 
@@ -181,7 +198,7 @@ class FileLocatorTest extends CIUnitTestCase
 
     public function testSearchWithFileExtension(): void
     {
-        $expected = APPPATH . 'Config/App.php';
+        $expected = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'App.php';
 
         $foundFiles = $this->locator->search('Config/App', 'php');
 
@@ -212,8 +229,8 @@ class FileLocatorTest extends CIUnitTestCase
 
         $this->assertSame(
             [
-                SYSTEMPATH . 'Language/en/Validation.php',
-                APPPATH . 'Language/en/Validation.php',
+                SYSTEMPATH . 'Language' . DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR . 'Validation.php',
+                APPPATH . 'Language' . DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR . 'Validation.php',
             ],
             $foundFiles
         );
@@ -228,9 +245,8 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $files = $this->locator->listFiles('Config/');
 
-        $expectedWin = APPPATH . 'Config\App.php';
-        $expectedLin = APPPATH . 'Config/App.php';
-        $this->assertTrue(in_array($expectedWin, $files, true) || in_array($expectedLin, $files, true));
+        $expected = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'App.php';
+        $this->assertTrue(in_array($expected, $files, true));
     }
 
     public function testListFilesDoesNotContainDirectories(): void
@@ -256,13 +272,11 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $files = $this->locator->listFiles('Filters/');
 
-        $expectedWin = SYSTEMPATH . 'Filters\DebugToolbar.php';
-        $expectedLin = SYSTEMPATH . 'Filters/DebugToolbar.php';
-        $this->assertTrue(in_array($expectedWin, $files, true) || in_array($expectedLin, $files, true));
+        $expected = SYSTEMPATH . 'Filters' . DIRECTORY_SEPARATOR . 'DebugToolbar.php';
+        $this->assertTrue(in_array($expected, $files, true));
 
-        $expectedWin = SYSTEMPATH . 'Filters\Filters.php';
-        $expectedLin = SYSTEMPATH . 'Filters/Filters.php';
-        $this->assertTrue(in_array($expectedWin, $files, true) || in_array($expectedLin, $files, true));
+        $expected = SYSTEMPATH . 'Filters' . DIRECTORY_SEPARATOR . 'Filters.php';
+        $this->assertTrue(in_array($expected, $files, true));
     }
 
     public function testListFilesWithPathNotExist(): void

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -246,7 +246,7 @@ class FileLocatorTest extends CIUnitTestCase
         $files = $this->locator->listFiles('Config/');
 
         $expected = APPPATH . 'Config' . DIRECTORY_SEPARATOR . 'App.php';
-        $this->assertTrue(in_array($expected, $files, true));
+        $this->assertContains($expected, $files);
     }
 
     public function testListFilesDoesNotContainDirectories(): void
@@ -273,10 +273,10 @@ class FileLocatorTest extends CIUnitTestCase
         $files = $this->locator->listFiles('Filters/');
 
         $expected = SYSTEMPATH . 'Filters' . DIRECTORY_SEPARATOR . 'DebugToolbar.php';
-        $this->assertTrue(in_array($expected, $files, true));
+        $this->assertContains($expected, $files);
 
         $expected = SYSTEMPATH . 'Filters' . DIRECTORY_SEPARATOR . 'Filters.php';
-        $this->assertTrue(in_array($expected, $files, true));
+        $this->assertContains($expected, $files);
     }
 
     public function testListFilesWithPathNotExist(): void

--- a/tests/system/Commands/ConfigurableSortImportsTest.php
+++ b/tests/system/Commands/ConfigurableSortImportsTest.php
@@ -29,10 +29,13 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
     {
         command('publish:language');
 
-        $file = APPPATH . 'Language/en/Foobar.php';
+        $file = APPPATH . 'Language' . DIRECTORY_SEPARATOR . 'en' . DIRECTORY_SEPARATOR . 'Foobar.php';
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
-        $this->assertNotSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
+        $this->assertNotSame(
+            sha1_file(SUPPORTPATH . 'Commands' . DIRECTORY_SEPARATOR . 'Foobar.php'),
+            sha1_file($file)
+        );
         if (is_file($file)) {
             unlink($file);
         }
@@ -42,10 +45,13 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
     {
         command('publish:language --lang es');
 
-        $file = APPPATH . 'Language/es/Foobar.php';
+        $file = APPPATH . 'Language' . DIRECTORY_SEPARATOR . 'es' . DIRECTORY_SEPARATOR . 'Foobar.php';
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
-        $this->assertNotSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
+        $this->assertNotSame(
+            sha1_file(SUPPORTPATH . 'Commands' . DIRECTORY_SEPARATOR . 'Foobar.php'),
+            sha1_file($file)
+        );
         if (is_file($file)) {
             unlink($file);
         }
@@ -59,10 +65,10 @@ final class ConfigurableSortImportsTest extends CIUnitTestCase
     {
         command('publish:language --lang ar --sort off');
 
-        $file = APPPATH . 'Language/ar/Foobar.php';
+        $file = APPPATH . 'Language' . DIRECTORY_SEPARATOR . 'ar' . DIRECTORY_SEPARATOR . 'Foobar.php';
         $this->assertStringContainsString('File created: ', $this->getStreamFilterBuffer());
         $this->assertFileExists($file);
-        $this->assertSame(sha1_file(SUPPORTPATH . 'Commands/Foobar.php'), sha1_file($file));
+        $this->assertSame(sha1_file(SUPPORTPATH . 'Commands' . DIRECTORY_SEPARATOR . 'Foobar.php'), sha1_file($file));
         if (is_file($file)) {
             unlink($file);
         }

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -474,6 +474,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
         $this->assertSame('foo', $tables[1]);
 
         if (is_file($config['database'])) {
+            $database->close();
             unlink($config['database']);
         }
     }

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -26,12 +26,12 @@ final class FileCollectionTest extends CIUnitTestCase
     /**
      * A known, valid file
      */
-    private string $file = SUPPORTPATH . 'Files/baker/banana.php';
+    private string $file = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php';
 
     /**
      * A known, valid directory
      */
-    private string $directory = SUPPORTPATH . 'Files/able/';
+    private string $directory = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR;
 
     /**
      * Initialize the helper, since some
@@ -72,7 +72,12 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $this->assertSame($this->directory, $method($link));
 
-        unlink($link);
+        /** @see https://www.php.net/manual/en/function.unlink.php */
+        if (PHP_OS === 'WINNT') {
+            rmdir($link);
+        } else {
+            unlink($link);
+        }
     }
 
     public function testResolveFileFile(): void
@@ -114,7 +119,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $collection = new class ([$this->file]) extends FileCollection {
             protected $files = [
-                SUPPORTPATH . 'Files/able/apple.php',
+                SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php',
             ];
         };
 
@@ -126,7 +131,9 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection = new class () extends FileCollection {
             protected function define(): void
             {
-                $this->add(SUPPORTPATH . 'Files/baker/banana.php');
+                $this->add(
+                    SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php'
+                );
             }
         };
 
@@ -137,7 +144,7 @@ final class FileCollectionTest extends CIUnitTestCase
     {
         $files = new FileCollection();
 
-        $files->add(SUPPORTPATH . 'Files/baker/banana.php');
+        $files->add(SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php');
 
         $this->assertSame([$this->file], $files->get());
     }
@@ -146,7 +153,9 @@ final class FileCollectionTest extends CIUnitTestCase
     {
         $files = new FileCollection();
 
-        $files->add(SUPPORTPATH . 'Files/baker/banana.php', true);
+        $files->add(
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php'
+        );
 
         $this->assertSame([$this->file], $files->get());
     }
@@ -161,7 +170,7 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'prune_ripe.php',
         ];
 
-        $files->add(SUPPORTPATH . 'Files/able');
+        $files->add(SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'able');
 
         $this->assertSame($expected, $files->get());
     }
@@ -174,8 +183,8 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $files->add(SUPPORTPATH . 'Files');
@@ -189,7 +198,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $expected = [
             $this->directory . 'apple.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
         ];
 
         $files->add([
@@ -208,12 +217,12 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
         ];
 
         $files->add([
-            SUPPORTPATH . 'Files/able', // directory
-            SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'able', // directory
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
         ]);
 
         $this->assertSame($expected, $files->get());
@@ -227,9 +236,9 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
-            SUPPORTPATH . 'Log/Handlers/TestHandler.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
+            SUPPORTPATH . 'Log' . DIRECTORY_SEPARATOR . 'Handlers' . DIRECTORY_SEPARATOR . 'TestHandler.php',
         ];
 
         $files->add([
@@ -393,8 +402,8 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $collection->addDirectory(SUPPORTPATH . 'Files', true);
@@ -409,8 +418,8 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $collection->addDirectories([
@@ -428,9 +437,9 @@ final class FileCollectionTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
-            SUPPORTPATH . 'Log/Handlers/TestHandler.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
+            SUPPORTPATH . 'Log' . DIRECTORY_SEPARATOR . 'Handlers' . DIRECTORY_SEPARATOR . 'TestHandler.php',
         ];
 
         $collection->addDirectories([
@@ -460,7 +469,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $expected = [
             $this->directory . 'apple.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
         ];
 
         $collection->removePattern('#[a-z]+_.*#');
@@ -475,8 +484,8 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $expected = [
             $this->directory . 'apple.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $collection->removePattern('*_*.php');
@@ -490,8 +499,8 @@ final class FileCollectionTest extends CIUnitTestCase
         $collection->addDirectory(SUPPORTPATH . 'Files', true);
 
         $expected = [
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $collection->removePattern('*.php', $this->directory);
@@ -519,7 +528,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $expected = [
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $collection->retainPattern('#[a-z]+_.*#');
@@ -548,8 +557,8 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $expected = [
             $this->directory . 'fig_3.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $collection->retainPattern('*_?.php', $this->directory);

--- a/tests/system/Helpers/FilesystemHelperTest.php
+++ b/tests/system/Helpers/FilesystemHelperTest.php
@@ -321,11 +321,11 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $filenames = get_filenames($vfs->url(), true, false, false);
 
         $expected = [
-            'vfs://root/boo/far',
-            'vfs://root/boo/faz',
-            'vfs://root/foo/bar',
-            'vfs://root/foo/baz',
-            'vfs://root/simpleFile',
+            'vfs://root' . DIRECTORY_SEPARATOR . 'boo' . DIRECTORY_SEPARATOR . 'far',
+            'vfs://root' . DIRECTORY_SEPARATOR . 'boo' . DIRECTORY_SEPARATOR . 'faz',
+            'vfs://root' . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR . 'bar',
+            'vfs://root' . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR . 'baz',
+            'vfs://root' . DIRECTORY_SEPARATOR . 'simpleFile',
         ];
         $this->assertSame($expected, $filenames);
     }
@@ -360,11 +360,11 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $expected = [
             'AnEmptyFolder',
             'boo',
-            'boo/far',
-            'boo/faz',
+            'boo' . DIRECTORY_SEPARATOR . 'far',
+            'boo' . DIRECTORY_SEPARATOR . 'faz',
             'foo',
-            'foo/bar',
-            'foo/baz',
+            'foo' . DIRECTORY_SEPARATOR . 'bar',
+            'foo' . DIRECTORY_SEPARATOR . 'baz',
             'simpleFile',
         ];
 
@@ -382,11 +382,11 @@ final class FilesystemHelperTest extends CIUnitTestCase
         $expected = [
             $vfs->url() . DIRECTORY_SEPARATOR . 'AnEmptyFolder',
             $vfs->url() . DIRECTORY_SEPARATOR . 'boo',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'boo/far',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'boo/faz',
+            $vfs->url() . DIRECTORY_SEPARATOR . 'boo' . DIRECTORY_SEPARATOR . 'far',
+            $vfs->url() . DIRECTORY_SEPARATOR . 'boo' . DIRECTORY_SEPARATOR . 'faz',
             $vfs->url() . DIRECTORY_SEPARATOR . 'foo',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'foo/bar',
-            $vfs->url() . DIRECTORY_SEPARATOR . 'foo/baz',
+            $vfs->url() . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR . 'bar',
+            $vfs->url() . DIRECTORY_SEPARATOR . 'foo' . DIRECTORY_SEPARATOR . 'baz',
             $vfs->url() . DIRECTORY_SEPARATOR . 'simpleFile',
         ];
 
@@ -401,14 +401,18 @@ final class FilesystemHelperTest extends CIUnitTestCase
     public function testGetFilenamesWithSymlinks(): void
     {
         $targetDir = APPPATH . 'Language';
-        $linkDir   = APPPATH . 'Controllers/Language';
+        $linkDir   = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Language';
         if (file_exists($linkDir)) {
-            unlink($linkDir);
+            if (PHP_OS !== 'WINNT') {
+                unlink($linkDir);
+            } else {
+                rmdir($linkDir);
+            }
         }
         symlink($targetDir, $linkDir);
 
         $targetFile = APPPATH . 'Common.php';
-        $linkFile   = APPPATH . 'Controllers/Common.php';
+        $linkFile   = APPPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Common.php';
         if (file_exists($linkFile)) {
             unlink($linkFile);
         }
@@ -423,15 +427,21 @@ final class FilesystemHelperTest extends CIUnitTestCase
             5 => 'en',
         ], get_filenames(APPPATH . 'Controllers'));
 
-        unlink($linkDir);
+        if (file_exists($linkDir)) {
+            if (PHP_OS !== 'WINNT') {
+                unlink($linkDir);
+            } else {
+                rmdir($linkDir);
+            }
+        }
         unlink($linkFile);
     }
 
     public function testGetDirFileInfo(): void
     {
-        $file1 = SUPPORTPATH . 'Files/baker/banana.php';
+        $file1 = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php';
         $info1 = get_file_info($file1);
-        $file2 = SUPPORTPATH . 'Files/baker/fig_3.php.txt';
+        $file2 = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt';
         $info2 = get_file_info($file2);
 
         $expected = [
@@ -451,7 +461,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
             ],
         ];
 
-        $result = get_dir_file_info(SUPPORTPATH . 'Files/baker');
+        $result = get_dir_file_info(SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker');
         ksort($result);
 
         $this->assertSame($expected, $result);
@@ -505,7 +515,7 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
     public function testGetFileInfoPerms(): void
     {
-        $file     = SUPPORTPATH . 'Files/baker/banana.php';
+        $file     = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php';
         $expected = 0664;
         chmod($file, $expected);
 
@@ -602,6 +612,6 @@ final class FilesystemHelperTest extends CIUnitTestCase
 
     public function testRealPathResolved(): void
     {
-        $this->assertSame(SUPPORTPATH . 'Models/', set_realpath(SUPPORTPATH . 'Files/../Models', true));
+        $this->assertSame(SUPPORTPATH . 'Models' . DIRECTORY_SEPARATOR, set_realpath(SUPPORTPATH . 'Files/../Models', true));
     }
 }

--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -25,12 +25,12 @@ final class PublisherInputTest extends CIUnitTestCase
     /**
      * A known, valid file
      */
-    private string $file = SUPPORTPATH . 'Files/baker/banana.php';
+    private string $file = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php';
 
     /**
      * A known, valid directory
      */
-    private string $directory = SUPPORTPATH . 'Files/able/';
+    private string $directory = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR;
 
     /**
      * Initialize the helper, since some
@@ -48,7 +48,7 @@ final class PublisherInputTest extends CIUnitTestCase
     {
         $publisher = new Publisher(SUPPORTPATH . 'Files');
 
-        $publisher->addPath('baker/banana.php');
+        $publisher->addPath('baker' . DIRECTORY_SEPARATOR . 'banana.php');
 
         $this->assertSame([$this->file], $publisher->get());
     }
@@ -57,7 +57,7 @@ final class PublisherInputTest extends CIUnitTestCase
     {
         $publisher = new Publisher(SUPPORTPATH . 'Files');
 
-        $publisher->addPath('baker/banana.php', true);
+        $publisher->addPath('baker' . DIRECTORY_SEPARATOR . 'banana.php', true);
 
         $this->assertSame([$this->file], $publisher->get());
     }
@@ -85,8 +85,8 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $publisher->addPath('Files');
@@ -102,7 +102,7 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
         ];
 
         $publisher->addPaths([
@@ -121,9 +121,9 @@ final class PublisherInputTest extends CIUnitTestCase
             $this->directory . 'apple.php',
             $this->directory . 'fig_3.php',
             $this->directory . 'prune_ripe.php',
-            SUPPORTPATH . 'Files/baker/banana.php',
-            SUPPORTPATH . 'Files/baker/fig_3.php.txt',
-            SUPPORTPATH . 'Log/Handlers/TestHandler.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
+            SUPPORTPATH . 'Log' . DIRECTORY_SEPARATOR . 'Handlers' . DIRECTORY_SEPARATOR . 'TestHandler.php',
         ];
 
         $publisher->addPaths([

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -37,12 +37,12 @@ final class PublisherOutputTest extends CIUnitTestCase
     /**
      * A known, valid file
      */
-    private string $file = SUPPORTPATH . 'Files/baker/banana.php';
+    private string $file = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php';
 
     /**
      * A known, valid directory
      */
-    private string $directory = SUPPORTPATH . 'Files/able/';
+    private string $directory = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR;
 
     /**
      * Initialize the helper, since some
@@ -85,27 +85,27 @@ final class PublisherOutputTest extends CIUnitTestCase
         $publisher = new Publisher($this->directory, $this->root->url());
         $publisher->addFile($this->file);
 
-        $this->assertFileDoesNotExist($this->root->url() . '/banana.php');
+        $this->assertFileDoesNotExist($this->root->url() . DIRECTORY_SEPARATOR . 'banana.php');
 
         $result = $publisher->copy(false);
 
         $this->assertTrue($result);
-        $this->assertFileExists($this->root->url() . '/banana.php');
+        $this->assertFileExists($this->root->url() . DIRECTORY_SEPARATOR . 'banana.php');
     }
 
     public function testCopyReplace(): void
     {
         $file      = $this->directory . 'apple.php';
-        $publisher = new Publisher($this->directory, $this->root->url() . '/able');
+        $publisher = new Publisher($this->directory, $this->root->url() . DIRECTORY_SEPARATOR . 'able');
         $publisher->addFile($file);
 
-        $this->assertFileExists($this->root->url() . '/able/apple.php');
-        $this->assertFalse(same_file($file, $this->root->url() . '/able/apple.php'));
+        $this->assertFileExists($this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php');
+        $this->assertFalse(same_file($file, $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php'));
 
         $result = $publisher->copy(true);
 
         $this->assertTrue($result);
-        $this->assertTrue(same_file($file, $this->root->url() . '/able/apple.php'));
+        $this->assertTrue(same_file($file, $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php'));
     }
 
     public function testCopyIgnoresSame(): void
@@ -113,35 +113,35 @@ final class PublisherOutputTest extends CIUnitTestCase
         $publisher = new Publisher($this->directory, $this->root->url());
         $publisher->addFile($this->file);
 
-        copy($this->file, $this->root->url() . '/banana.php');
+        copy($this->file, $this->root->url() . DIRECTORY_SEPARATOR . 'banana.php');
 
         $result = $publisher->copy(false);
         $this->assertTrue($result);
 
         $result = $publisher->copy(true);
         $this->assertTrue($result);
-        $this->assertSame([$this->root->url() . '/banana.php'], $publisher->getPublished());
+        $this->assertSame([$this->root->url() . DIRECTORY_SEPARATOR . 'banana.php'], $publisher->getPublished());
     }
 
     public function testCopyIgnoresCollision(): void
     {
         $publisher = new Publisher($this->directory, $this->root->url());
 
-        mkdir($this->root->url() . '/banana.php');
+        mkdir($this->root->url() . DIRECTORY_SEPARATOR . 'banana.php');
 
         $result = $publisher->addFile($this->file)->copy(false);
 
         $this->assertTrue($result);
         $this->assertSame([], $publisher->getErrors());
-        $this->assertSame([$this->root->url() . '/banana.php'], $publisher->getPublished());
+        $this->assertSame([$this->root->url() . DIRECTORY_SEPARATOR . 'banana.php'], $publisher->getPublished());
     }
 
     public function testCopyCollides(): void
     {
         $publisher = new Publisher($this->directory, $this->root->url());
-        $expected  = lang('Publisher.collision', ['dir', $this->file, $this->root->url() . '/banana.php']);
+        $expected  = lang('Publisher.collision', ['dir', $this->file, $this->root->url() . DIRECTORY_SEPARATOR . 'banana.php']);
 
-        mkdir($this->root->url() . '/banana.php');
+        mkdir($this->root->url() . DIRECTORY_SEPARATOR . 'banana.php');
 
         $result = $publisher->addFile($this->file)->copy(true);
         $errors = $publisher->getErrors();
@@ -157,55 +157,55 @@ final class PublisherOutputTest extends CIUnitTestCase
     {
         $publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
         $expected  = [
-            $this->root->url() . '/able/apple.php',
-            $this->root->url() . '/able/fig_3.php',
-            $this->root->url() . '/able/prune_ripe.php',
-            $this->root->url() . '/baker/banana.php',
-            $this->root->url() . '/baker/fig_3.php.txt',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'fig_3.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'prune_ripe.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
-        $this->assertFileDoesNotExist($this->root->url() . '/able/fig_3.php');
-        $this->assertDirectoryDoesNotExist($this->root->url() . '/baker');
+        $this->assertFileDoesNotExist($this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'fig_3.php');
+        $this->assertDirectoryDoesNotExist($this->root->url() . DIRECTORY_SEPARATOR . 'baker');
 
         $result = $publisher->addPath('/')->merge(false);
 
         $this->assertTrue($result);
-        $this->assertFileExists($this->root->url() . '/able/fig_3.php');
-        $this->assertDirectoryExists($this->root->url() . '/baker');
+        $this->assertFileExists($this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'fig_3.php');
+        $this->assertDirectoryExists($this->root->url() . DIRECTORY_SEPARATOR . 'baker');
         $this->assertSame($expected, $publisher->getPublished());
     }
 
     public function testMergeReplace(): void
     {
-        $this->assertFalse(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
+        $this->assertFalse(same_file($this->directory . 'apple.php', $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php'));
         $publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
         $expected  = [
-            $this->root->url() . '/able/apple.php',
-            $this->root->url() . '/able/fig_3.php',
-            $this->root->url() . '/able/prune_ripe.php',
-            $this->root->url() . '/baker/banana.php',
-            $this->root->url() . '/baker/fig_3.php.txt',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'fig_3.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'prune_ripe.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
         $result = $publisher->addPath('/')->merge(true);
 
         $this->assertTrue($result);
-        $this->assertTrue(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
+        $this->assertTrue(same_file($this->directory . 'apple.php', $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php'));
         $this->assertSame($expected, $publisher->getPublished());
     }
 
     public function testMergeCollides(): void
     {
         $publisher = new Publisher(SUPPORTPATH . 'Files', $this->root->url());
-        $expected  = lang('Publisher.collision', ['dir', $this->directory . 'fig_3.php', $this->root->url() . '/able/fig_3.php']);
+        $expected  = lang('Publisher.collision', ['dir', $this->directory . 'fig_3.php', $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'fig_3.php']);
         $published = [
-            $this->root->url() . '/able/apple.php',
-            $this->root->url() . '/able/prune_ripe.php',
-            $this->root->url() . '/baker/banana.php',
-            $this->root->url() . '/baker/fig_3.php.txt',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'prune_ripe.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php',
+            $this->root->url() . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'fig_3.php.txt',
         ];
 
-        mkdir($this->root->url() . '/able/fig_3.php');
+        mkdir($this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'fig_3.php');
 
         $result = $publisher->addPath('/')->merge(true);
         $errors = $publisher->getErrors();
@@ -224,8 +224,8 @@ final class PublisherOutputTest extends CIUnitTestCase
         $result = $publisher->publish();
 
         $this->assertTrue($result);
-        $this->assertFileExists($this->root->url() . '/able/fig_3.php');
-        $this->assertDirectoryExists($this->root->url() . '/baker');
-        $this->assertTrue(same_file($this->directory . 'apple.php', $this->root->url() . '/able/apple.php'));
+        $this->assertFileExists($this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'fig_3.php');
+        $this->assertDirectoryExists($this->root->url() . DIRECTORY_SEPARATOR . 'baker');
+        $this->assertTrue(same_file($this->directory . 'apple.php', $this->root->url() . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR . 'apple.php'));
     }
 }

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -27,12 +27,12 @@ final class PublisherSupportTest extends CIUnitTestCase
     /**
      * A known, valid file
      */
-    private string $file = SUPPORTPATH . 'Files/baker/banana.php';
+    private string $file = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'baker' . DIRECTORY_SEPARATOR . 'banana.php';
 
     /**
      * A known, valid directory
      */
-    private string $directory = SUPPORTPATH . 'Files/able/';
+    private string $directory = SUPPORTPATH . 'Files' . DIRECTORY_SEPARATOR . 'able' . DIRECTORY_SEPARATOR;
 
     /**
      * Initialize the helper, since some


### PR DESCRIPTION
**Description**
See #7474

A lots of directory separator mismatch in path fixed.

CodeIgniter\Database\Migrations\MigrationRunnerTest::testMigrationUsesSameConnectionAsMigrationRunner
ErrorException: unlink(\writable\runner.sqlite): Resource temporarily unavailable
\tests\system\Database\Migrations\MigrationRunnerTest.php:477
Propably related to: https://bugs.php.net/bug.php?id=78930

CodeIgniter\HTTP\Files\FileMovingTest::testStore
ErrorException: mkdir(): No such file or directory

\system\HTTP\Files\UploadedFile.php:181
\system\HTTP\Files\UploadedFile.php:135
\system\HTTP\Files\UploadedFile.php:355
\tests\system\HTTP\Files\FileMovingTest.php:215

On Windows path was: WRITEPATH . 'uploads/vfs://path/to/file' 

In addition change composer test command to work on slower computers.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
