### PR TITLE
docs: fix typo in changelog v4.6.0

### DIFF
--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -104,7 +104,7 @@ Method Signature Changes
 - **View:** The return type of the ``renderSection()`` method has been
   changed to ``string``, and now the method does not call ``echo``.
 - **Time:** The first parameter type of the ``createFromTimestamp()`` has been
-  changed from ``int`` to ``int|float``, and the return type ``static``` has been
+  changed from ``int`` to ``int|float``, and the return type ``static`` has been
   added.
 
 Removed Type Definitions


### PR DESCRIPTION
**Description**
- fix typo

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
