### PR TITLE
fix: TimeTrait::createFromTimestamp() method signature for PHP 8.4

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -7556,12 +7556,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/I18n/Time.php',
 ];
 $ignoreErrors[] = [
-	// identifier: method.childReturnType
-	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\Time\\) of method CodeIgniter\\\\I18n\\\\Time\\:\\:setTimezone\\(\\) should be covariant with return type \\(static\\(DateTimeImmutable\\)\\) of method DateTimeImmutable\\:\\:setTimezone\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/I18n/Time.php',
-];
-$ignoreErrors[] = [
 	// identifier: ternary.shortNotAllowed
 	'message' => '#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#',
 	'count' => 4,
@@ -7576,12 +7570,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: method.childReturnType
 	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\TimeLegacy\\) of method CodeIgniter\\\\I18n\\\\TimeLegacy\\:\\:setTimestamp\\(\\) should be covariant with return type \\(static\\(DateTime\\)\\) of method DateTime\\:\\:setTimestamp\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.childReturnType
-	'message' => '#^Return type \\(CodeIgniter\\\\I18n\\\\TimeLegacy\\) of method CodeIgniter\\\\I18n\\\\TimeLegacy\\:\\:setTimezone\\(\\) should be covariant with return type \\(static\\(DateTime\\)\\) of method DateTime\\:\\:setTimezone\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/system/I18n/TimeLegacy.php',
 ];

--- a/system/I18n/Time.php
+++ b/system/I18n/Time.php
@@ -39,6 +39,8 @@ use Stringable;
  * @property-read string $weekOfYear
  * @property-read string $year
  *
+ * @phpstan-consistent-constructor
+ *
  * @see \CodeIgniter\I18n\TimeTest
  */
 class Time extends DateTimeImmutable implements Stringable

--- a/system/I18n/TimeLegacy.php
+++ b/system/I18n/TimeLegacy.php
@@ -39,6 +39,8 @@ use DateTime;
  * @property string $weekOfYear  read-only
  * @property string $year        read-only
  *
+ * @phpstan-consistent-constructor
+ *
  * @deprecated Use Time instead.
  * @see \CodeIgniter\I18n\TimeLegacyTest
  */

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -275,7 +275,7 @@ trait TimeTrait
     /**
      * Takes an instance of DateTimeInterface and returns an instance of Time with it's same values.
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -284,7 +284,7 @@ trait TimeTrait
         $date     = $dateTime->format('Y-m-d H:i:s');
         $timezone = $dateTime->getTimezone();
 
-        return new self($date, $timezone, $locale);
+        return new static($date, $timezone, $locale);
     }
 
     /**
@@ -672,7 +672,7 @@ trait TimeTrait
      *
      * @param DateTimeZone|string $timezone
      *
-     * @return self
+     * @return static
      *
      * @throws Exception
      */
@@ -681,7 +681,7 @@ trait TimeTrait
     {
         $timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
 
-        return self::createFromInstance($this->toDateTime()->setTimezone($timezone), $this->locale);
+        return static::createFromInstance($this->toDateTime()->setTimezone($timezone), $this->locale);
     }
 
     /**

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -261,13 +261,11 @@ trait TimeTrait
      *
      * @param DateTimeZone|string|null $timezone
      *
-     * @return self
-     *
      * @throws Exception
      */
-    public static function createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null)
+    public static function createFromTimestamp(float|int $timestamp, $timezone = null, ?string $locale = null): static
     {
-        $time = new self(gmdate('Y-m-d H:i:s', $timestamp), 'UTC', $locale);
+        $time = new static(gmdate('Y-m-d H:i:s', $timestamp), 'UTC', $locale);
 
         $timezone ??= date_default_timezone_get();
 

--- a/user_guide_src/source/changelogs/v4.5.5.rst
+++ b/user_guide_src/source/changelogs/v4.5.5.rst
@@ -14,6 +14,18 @@ Release Date: Unreleased
 BREAKING
 ********
 
+.. _v455-method-signature-changes:
+
+Method Signature Changes
+========================
+
+- **Time:** For PHP 8.4 compatibility only, the first parameter type of the
+  ``createFromTimestamp()`` method has been changed from ``int`` to ``int|float``,
+  and the return type ``static`` has been added. But **note that the**
+  ``createFromTimestamp()`` **method still cannot handle a float value, and the
+  behavior is not yet changed**. That is, the behavior is not the exactly same as
+  PHP 8.4's ``DateTimeImmutable::createFromTimestamp()`` method.
+
 ***************
 Message Changes
 ***************

--- a/user_guide_src/source/installation/upgrade_455.rst
+++ b/user_guide_src/source/installation/upgrade_455.rst
@@ -20,6 +20,13 @@ Mandatory File Changes
 Breaking Changes
 ****************
 
+Method Signature Changes
+========================
+
+Some method signature changes have been made. Classes that extend them should
+update their APIs to reflect the changes. See :ref:`ChangeLog <v455-method-signature-changes>`
+for details.
+
 *********************
 Breaking Enhancements
 *********************


### PR DESCRIPTION
**Description**
See #9116
Related  #9105

> PHP Fatal error:  Declaration of CodeIgniter\I18n\TimeTrait::createFromTimestamp(int $timestamp, $timezone = null, ?string $locale = null) must be compatible with DateTimeImmutable::createFromTimestamp(int|float $timestamp): static in /home/runner/work/CodeIgniter4/CodeIgniter4/system/I18n/TimeTrait.php on line 268
https://github.com/codeigniter4/CodeIgniter4/actions/runs/10481860628/job/29032020981?pr=9133

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
