### PR TITLE
refactor: remove unnecessary `is_countable()` check in `getMethodParams()`

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1604,7 +1604,7 @@ class RouteCollection implements RouteCollectionInterface
     private function getMethodParams(string $from): string
     {
         preg_match_all('/\(.+?\)/', $from, $matches);
-        $count = is_countable($matches[0]) ? count($matches[0]) : 0;
+        $count = count($matches[0]);
 
         $params = '';
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
This PR optimizes the getMethodParams method by removing the unnecessary `is_countable()` check.

The `preg_match_all()` function guarantees that `$matches` will always be an array.
If no matches are found, `$matches[0]` will be an empty array, and the function will return 0.

See : https://github.com/codeigniter4/CodeIgniter4/actions/runs/11033764630/job/30645688529?pr=9202

```console
 ------ --------------------------------------------------------------------- 
  Line   system/Router/RouteCollection.php                                    
 ------ --------------------------------------------------------------------- 
  1614   Call to function is_countable() with array<int, string> will always  
         evaluate to true.                                                    
         🪪  function.alreadyNarrowedType      
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
