### PR TITLE
fix: respect complex language strings when using validation

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -928,14 +928,15 @@ class Validation implements ValidationInterface
         // Check if custom message has been defined by user
         if (isset($this->customErrors[$field][$rule])) {
             return lang($this->customErrors[$field][$rule], $args);
-        } elseif (null !== $originalField && isset($this->customErrors[$originalField][$rule])) {
-            return lang($this->customErrors[$originalField][$rule], $args);
-        } else {
-            // Try to grab a localized version of the message...
-            // lang() will return the rule name back if not found,
-            // so there will always be a string being returned.
-            return lang('Validation.' . $rule, $args);
         }
+        if (null !== $originalField && isset($this->customErrors[$originalField][$rule])) {
+            return lang($this->customErrors[$originalField][$rule], $args);
+        }
+
+        // Try to grab a localized version of the message...
+        // lang() will return the rule name back if not found,
+        // so there will always be a string being returned.
+        return lang('Validation.' . $rule, $args);
     }
 
     /**

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -919,26 +919,23 @@ class Validation implements ValidationInterface
     ): string {
         $param ??= '';
 
+        $args = [
+            'field' => ($label === null || $label === '') ? $field : lang($label),
+            'param' => (! isset($this->rules[$param]['label'])) ? $param : lang($this->rules[$param]['label']),
+            'value' => $value ?? '',
+        ];
+
         // Check if custom message has been defined by user
         if (isset($this->customErrors[$field][$rule])) {
-            $message = lang($this->customErrors[$field][$rule]);
+            return lang($this->customErrors[$field][$rule], $args);
         } elseif (null !== $originalField && isset($this->customErrors[$originalField][$rule])) {
-            $message = lang($this->customErrors[$originalField][$rule]);
+            return lang($this->customErrors[$originalField][$rule], $args);
         } else {
             // Try to grab a localized version of the message...
             // lang() will return the rule name back if not found,
             // so there will always be a string being returned.
-            $message = lang('Validation.' . $rule);
+            return lang('Validation.' . $rule, $args);
         }
-
-        $message = str_replace('{field}', ($label === null || $label === '') ? $field : lang($label), $message);
-        $message = str_replace(
-            '{param}',
-            (! isset($this->rules[$param]['label'])) ? $param : lang($this->rules[$param]['label']),
-            $message
-        );
-
-        return str_replace('{value}', $value ?? '', $message);
     }
 
     /**

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1351,6 +1351,30 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame('The Foo Bar Translated field is very short.', $this->validation->getError('foo'));
     }
 
+    public function testTranslatedLabelWithCustomErrorMessageAndComplexLanguageString(): void
+    {
+        // Lithuanian language used as an example
+        $rules = [
+            'foo' => [
+                'label'  => 'Lauko pavadinimas',
+                'rules'  => 'min_length[5]',
+                'errors' => [
+                    'min_length' => '{param, plural,
+                        =0 {Lauke „{field}" negali būti mažiau nei nulis ženklų}
+                        =1 {Lauke „{field}" negali būti mažiau nei vienas ženklas}
+                        one {Lauke „{field}" negali būti mažiau nei # ženklas}
+                        few {Lauke „{field}" negali būti mažiau nei # ženklai}
+                        other {Lauke „{field}" negali būti mažiau nei # ženklų}
+                    }',
+                ],
+            ],
+        ];
+
+        $this->validation->setRules($rules, []);
+        $this->validation->run(['foo' => 'abc']);
+        $this->assertSame('Lauke „Lauko pavadinimas" negali būti mažiau nei 5 ženklų', $this->validation->getError('foo'));
+    }
+
     public function testTranslatedLabelTagReplacement(): void
     {
         $data = ['Username' => 'Pizza'];

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Validation:** Fixed a bug where complex language strings were not properly handled.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
This PR fixes a bug where complex language strings in the validation class are not handled properly.

The problem was that in the validation class, we were forming the final message using the `str_replace()` function, instead of using the built-in solutions that `MessageFormatter::formatMessage` gives us. 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide