### PR TITLE
fix: pin python version for sphinx

### DIFF
--- a/.github/workflows/deploy-distributables.yml
+++ b/.github/workflows/deploy-distributables.yml
@@ -159,11 +159,15 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           path: userguide
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install Sphinx
         run: |
-          sudo apt install python3-sphinx
-          sudo pip3 install sphinxcontrib-phpdomain
-          sudo pip3 install sphinx_rtd_theme
+          python -m pip install --upgrade pip
+          pip install -r ./source/user_guide_src/requirements.txt
 
       - name: Chmod
         run: chmod +x ./source/.github/scripts/deploy-userguide

--- a/.github/workflows/deploy-userguide-latest.yml
+++ b/.github/workflows/deploy-userguide-latest.yml
@@ -33,11 +33,20 @@ jobs:
           php-version: '8.1'
           coverage: none
 
-      # Build the latest User Guide
-      - name: Build with Sphinx
-        uses: ammaraskar/sphinx-action@0.4
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          docs-folder: user_guide_src/
+          python-version: '3.12'
+
+      - name: Install Sphinx
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r user_guide_src/requirements.txt
+
+      # Build the latest User Guide
+      - name: Build Docs with Sphinx
+        run: make html
+        working-directory: user_guide_src
 
       - name: Add "Edit this page" links
         run: |

--- a/.github/workflows/test-userguide.yml
+++ b/.github/workflows/test-userguide.yml
@@ -26,10 +26,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Sphinx
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r user_guide_src/requirements.txt
+
       - name: Detect usage of tabs in RST files
         run: php utils/check_tabs_in_rst.php
 
-      - uses: ammaraskar/sphinx-action@0.4
-        with:
-          docs-folder: user_guide_src
-          build-command: 'make html SPHINXOPTS="-W --keep-going -w /tmp/sphinx-log"'
+      - name: Build Docs with Sphinx
+        run: make html SPHINXOPTS="-W --keep-going -w /tmp/sphinx-log"
+        working-directory: user_guide_src


### PR DESCRIPTION
**Description**
This PR pins the Python version to `3.12`. Recently, we are not able to build the user guide correctly. This is because the `imghdr` module was removed in Python `3.13`.

```
Running Sphinx v5.3.0

Extension error:
Could not import extension sphinx.builders.epub3 (exception: No module named 'imghdr')
make: *** [Makefile:20: html] Error 2
```

https://github.com/codeigniter4/CodeIgniter4/actions/runs/11307496056/job/31449280998?pr=9221

More information about removing the `imghdr` module:
https://github.com/sphinx-doc/sphinx/issues/10440

Since for some reason we are blocked on Sphinx v5 (I'm guessing because of some extensions?), pinning the Python version is the only option.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
