### PR TITLE
refactor: return type to closuer in FilterCheck

### DIFF
--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -167,7 +167,7 @@ class FilterCheck extends BaseCommand
      */
     private function colorItems(array $array): array
     {
-        return array_map(function ($item) {
+        return array_map(function ($item): array|string {
             if (is_array($item)) {
                 return $this->colorItems($item);
             }


### PR DESCRIPTION
**Description**
Fix return type
```console
> vendor/bin/rector process --dry-run
 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
1 file with changes
===================

1) system/Commands/Utilities/FilterCheck.php:166

    ---------- begin diff ----------
@@ @@
      */
     private function colorItems(array $array): array
     {
-        return array_map(function ($item) {
+        return array_map(function ($item): array|string {
             if (is_array($item)) {
                 return $this->colorItems($item);
             }
    ----------- end diff -----------

Applied rules:
 * ClosureReturnTypeRector

```