### PR TITLE
fix: Invalid XML response

### DIFF
--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -626,7 +626,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $request = $this->withBodyFormat('xml')->setRequestBody($request, $data);
 
         $expectedXml = '<?xml version="1.0"?>
-<response><true>1</true><false/><int>2</int><null/><float>1.23</float><string>foo</string></response>
+<response><true>1</true><false></false><int>2</int><null></null><float>1.23</float><string>foo</string></response>
 ';
 
         $this->assertSame($expectedXml, $request->getBody());


### PR DESCRIPTION
**Description**
I don't understand why this is not detected on github, but there is a bug in the local environment.
Perhaps the cache is interfering here
Replace to `<false></false>`:
 
```console
1) CodeIgniter\Test\FeatureTestTraitTest::testSetupRequestBodyWithXml
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '<?xml version="1.0"?>
-<response><true>1</true><false/><int>2</int><null/><float>1.23</float><string>foo</string></response>
+<response><true>1</true><false></false><int>2</int><null></null><float>1.23</float><string>foo</string></response>
 '
```