### PR TITLE
refactor: starter key handling in SodiumHandler

### DIFF
--- a/system/Encryption/Handlers/SodiumHandler.php
+++ b/system/Encryption/Handlers/SodiumHandler.php
@@ -26,7 +26,7 @@ class SodiumHandler extends BaseHandler
     /**
      * Starter key
      *
-     * @var string
+     * @var string|null Null is used for buffer cleanup.
      */
     protected $key = '';
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
While I recognize that this change might be seen as a BC, it appears that it will not significantly impact many users. The improved validation of the starter key in the SodiumHandler class primarily focuses on enhancing error handling and preventing potential issues related to an empty key, which should lead to a more robust encryption process.

See : https://github.com/codeigniter4/CodeIgniter4/actions/runs/11033764630/job/30645688529?pr=9202

```console
 ------ ----------------------------------------------------------------------- 
  Line   system/Encryption/Handlers/SodiumHandler.php                           
 ------ ----------------------------------------------------------------------- 
  66     Property CodeIgniter\Encryption\Handlers\SodiumHandler::$key (string)  
         does not accept null.                                                  
         🪪  assign.propertyType                                                
  108    Property CodeIgniter\Encryption\Handlers\SodiumHandler::$key (string)  
         does not accept null.                                                  
         🪪  assign.propertyType                                                
 ------ ----------------------------------------------------------------------- 
```


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
