### PR TITLE
refactor: improve error message for missing PHP DB extensions

### DIFF
--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -146,10 +146,15 @@ class Database
     /**
      * Check the PHP database extension is loaded.
      *
-     * @param string $driver DB driver
+     * @param string $driver DB driver or FQCN for custom driver
      */
     private function checkDbExtension(string $driver): bool
     {
+        if (str_contains($driver, '\\')) {
+            // Cannot check a fully qualified classname for a custom driver.
+            return true;
+        }
+
         $extensionMap = [
             // DBDriver => PHP extension
             'MySQLi'  => 'mysqli',

--- a/system/Database/Database.php
+++ b/system/Database/Database.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
+use CodeIgniter\Exceptions\ConfigException;
+use CodeIgniter\Exceptions\CriticalError;
 use InvalidArgumentException;
 
 /**
@@ -53,6 +55,8 @@ class Database
         if (empty($params['DBDriver'])) {
             throw new InvalidArgumentException('You have not selected a database type to connect to.');
         }
+
+        assert($this->checkDbExtension($params['DBDriver']));
 
         $this->connections[$alias] = $this->initDriver($params['DBDriver'], 'Connection', $params);
 
@@ -124,9 +128,9 @@ class Database
     /**
      * Creates a database object.
      *
-     * @param string       $driver   Driver name. FQCN can be used.
-     * @param string       $class    'Connection'|'Forge'|'Utils'
-     * @param array|object $argument The constructor parameter.
+     * @param string                    $driver   Driver name. FQCN can be used.
+     * @param string                    $class    'Connection'|'Forge'|'Utils'
+     * @param array|ConnectionInterface $argument The constructor parameter or DB connection
      *
      * @return BaseConnection|BaseUtils|Forge
      */
@@ -137,5 +141,39 @@ class Database
             : $driver . '\\' . $class;
 
         return new $classname($argument);
+    }
+
+    /**
+     * Check the PHP database extension is loaded.
+     *
+     * @param string $driver DB driver
+     */
+    private function checkDbExtension(string $driver): bool
+    {
+        $extensionMap = [
+            // DBDriver => PHP extension
+            'MySQLi'  => 'mysqli',
+            'SQLite3' => 'sqlite3',
+            'Postgre' => 'pgsql',
+            'SQLSRV'  => 'sqlsrv',
+            'OCI8'    => 'oci8',
+        ];
+
+        $extension = $extensionMap[$driver] ?? '';
+
+        if ($extension === '') {
+            $message = 'Invalid DBDriver name: "' . $driver . '"';
+
+            throw new ConfigException($message);
+        }
+
+        if (extension_loaded($extension)) {
+            return true;
+        }
+
+        $message = 'The required PHP extension "' . $extension . '" is not loaded.'
+            . ' Install and enable it to use "' . $driver . '" driver.';
+
+        throw new CriticalError($message);
     }
 }


### PR DESCRIPTION
**Description**
Supersedes #9051
See #9158

```console
$ php spark db:create report

CodeIgniter v4.5.4 Command Line Tool - Server Time: 2024-08-30 00:59:08 UTC+00:00

[CodeIgniter\Exceptions\CriticalError]
The required PHP extension "sqlsrv" is not loaded. Install and enable it to use "SQLSRV" driver.
at SYSTEMPATH/Database/Database.php:177

...
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
