### PR TITLE
fix: auto_link() include trailing slashes

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -351,7 +351,7 @@ if (! function_exists('auto_link')) {
     function auto_link(string $str, string $type = 'both', bool $popup = false): string
     {
         // Find and replace any URLs.
-        if ($type !== 'email' && preg_match_all('#(\w*://|www\.)[^\s()<>;]+\w#i', $str, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
+        if ($type !== 'email' && preg_match_all('#(\w*://|www\.)[^\s()<>;]+[\w\/]#i', $str, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
             // Set our target HTML if using popup links.
             $target = ($popup) ? ' target="_blank"' : '';
 


### PR DESCRIPTION
**Description**
Fixes: #9165
Adjusted regular expression to include trailing slash.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
