### PR TITLE
[4.6] feat: force PHP default 32 chars length at 4 bits to Session ID

### DIFF
--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -309,32 +309,25 @@ class FileHandler extends BaseHandler
 
     /**
      * Configure Session ID regular expression
+     *
+     * To make life easier, we force the PHP defaults. Because PHP9 forces them.
+     * See https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character
      */
     protected function configureSessionIDRegex()
     {
         $bitsPerCharacter = (int) ini_get('session.sid_bits_per_character');
-        $SIDLength        = (int) ini_get('session.sid_length');
+        $sidLength        = (int) ini_get('session.sid_length');
 
-        if (($bits = $SIDLength * $bitsPerCharacter) < 160) {
-            // Add as many more characters as necessary to reach at least 160 bits
-            $SIDLength += (int) ceil((160 % $bits) / $bitsPerCharacter);
-            ini_set('session.sid_length', (string) $SIDLength);
+        // We force the PHP defaults.
+        if (PHP_VERSION_ID < 90000) {
+            if ($bitsPerCharacter !== 4) {
+                ini_set('session.sid_bits_per_character', '4');
+            }
+            if ($sidLength !== 32) {
+                ini_set('session.sid_length', '32');
+            }
         }
 
-        switch ($bitsPerCharacter) {
-            case 4:
-                $this->sessionIDRegex = '[0-9a-f]';
-                break;
-
-            case 5:
-                $this->sessionIDRegex = '[0-9a-v]';
-                break;
-
-            case 6:
-                $this->sessionIDRegex = '[0-9a-zA-Z,-]';
-                break;
-        }
-
-        $this->sessionIDRegex .= '{' . $SIDLength . '}';
+        $this->sessionIDRegex = '[0-9a-f]{32}';
     }
 }

--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -316,49 +316,25 @@ class Session implements SessionInterface
     /**
      * Configure session ID length
      *
-     * To make life easier, we used to force SHA-1 and 4 bits per
-     * character on everyone. And of course, someone was unhappy.
-     *
-     * Then PHP 7.1 broke backwards-compatibility because ext/session
-     * is such a mess that nobody wants to touch it with a pole stick,
-     * and the one guy who does, nobody has the energy to argue with.
-     *
-     * So we were forced to make changes, and OF COURSE something was
-     * going to break and now we have this pile of shit. -- Narf
+     * To make life easier, we force the PHP defaults. Because PHP9 forces them.
+     * See https://wiki.php.net/rfc/deprecations_php_8_4#sessionsid_length_and_sessionsid_bits_per_character
      */
     protected function configureSidLength()
     {
-        $bitsPerCharacter = (int) (ini_get('session.sid_bits_per_character') !== false
-            ? ini_get('session.sid_bits_per_character')
-            : 4);
+        $bitsPerCharacter = (int) ini_get('session.sid_bits_per_character');
+        $sidLength        = (int) ini_get('session.sid_length');
 
-        $sidLength = (int) (ini_get('session.sid_length') !== false
-            ? ini_get('session.sid_length')
-            : 40);
-
-        if (($sidLength * $bitsPerCharacter) < 160) {
-            $bits = ($sidLength * $bitsPerCharacter);
-            // Add as many more characters as necessary to reach at least 160 bits
-            $sidLength += (int) ceil((160 % $bits) / $bitsPerCharacter);
-            ini_set('session.sid_length', (string) $sidLength);
+        // We force the PHP defaults.
+        if (PHP_VERSION_ID < 90000) {
+            if ($bitsPerCharacter !== 4) {
+                ini_set('session.sid_bits_per_character', '4');
+            }
+            if ($sidLength !== 32) {
+                ini_set('session.sid_length', '32');
+            }
         }
 
-        // Yes, 4,5,6 are the only known possible values as of 2016-10-27
-        switch ($bitsPerCharacter) {
-            case 4:
-                $this->sidRegexp = '[0-9a-f]';
-                break;
-
-            case 5:
-                $this->sidRegexp = '[0-9a-v]';
-                break;
-
-            case 6:
-                $this->sidRegexp = '[0-9a-zA-Z,-]';
-                break;
-        }
-
-        $this->sidRegexp .= '{' . $sidLength . '}';
+        $this->sidRegexp = '[0-9a-f]{32}';
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -90,6 +90,13 @@ environment, this behavior has been fixed so that error details are displayed if
 With this fix, the error details are now displayed under the same conditions for
 both HTML requests and non-HTML requests.
 
+Session ID (SID)
+----------------
+
+Now ``Session`` library forces to use the PHP default 32 character SIDs, with 4
+bits of entropy per character.
+See :ref:`Upgrading Guide <upgrade-460-sid-change>` for details.
+
 .. _v460-interface-changes:
 
 Interface Changes

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -126,6 +126,27 @@ The following is an example of code that will no longer work:
 
 .. literalinclude:: upgrade_460/001.php
 
+.. _upgrade-460-sid-change:
+
+Session ID (SID) Change
+=======================
+
+Now :doc:`../libraries/sessions` forces to use the PHP default 32 character SIDs,
+with 4 bits of entropy per character. This change is to match the behavior of
+PHP 9.
+
+In other words, the following settings are always used:
+
+.. code-block:: ini
+
+    session.sid_bits_per_character = 4
+    session.sid_length = 32
+
+In previous versions, the PHP ini settings was respected. So this change may
+change your SID length.
+
+If you cannot accept this change, customize the Session library.
+
 Interface Changes
 =================
 


### PR DESCRIPTION
**Description**
Supersedes #9135
See #9116 and https://github.com/codeigniter4/CodeIgniter4/issues/9116#issuecomment-2300918329

These INI settings have been deprecated in PHP 8.4. 
This PR enforces the behavior in PHP 9.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
