### PR TITLE
refactor: cleanup `DatabaseHandler::gc()` for session

### DIFF
--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -284,7 +284,7 @@ class DatabaseHandler extends BaseHandler
     {
         return $this->db->table($this->table)->where(
             'timestamp <',
-            "now() - INTERVAL  {$max_lifetime} second ",
+            "now() - INTERVAL {$max_lifetime} second",
             false
         )->delete() ? 1 : $this->fail();
     }

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -282,12 +282,9 @@ class DatabaseHandler extends BaseHandler
     #[ReturnTypeWillChange]
     public function gc($max_lifetime)
     {
-        $separator = ' ';
-        $interval  = implode($separator, ['', "{$max_lifetime} second", '']);
-
         return $this->db->table($this->table)->where(
             'timestamp <',
-            "now() - INTERVAL {$interval}",
+            "now() - INTERVAL  {$max_lifetime} second ",
             false
         )->delete() ? 1 : $this->fail();
     }


### PR DESCRIPTION
**Description**
While making changes to [#9928](https://github.com/codeigniter4/CodeIgniter4/pull/9228) noticed there were two variables prior to the return statement which add horizontal space padding around $max_lifetime. These statements are unnecessary and do not enhance code readability.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
