### PR TITLE
docs: add Getting Routing Information

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -151,6 +151,18 @@ a simple view:
 
 .. literalinclude:: routing/020.php
 
+Retrieving the Controller and Method Names
+------------------------------------------
+
+In some cases, you might need to determine which controller and method have been triggered by the current HTTP request.
+This can be useful for logging, debugging, or conditional logic based on the active controller method.
+
+CodeIgniter 4 provides a simple way to access the current route's controller and method names using the ``Services::router()`` class. Here is an example:
+
+.. literalinclude:: routing/071.php
+
+This functionality is particularly useful when you need to dynamically interact with your controller or log which method is handling a particular request.
+
 Specifying Route Paths
 ======================
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -151,18 +151,6 @@ a simple view:
 
 .. literalinclude:: routing/020.php
 
-Retrieving the Controller and Method Names
-------------------------------------------
-
-In some cases, you might need to determine which controller and method have been triggered by the current HTTP request.
-This can be useful for logging, debugging, or conditional logic based on the active controller method.
-
-CodeIgniter 4 provides a simple way to access the current route's controller and method names using the ``Router`` class. Here is an example:
-
-.. literalinclude:: routing/071.php
-
-This functionality is particularly useful when you need to dynamically interact with your controller or log which method is handling a particular request.
-
 Specifying Route Paths
 ======================
 
@@ -1139,3 +1127,36 @@ You can specify the host in the request URL with the ``--host`` option:
 .. code-block:: console
 
     php spark routes --host accounts.example.com
+
+Getting Routing Information
+***************************
+
+In CodeIgniter 4, understanding and managing routing information is crucial for handling HTTP requests effectively.
+This involves retrieving details about the active controller and method, as well as the filters applied to a specific route.
+Below, we explore how to access this routing information to assist in tasks such as logging, debugging, or implementing conditional logic.
+
+Retrieving the Controller and Method Names
+==========================================
+
+In some cases, you might need to determine which controller and method have been triggered by the current HTTP request.
+This can be useful for logging, debugging, or conditional logic based on the active controller method.
+
+CodeIgniter 4 provides a simple way to access the current route's controller and method names using the ``Router`` class. Here is an example:
+
+.. literalinclude:: routing/071.php
+
+This functionality is particularly useful when you need to dynamically interact with your controller or log which method is handling a particular request.
+
+Accessing Active Filters for a Route
+====================================
+
+:doc:`Filters <filters>` are a powerful feature that enables you to perform operations such as authentication, logging, and security checks before or after processing HTTP requests.
+To access the active filters for a specific route, you can use the :php:meth:`CodeIgniter\\Router\\Router::getFilters()` method from the ``Router`` class.
+
+This method returns a list of filters that are currently active for the route being processed:
+
+.. literalinclude:: routing/072.php
+
+.. note:: The ``getFilters()`` method returns only the filters defined for the specific route.
+     It does not include global filters or those specified in configuration files.
+

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -1136,7 +1136,7 @@ This involves retrieving details about the active controller and method, as well
 Below, we explore how to access this routing information to assist in tasks such as logging, debugging, or implementing conditional logic.
 
 Retrieving the Current Controller/Method Names
-==========================================
+==============================================
 
 In some cases, you might need to determine which controller and method have been triggered by the current HTTP request.
 This can be useful for logging, debugging, or conditional logic based on the active controller method.
@@ -1148,7 +1148,7 @@ CodeIgniter 4 provides a simple way to access the current route's controller and
 This functionality is particularly useful when you need to dynamically interact with your controller or log which method is handling a particular request.
 
 Getting Active Filters for the Current Route
-====================================
+============================================
 
 :doc:`Filters <filters>` are a powerful feature that enables you to perform operations such as authentication, logging, and security checks before or after processing HTTP requests.
 To access the active filters for a specific route, you can use the :php:meth:`CodeIgniter\\Router\\Router::getFilters()` method from the ``Router`` class.

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -1135,7 +1135,7 @@ In CodeIgniter 4, understanding and managing routing information is crucial for 
 This involves retrieving details about the active controller and method, as well as the filters applied to a specific route.
 Below, we explore how to access this routing information to assist in tasks such as logging, debugging, or implementing conditional logic.
 
-Retrieving the Controller and Method Names
+Retrieving the Current Controller/Method Names
 ==========================================
 
 In some cases, you might need to determine which controller and method have been triggered by the current HTTP request.
@@ -1147,7 +1147,7 @@ CodeIgniter 4 provides a simple way to access the current route's controller and
 
 This functionality is particularly useful when you need to dynamically interact with your controller or log which method is handling a particular request.
 
-Accessing Active Filters for a Route
+Getting Active Filters for the Current Route
 ====================================
 
 :doc:`Filters <filters>` are a powerful feature that enables you to perform operations such as authentication, logging, and security checks before or after processing HTTP requests.
@@ -1158,5 +1158,5 @@ This method returns a list of filters that are currently active for the route be
 .. literalinclude:: routing/072.php
 
 .. note:: The ``getFilters()`` method returns only the filters defined for the specific route.
-     It does not include global filters or those specified in configuration files.
+     It does not include global filters or those specified in the **app/Config/Filters.php** file.
 

--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -157,7 +157,7 @@ Retrieving the Controller and Method Names
 In some cases, you might need to determine which controller and method have been triggered by the current HTTP request.
 This can be useful for logging, debugging, or conditional logic based on the active controller method.
 
-CodeIgniter 4 provides a simple way to access the current route's controller and method names using the ``Services::router()`` class. Here is an example:
+CodeIgniter 4 provides a simple way to access the current route's controller and method names using the ``Router`` class. Here is an example:
 
 .. literalinclude:: routing/071.php
 

--- a/user_guide_src/source/incoming/routing/071.php
+++ b/user_guide_src/source/incoming/routing/071.php
@@ -1,9 +1,10 @@
 <?php
-
-use Config\Services;
-
-// Get the router instance
-$router = Services::router();
+/**
+ * Get the router instance
+ *
+ * @var \CodeIgniter\Router\Router $router
+ */
+$router = service('router');
 
 // Retrieve the fully qualified class name of the controller handling the current request.
 $controller = $router->controllerName();

--- a/user_guide_src/source/incoming/routing/071.php
+++ b/user_guide_src/source/incoming/routing/071.php
@@ -1,4 +1,5 @@
 <?php
+
 // Get the router instance.
 /** @var \CodeIgniter\Router\Router $router */
 $router = service('router');

--- a/user_guide_src/source/incoming/routing/071.php
+++ b/user_guide_src/source/incoming/routing/071.php
@@ -11,5 +11,5 @@ $controller = $router->controllerName();
 // Retrieve the method name being executed in the controller for the current request.
 $method = $router->methodName();
 
-echo "Current Controller: " . $controller . "<br>";
-echo "Current Method: " . $method;
+echo 'Current Controller: ' . $controller . '<br>';
+echo 'Current Method: ' . $method;

--- a/user_guide_src/source/incoming/routing/071.php
+++ b/user_guide_src/source/incoming/routing/071.php
@@ -1,0 +1,15 @@
+<?php
+
+use Config\Services;
+
+// Get the router instance
+$router = Services::router();
+
+// Retrieve the fully qualified class name of the controller handling the current request.
+$controller = $router->controllerName();
+
+// Retrieve the method name being executed in the controller for the current request.
+$method = $router->methodName();
+
+echo "Current Controller: " . $controller . "<br>";
+echo "Current Method: " . $method;

--- a/user_guide_src/source/incoming/routing/071.php
+++ b/user_guide_src/source/incoming/routing/071.php
@@ -1,9 +1,6 @@
 <?php
-/**
- * Get the router instance
- *
- * @var \CodeIgniter\Router\Router $router
- */
+// Get the router instance.
+/** @var \CodeIgniter\Router\Router $router */
 $router = service('router');
 
 // Retrieve the fully qualified class name of the controller handling the current request.

--- a/user_guide_src/source/incoming/routing/072.php
+++ b/user_guide_src/source/incoming/routing/072.php
@@ -2,7 +2,7 @@
 
 // Get the router instance.
 /** @var \CodeIgniter\Router\Router $router */
-$router = service('router');
+$router  = service('router');
 $filters = $router->getFilters();
 
 echo 'Active Filters for the Route: ' . implode(', ', $filters);

--- a/user_guide_src/source/incoming/routing/072.php
+++ b/user_guide_src/source/incoming/routing/072.php
@@ -1,0 +1,8 @@
+<?php
+
+// Get the router instance.
+/** @var \CodeIgniter\Router\Router $router */
+$router = service('router');
+$filters = $router->getFilters();
+
+echo 'Active Filters for the Route: ' . implode(', ', $filters);


### PR DESCRIPTION
**Description**
I was unable to find clear documentation on how to retrieve the controller and method names for the current route in CodeIgniter 4. After searching through the user guide without success, I had to read the source code to figure out the correct approach. While I'm not entirely sure if this has been documented elsewhere, I believe this addition will be helpful for developers who need to dynamically interact with the controller or method handling the current request.

- Retrieving the Controller and Method Names
- Accessing Active Filters in Router

![Screenshot 2024-08-19 180907](https://github.com/user-attachments/assets/693687d7-4cb8-48bb-a3f8-431eda6a60d5)
![Screenshot 2024-08-19 181039](https://github.com/user-attachments/assets/ca3fc5eb-3952-4084-a99c-bb27314bb60a)


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
