### PR TITLE
fix: Allow lists on FeatureTestTrait#post $params

### DIFF
--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -290,7 +290,7 @@ trait RequestTrait
         }
 
         // Does the index contain array notation?
-        if (($count = preg_match_all('/(?:^[^\[]+)|\[[^]]*\]/', $index, $matches)) > 1) {
+        if (is_string($index) && ($count = preg_match_all('/(?:^[^\[]+)|\[[^]]*\]/', $index, $matches)) > 1) {
             $value = $this->globals[$name];
 
             for ($i = 0; $i < $count; $i++) {

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -557,7 +557,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertStringContainsString('[]', $response->getBody());
     }
 
-    public function testCallWithJsonRequest(): void
+    public function testCallWithAssociativeJsonRequest(): void
     {
         $this->withRoutes([
             [
@@ -573,6 +573,26 @@ final class FeatureTestTraitTest extends CIUnitTestCase
             'null'   => null,
             'float'  => 1.23,
             'string' => 'foo',
+        ];
+        $response = $this->withBodyFormat('json')
+            ->call(Method::POST, 'home', $data);
+
+        $response->assertOK();
+        $response->assertJSONExact($data);
+    }
+
+    public function testCallWithListJsonRequest(): void
+    {
+        $this->withRoutes([
+            [
+                'POST',
+                'home',
+                '\Tests\Support\Controllers\Popcorn::echoJson',
+            ],
+        ]);
+        $data = [
+            ['one' => 1, 'two' => 2],
+            ['one' => 2, 'two' => 2],
         ];
         $response = $this->withBodyFormat('json')
             ->call(Method::POST, 'home', $data);

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+**FeatureTestTrait:** Allows `#call` and `#post` to process JSON lists. It failed because `RequestTrait#fetchGlobal` expected the second parameter ($index) to be an associative array.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description****

Fixes a bug that doesn't allow to send lists in JSON format in `FeatureTestTrait#post` or `#call('POST',...`. This because it expected params to always be an associative array.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
