### PR TITLE
fix: change session start log level

### DIFF
--- a/system/Session/Session.php
+++ b/system/Session/Session.php
@@ -258,7 +258,7 @@ class Session implements SessionInterface
         }
 
         $this->initVars();
-        $this->logger->info("Session: Class initialized using '" . $this->config->driver . "' driver.");
+        $this->logger->debug("Session: Class initialized using '" . $this->config->driver . "' driver.");
 
         return $this;
     }

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -29,6 +29,7 @@ Deprecations
 **********
 Bugs Fixed
 **********
+- **Session Library:** The session initialization debug message now uses the correct log type "debug" instead of "info". (#9221)
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -29,7 +29,7 @@ Deprecations
 **********
 Bugs Fixed
 **********
-- **Session Library:** The session initialization debug message now uses the correct log type "debug" instead of "info". (#9221)
+- **Session Library:** The session initialization debug message now uses the correct log type "debug" instead of "info".
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
The session class clutters out-of-the-box configured logs with debug information about its driver initialization on startup, using a `INFO` classification.
This is especially problematic in authenticated webapps as every request will write at least one info message. 
The message itself has a debug purpose and therefore should be classified as `DEBUG`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
