### PR TITLE
fix: auto_link() converts invalid strings like `://codeigniter.com`

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -351,7 +351,7 @@ if (! function_exists('auto_link')) {
     function auto_link(string $str, string $type = 'both', bool $popup = false): string
     {
         // Find and replace any URLs.
-        if ($type !== 'email' && preg_match_all('#(\w*://|www\.)[a-z0-9]+(-+[a-z0-9]+)*(\.[a-z0-9]+(-+[a-z0-9]+)*)+(/([^\s()<>;]+\w)?/?)?#i', $str, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
+        if ($type !== 'email' && preg_match_all('#([a-z][a-z0-9+\-.]*://|www\.)[a-z0-9]+(-+[a-z0-9]+)*(\.[a-z0-9]+(-+[a-z0-9]+)*)+(/([^\s()<>;]+\w)?/?)?#i', $str, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
             // Set our target HTML if using popup links.
             $target = ($popup) ? ' target="_blank"' : '';
 

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -351,7 +351,15 @@ if (! function_exists('auto_link')) {
     function auto_link(string $str, string $type = 'both', bool $popup = false): string
     {
         // Find and replace any URLs.
-        if ($type !== 'email' && preg_match_all('#([a-z][a-z0-9+\-.]*://|www\.)[a-z0-9]+(-+[a-z0-9]+)*(\.[a-z0-9]+(-+[a-z0-9]+)*)+(/([^\s()<>;]+\w)?/?)?#i', $str, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
+        if (
+            $type !== 'email'
+            && preg_match_all(
+                '#([a-z][a-z0-9+\-.]*://|www\.)[a-z0-9]+(-+[a-z0-9]+)*(\.[a-z0-9]+(-+[a-z0-9]+)*)+(/([^\s()<>;]+\w)?/?)?#i',
+                $str,
+                $matches,
+                PREG_OFFSET_CAPTURE | PREG_SET_ORDER
+            )
+        ) {
             // Set our target HTML if using popup links.
             $target = ($popup) ? ' target="_blank"' : '';
 
@@ -370,7 +378,15 @@ if (! function_exists('auto_link')) {
         }
 
         // Find and replace any emails.
-        if ($type !== 'url' && preg_match_all('#([\w\.\-\+]+@[a-z0-9\-]+\.[a-z0-9\-\.]+[^[:punct:]\s])#i', $str, $matches, PREG_OFFSET_CAPTURE)) {
+        if (
+            $type !== 'url'
+            && preg_match_all(
+                '#([\w\.\-\+]+@[a-z0-9\-]+\.[a-z0-9\-\.]+[^[:punct:]\s])#i',
+                $str,
+                $matches,
+                PREG_OFFSET_CAPTURE
+            )
+        ) {
             foreach (array_reverse($matches[0]) as $match) {
                 if (filter_var($match[0], FILTER_VALIDATE_EMAIL) !== false) {
                     $str = substr_replace($str, safe_mailto($match[0]), $match[1], strlen($match[0]));

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -523,7 +523,7 @@ final class MiscUrlTest extends CIUnitTestCase
             ],
             'test06' => [
                 'This one: ://codeigniter.com must not break this one: http://codeigniter.com',
-                'This one: <a href="://codeigniter.com">://codeigniter.com</a> must not break this one: <a href="http://codeigniter.com">http://codeigniter.com</a>',
+                'This one: ://codeigniter.com must not break this one: <a href="http://codeigniter.com">http://codeigniter.com</a>',
             ],
             'test07' => [
                 'Visit example.com or email foo@bar.com',
@@ -623,7 +623,7 @@ final class MiscUrlTest extends CIUnitTestCase
             ],
             'test06' => [
                 'This one: ://codeigniter.com must not break this one: http://codeigniter.com',
-                'This one: <a href="://codeigniter.com">://codeigniter.com</a> must not break this one: <a href="http://codeigniter.com">http://codeigniter.com</a>',
+                'This one: ://codeigniter.com must not break this one: <a href="http://codeigniter.com">http://codeigniter.com</a>',
             ],
             'test07' => [
                 'Visit example.com or email foo@bar.com',
@@ -675,7 +675,7 @@ final class MiscUrlTest extends CIUnitTestCase
             ],
             'test06' => [
                 'This one: ://codeigniter.com must not break this one: http://codeigniter.com',
-                'This one: <a href="://codeigniter.com" target="_blank">://codeigniter.com</a> must not break this one: <a href="http://codeigniter.com" target="_blank">http://codeigniter.com</a>',
+                'This one: ://codeigniter.com must not break this one: <a href="http://codeigniter.com" target="_blank">http://codeigniter.com</a>',
             ],
             'test07' => [
                 'Visit example.com or email foo@bar.com',


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/issues/9165#issuecomment-2333630422
- fix a bug that `auto_link()` converts invalid strings without a scheme like `://codeigniter.com`

> scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
https://datatracker.ietf.org/doc/html/rfc3986#section-3.1

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
