### PR TITLE
fix: case-insensitivity in the `like()` method when in use with accented characters

### DIFF
--- a/.github/workflows/reusable-phpunit-test.yml
+++ b/.github/workflows/reusable-phpunit-test.yml
@@ -138,7 +138,7 @@ jobs:
     steps:
       - name: Create database for MSSQL Server
         if: ${{ inputs.db-platform == 'SQLSRV' }}
-        run: sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q "CREATE DATABASE test"
+        run: sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q "CREATE DATABASE test COLLATE Latin1_General_100_CS_AS_SC_UTF8"
 
       - name: Install latest ImageMagick
         if: ${{ contains(inputs.extra-extensions, 'imagick') }}

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1151,7 +1151,7 @@ class BaseBuilder
 
         foreach ($keyValue as $k => $v) {
             if ($insensitiveSearch) {
-                $v = mb_strtolower($v);
+                $v = mb_strtolower($v, 'UTF-8');
             }
 
             $prefix = empty($this->{$clause}) ? $this->groupGetType('') : $this->groupGetType($type);

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -1151,7 +1151,7 @@ class BaseBuilder
 
         foreach ($keyValue as $k => $v) {
             if ($insensitiveSearch) {
-                $v = strtolower($v);
+                $v = mb_strtolower($v);
             }
 
             $prefix = empty($this->{$clause}) ? $this->groupGetType('') : $this->groupGetType($type);

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -212,10 +212,10 @@ class Forge extends BaseForge
 
             $sql = <<<SQL
                 SELECT name
-                FROM SYS.DEFAULT_CONSTRAINTS
-                WHERE PARENT_OBJECT_ID = OBJECT_ID('{$fullTable}')
-                AND PARENT_COLUMN_ID IN (
-                SELECT column_id FROM sys.columns WHERE NAME IN ({$fields}) AND object_id = OBJECT_ID(N'{$fullTable}')
+                FROM sys.default_constraints
+                WHERE parent_object_id = OBJECT_ID('{$fullTable}')
+                AND parent_column_id IN (
+                SELECT column_id FROM sys.columns WHERE name IN ({$fields}) AND object_id = OBJECT_ID(N'{$fullTable}')
                 )
                 SQL;
 

--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -92,6 +92,7 @@ class Migration_Create_test_tables extends Migration
 
         if ($this->db->DBDriver === 'SQLSRV') {
             unset($dataTypeFields['type_timestamp']);
+            $dataTypeFields['type_text'] = ['type' => 'NVARCHAR(max)', 'null' => true];
         }
 
         if ($this->db->DBDriver === 'Postgre' || $this->db->DBDriver === 'SQLSRV') {

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -87,12 +87,24 @@ class CITestSeeder extends Seeder
                     'value' => 'value',
                 ],
                 [
-                    'key'   => 'multibyte characters 1',
+                    'key'   => 'multibyte characters pl',
                     'value' => 'śćźżłąęó',
                 ],
                 [
-                    'key'   => 'multibyte characters 2',
+                    'key'   => 'multibyte characters fa',
                     'value' => 'خٌوب',
+                ],
+                [
+                    'key'   => 'multibyte characters bn',
+                    'value' => 'টাইপ',
+                ],
+                [
+                    'key'   => 'multibyte characters ko',
+                    'value' => '캐스팅',
+                ],
+                [
+                    'key'   => 'multibyte characters ml',
+                    'value' => 'ടൈപ്പ്',
                 ],
             ],
             'type_test' => [

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -87,8 +87,12 @@ class CITestSeeder extends Seeder
                     'value' => 'value',
                 ],
                 [
-                    'key'   => 'accented characters',
+                    'key'   => 'multibyte characters 1',
                     'value' => 'śćźżłąęó',
+                ],
+                [
+                    'key'   => 'multibyte characters 2',
+                    'value' => 'خٌوب',
                 ],
             ],
             'type_test' => [

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -86,6 +86,10 @@ class CITestSeeder extends Seeder
                     'key'   => 'key',
                     'value' => 'value',
                 ],
+                [
+                    'key'   => 'accented characters',
+                    'value' => 'śćźżłąęó',
+                ],
             ],
             'type_test' => [
                 [

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1615,9 +1615,15 @@ final class ForgeTest extends CIUnitTestCase
     public function testAddTextColumnWithConstraint(): void
     {
         // some DBMS do not allow a constraint for type TEXT
-        $this->forge->addColumn('user', [
-            'text_with_constraint' => ['type' => 'text', 'constraint' => 255, 'default' => ''],
-        ]);
+        if ($this->db->DBDriver === 'SQLSRV') {
+            $this->forge->addColumn('user', [
+                'text_with_constraint' => ['type' => 'nvarchar(max)', 'default' => ''],
+            ]);
+        } else {
+            $this->forge->addColumn('user', [
+                'text_with_constraint' => ['type' => 'text', 'constraint' => 255, 'default' => ''],
+            ]);
+        }
 
         $this->assertTrue($this->db->fieldExists('text_with_constraint', 'user'));
 

--- a/tests/system/Database/Live/GetTest.php
+++ b/tests/system/Database/Live/GetTest.php
@@ -178,7 +178,7 @@ final class GetTest extends CIUnitTestCase
             $this->assertSame('int', $typeTest[0]->type_name); // INTEGER AUTOINC
             $this->assertSame('varchar', $typeTest[1]->type_name);  // VARCHAR
             $this->assertSame('char', $typeTest[2]->type_name);  // CHAR
-            $this->assertSame('text', $typeTest[3]->type_name);  // TEXT
+            $this->assertSame('nvarchar', $typeTest[3]->type_name);  // TEXT
             $this->assertSame('smallint', $typeTest[4]->type_name);  // SMALLINT
             $this->assertSame('int', $typeTest[5]->type_name);  // INTEGER
             $this->assertSame('float', $typeTest[6]->type_name);  // FLOAT

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -77,7 +77,7 @@ final class LikeTest extends CIUnitTestCase
     }
 
     #[DataProvider('provideMultibyteCharacters')]
-    public function testLikeCaseInsensitiveWithMultibyteCharacter($match, $result): void
+    public function testLikeCaseInsensitiveWithMultibyteCharacter(string $match, string $result): void
     {
         $wai = $this->db->table('without_auto_increment')->like('value', $match, 'both', null, true)->get();
         $wai = $wai->getRow();
@@ -85,6 +85,9 @@ final class LikeTest extends CIUnitTestCase
         $this->assertSame($result, $wai->key);
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
     public static function provideMultibyteCharacters(): iterable
     {
         yield from [

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -75,6 +75,14 @@ final class LikeTest extends CIUnitTestCase
         $this->assertSame('Developer', $job->name);
     }
 
+    public function testLikeCaseInsensitiveWithAccentedCharacter(): void
+    {
+        $wai = $this->db->table('without_auto_increment')->like('value', 'ŁĄ', 'both', null, true)->get();
+        $wai = $wai->getRow();
+
+        $this->assertSame('accented characters', $wai->key);
+    }
+
     public function testOrLike(): void
     {
         $jobs = $this->db->table('job')->like('name', 'ian')

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -79,6 +79,12 @@ final class LikeTest extends CIUnitTestCase
     #[DataProvider('provideMultibyteCharacters')]
     public function testLikeCaseInsensitiveWithMultibyteCharacter(string $match, string $result): void
     {
+        if ($this->db->DBDriver === 'SQLSRV') {
+            $this->markTestSkipped(
+                'Currently Builder class does not fully support Unicode strings in SQLSRV.'
+            );
+        }
+
         $wai = $this->db->table('without_auto_increment')->like('value', $match, 'both', null, true)->get();
         $wai = $wai->getRow();
 

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Database\Live;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\CITestSeeder;
 
@@ -75,17 +76,24 @@ final class LikeTest extends CIUnitTestCase
         $this->assertSame('Developer', $job->name);
     }
 
-    public function testLikeCaseInsensitiveWithMultibyteCharacter(): void
+    #[DataProvider('provideMultibyteCharacters')]
+    public function testLikeCaseInsensitiveWithMultibyteCharacter($match, $result): void
     {
-        $wai = $this->db->table('without_auto_increment')->like('value', 'ŁĄ', 'both', null, true)->get();
+        $wai = $this->db->table('without_auto_increment')->like('value', $match, 'both', null, true)->get();
         $wai = $wai->getRow();
 
-        $this->assertSame('multibyte characters 1', $wai->key);
+        $this->assertSame($result, $wai->key);
+    }
 
-        $wai = $this->db->table('without_auto_increment')->like('value', 'خٌوب', 'both', null, true)->get();
-        $wai = $wai->getRow();
-
-        $this->assertSame('multibyte characters 2', $wai->key);
+    public static function provideMultibyteCharacters(): iterable
+    {
+        yield from [
+            'polish'    => ['ŁĄ', 'multibyte characters pl'],
+            'farsi'     => ['خٌوب', 'multibyte characters fa'],
+            'bengali'   => ['টাইপ', 'multibyte characters bn'],
+            'korean'    => ['캐스팅', 'multibyte characters ko'],
+            'malayalam' => ['ടൈപ്പ്', 'multibyte characters ml'],
+        ];
     }
 
     public function testOrLike(): void

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -75,12 +75,17 @@ final class LikeTest extends CIUnitTestCase
         $this->assertSame('Developer', $job->name);
     }
 
-    public function testLikeCaseInsensitiveWithAccentedCharacter(): void
+    public function testLikeCaseInsensitiveWithMultibyteCharacter(): void
     {
         $wai = $this->db->table('without_auto_increment')->like('value', 'ŁĄ', 'both', null, true)->get();
         $wai = $wai->getRow();
 
-        $this->assertSame('accented characters', $wai->key);
+        $this->assertSame('multibyte characters 1', $wai->key);
+
+        $wai = $this->db->table('without_auto_increment')->like('value', 'خٌوب', 'both', null, true)->get();
+        $wai = $wai->getRow();
+
+        $this->assertSame('multibyte characters 2', $wai->key);
     }
 
     public function testOrLike(): void

--- a/tests/system/Database/Live/LikeTest.php
+++ b/tests/system/Database/Live/LikeTest.php
@@ -79,12 +79,6 @@ final class LikeTest extends CIUnitTestCase
     #[DataProvider('provideMultibyteCharacters')]
     public function testLikeCaseInsensitiveWithMultibyteCharacter(string $match, string $result): void
     {
-        if ($this->db->DBDriver === 'SQLSRV') {
-            $this->markTestSkipped(
-                'Currently Builder class does not fully support Unicode strings in SQLSRV.'
-            );
-        }
-
         $wai = $this->db->table('without_auto_increment')->like('value', $match, 'both', null, true)->get();
         $wai = $wai->getRow();
 

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -32,6 +32,7 @@ Bugs Fixed
 - **Session Library:** The session initialization debug message now uses the correct log type "debug" instead of "info".
 
 - **Validation:** Fixed the `getValidated()` method that did not return valid data when validation rules used multiple asterisks.
+- **Database:** Fixed the case insensitivity option in the ``like()`` method when dealing with accented characters.
 
 - **Parser:** Fixed bug that caused equal key names to be replaced by the key name defined first.
 


### PR DESCRIPTION
**Description**
This PR fixes the case insensitivity option in the `like()` method when we deal with accented characters.

Closes #9236

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
