### PR TITLE
fix: TypeError for routes when translateURIDashes is enabled

### DIFF
--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -247,7 +247,7 @@ class Router implements RouterInterface
      */
     public function controllerName()
     {
-        return $this->translateURIDashes
+        return $this->translateURIDashes && ! $this->controller instanceof Closure
             ? str_replace('-', '_', $this->controller)
             : $this->controller;
     }

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
+use Closure;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
@@ -69,6 +70,7 @@ final class RouterTest extends CIUnitTestCase
             'posts/(:num)/edit'                               => 'Blog::edit/$1',
             'books/(:num)/(:alpha)/(:num)'                    => 'Blog::show/$3/$1',
             'closure/(:num)/(:alpha)'                         => static fn ($num, $str) => $num . '-' . $str,
+            'closure-dash/(:num)/(:alpha)'                    => static fn ($num, $str) => $num . '-' . $str,
             '{locale}/pages'                                  => 'App\Pages::list_all',
             'test/(:any)/lang/{locale}'                       => 'App\Pages::list_all',
             'admin/admins'                                    => 'App\Admin\Admins::list_all',
@@ -209,6 +211,22 @@ final class RouterTest extends CIUnitTestCase
         $router->handle('closure/123/alpha');
 
         $closure = $router->controllerName();
+
+        $expects = $closure(...$router->params());
+
+        $this->assertIsCallable($router->controllerName());
+        $this->assertSame($expects, '123-alpha');
+    }
+
+    public function testClosuresWithTranslateURIDashes(): void
+    {
+        $router = new Router($this->collection, $this->request);
+        $router->setTranslateURIDashes(true);
+
+        $router->handle('closure-dash/123/alpha');
+        $closure = $router->controllerName();
+
+        $this->assertInstanceOf(Closure::class, $closure);
 
         $expects = $closure(...$router->params());
 

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Routing:** Fixed a TypeError in `str_replace()` when `Routing::$translateURIDashes` is set to `true` and a route is defined using a closure.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
This pull request addresses a `TypeError` that occurs in CodeIgniter 4 when the `translateURIDashes` property is set to `true` in the `Routes.php` configuration file and an `OPTIONS` route is defined using a closure. The error message indicates that the `str_replace()` function receives a `Closure` instead of the expected `string` or `array`.


**Related Issue:**
Fixes #9208 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
