### PR TITLE
test: remove DB files after tests

### DIFF
--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -81,8 +81,11 @@ final class ForgeTest extends CIUnitTestCase
         $this->assertFalse($result);
 
         $db->close();
+
         if ($this->db->DBDriver !== 'SQLite3') {
             $this->forge->dropDatabase($dbName);
+        } elseif (is_file($db->database)) {
+            unlink($db->database);
         }
     }
 


### PR DESCRIPTION
**Description**
After all the tests, the database files remain. They should be deleted.
```console
$ tree -L 1  --dirsfirst
.
├── cache
├── debugbar
├── logs
├── session
├── uploads
├── database.db
├── index.html
└── test_com.sitedb.web

6 directories, 3 files
```

