### PR TITLE
chore: update php-cs-fixer to ^3.63.2

### DIFF
--- a/utils/composer.json
+++ b/utils/composer.json
@@ -3,7 +3,7 @@
         "php": "^8.1",
         "codeigniter/coding-standard": "^1.7",
         "ergebnis/composer-normalize": "^2.28",
-        "friendsofphp/php-cs-fixer": "3.62.*",
+        "friendsofphp/php-cs-fixer": "^3.63.2",
         "nexusphp/cs-config": "^3.6",
         "phpmetrics/phpmetrics": "^2.8 || ^3.0rc6",
         "vimeo/psalm": "^5.0"


### PR DESCRIPTION
**Description**
Closes #9154
Follow-up #9152

```console
$ composer cs-fix
> Composer\Config::disableProcessTimeout
> utils/vendor/bin/php-cs-fixer fix --ansi --verbose --diff --config=.php-cs-fixer.user-guide.php
PHP CS Fixer 3.63.2 7th Gear by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.20
Running analysis on 4 cores with 10 files per process.
Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!
Loaded config CodeIgniter4 Coding Standards from ".php-cs-fixer.user-guide.php".
Using cache file "build/.php-cs-fixer.user-guide.cache".
 1593/1593 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Fixed 0 of 1593 files in 2.020 seconds, 20.00 MB memory used
> utils/vendor/bin/php-cs-fixer fix --ansi --verbose --diff --config=.php-cs-fixer.no-header.php
PHP CS Fixer 3.63.2 7th Gear by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.20
Running analysis on 4 cores with 10 files per process.
Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!
Loaded config CodeIgniter4 Coding Standards from ".php-cs-fixer.no-header.php".
Using cache file "build/.php-cs-fixer.no-header.cache".
 62/62 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Fixed 0 of 62 files in 1.456 seconds, 16.00 MB memory used
> utils/vendor/bin/php-cs-fixer fix --ansi --verbose --diff --config=.php-cs-fixer.tests.php
PHP CS Fixer 3.63.2 7th Gear by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.20
Running analysis on 4 cores with 10 files per process.
Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!
Loaded config CodeIgniter4 Coding Standards from ".php-cs-fixer.tests.php".
Using cache file "build/.php-cs-fixer.tests.cache".
 485/485 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Fixed 0 of 485 files in 1.689 seconds, 18.00 MB memory used
> utils/vendor/bin/php-cs-fixer fix --ansi --verbose --diff
PHP CS Fixer 3.63.2 7th Gear by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.2.20
Running analysis on 4 cores with 10 files per process.
Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!
Loaded config CodeIgniter4 Coding Standards from "/Users/kenji/work/codeigniter/official/CodeIgniter4/.php-cs-fixer.dist.php".
Using cache file "build/.php-cs-fixer.cache".
 469/469 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Fixed 0 of 469 files in 1.594 seconds, 18.00 MB memory used
```

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
