### PR TITLE
[4.6] chore: add PHP 8.4 to test-phpunit.yml

### DIFF
--- a/.github/workflows/reusable-phpunit-test.yml
+++ b/.github/workflows/reusable-phpunit-test.yml
@@ -203,6 +203,7 @@ jobs:
           DB: ${{ inputs.db-platform }}
           TACHYCARDIA_MONITOR_GA: ${{ inputs.enable-profiling && 'enabled' || '' }}
           TERM: xterm-256color
+        continue-on-error: ${{ inputs.php-version == '8.4' }}
 
       - name: Upload coverage results as artifact
         if: ${{ inputs.enable-artifact-upload }}

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -59,8 +59,9 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         include:
-          - php-version: '8.3'
+          - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
@@ -88,6 +89,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         db-platform:
           - MySQLi
           - OCI8
@@ -100,7 +102,7 @@ jobs:
           - php-version: '8.1'
             db-platform: MySQLi
             mysql-version: '5.7'
-          - php-version: '8.3'
+          - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
@@ -129,8 +131,9 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         include:
-          - php-version: '8.3'
+          - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
@@ -157,8 +160,9 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         include:
-          - php-version: '8.3'
+          - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -62,7 +62,6 @@ jobs:
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
-            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -103,7 +102,6 @@ jobs:
             mysql-version: '5.7'
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
-            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -134,7 +132,6 @@ jobs:
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
-            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -163,7 +160,6 @@ jobs:
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
-            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -63,6 +63,7 @@ jobs:
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
+            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -104,6 +105,7 @@ jobs:
             mysql-version: '5.7'
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
+            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -135,6 +137,7 @@ jobs:
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
+            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:
@@ -164,6 +167,7 @@ jobs:
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
+            continue-on-error: true
 
     uses: ./.github/workflows/reusable-phpunit-test.yml # @TODO Extract to codeigniter4/.github repo
     with:

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -59,7 +59,6 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4'
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
@@ -90,7 +89,6 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4'
         db-platform:
           - MySQLi
           - OCI8
@@ -133,7 +131,6 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4'
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'
@@ -163,7 +160,6 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
-          - '8.4'
         include:
           - php-version: '8.4'
             composer-option: '--ignore-platform-req=php'

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
             "CodeIgniter\\ComposerScripts::postUpdate"
         ],
         "post-autoload-dump": [
-            "@composer update --working-dir=utils"
+            "@composer update --working-dir=utils --ignore-platform-req=php"
         ],
         "analyze": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
**Description**
Supersedes #9133
See #9116

- add PHP 8.4 to test-phpunit.yml
- add `--ignore-platform-req=php` temporarily to `@composer update --working-dir=utils`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
