### PR TITLE
fix: `DownloadResponse` cache headers

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -5930,12 +5930,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
 ];
 $ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:setCache\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/system/HTTP/DownloadResponse.php',
-];
-$ignoreErrors[] = [
 	// identifier: method.childReturnType
 	'message' => '#^Return type \\(CodeIgniter\\\\HTTP\\\\DownloadResponse\\) of method CodeIgniter\\\\HTTP\\\\DownloadResponse\\:\\:sendBody\\(\\) should be covariant with return type \\(\\$this\\(CodeIgniter\\\\HTTP\\\\Response\\)\\) of method CodeIgniter\\\\HTTP\\\\Response\\:\\:sendBody\\(\\)$#',
 	'count' => 1,

--- a/system/Exceptions/DownloadException.php
+++ b/system/Exceptions/DownloadException.php
@@ -47,6 +47,8 @@ class DownloadException extends RuntimeException implements ExceptionInterface
     }
 
     /**
+     * @deprecated Since v4.5.6
+     *
      * @return static
      */
     public static function forCannotSetCache()

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -243,16 +243,6 @@ class DownloadResponse extends Response
     }
 
     /**
-     * Disables cache configuration.
-     *
-     * @throws DownloadException
-     */
-    public function setCache(array $options = [])
-    {
-        throw DownloadException::forCannotSetCache();
-    }
-
-    /**
      * {@inheritDoc}
      *
      * @return $this
@@ -290,10 +280,8 @@ class DownloadResponse extends Response
             $this->setHeader('Content-Disposition', $this->getContentDisposition());
         }
 
-        $this->setHeader('Expires-Disposition', '0');
         $this->setHeader('Content-Transfer-Encoding', 'binary');
         $this->setHeader('Content-Length', (string) $this->getContentLength());
-        $this->noCache();
     }
 
     /**

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -29,16 +29,14 @@ Deprecations
 **********
 Bugs Fixed
 **********
+
 - **RequestTrait:** Fixed a bug where the ``fetchGlobal()`` method did not allow handling data by numeric key when stored as a list.
-
 - **Session Library:** The session initialization debug message now uses the correct log type "debug" instead of "info".
-
-- **Validation:** Fixed the `getValidated()` method that did not return valid data when validation rules used multiple asterisks.
-
+- **Validation:** Fixed the ``getValidated()`` method that did not return valid data when validation rules used multiple asterisks.
 - **Database:** Fixed the case insensitivity option in the ``like()`` method when dealing with accented characters.
-
 - **Parser:** Fixed bug that caused equal key names to be replaced by the key name defined first.
-
+- **DownloadResponse:** Fixed a bug that prevented setting custom cache headers. We can now also use the ``setCache()`` method.
+- **DownloadResponse:** Fixed a bug involving sending a custom "Expires-Disposition" header.
 - **Routing:** Fixed a TypeError in `str_replace()` when `Routing::$translateURIDashes` is set to `true` and a route is defined using a closure.
 
 See the repo's


### PR DESCRIPTION
**Description**
This PR fixes a bug when we cannot update the `Cache-Control` header for a `DownloadResponse` class.

By default, the cache is disabled by calling the `noCache()` method in the constructor of the parent class. But now we are able to override these settings simply by using the `setHeader()` or `setCache()` methods.

I don't know why previously it was decided that `setCache()` would throw an exception since setting the cache should be possible. In many cases, we probably don't want to do that, but still... it should be possible.

Last but not least, the header `Expire-Disposition` (this is the first time I have seen it) was removed since I don't think it's a valid one and has no effect.

Ref: #9234

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
