### PR TITLE
[4.6] feat: workaround for implicit nullable deprecations in PHP 8.4

### DIFF
--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -262,12 +262,16 @@ class Exceptions
      *
      * "Implicitly marking parameter $xxx as nullable is deprecated,
      *  the explicit nullable type must be used instead"
+     *
+     * @TODO remove this before v4.6.0 release
      */
     private function isImplicitNullableDeprecationError(string $message, ?string $file = null, ?int $line = null): bool
     {
         if (
             PHP_VERSION_ID >= 80400
             && str_contains($message, 'the explicit nullable type must be used instead')
+            // Only Kint and Faker, which cause this error, are logged.
+            && (str_starts_with($message, 'Kint\\') || str_starts_with($message, 'Faker\\'))
         ) {
             log_message(
                 LogLevel::WARNING,


### PR DESCRIPTION
~~Needs  #9139~~

**Description**
See #9116

- add workaround for the error like the following.

> ErrorException: Kint\Parser\Parser::__construct(): Implicitly marking parameter $caller as nullable is deprecated, the explicit nullable type must be used instead

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
