### PR TITLE
fix: Parser - Equal key name replace conflict

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -256,7 +256,7 @@ class Parser extends View
 
         // Parse stack for each parse type (Single and Pairs)
         $replaceSingleStack = [];
-        $replacePairsStack = [];
+        $replacePairsStack  = [];
 
         // loop over the data variables, saving regex and data
         // for later replacement.
@@ -264,10 +264,10 @@ class Parser extends View
             $escape = true;
 
             if (is_array($val)) {
-                $escape  = false;
-                array_push($replacePairsStack, ['replace' => $this->parsePair($key, $val, $template), 'escape' => $escape]);
+                $escape              = false;
+                $replacePairsStack[] = ['replace' => $this->parsePair($key, $val, $template), 'escape' => $escape];
             } else {
-                array_push($replaceSingleStack, ['replace' => $this->parseSingle($key, (string) $val), 'escape' => $escape]);
+                $replaceSingleStack[] = ['replace' => $this->parseSingle($key, (string) $val), 'escape' => $escape];
             }
         }
 
@@ -275,10 +275,9 @@ class Parser extends View
         // This allows for nested data with the same key to be replaced properly
         $replace = array_merge($replacePairsStack, $replaceSingleStack);
 
-        // Loop over each replace array item which 
+        // Loop over each replace array item which
         // holds all the data to be replaced
         foreach ($replace as $replaceItem) {
-
             // Loop over the actual data to be replaced
             foreach ($replaceItem['replace'] as $pattern => $content) {
                 $template = $this->replaceSingle($pattern, $content, $template, $replaceItem['escape']);

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -265,9 +265,15 @@ class Parser extends View
 
             if (is_array($val)) {
                 $escape              = false;
-                $replacePairsStack[] = ['replace' => $this->parsePair($key, $val, $template), 'escape' => $escape];
+                $replacePairsStack[] = [
+                    'replace' => $this->parsePair($key, $val, $template),
+                    'escape'  => $escape,
+                ];
             } else {
-                $replaceSingleStack[] = ['replace' => $this->parseSingle($key, (string) $val), 'escape' => $escape];
+                $replaceSingleStack[] = [
+                    'replace' => $this->parseSingle($key, (string) $val),
+                    'escape'  => $escape,
+                ];
             }
         }
 

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -254,20 +254,34 @@ class Parser extends View
         // it can potentially modify any template between its tags.
         $template = $this->parsePlugins($template);
 
-        // loop over the data variables, replacing
-        // the content as we go.
+        // Parse stack for each parse type (Single and Pairs)
+        $replaceSingleStack = [];
+        $replacePairsStack = [];
+
+        // loop over the data variables, saving regex and data
+        // for later replacement.
         foreach ($data as $key => $val) {
             $escape = true;
 
             if (is_array($val)) {
                 $escape  = false;
-                $replace = $this->parsePair($key, $val, $template);
+                array_push($replacePairsStack, ['replace' => $this->parsePair($key, $val, $template), 'escape' => $escape]);
             } else {
-                $replace = $this->parseSingle($key, (string) $val);
+                array_push($replaceSingleStack, ['replace' => $this->parseSingle($key, (string) $val), 'escape' => $escape]);
             }
+        }
 
-            foreach ($replace as $pattern => $content) {
-                $template = $this->replaceSingle($pattern, $content, $template, $escape);
+        // Merge both stacks, pairs first + single stacks
+        // This allows for nested data with the same key to be replaced properly
+        $replace = array_merge($replacePairsStack, $replaceSingleStack);
+
+        // Loop over each replace array item which 
+        // holds all the data to be replaced
+        foreach ($replace as $replaceItem) {
+
+            // Loop over the actual data to be replaced
+            foreach ($replaceItem['replace'] as $pattern => $content) {
+                $template = $this->replaceSingle($pattern, $content, $template, $replaceItem['escape']);
             }
         }
 

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -1061,4 +1061,44 @@ final class ParserTest extends CIUnitTestCase
             EOL;
         $this->assertSame($expected, $this->parser->renderString($template));
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/9245
+     */
+    public function testParseSameArrayKeyName(): void
+    {
+        $data = [
+            'type'   => 'Super Powers',
+            'powers' => [
+                [
+                    'type' => 'invisibility',
+                ],
+            ],
+        ];
+
+        $template = '{type} like {powers}{type}{/powers}';
+
+        $this->parser->setData($data);
+        $this->assertSame('Super Powers like invisibility', $this->parser->renderString($template));
+    }
+
+    public function testParseSameArrayKeyNameNested(): void
+    {
+        $data = [
+            'title'   => 'My title',
+            'similar' => [
+                ['items' => [
+                    [
+                        'title' => 'My similar title',
+                    ],
+                ],
+                ],
+            ],
+        ];
+
+        $template = '{title} with similar item {similar}{items}{title}{/items}{/similar}';
+
+        $this->parser->setData($data);
+        $this->assertSame('My title with similar item My similar title', $this->parser->renderString($template));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -33,6 +33,8 @@ Bugs Fixed
 
 - **Validation:** Fixed the `getValidated()` method that did not return valid data when validation rules used multiple asterisks.
 
+- **Parser:** Fixed bug that caused equal key names to be replaced by the key name defined first.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
Fixes the conflict when replacing View Parser {variables} in the provided data with the same key name, even when on different levels.

This fix focus on ```parse()``` method, in which the return of ```parsePair``` and ```parseSingle``` methods are stored independently , then merged together (Pairs with Single), and finally replaced. With this approach, the replacement happens from the Pairs to Single and the output is as expected.

More details and examples in issue #9245 

Fixes #9245 

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
