### PR TITLE
feat: support CURL HTTP3

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -658,6 +658,12 @@ class CURLRequest extends OutgoingRequest
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
             } elseif ($version === '2.0') {
                 $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
+            } elseif ($version === '3.0') {
+                if (! defined('CURL_HTTP_VERSION_3')) {
+                    define('CURL_HTTP_VERSION_3', 30);
+                }
+
+                $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_3;
             }
         }
 

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1164,6 +1164,10 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
 
         $options = $this->request->curl_options;
 
+        if (! defined('CURL_HTTP_VERSION_3')) {
+            define('CURL_HTTP_VERSION_3', 30);
+        }
+
         $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
         $this->assertSame(CURL_HTTP_VERSION_3, $options[CURLOPT_HTTP_VERSION]);
     }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1156,6 +1156,18 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
         $this->assertSame(CURL_HTTP_VERSION_2_0, $options[CURLOPT_HTTP_VERSION]);
     }
 
+    public function testHTTPv3(): void
+    {
+        $this->request->request('POST', '/post', [
+            'version' => 3.0,
+        ]);
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_HTTP_VERSION, $options);
+        $this->assertSame(CURL_HTTP_VERSION_3, $options[CURLOPT_HTTP_VERSION]);
+    }
+
     public function testCookieOption(): void
     {
         $holder = SUPPORTPATH . 'HTTP/Files/CookiesHolder.txt';


### PR DESCRIPTION
**Description**
PHP 8.4 coming soon, see #9116

Reference:
- php/php-src#15350
- https://gist.github.com/bagder/a88d3bedc8ecb69d19aeb542fa538e9b
- https://php.watch/articles/php-curl-http3

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
