### PR TITLE
[4.6] docs: add note about PHP versions supported by CI4 versions

### DIFF
--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -19,7 +19,7 @@ PHP and Required Extensions
 .. warning::
     - The end of life date for PHP 7.4 was November 28, 2022.
     - The end of life date for PHP 8.0 was November 26, 2023.
-    - If you are still using PHP 7.4 or 8.0, you should upgrade immediately.
+    - **If you are still using PHP 7.4 or 8.0, you should upgrade immediately.**
     - The end of life date for PHP 8.1 will be December 31, 2025.
 
 .. note::

--- a/user_guide_src/source/intro/requirements.rst
+++ b/user_guide_src/source/intro/requirements.rst
@@ -22,6 +22,13 @@ PHP and Required Extensions
     - If you are still using PHP 7.4 or 8.0, you should upgrade immediately.
     - The end of life date for PHP 8.1 will be December 31, 2025.
 
+.. note::
+    - PHP 8.4 requires CodeIgniter 4.6.0 or later.
+    - PHP 8.3 requires CodeIgniter 4.4.4 or later.
+    - PHP 8.2 requires CodeIgniter 4.2.11 or later.
+    - PHP 8.1 requires CodeIgniter 4.1.6 or later.
+    - **Note that we only maintain the latest version.**
+
 ***********************
 Optional PHP Extensions
 ***********************


### PR DESCRIPTION
**Description**
- add a note

![Screenshot 2024-08-22 9 00 14](https://github.com/user-attachments/assets/024669e5-9542-443e-a4f8-310d4ea0fe08)

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
