### PR TITLE
fix: populateGlobals for JSON and XML body format

### DIFF
--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -375,11 +375,11 @@ trait FeatureTestTrait
 
         $request->setGlobal('get', $get);
 
-        if ($name === 'get') {
+        if ($name === 'get' || ($name === 'post' && in_array($this->bodyFormat, ['json', 'xml'], true))) {
             $request->setGlobal('request', $request->fetchGlobal('get'));
         }
 
-        if ($name === 'post') {
+        if ($name === 'post' && ! in_array($this->bodyFormat, ['json', 'xml'], true)) {
             $request->setGlobal($name, $params);
             $request->setGlobal(
                 'request',

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -557,7 +557,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertStringContainsString('[]', $response->getBody());
     }
 
-    public function testCallWithJsonRequest(): void
+    public function testCallWithAssociativeJsonRequest(): void
     {
         $this->withRoutes([
             [
@@ -573,6 +573,26 @@ final class FeatureTestTraitTest extends CIUnitTestCase
             'null'   => null,
             'float'  => 1.23,
             'string' => 'foo',
+        ];
+        $response = $this->withBodyFormat('json')
+            ->call(Method::POST, 'home', $data);
+
+        $response->assertOK();
+        $response->assertJSONExact($data);
+    }
+
+    public function testCallWithListJsonRequest(): void
+    {
+        $this->withRoutes([
+            [
+                'POST',
+                'home',
+                '\Tests\Support\Controllers\Popcorn::echoJson',
+            ],
+        ]);
+        $data = [
+            ['one' => 1, 'two' => 2],
+            ['one' => 2, 'two' => 2],
         ];
         $response = $this->withBodyFormat('json')
             ->call(Method::POST, 'home', $data);


### PR DESCRIPTION
**Description**
This PR fixes a bug in the `populateGlobals()` method in the `FeatureTestTrait` class.
If the body format is set to `json` or `xml`, we should not use `setGlobal()` for `post` requests.
The `POST` array should be empty since the data is stored in the raw input stream.

I think this is the proper way to solve the problem, although if anyone sees any issues, feedback is welcome (as always).

Closes #9204

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
