### PR TITLE
[4.6] fix: inconsistency in detailed error reporting

### DIFF
--- a/system/Debug/ExceptionHandler.php
+++ b/system/Debug/ExceptionHandler.php
@@ -75,8 +75,10 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
                 );
             }
 
+            // Handles non-HTML requests.
             if (! str_contains($request->getHeaderLine('accept'), 'text/html')) {
-                $data = (ENVIRONMENT === 'development' || ENVIRONMENT === 'testing')
+                // If display_errors is enabled, shows the error details.
+                $data = $this->isDisplayErrorsEnabled()
                     ? $this->collectVars($exception, $statusCode)
                     : '';
 
@@ -135,6 +137,7 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
         $view = 'production.php';
 
         if ($this->isDisplayErrorsEnabled()) {
+            // If display_errors is enabled, shows the error details.
             $view = 'error_exception.php';
         }
 

--- a/system/Debug/ExceptionHandler.php
+++ b/system/Debug/ExceptionHandler.php
@@ -134,13 +134,7 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
         // Production environments should have a custom exception file.
         $view = 'production.php';
 
-        if (
-            in_array(
-                strtolower(ini_get('display_errors')),
-                ['1', 'true', 'on', 'yes'],
-                true
-            )
-        ) {
+        if ($this->isDisplayErrorsEnabled()) {
             $view = 'error_exception.php';
         }
 
@@ -157,5 +151,14 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
         }
 
         return $view;
+    }
+
+    private function isDisplayErrorsEnabled(): bool
+    {
+        return in_array(
+            strtolower(ini_get('display_errors')),
+            ['1', 'true', 'on', 'yes'],
+            true
+        );
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -77,6 +77,19 @@ Time::setTimestamp()
 ``Time::setTimestamp()`` behavior has been fixed.
 See :ref:`Upgrading Guide <upgrade-460-time-set-timestamp>` for details.
 
+Error Reporting to Non-HTML Requests
+------------------------------------
+
+In previous versions, when a request does not accept HTML, CodeIgniter showed
+error details only in the ``development`` and ``testing`` environments.
+
+But because it is not possible to display error details when using a custom
+environment, this behavior has been fixed so that error details are displayed if
+``display_errors`` in PHP ini setting is enabled.
+
+With this fix, the error details are now displayed under the same conditions for
+both HTML requests and non-HTML requests.
+
 .. _v460-interface-changes:
 
 Interface Changes

--- a/user_guide_src/source/general/errors.rst
+++ b/user_guide_src/source/general/errors.rst
@@ -57,8 +57,12 @@ Configuration
 Error Reporting
 ---------------
 
-By default, CodeIgniter will display a detailed error report with all errors in the ``development`` and ``testing`` environments, and will not
-display any errors in the ``production`` environment.
+When ``display_errors`` in PHP ini setting is enabled, CodeIgniter will display
+a detailed error report with all errors
+
+So by default, CodeIgniter will display a detailed error report in the ``development``
+and ``testing`` environments, and will not display any errors in the ``production``
+environment.
 
 .. image:: ../images/error.png
 
@@ -251,7 +255,7 @@ the **error_404.php** in the **app/Views/errors/cli** folder.
 If there is no view file corresponding to the HTTP status code, **production.php**
 or **error_exception.php** will be displayed.
 
-.. note:: If ``display_errors`` is on in the PHP INI configuration,
+.. note:: If ``display_errors`` is on in the PHP ini setting,
     **error_exception.php** is selected and a detailed error report is displayed.
 
 You should customize all of the error views in the **app/Views/errors/html** folder


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/9120#issuecomment-2295905729

- fix the condition to show error details for non-HTML requests

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
