### PR TITLE
fix: prioritize headers set by the `Response` class

### DIFF
--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -408,6 +408,7 @@ trait ResponseTrait
                 );
             } else {
                 $replace = true;
+
                 foreach ($value as $header) {
                     header(
                         $name . ': ' . $header->getValueLine(),

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -403,16 +403,18 @@ trait ResponseTrait
             if ($value instanceof Header) {
                 header(
                     $name . ': ' . $value->getValueLine(),
-                    false,
+                    true,
                     $this->getStatusCode()
                 );
             } else {
+                $replace = true;
                 foreach ($value as $header) {
                     header(
                         $name . ': ' . $header->getValueLine(),
-                        false,
+                        $replace,
                         $this->getStatusCode()
                     );
+                    $replace = false;
                 }
             }
         }

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -133,7 +133,7 @@ Response headers:
     Expires: Sun, 17 Nov 2024 14:17:37 GMT
 
 Now, we don't know which one will be picked by the browser or which header is the correct one.
-With changes in this version our previous header will be override:
+With changes in this version our previous header will be overridden:
 
 .. code-block:: none
 

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -99,6 +99,16 @@ See :ref:`Upgrading Guide <upgrade-460-sid-change>` for details.
 
 .. _v460-interface-changes:
 
+Headers
+-------
+
+The headers set by the ``Response`` class replace those that can be set by the PHP
+``header()`` function.
+
+In previous versions, headers set by the ``Response`` class were added to existing
+ones - giving no options to change them. That could lead to unexpected behavior when
+the same headers were set with mutually exclusive directives.
+
 Interface Changes
 =================
 
@@ -297,6 +307,10 @@ Deprecations
 **********
 Bugs Fixed
 **********
+
+- **Response:**
+    - Headers set using the ``Response`` class are now prioritized and replace headers
+      that can be set manually using the PHP ``header()`` function.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -109,6 +109,38 @@ In previous versions, headers set by the ``Response`` class were added to existi
 ones - giving no options to change them. That could lead to unexpected behavior when
 the same headers were set with mutually exclusive directives.
 
+For example, session will automatically set headers with the ``header()`` function:
+
+.. code-block:: none
+
+    Expires: Thu, 19 Nov 1981 08:52:00 GMT
+    Cache-Control: no-store, no-cache, must-revalidate
+    Pragma: no-cache
+
+So if we set **Expires** header one more time we will end up with a duplicated header:
+
+.. code-block:: php
+
+    $response->removeHeader('Expires'); // has no effect
+    return $response->setHeader('Expires', 'Sun, 17 Nov 2024 14:17:37 GMT');
+
+Response headers:
+
+.. code-block:: none
+
+    Expires: Thu, 19 Nov 1981 08:52:00 GMT
+    // ...
+    Expires: Sun, 17 Nov 2024 14:17:37 GMT
+
+Now, we don't know which one will be picked by the browser or which header is the correct one.
+With changes in this version our previous header will be override:
+
+.. code-block:: none
+
+    Cache-Control: no-store, no-cache, must-revalidate
+    Pragma: no-cache
+    Expires: Sun, 17 Nov 2024 14:17:37 GMT
+
 Interface Changes
 =================
 

--- a/user_guide_src/source/outgoing/response.rst
+++ b/user_guide_src/source/outgoing/response.rst
@@ -57,6 +57,10 @@ which can be either a string or an array of values that will be combined correct
 Using these functions instead of using the native PHP functions allows you to ensure that no headers are sent
 prematurely, causing errors, and makes testing possible.
 
+.. important:: Since v4.6.0, if you set a header using PHP's native ``header()``
+    function and then use the ``Response`` class to set the same header, the
+    previous one will be overwritten.
+
 .. note:: This method just sets headers to the response instance. So, if you create
     and return another response instance (e.g., if you call :php:func:`redirect()`),
     the headers set here will not be sent automatically.


### PR DESCRIPTION
**Description**
This PR changes the way headers are set. Now headers set by the `Response` class will be prioritized and will replace those set by calling the `header()` function.

Why is this important? Without this change, we cannot override the headers set previously with the `header()` function.

This is relevant, especially when we work with a session. By default, `session.cache_limiter` is set to `nocache`, which is fine for the default setting and will automatically set headers:
```
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate
Pragma: no-cache
```
But we have no option to change these headers, even when we set different `Cache-Control` etc with the `Response` class. If we do so, we end up with two entries for `Cache-Control`, which will possibly lead to unexpected behavior. We also cannot remove the default headers set by `session.cache_limiter`, because they are set with the `header()` function directly.

Headers set with the `Response` class should be prioritized. This is potentially a BC break, but also a bugfix.

Ref: #9234

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
