### PR TITLE
perf: Improve call as `service()`

### DIFF
--- a/admin/starter/tests/session/ExampleSessionTest.php
+++ b/admin/starter/tests/session/ExampleSessionTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 
 /**
  * @internal
@@ -10,7 +9,7 @@ final class ExampleSessionTest extends CIUnitTestCase
 {
     public function testSessionSimple(): void
     {
-        $session = Services::session();
+        $session = service('session');
 
         $session->set('logged_in', 123);
         $this->assertSame(123, $session->get('logged_in'));

--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -2,7 +2,6 @@
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
-use Config\Services;
 use Tests\Support\Libraries\ConfigReader;
 
 /**
@@ -17,7 +16,7 @@ final class HealthTest extends CIUnitTestCase
 
     public function testBaseUrlHasBeenSet(): void
     {
-        $validation = Services::validation();
+        $validation = service('validation');
 
         $env = false;
 

--- a/app/Config/Events.php
+++ b/app/Config/Events.php
@@ -44,10 +44,10 @@ Events::on('pre_system', static function (): void {
      */
     if (CI_DEBUG && ! is_cli()) {
         Events::on('DBQuery', 'CodeIgniter\Debug\Toolbar\Collectors\Database::collect');
-        Services::toolbar()->respond();
+        service('toolbar')->respond();
         // Hot Reload route - for framework use on the hot reloader.
         if (ENVIRONMENT === 'development') {
-            Services::routes()->get('__hot-reload', static function (): void {
+            service('routes')->get('__hot-reload', static function (): void {
                 (new HotReloader())->run();
             });
         }

--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -72,6 +72,6 @@ class Format extends BaseConfig
      */
     public function getFormatter(string $mime)
     {
-        return Services::format()->getFormatter($mime);
+        return service('format')->getFormatter($mime);
     }
 }

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -53,6 +53,6 @@ abstract class BaseController extends Controller
 
         // Preload any models, libraries, etc, here.
 
-        // E.g.: $this->session = \Config\Services::session();
+        // E.g.: $this->session = service('session');
     }
 }

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -1,6 +1,5 @@
 <?php
 use CodeIgniter\HTTP\Header;
-use Config\Services;
 use CodeIgniter\CodeIgniter;
 
 $errorId = uniqid('error', true);

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -225,7 +225,7 @@ $errorId = uniqid('error', true);
 
             <!-- Request -->
             <div class="content" id="request">
-                <?php $request = Services::request(); ?>
+                <?php $request = service('request'); ?>
 
                 <table>
                     <tbody>
@@ -343,7 +343,7 @@ $errorId = uniqid('error', true);
 
             <!-- Response -->
             <?php
-                $response = Services::response();
+                $response = service('response');
                 $response->setStatusCode(http_response_code());
             ?>
             <div class="content" id="response">

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -18362,12 +18362,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/View/ParserTest.php',
 ];
 $ignoreErrors[] = [
-	// identifier: missingType.iterableValue
-	'message' => '#^Method class@anonymous/tests/system/View/ParserTest\\.php\\:340\\:\\:toArray\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/View/ParserTest.php',
-];
-$ignoreErrors[] = [
 	// identifier: argument.type
 	'message' => '#^Parameter \\#2 \\$context of method CodeIgniter\\\\View\\\\Parser\\:\\:setData\\(\\) expects \'attr\'\\|\'css\'\\|\'html\'\\|\'js\'\\|\'raw\'\\|\'url\'\\|null, \'unknown\' given\\.$#',
 	'count' => 3,
@@ -18376,18 +18370,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: assign.propertyType
 	'message' => '#^Property CodeIgniter\\\\View\\\\ParserTest\\:\\:\\$loader \\(CodeIgniter\\\\Autoloader\\\\FileLocator\\) does not accept CodeIgniter\\\\Autoloader\\\\FileLocatorInterface\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/View/ParserTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.property
-	'message' => '#^Property class@anonymous/tests/system/View/ParserTest\\.php\\:340\\:\\:\\$bar has no type specified\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/View/ParserTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.property
-	'message' => '#^Property class@anonymous/tests/system/View/ParserTest\\.php\\:340\\:\\:\\$foo has no type specified\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/View/ParserTest.php',
 ];

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -19,7 +19,6 @@ use Composer\InstalledVersions;
 use Config\Autoload;
 use Config\Kint as KintConfig;
 use Config\Modules;
-use Config\Services;
 use InvalidArgumentException;
 use Kint;
 use Kint\Renderer\CliRenderer;
@@ -537,7 +536,7 @@ class Autoloader
             Kint::$plugins = $config->plugins;
         }
 
-        $csp = Services::csp();
+        $csp = service('csp');
         if ($csp->enabled()) {
             RichRenderer::$js_nonce  = $csp->getScriptNonce();
             RichRenderer::$css_nonce = $csp->getStyleNonce();

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -26,7 +26,6 @@ use CodeIgniter\I18n\Time;
 use CodeIgniter\Pager\Pager;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Feature;
-use Config\Services;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
@@ -1609,7 +1608,7 @@ abstract class BaseModel
     protected function ensureValidation(): void
     {
         if ($this->validation === null) {
-            $this->validation = Services::validation(null, false);
+            $this->validation = service('validation', null, false);
         }
     }
 

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -246,12 +246,12 @@ class Boot
 
     protected static function autoloadHelpers(): void
     {
-        Services::autoloader()->loadHelpers();
+        service('autoloader')->loadHelpers();
     }
 
     protected static function setExceptionHandler(): void
     {
-        Services::exceptions()->initialize();
+        service('exceptions')->initialize();
     }
 
     protected static function checkMissingExtensions(): void
@@ -290,7 +290,7 @@ class Boot
 
     protected static function initializeKint(): void
     {
-        Services::autoloader()->initializeKint(CI_DEBUG);
+        service('autoloader')->initializeKint(CI_DEBUG);
     }
 
     protected static function loadConfigCache(): FactoriesCache
@@ -308,7 +308,7 @@ class Boot
      */
     protected static function initializeCodeIgniter(): CodeIgniter
     {
-        $app = Config\Services::codeigniter();
+        $app = service('codeigniter');
         $app->initialize();
         $context = is_cli() ? 'php-cli' : 'web';
         $app->setContext($context);

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\CLI;
 
 use CodeIgniter\CLI\Exceptions\CLIException;
-use Config\Services;
 use InvalidArgumentException;
 use Throwable;
 
@@ -416,7 +415,7 @@ class CLI
     {
         $label      = $field;
         $field      = 'temp';
-        $validation = Services::validation(null, false);
+        $validation = service('validation', null, false);
         $validation->setRules([
             $field => [
                 'label' => $label,

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Request;
@@ -68,7 +67,7 @@ final class FilterCollector
             ];
         }
 
-        $request = Services::incomingrequest(null, false);
+        $request = service('incomingrequest', null, false);
         $request->setMethod($method);
 
         $router  = $this->createRouter($request);
@@ -86,7 +85,7 @@ final class FilterCollector
      */
     public function getRequiredFilters(): array
     {
-        $request = Services::incomingrequest(null, false);
+        $request = service('incomingrequest', null, false);
         $request->setMethod(Method::GET);
 
         $router  = $this->createRouter($request);

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -705,7 +705,7 @@ class Services extends BaseService
             // See https://www.php.net/manual/en/function.session-cache-limiter.php.
             // The headers are not managed by CI's Response class.
             // So, we remove CI's default Cache-Control header.
-            AppServices::response()->removeHeader('Cache-Control');
+            AppServices::get('response')->removeHeader('Cache-Control');
 
             $session->start();
         }

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -19,7 +19,6 @@ use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\I18n\Time;
 use Config\Database;
 use Config\Migrations as MigrationsConfig;
-use Config\Services;
 use RuntimeException;
 use stdClass;
 
@@ -390,7 +389,7 @@ class MigrationRunner
      */
     public function findMigrations(): array
     {
-        $namespaces = $this->namespace ? [$this->namespace] : array_keys(Services::autoloader()->getNamespace());
+        $namespaces = $this->namespace ? [$this->namespace] : array_keys(service('autoloader')->getNamespace());
         $migrations = [];
 
         foreach ($namespaces as $namespace) {
@@ -415,7 +414,7 @@ class MigrationRunner
     public function findNamespaceMigrations(string $namespace): array
     {
         $migrations = [];
-        $locator    = Services::locator(true);
+        $locator    = service('locator', true);
 
         if (! empty($this->path)) {
             helper('filesystem');
@@ -455,7 +454,7 @@ class MigrationRunner
             return false;
         }
 
-        $locator = Services::locator(true);
+        $locator = service('locator', true);
 
         $migration = new stdClass();
 

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -22,7 +22,6 @@ use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Exceptions as ExceptionsConfig;
 use Config\Paths;
-use Config\Services;
 use ErrorException;
 use Psr\Log\LogLevel;
 use Throwable;
@@ -126,7 +125,7 @@ class Exceptions
 
         [$statusCode, $exitCode] = $this->determineCodes($exception);
 
-        $this->request = Services::request();
+        $this->request = service('request');
 
         if ($this->config->log === true && ! in_array($statusCode, $this->config->ignoreCodes, true)) {
             $uri       = $this->request->getPath() === '' ? '/' : $this->request->getPath();
@@ -155,7 +154,7 @@ class Exceptions
             }
         }
 
-        $this->response = Services::response();
+        $this->response = service('response');
 
         if (method_exists($this->config, 'handler')) {
             // Use new ExceptionHandler

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -25,7 +25,6 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\I18n\Time;
-use Config\Services;
 use Config\Toolbar as ToolbarConfig;
 use Kint\Kint;
 
@@ -386,7 +385,7 @@ class Toolbar
                 return;
             }
 
-            $toolbar = Services::toolbar(config(ToolbarConfig::class));
+            $toolbar = service('toolbar', config(ToolbarConfig::class));
             $stats   = $app->getPerformanceStats();
             $data    = $toolbar->run(
                 $stats['startTime'],
@@ -529,7 +528,7 @@ class Toolbar
             case 'html':
                 $data['styles'] = [];
                 extract($data);
-                $parser = Services::parser($this->config->viewsPath, null, false);
+                $parser = service('parser', $this->config->viewsPath, null, false);
                 ob_start();
                 include $this->config->viewsPath . 'toolbar.tpl.php';
                 $output = ob_get_clean();

--- a/system/Debug/Toolbar/Collectors/Logs.php
+++ b/system/Debug/Toolbar/Collectors/Logs.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use Config\Services;
-
 /**
  * Loags collector
  */
@@ -92,6 +90,6 @@ class Logs extends BaseCollector
             return $this->data;
         }
 
-        return $this->data = Services::logger(true)->logCache ?? [];
+        return $this->data = service('logger', true)->logCache ?? [];
     }
 }

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
 use CodeIgniter\Router\DefinedRouteCollector;
-use Config\Services;
 use ReflectionException;
 use ReflectionFunction;
 use ReflectionMethod;
@@ -74,8 +73,8 @@ class Routes extends BaseCollector
      */
     public function display(): array
     {
-        $rawRoutes = Services::routes(true);
-        $router    = Services::router(null, null, true);
+        $rawRoutes = service('routes', true);
+        $router    = service('router', null, null, true);
 
         // Get our parameters
         // Closure routes
@@ -153,7 +152,7 @@ class Routes extends BaseCollector
      */
     public function getBadgeValue(): int
     {
-        $rawRoutes = Services::routes(true);
+        $rawRoutes = service('routes', true);
 
         return count($rawRoutes->getRoutes());
     }

--- a/system/Debug/Toolbar/Collectors/Timers.php
+++ b/system/Debug/Toolbar/Collectors/Timers.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Debug\Toolbar\Collectors;
 
-use Config\Services;
-
 /**
  * Timers collector
  */
@@ -52,7 +50,7 @@ class Timers extends BaseCollector
     {
         $data = [];
 
-        $benchmark = Services::timer(true);
+        $benchmark = service('timer', true);
         $rows      = $benchmark->getTimers(6);
 
         foreach ($rows as $name => $info) {

--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Exceptions;
 
-use Config\Services;
 use OutOfBoundsException;
 
 class PageNotFoundException extends OutOfBoundsException implements ExceptionInterface, HTTPExceptionInterface

--- a/system/Exceptions/PageNotFoundException.php
+++ b/system/Exceptions/PageNotFoundException.php
@@ -78,7 +78,7 @@ class PageNotFoundException extends OutOfBoundsException implements ExceptionInt
      */
     private static function lang(string $line, array $args = []): string
     {
-        $lang = Services::language(null, false);
+        $lang = service('language', null, false);
 
         return $lang->getLine($line, $args);
     }

--- a/system/Filters/Honeypot.php
+++ b/system/Filters/Honeypot.php
@@ -17,7 +17,6 @@ use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
 
 /**
  * Honeypot filter
@@ -40,7 +39,7 @@ class Honeypot implements FilterInterface
             return;
         }
 
-        if (Services::honeypot()->hasContent($request)) {
+        if (service('honeypot')->hasContent($request)) {
             throw HoneypotException::isBot();
         }
     }

--- a/system/HTTP/RedirectResponse.php
+++ b/system/HTTP/RedirectResponse.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
-use Config\Services;
 
 /**
  * Handle a redirect response
@@ -148,7 +147,7 @@ class RedirectResponse extends Response
      */
     public function withCookies()
     {
-        $this->cookieStore = new CookieStore(Services::response()->getCookies());
+        $this->cookieStore = new CookieStore(service('response')->getCookies());
 
         return $this;
     }
@@ -163,7 +162,7 @@ class RedirectResponse extends Response
      */
     public function withHeaders()
     {
-        foreach (Services::response()->headers() as $name => $value) {
+        foreach (service('response')->headers() as $name => $value) {
             if ($value instanceof Header) {
                 $this->setHeader($name, $value->getValue());
             } else {

--- a/system/HTTP/Response.php
+++ b/system/HTTP/Response.php
@@ -18,7 +18,6 @@ use CodeIgniter\Cookie\CookieStore;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use Config\App;
 use Config\Cookie as CookieConfig;
-use Config\Services;
 
 /**
  * Representation of an outgoing, server-side response.
@@ -158,7 +157,7 @@ class Response extends Message implements ResponseInterface
         $this->noCache();
 
         // We need CSP object even if not enabled to avoid calls to non existing methods
-        $this->CSP = Services::csp();
+        $this->CSP = service('csp');
 
         $this->cookieStore = new CookieStore([]);
 

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -155,7 +155,7 @@ class ChromeLoggerHandler extends BaseHandler
      */
     public function sendLogs(?ResponseInterface &$response = null)
     {
-        if ($response instanceof ResponseInterface) {
+        if (! $response instanceof ResponseInterface) {
             $response = service('response', null, true);
         }
 

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Log\Handlers;
 
 use CodeIgniter\HTTP\ResponseInterface;
-use Config\Services;
 
 /**
  * Class ChromeLoggerHandler
@@ -156,8 +155,8 @@ class ChromeLoggerHandler extends BaseHandler
      */
     public function sendLogs(?ResponseInterface &$response = null)
     {
-        if (! $response instanceof ResponseInterface) {
-            $response = Services::response(null, true);
+        if ($response instanceof ResponseInterface) {
+            $response = service('response', null, true);
         }
 
         $data = base64_encode(

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -21,7 +21,6 @@ use CodeIgniter\Router\Exceptions\RouterException;
 use Config\App;
 use Config\Modules;
 use Config\Routing;
-use Config\Services;
 use InvalidArgumentException;
 
 /**
@@ -283,7 +282,7 @@ class RouteCollection implements RouteCollectionInterface
         $this->fileLocator  = $locator;
         $this->moduleConfig = $moduleConfig;
 
-        $this->httpHost = Services::request()->getServer('HTTP_HOST');
+        $this->httpHost = service('request')->getServer('HTTP_HOST');
 
         // Setup based on config file. Let routes file override.
         $this->defaultNamespace   = rtrim($routing->defaultNamespace, '\\') . '\\';

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -109,14 +109,14 @@ trait ControllerTestTrait
             $tempUri = service('uri');
             Services::injectMock('uri', $this->uri);
 
-            $this->withRequest(Services::incomingrequest($this->appConfig, false));
+            $this->withRequest(service('incomingrequest', $this->appConfig, false));
 
             // Restore the URI service
             Services::injectMock('uri', $tempUri);
         }
 
         if (empty($this->response)) {
-            $this->response = Services::response($this->appConfig, false);
+            $this->response = service('response', $this->appConfig, false);
         }
 
         if (empty($this->logger)) {
@@ -285,7 +285,7 @@ trait ControllerTestTrait
         Services::injectMock('uri', $this->uri);
 
         // Update the Request instance, because Request has the SiteURI instance.
-        $this->request = Services::incomingrequest(null, false);
+        $this->request = service('incomingrequest', null, false);
         Services::injectMock('request', $this->request);
 
         return $this;

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -200,10 +200,10 @@ trait FeatureTestTrait
         Services::injectMock('request', $request);
 
         // Make sure filters are reset between tests
-        Services::injectMock('filters', Services::filters(null, false));
+        Services::injectMock('filters', service('filters', null, false));
 
         // Make sure validation is reset between tests
-        Services::injectMock('validation', Services::validation(null, false));
+        Services::injectMock('validation', service('validation', null, false));
 
         $response = $this->app
             ->setContext('web')
@@ -321,7 +321,7 @@ trait FeatureTestTrait
 
         Services::injectMock('uri', $uri);
 
-        $request = Services::incomingrequest($config, false);
+        $request = service('incomingrequest', $config, false);
 
         $request->setMethod($method);
         $request->setProtocolVersion('1.1');

--- a/system/Test/bootstrap.php
+++ b/system/Test/bootstrap.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use CodeIgniter\Boot;
 use Config\Paths;
-use Config\Services;
 
 error_reporting(E_ALL);
 ini_set('display_errors', '1');
@@ -88,4 +87,4 @@ Boot::bootTest($paths);
  * ---------------------------------------------------------------
  */
 
-Services::routes()->loadRoutes();
+service('routes')->loadRoutes();

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -21,7 +21,6 @@ use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use CodeIgniter\View\RendererInterface;
-use Config\Services;
 use Config\Validation as ValidationConfig;
 use InvalidArgumentException;
 use LogicException;
@@ -796,7 +795,7 @@ class Validation implements ValidationInterface
                     $placeholderFields = $this->retrievePlaceholders($row, $data);
 
                     foreach ($placeholderFields as $field) {
-                        $validator ??= Services::validation(null, false);
+                        $validator ??= service('validation', null, false);
                         assert($validator instanceof Validation);
 
                         $placeholderRules = $rules[$field]['rules'] ?? null;

--- a/system/View/Cell.php
+++ b/system/View/Cell.php
@@ -17,7 +17,6 @@ use CodeIgniter\Cache\CacheInterface;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\View\Cells\Cell as BaseCell;
 use CodeIgniter\View\Exceptions\ViewException;
-use Config\Services;
 use ReflectionException;
 use ReflectionMethod;
 
@@ -93,7 +92,7 @@ class Cell
         }
 
         if (method_exists($instance, 'initController')) {
-            $instance->initController(Services::request(), service('response'), service('logger'));
+            $instance->initController(service('request'), service('response'), service('logger'));
         }
 
         if (! method_exists($instance, $method)) {

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -20,7 +20,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
 use Config\Autoload;
 use Config\Modules;
-use Config\Services;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -112,7 +111,7 @@ final class AutoloaderTest extends CIUnitTestCase
 
     public function testServiceAutoLoaderFromShareInstances(): void
     {
-        $classLoader = $this->getPrivateMethodInvoker(Services::autoloader(), 'loadInNamespace');
+        $classLoader = $this->getPrivateMethodInvoker(service('autoloader'), 'loadInNamespace');
 
         // look for Home controller, as that should be in base repo
         $actual   = $classLoader(Home::class);
@@ -122,7 +121,7 @@ final class AutoloaderTest extends CIUnitTestCase
 
     public function testServiceAutoLoader(): void
     {
-        $autoloader = Services::autoloader(false);
+        $autoloader = service('autoloader', false);
         $autoloader->initialize(new Autoload(), new Modules());
         $autoloader->register();
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -58,7 +58,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $this->codeigniter = new MockCodeIgniter(new App());
 
-        $response = Services::response();
+        $response = service('response');
         $response->pretend();
     }
 
@@ -110,11 +110,11 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add('pages/(:segment)', static function ($segment): void {
             echo 'You want to see "' . esc($segment) . '" page.';
         });
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -131,10 +131,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME']    = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->setAutoRoute(false);
         $routes->set404Override('Tests\Support\Errors::show404');
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -151,10 +151,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->setAutoRoute(false);
         $routes->set404Override('Tests\Support\Controllers\Popcorn::pop');
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         $response = $this->codeigniter->run($routes, true);
@@ -169,10 +169,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->setAutoRoute(false);
         $routes->set404Override('Tests\Support\Controllers\Popcorn::pop');
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         $response = $this->codeigniter->run($routes, true);
@@ -186,12 +186,12 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $routes = new RouteCollection(Services::locator(), new Modules(), new Routing());
+        $routes = new RouteCollection(service('locator'), new Modules(), new Routing());
         $routes->setAutoRoute(false);
         $routes->set404Override(static function (): void {
             echo '404 Override by Closure.';
         });
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -211,12 +211,12 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add(
             'pages/(:segment)',
             static fn ($segment) => 'You want to see "' . esc($segment) . '" page.'
         );
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -235,14 +235,14 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add('pages/(:segment)', static function ($segment) {
-            $response = Services::response();
+            $response = service('response');
             $string   = "You want to see 'about' page.";
 
             return $response->setBody($string);
         });
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -264,13 +264,13 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add('pages/(:segment)', static function ($segment) {
-            $response = Services::response();
+            $response = service('response');
 
             return $response->download('some.txt', 'some text', true);
         });
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -289,14 +289,14 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add(
             'pages/about',
-            static fn () => Services::incomingrequest()->getBody(),
+            static fn () => service('incomingrequest')->getBody(),
             ['filter' => Customfilter::class]
         );
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -319,15 +319,15 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/pages/about';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add(
             'pages/about',
-            static fn () => Services::incomingrequest()->getBody(),
+            static fn () => service('incomingrequest')->getBody(),
             // Set filter with no argument.
             ['filter' => 'test-customfilter']
         );
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         /** @var FiltersConfig $filterConfig */
@@ -338,7 +338,7 @@ final class CodeIgniterTest extends CIUnitTestCase
                 'before' => ['pages/*'],
             ],
         ];
-        Services::filters($filterConfig);
+        service('filters', $filterConfig);
 
         $this->codeigniter->run();
 
@@ -354,13 +354,13 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add(
             'pages/about',
-            static fn () => Services::incomingrequest()->getBody(),
+            static fn () => service('incomingrequest')->getBody(),
             ['filter' => Customfilter::class]
         );
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -378,7 +378,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argv'] = ['index.php', '/'];
         $_SERVER['argc'] = 2;
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $this->assertInstanceOf(Response::class, $response);
     }
@@ -389,7 +389,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $router = Services::router(null, Services::incomingrequest(), false);
+        $router = service('router', null, service('incomingrequest'), false);
         Services::injectMock('router', $router);
 
         ob_start();
@@ -478,12 +478,12 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add('pages/named', static function (): void {
         }, ['as' => 'name']);
         $routes->addRedirect('example', 'name');
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -502,12 +502,12 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add('pages/uri', static function (): void {
         });
         $routes->addRedirect('example', 'pages/uri');
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -531,11 +531,11 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD']  = 'GET';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         // addRedirect() sets status code 302 by default.
         $routes->addRedirect('example', 'pages/notset');
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -558,10 +558,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD']  = 'GET';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->addRedirect('example', 'pages/notset', 301);
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -583,10 +583,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD']  = 'POST';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->addRedirect('example', 'pages/notset', 301);
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -606,12 +606,12 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->get('/', static function (): never {
             throw new RedirectException('redirect-exception', 503);
         });
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         $response = $this->codeigniter->run($routes, true);
@@ -626,7 +626,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['argc'] = 2;
 
         // Inject mock router.
-        $router = Services::router(null, Services::incomingrequest(), false);
+        $router = service('router', null, service('incomingrequest'), false);
         Services::injectMock('router', $router);
 
         ob_start();
@@ -648,10 +648,10 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD']  = 'GET';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->addRedirect('example', 'pages/notset', 301);
 
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -670,13 +670,13 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add('image', static function () {
-            $response = Services::response();
+            $response = service('response');
 
             return $response->setContentType('image/jpeg', '');
         });
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         ob_start();
@@ -713,7 +713,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['REQUEST_METHOD']  = 'CLI';
 
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->cli('cli', '\Tests\Support\Controllers\Popcorn::index');
 
         ob_start();
@@ -735,7 +735,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $_POST['_method'] = Method::PUT;
 
-        $routes = \Config\Services::routes();
+        $routes = service('routes');
         $routes->setDefaultNamespace('App\Controllers');
         $routes->resetRoutes();
         $routes->post('/', 'Home::index');
@@ -745,7 +745,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->run();
         ob_get_clean();
 
-        $this->assertSame(Method::PUT, Services::incomingrequest()->getMethod());
+        $this->assertSame(Method::PUT, service('incomingrequest')->getMethod());
     }
 
     public function testSpoofRequestMethodCannotUseGET(): void
@@ -760,7 +760,7 @@ final class CodeIgniterTest extends CIUnitTestCase
 
         $_POST['_method'] = 'GET';
 
-        $routes = \Config\Services::routes();
+        $routes = service('routes');
         $routes->setDefaultNamespace('App\Controllers');
         $routes->resetRoutes();
         $routes->post('/', 'Home::index');
@@ -770,7 +770,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $this->codeigniter->run();
         ob_get_clean();
 
-        $this->assertSame('POST', Services::incomingrequest()->getMethod());
+        $this->assertSame('POST', service('incomingrequest')->getMethod());
     }
 
     /**
@@ -789,22 +789,22 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['REQUEST_URI'] = '/test';
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->add('test', static function () {
             CodeIgniter::cache(3600);
 
-            $response = Services::response();
+            $response = service('response');
             $string   = 'This is a test page. Elapsed time: {elapsed_time}';
 
             return $response->setBody($string);
         });
-        $router = Services::router($routes, Services::incomingrequest());
+        $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
 
         /** @var FiltersConfig $filterConfig */
         $filterConfig                   = config('Filters');
         $filterConfig->globals['after'] = ['secureheaders'];
-        Services::filters($filterConfig);
+        service('filters', $filterConfig);
 
         // The first response to be cached.
         ob_start();
@@ -812,7 +812,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('This is a test page', $output);
-        $response = Services::response();
+        $response = service('response');
         $headers  = $response->headers();
         $this->assertArrayHasKey('X-Frame-Options', $headers);
 
@@ -822,7 +822,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $output = ob_get_clean();
 
         $this->assertStringContainsString('This is a test page', $output);
-        $response = Services::response();
+        $response = service('response');
         $headers  = $response->headers();
         $this->assertArrayHasKey('X-Frame-Options', $headers);
 
@@ -868,18 +868,18 @@ final class CodeIgniterTest extends CIUnitTestCase
             $_SERVER['SCRIPT_NAME'] = '/index.php';
             $this->codeigniter      = new MockCodeIgniter(new App());
 
-            $routes    = Services::routes(true);
+            $routes    = service('routes', true);
             $routePath = explode('?', $testingUrl)[0];
             $string    = 'This is a test page, to check cache configuration';
             $routes->add($routePath, static function () use ($string) {
-                Services::responsecache()->setTtl(60);
-                $response = Services::response();
+                service('responsecache')->setTtl(60);
+                $response = service('response');
 
                 return $response->setBody($string);
             });
 
             // Inject router
-            $router = Services::router($routes, Services::incomingrequest(null, false));
+            $router = service('router', $routes, service('incomingrequest', null, false));
             Services::injectMock('router', $router);
 
             // Cache the page output using default caching function and $cacheConfig
@@ -952,14 +952,14 @@ final class CodeIgniterTest extends CIUnitTestCase
         $_SERVER['SCRIPT_NAME'] = '/index.php';
 
         // Inject mock router.
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->setAutoRoute(true);
 
         // Inject the before filter.
         $filterConfig                            = config('Filters');
         $filterConfig->aliases['redirectFilter'] = RedirectFilter::class;
         $filterConfig->globals['before']         = ['redirectFilter'];
-        Services::filters($filterConfig);
+        service('filters', $filterConfig);
 
         $this->expectException(PageNotFoundException::class);
 

--- a/tests/system/Commands/BaseCommandTest.php
+++ b/tests/system/Commands/BaseCommandTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Commands;
 
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Commands\AppInfo;
 
@@ -30,7 +29,7 @@ final class BaseCommandTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->logger = Services::logger();
+        $this->logger = service('logger');
     }
 
     public function testMagicIssetTrue(): void

--- a/tests/system/Commands/CommandTest.php
+++ b/tests/system/Commands/CommandTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\CLI\Commands;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
-use Config\Services;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Commands\ParamsReveal;
@@ -39,8 +38,8 @@ final class CommandTest extends CIUnitTestCase
 
         parent::setUp();
 
-        $this->logger   = Services::logger();
-        $this->commands = Services::commands();
+        $this->logger   = service('logger');
+        $this->commands = service('commands');
     }
 
     protected function getBuffer(): string

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -46,7 +46,7 @@ final class RoutesTest extends CIUnitTestCase
 
     private function getCleanRoutes(): RouteCollection
     {
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->resetRoutes();
         $routes->loadRoutes();
 
@@ -243,7 +243,7 @@ final class RoutesTest extends CIUnitTestCase
 
     public function testRoutesCommandRouteWithRegexp(): void
     {
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->resetRoutes();
         $routes->options('picker/(.+)', 'Options::index');
 

--- a/tests/system/Commands/ScaffoldGeneratorTest.php
+++ b/tests/system/Commands/ScaffoldGeneratorTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\Autoload;
 use Config\Modules;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -31,7 +30,7 @@ final class ScaffoldGeneratorTest extends CIUnitTestCase
     protected function setUp(): void
     {
         $this->resetServices();
-        Services::autoloader()->initialize(new Autoload(), new Modules());
+        service('autoloader')->initialize(new Autoload(), new Modules());
 
         parent::setUp();
     }

--- a/tests/system/Commands/Translation/LocalizationFinderTest.php
+++ b/tests/system/Commands/Translation/LocalizationFinderTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Commands\Translation;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\App;
-use Config\Services;
 use Locale;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -68,7 +67,7 @@ final class LocalizationFinderTest extends CIUnitTestCase
         self::$locale = 'test_locale_incorrect';
         $this->makeLocaleDirectory();
 
-        $status = Services::commands()->run('lang:find', [
+        $status = service('commands')->run('lang:find', [
             'dir'    => 'Translation',
             'locale' => self::$locale,
         ]);
@@ -89,7 +88,7 @@ final class LocalizationFinderTest extends CIUnitTestCase
     {
         $this->makeLocaleDirectory();
 
-        $status = Services::commands()->run('lang:find', [
+        $status = service('commands')->run('lang:find', [
             'dir' => 'Translation/NotExistFolder',
         ]);
 

--- a/tests/system/Commands/Utilities/ConfigCheckTest.php
+++ b/tests/system/Commands/Utilities/ConfigCheckTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Commands\Utilities;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\StreamFilterTrait;
 use Config\App;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -74,7 +73,7 @@ final class ConfigCheckTest extends CIUnitTestCase
 
     public function testGetKintD(): void
     {
-        $command  = new ConfigCheck(Services::logger(), Services::commands());
+        $command  = new ConfigCheck(service('logger'), service('commands'));
         $getKintD = $this->getPrivateMethodInvoker($command, 'getKintD');
 
         $output = $getKintD(new App());
@@ -114,7 +113,7 @@ final class ConfigCheckTest extends CIUnitTestCase
 
     public function testGetVarDump(): void
     {
-        $command    = new ConfigCheck(Services::logger(), Services::commands());
+        $command    = new ConfigCheck(service('logger'), service('commands'));
         $getVarDump = $this->getPrivateMethodInvoker($command, 'getVarDump');
 
         $output = $getVarDump(new App());

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollectorTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Filters;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -34,7 +33,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
 
     private function createAutoRouteCollector(array $filterConfigFilters): AutoRouteCollector
     {
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->resetRoutes();
         $routes->setAutoRoute(true);
         config('Feature')->autoRoutesImproved = true;
@@ -44,7 +43,7 @@ final class AutoRouteCollectorTest extends CIUnitTestCase
         /** @var Filters $filterConfig */
         $filterConfig          = config('Filters');
         $filterConfig->filters = $filterConfigFilters;
-        Services::filters($filterConfig);
+        service('filters', $filterConfig);
 
         return new AutoRouteCollector(
             $namespace,

--- a/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterCollectorTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Commands\Utilities\Routes;
 
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -26,7 +25,7 @@ final class FilterCollectorTest extends CIUnitTestCase
 {
     public function testGet(): void
     {
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->resetRoutes();
         $routes->setDefaultNamespace('App\Controllers');
         $routes->get('/', 'Home::index');

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\CSRF;
 use CodeIgniter\Filters\DebugToolbar;
 use CodeIgniter\Filters\Filters;
@@ -47,8 +46,8 @@ final class FilterFinderTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->request  = Services::request();
-        $this->response = Services::response();
+        $this->request  = service('request');
+        $this->response = service('response');
 
         $this->moduleConfig          = new Modules();
         $this->moduleConfig->enabled = false;
@@ -56,7 +55,7 @@ final class FilterFinderTest extends CIUnitTestCase
 
     private function createRouteCollection(array $routes = []): RouteCollection
     {
-        $collection = new RouteCollection(Services::locator(), $this->moduleConfig, new Routing());
+        $collection = new RouteCollection(service('locator'), $this->moduleConfig, new Routing());
 
         $routes = ($routes !== []) ? $routes : [
             'users'                   => 'Users::index',

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Commands\Utilities\Routes;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -49,7 +48,7 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
 
     public function testGetFromPlaceholderCustomPlaceholder(): void
     {
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->addPlaceholder(
             'uuid',
             '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -630,11 +630,11 @@ final class CommonFunctionsTest extends CIUnitTestCase
     #[WithoutErrorHandler]
     public function testForceHttpsNullRequestAndResponse(): void
     {
-        $this->assertNull(Services::response()->header('Location'));
+        $this->assertNull(service('response')->header('Location'));
 
-        Services::response()->setCookie('force', 'cookie');
-        Services::response()->setHeader('Force', 'header');
-        Services::response()->setBody('default body');
+        service('response')->setCookie('force', 'cookie');
+        service('response')->setHeader('Force', 'header');
+        service('response')->setBody('default body');
 
         try {
             force_https();
@@ -726,7 +726,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $config->CSPEnabled = true;
 
         // Initialize Kint
-        Services::autoloader()->initializeKint(CI_DEBUG);
+        service('autoloader')->initializeKint(CI_DEBUG);
 
         $cliDetection        = Kint::$cli_detection;
         Kint::$cli_detection = false;
@@ -750,7 +750,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $config->CSPEnabled = true;
 
         // Initialize Kint
-        Services::autoloader()->initializeKint(CI_DEBUG);
+        service('autoloader')->initializeKint(CI_DEBUG);
 
         Kint::$cli_detection = false;
 

--- a/tests/system/CommonHelperTest.php
+++ b/tests/system/CommonHelperTest.php
@@ -82,7 +82,7 @@ final class CommonHelperTest extends CIUnitTestCase
     private function getMockLocator()
     {
         return $this->getMockBuilder(FileLocator::class)
-            ->setConstructorArgs([Services::autoloader()])
+            ->setConstructorArgs([service('autoloader')])
             ->onlyMethods(['search'])
             ->getMock();
     }
@@ -90,7 +90,7 @@ final class CommonHelperTest extends CIUnitTestCase
     public function testHelperWithFatalLocatorThrowsException(): void
     {
         // Replace the locator with one that will fail if it is called
-        $locator = new FatalLocator(Services::autoloader());
+        $locator = new FatalLocator(service('autoloader'));
         Services::injectMock('locator', $locator);
 
         try {
@@ -109,7 +109,7 @@ final class CommonHelperTest extends CIUnitTestCase
         helper('baguette');
 
         // Replace the locator with one that will fail if it is called
-        $locator = new FatalLocator(Services::autoloader());
+        $locator = new FatalLocator(service('autoloader'));
         Services::injectMock('locator', $locator);
 
         try {

--- a/tests/system/CommonSingleServiceTest.php
+++ b/tests/system/CommonSingleServiceTest.php
@@ -48,7 +48,7 @@ final class CommonSingleServiceTest extends CIUnitTestCase
     {
         if ($service === 'commands') {
             $locator = $this->getMockBuilder(FileLocator::class)
-                ->setConstructorArgs([Services::autoloader()])
+                ->setConstructorArgs([service('autoloader')])
                 ->onlyMethods(['listFiles'])
                 ->getMock();
 

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -216,7 +216,7 @@ final class ServicesTest extends CIUnitTestCase
 
     public function testNewToolbar(): void
     {
-        $actual = Services::toolbar(null);
+        $actual = service('toolbar', null);
         $this->assertInstanceOf(Toolbar::class, $actual);
     }
 
@@ -385,7 +385,7 @@ final class ServicesTest extends CIUnitTestCase
 
     public function testFormat(): void
     {
-        $this->assertInstanceOf(Format::class, Services::format());
+        $this->assertInstanceOf(Format::class, service('format'));
     }
 
     public function testUnsharedFormat(): void

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -23,7 +23,6 @@ use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use Config\App;
-use Config\Services;
 use Config\Validation as ValidationConfig;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\Group;
@@ -61,7 +60,7 @@ final class ControllerTest extends CIUnitTestCase
         $config         = new App();
         $this->request  = new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
         $this->response = new Response($config);
-        $this->logger   = Services::logger();
+        $this->logger   = service('logger');
     }
 
     public function testConstructor(): void
@@ -149,7 +148,7 @@ final class ControllerTest extends CIUnitTestCase
 
         $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup'));
-        $this->assertSame('You must choose a username.', Services::validation()->getError('username'));
+        $this->assertSame('You must choose a username.', service('validation')->getError('username'));
     }
 
     public function testValidateWithStringRulesFoundUseMessagesParameter(): void
@@ -174,7 +173,7 @@ final class ControllerTest extends CIUnitTestCase
                 'required' => 'You must choose a username.',
             ],
         ]));
-        $this->assertSame('You must choose a username.', Services::validation()->getError('username'));
+        $this->assertSame('You must choose a username.', service('validation')->getError('username'));
     }
 
     public function testValidateData(): void
@@ -196,7 +195,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->assertFalse($method($data, $rule));
         $this->assertSame(
             'The password field must be at least 10 characters in length.',
-            Services::validation()->getError('password')
+            service('validation')->getError('password')
         );
     }
 
@@ -225,11 +224,11 @@ final class ControllerTest extends CIUnitTestCase
         $this->assertFalse($method($data, $rules, $errors));
         $this->assertSame(
             '"username" must be 3 letters or longer.',
-            Services::validation()->getError('username')
+            service('validation')->getError('username')
         );
         $this->assertSame(
             'The password field must be at least 10 characters in length.',
-            Services::validation()->getError('password')
+            service('validation')->getError('password')
         );
     }
 
@@ -263,11 +262,11 @@ final class ControllerTest extends CIUnitTestCase
         $this->assertFalse($method($data, $rules));
         $this->assertSame(
             '"Username" must be 3 letters or longer.',
-            Services::validation()->getError('username')
+            service('validation')->getError('username')
         );
         $this->assertSame(
             'The Password field must be at least 10 characters in length.',
-            Services::validation()->getError('password')
+            service('validation')->getError('password')
         );
     }
 

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Database\DatabaseTestCase;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -68,7 +67,7 @@ final class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
 
     protected function setUpAddNamespace(): void
     {
-        Services::autoloader()->addNamespace(
+        service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
             SUPPORTPATH . 'MigrationTestMigrations'
         );

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Database\DatabaseTestCase;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -68,7 +67,7 @@ final class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
 
     protected function setUpAddNamespace(): void
     {
-        Services::autoloader()->addNamespace(
+        service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
             SUPPORTPATH . 'MigrationTestMigrations'
         );

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Database;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Database\Seeds\AnotherSeeder;
 use Tests\Support\Database\Seeds\CITestSeeder;
@@ -73,7 +72,7 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
 
     protected function setUpAddNamespace(): void
     {
-        Services::autoloader()->addNamespace(
+        service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
             SUPPORTPATH . 'MigrationTestMigrations'
         );

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -21,7 +21,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
 use Config\Migrations;
-use Config\Services;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\Group;
@@ -60,7 +59,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
     protected function setUpAddNamespace(): void
     {
-        Services::autoloader()->addNamespace(
+        service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
             SUPPORTPATH . 'MigrationTestMigrations'
         );

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -107,8 +107,8 @@ final class ExceptionHandlerTest extends CIUnitTestCase
     {
         $exception = PageNotFoundException::forControllerNotFound('Foo', 'bar');
 
-        $request  = Services::incomingrequest(null, false);
-        $response = Services::response(null, false);
+        $request  = service('incomingrequest', null, false);
+        $response = service('response', null, false);
         $response->pretend();
 
         ob_start();
@@ -126,9 +126,9 @@ final class ExceptionHandlerTest extends CIUnitTestCase
     {
         $exception = PageNotFoundException::forControllerNotFound('Foo', 'bar');
 
-        $request = Services::incomingrequest(null, false);
+        $request = service('incomingrequest', null, false);
         $request->setHeader('accept', 'text/html');
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
         $response->pretend();
 
         ob_start();
@@ -144,7 +144,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
         $request = Services::clirequest(null, false);
         $request->setHeader('accept', 'text/html');
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
         $response->pretend();
 
         $this->handler->handle($exception, $request, $response, 404, EXIT_ERROR);

--- a/tests/system/Filters/CSRFTest.php
+++ b/tests/system/Filters/CSRFTest.php
@@ -51,7 +51,7 @@ final class CSRFTest extends CIUnitTestCase
         ];
 
         $this->request  = Services::clirequest(null, false);
-        $this->response = Services::response();
+        $this->response = service('response');
 
         $filters = new Filters($this->config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';
@@ -68,8 +68,8 @@ final class CSRFTest extends CIUnitTestCase
             'after'  => [],
         ];
 
-        $this->request  = Services::incomingrequest(null, false);
-        $this->response = Services::response();
+        $this->request  = service('incomingrequest', null, false);
+        $this->response = service('response');
 
         $filters = new Filters($this->config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';

--- a/tests/system/Filters/CorsTest.php
+++ b/tests/system/Filters/CorsTest.php
@@ -22,7 +22,6 @@ use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -145,10 +144,10 @@ final class CorsTest extends CIUnitTestCase
             return $response;
         }
 
-        $response ??= Services::response();
+        $response ??= service('response');
 
         $response = $this->cors->after($request, $response);
-        $response ??= Services::response();
+        $response ??= service('response');
 
         $this->response = $response;
 

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
@@ -40,8 +39,8 @@ final class DebugToolbarTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->request  = Services::request();
-        $this->response = Services::response();
+        $this->request  = service('request');
+        $this->response = service('response');
     }
 
     public function testDebugToolbarFilter(): void

--- a/tests/system/Filters/DebugToolbarTest.php
+++ b/tests/system/Filters/DebugToolbarTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Filters;
 
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Filters as FilterConfig;
@@ -31,7 +32,7 @@ final class DebugToolbarTest extends CIUnitTestCase
     /**
      * @var CLIRequest|IncomingRequest
      */
-    private $request;
+    private RequestInterface $request;
 
     private Response $response;
 

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Filters\Exceptions\FilterException;
 use CodeIgniter\Filters\fixtures\GoogleCurious;
@@ -66,16 +65,16 @@ final class FiltersTest extends CIUnitTestCase
             'App'           => APPPATH,
             'Tests\Support' => TESTPATH . '_support',
         ];
-        Services::autoloader()->addNamespace($defaults);
+        service('autoloader')->addNamespace($defaults);
 
         $_SERVER = [];
 
-        $this->response = Services::response();
+        $this->response = service('response');
     }
 
     private function createFilters(FiltersConfig $config, $request = null): Filters
     {
-        $request ??= Services::request();
+        $request ??= service('request');
 
         return new Filters($config, $request, $this->response);
     }

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\Filters;
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Honeypot;
@@ -36,9 +37,9 @@ final class HoneypotTest extends CIUnitTestCase
     private Honeypot $honey;
 
     /**
-     * @var CLIRequest|IncomingRequest|null
+     * @var CLIRequest|IncomingRequest
      */
-    private $request;
+    private RequestInterface $request;
 
     private ?Response $response = null;
 

--- a/tests/system/Filters/HoneypotTest.php
+++ b/tests/system/Filters/HoneypotTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
@@ -62,8 +61,8 @@ final class HoneypotTest extends CIUnitTestCase
             'after'  => [],
         ];
 
-        $this->request  = Services::request(null, false);
-        $this->response = Services::response();
+        $this->request  = service('request', null, false);
+        $this->response = service('response');
 
         $filters = new Filters($this->config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';
@@ -80,8 +79,8 @@ final class HoneypotTest extends CIUnitTestCase
         ];
 
         unset($_POST[$this->honey->name]);
-        $this->request  = Services::request(null, false);
-        $this->response = Services::response();
+        $this->request  = service('request', null, false);
+        $this->response = service('response');
 
         $expected = $this->request;
 
@@ -101,8 +100,8 @@ final class HoneypotTest extends CIUnitTestCase
             'after'  => ['honeypot'],
         ];
 
-        $this->request  = Services::request(null, false);
-        $this->response = Services::response();
+        $this->request  = service('request', null, false);
+        $this->response = service('response');
 
         $filters = new Filters($this->config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';
@@ -121,8 +120,8 @@ final class HoneypotTest extends CIUnitTestCase
             'after'  => ['honeypot'],
         ];
 
-        $this->request  = Services::request(null, false);
-        $this->response = Services::response();
+        $this->request  = service('request', null, false);
+        $this->response = service('response');
 
         $filters = new Filters($this->config, $this->request, $this->response);
         $uri     = 'admin/foo/bar';

--- a/tests/system/Filters/SecureHeadersTest.php
+++ b/tests/system/Filters/SecureHeadersTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -26,8 +25,8 @@ final class SecureHeadersTest extends CIUnitTestCase
     public function testAfter(): void
     {
         $filter   = new SecureHeaders();
-        $request  = Services::request(null, false);
-        $response = Services::response(null, false);
+        $request  = service('request', null, false);
+        $response = service('response', null, false);
 
         $filter->after($request, $response);
 

--- a/tests/system/Filters/fixtures/GoogleYou.php
+++ b/tests/system/Filters/fixtures/GoogleYou.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Filters\fixtures;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
@@ -22,7 +21,7 @@ class GoogleYou implements FilterInterface
 {
     public function before(RequestInterface $request, $arguments = null)
     {
-        $response = Services::response();
+        $response = service('response');
         $response->setBody('http://google.com');
 
         return $response;

--- a/tests/system/HTTP/CorsTest.php
+++ b/tests/system/HTTP/CorsTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -41,7 +40,7 @@ final class CorsTest extends CIUnitTestCase
 
     private function createRequest(): IncomingRequest
     {
-        return Services::incomingrequest(null, false);
+        return service('incomingrequest', null, false);
     }
 
     /**
@@ -103,7 +102,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Access-Control-Request-Method', 'PUT')
             ->setHeader('Origin', 'http://localhost:8080');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->handlePreflightRequest($request, $response);
 
@@ -138,7 +137,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Access-Control-Request-Method', 'PUT')
             ->setHeader('Origin', 'https://api.example.com');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->handlePreflightRequest($request, $response);
 
@@ -175,7 +174,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Access-Control-Request-Method', 'PUT')
             ->setHeader('Origin', 'https://api.example.com');
 
-        $response = Services::response(null, false)
+        $response = service('response', null, false)
             ->setHeader('Vary', 'Accept-Language');
 
         $response = $cors->handlePreflightRequest($request, $response);
@@ -213,7 +212,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Access-Control-Request-Method', 'PUT')
             ->setHeader('Origin', 'https://bad.site.com');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->handlePreflightRequest($request, $response);
 
@@ -239,7 +238,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Access-Control-Request-Method', 'PUT')
             ->setHeader('Origin', 'https://api.example.com');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->handlePreflightRequest($request, $response);
 
@@ -276,7 +275,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Access-Control-Request-Method', 'PUT')
             ->setHeader('Origin', 'https://bad.site.com');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->handlePreflightRequest($request, $response);
 
@@ -303,7 +302,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Access-Control-Request-Method', 'PUT')
             ->setHeader('Origin', 'http://localhost:8080');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->handlePreflightRequest($request, $response);
 
@@ -340,7 +339,7 @@ final class CorsTest extends CIUnitTestCase
             ->withMethod('GET')
             ->setHeader('Origin', 'http://localhost:8080');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->addResponseHeaders($request, $response);
 
@@ -371,7 +370,7 @@ final class CorsTest extends CIUnitTestCase
             ->withMethod('POST')
             ->setHeader('Origin', 'http://localhost:8080');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->addResponseHeaders($request, $response);
 
@@ -395,7 +394,7 @@ final class CorsTest extends CIUnitTestCase
             ->setHeader('Cookie', 'pageAccess=2')
             ->setHeader('Origin', 'http://localhost:8080');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->addResponseHeaders($request, $response);
 
@@ -423,7 +422,7 @@ final class CorsTest extends CIUnitTestCase
             ->withMethod('GET')
             ->setHeader('Origin', 'http://localhost:8080');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->addResponseHeaders($request, $response);
 
@@ -449,7 +448,7 @@ final class CorsTest extends CIUnitTestCase
             ->withMethod('PUT')
             ->setHeader('Origin', 'https://api.example.com');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->addResponseHeaders($request, $response);
 
@@ -481,7 +480,7 @@ final class CorsTest extends CIUnitTestCase
             ->withMethod('PUT')
             ->setHeader('Origin', 'https://api.example.com');
 
-        $response = Services::response(null, false)
+        $response = service('response', null, false)
             ->setHeader('Vary', 'Accept-Language');
 
         $response = $cors->addResponseHeaders($request, $response);
@@ -508,7 +507,7 @@ final class CorsTest extends CIUnitTestCase
             ->withMethod('PUT')
             ->setHeader('Origin', 'https://bad.site.com');
 
-        $response = Services::response(null, false);
+        $response = service('response', null, false);
 
         $response = $cors->addResponseHeaders($request, $response);
 

--- a/tests/system/HTTP/RedirectExceptionTest.php
+++ b/tests/system/HTTP/RedirectExceptionTest.php
@@ -46,7 +46,7 @@ final class RedirectExceptionTest extends TestCase
     public function testResponse(): void
     {
         $response = (new RedirectException(
-            Services::response()
+            service('response')
                 ->redirect('redirect')
                 ->setCookie('cookie', 'value')
                 ->setHeader('Redirect-Header', 'value')
@@ -65,12 +65,12 @@ final class RedirectExceptionTest extends TestCase
             'The Response object passed to RedirectException does not contain a redirect address.'
         );
 
-        new RedirectException(Services::response());
+        new RedirectException(service('response'));
     }
 
     public function testResponseWithoutStatusCode(): void
     {
-        $response = (new RedirectException(Services::response()->setHeader('Location', 'location')))->getResponse();
+        $response = (new RedirectException(service('response')->setHeader('Location', 'location')))->getResponse();
 
         $this->assertSame('location', $response->getHeaderLine('location'));
         $this->assertSame(302, $response->getStatusCode());
@@ -82,7 +82,7 @@ final class RedirectExceptionTest extends TestCase
 
         $uri      = 'http://location';
         $expected = 'INFO - ' . Time::now()->format('Y-m-d') . ' --> REDIRECTED ROUTE at ' . $uri;
-        $response = (new RedirectException(Services::response()->redirect($uri)))->getResponse();
+        $response = (new RedirectException(service('response')->redirect($uri)))->getResponse();
 
         $logs = TestHandler::getLogs();
 
@@ -97,7 +97,7 @@ final class RedirectExceptionTest extends TestCase
 
         $uri      = 'http://location';
         $expected = 'INFO - ' . Time::now()->format('Y-m-d') . ' --> REDIRECTED ROUTE at ' . $uri;
-        $response = (new RedirectException(Services::response()->redirect($uri, 'refresh')))->getResponse();
+        $response = (new RedirectException(service('response')->redirect($uri, 'refresh')))->getResponse();
 
         $logs = TestHandler::getLogs();
 

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -54,7 +54,7 @@ final class RedirectResponseTest extends CIUnitTestCase
         $this->config          = new App();
         $this->config->baseURL = 'http://example.com/';
 
-        $this->routes = new RouteCollection(Services::locator(), new Modules(), new Routing());
+        $this->routes = new RouteCollection(service('locator'), new Modules(), new Routing());
         Services::injectMock('routes', $this->routes);
 
         $this->request = new MockIncomingRequest(
@@ -237,7 +237,7 @@ final class RedirectResponseTest extends CIUnitTestCase
     {
         $_SESSION = [];
 
-        $baseResponse = Services::response();
+        $baseResponse = service('response');
         $baseResponse->setCookie('foo', 'bar');
 
         $response = new RedirectResponse(new App());

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -18,7 +18,6 @@ use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockResponse;
 use Config\App;
-use Config\Services;
 use DateTime;
 use DateTimeZone;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -169,7 +168,7 @@ final class ResponseTest extends CIUnitTestCase
         $this->resetServices();
 
         $response = new Response($config);
-        $pager    = Services::pager();
+        $pager    = service('pager');
 
         $pager->store('default', 3, 10, 200);
         $response->setLink($pager);
@@ -390,7 +389,7 @@ final class ResponseTest extends CIUnitTestCase
                 3,
             ],
         ];
-        $expected = Services::format()->getFormatter('application/json')->format($body);
+        $expected = service('format')->getFormatter('application/json')->format($body);
 
         $response = new Response(new App());
         $response->setJSON($body);
@@ -409,7 +408,7 @@ final class ResponseTest extends CIUnitTestCase
                 3,
             ],
         ];
-        $expected = Services::format()->getFormatter('application/json')->format($body);
+        $expected = service('format')->getFormatter('application/json')->format($body);
 
         $response = new Response(new App());
         $response->setBody($body);
@@ -427,7 +426,7 @@ final class ResponseTest extends CIUnitTestCase
                 3,
             ],
         ];
-        $expected = Services::format()->getFormatter('application/xml')->format($body);
+        $expected = service('format')->getFormatter('application/xml')->format($body);
 
         $response = new Response(new App());
         $response->setXML($body);
@@ -446,7 +445,7 @@ final class ResponseTest extends CIUnitTestCase
                 3,
             ],
         ];
-        $expected = Services::format()->getFormatter('application/xml')->format($body);
+        $expected = service('format')->getFormatter('application/xml')->format($body);
 
         $response = new Response(new App());
         $response->setBody($body);

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -1046,7 +1046,7 @@ final class URITest extends CIUnitTestCase
         $config->indexPage = '';
         Factories::injectMock('config', 'App', $config);
 
-        $request = Services::request($config);
+        $request = service('request', $config);
         Services::injectMock('request', $request);
 
         // going through request
@@ -1080,7 +1080,7 @@ final class URITest extends CIUnitTestCase
         $config->indexPage = 'index.php';
         Factories::injectMock('config', 'App', $config);
 
-        $request = Services::request($config);
+        $request = service('request', $config);
         Services::injectMock('request', $request);
 
         // going through request
@@ -1120,7 +1120,7 @@ final class URITest extends CIUnitTestCase
         $config->forceGlobalSecureRequests = true;
         Factories::injectMock('config', 'App', $config);
 
-        $request = Services::request($config);
+        $request = service('request', $config);
         Services::injectMock('request', $request);
 
         // Detected by request

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -49,7 +49,7 @@ final class CookieHelperTest extends CIUnitTestCase
         $this->expire = 9999;
 
         Services::injectMock('response', new MockResponse(new App()));
-        $this->response = Services::response();
+        $this->response = service('response');
         $request        = new IncomingRequest(new App(), new SiteURI(new App()), null, new UserAgent());
         Services::injectMock('request', $request);
 

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -48,7 +48,7 @@ final class FormHelperTest extends CIUnitTestCase
         $uri = new SiteURI($config);
         Services::injectMock('uri', $uri);
 
-        $request = Services::request($config);
+        $request = service('request', $config);
         Services::injectMock('request', $request);
     }
 
@@ -1050,7 +1050,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testValidationErrorsFromValidation(): void
     {
-        $validation = Services::validation();
+        $validation = service('validation');
         $validation->setRule('id', 'ID', 'required')->run([]);
 
         $this->assertSame(['id' => 'The ID field is required.'], validation_errors());
@@ -1058,7 +1058,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testValidationListErrors(): void
     {
-        $validation = Services::validation();
+        $validation = service('validation');
         $validation->setRule('id', 'ID', 'required')->run([]);
 
         $html = validation_list_errors();
@@ -1068,7 +1068,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testValidationShowError(): void
     {
-        $validation = Services::validation();
+        $validation = service('validation');
         $validation->setRule('id', 'ID', 'required')->run([]);
 
         $html = validation_show_error('id');
@@ -1081,7 +1081,7 @@ final class FormHelperTest extends CIUnitTestCase
 
     public function testValidationShowErrorForWildcards(): void
     {
-        $validation = Services::validation();
+        $validation = service('validation');
         $validation->setRule('user.*.name', 'Name', 'required')
             ->run([
                 'user' => [

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -44,7 +44,7 @@ final class MiscUrlTest extends CIUnitTestCase
         parent::setUp();
 
         Services::reset(true);
-        Services::routes()->loadRoutes();
+        service('routes')->loadRoutes();
 
         // Set a common base configuration (overriden by individual tests)
         $this->config            = new App();
@@ -956,7 +956,7 @@ final class MiscUrlTest extends CIUnitTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Missing argument for "(:alpha)" in route "(:alpha)/login".');
 
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->group('(:alpha)', static function ($routes): void {
             $routes->match(['GET'], 'login', 'Common\LoginController::loginView', ['as' => 'loginURL']);
         });

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Honeypot;
 
 use CodeIgniter\Config\Factories;
-use CodeIgniter\Config\Services;
 use CodeIgniter\Filters\Filters;
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\CLIRequest;
@@ -54,8 +53,8 @@ final class HoneypotTest extends CIUnitTestCase
         $_SERVER['REQUEST_METHOD']  = 'POST';
         $_POST[$this->config->name] = 'hey';
 
-        $this->request  = Services::request(null, false);
-        $this->response = Services::response();
+        $this->request  = service('request', null, false);
+        $this->response = service('response');
     }
 
     public function testAttachHoneypot(): void
@@ -99,7 +98,7 @@ final class HoneypotTest extends CIUnitTestCase
         $config             = new App();
         $config->CSPEnabled = true;
         Factories::injectMock('config', 'App', $config);
-        $this->response = Services::response($config, false);
+        $this->response = service('response', $config, false);
 
         $this->config   = new HoneypotConfig();
         $this->honeypot = new Honeypot($this->config);
@@ -118,7 +117,7 @@ final class HoneypotTest extends CIUnitTestCase
         $config             = new App();
         $config->CSPEnabled = true;
         Factories::injectMock('config', 'App', $config);
-        $this->response = Services::response($config, false);
+        $this->response = service('response', $config, false);
 
         $this->config   = new HoneypotConfig();
         $this->honeypot = new Honeypot($this->config);
@@ -132,7 +131,7 @@ final class HoneypotTest extends CIUnitTestCase
     public function testHasntContent(): void
     {
         unset($_POST[$this->config->name]);
-        $this->request = Services::request();
+        $this->request = service('request');
 
         $this->assertFalse($this->honeypot->hasContent($this->request));
     }

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -18,6 +18,7 @@ use CodeIgniter\Filters\Filters;
 use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
@@ -38,7 +39,7 @@ final class HoneypotTest extends CIUnitTestCase
     /**
      * @var CLIRequest|IncomingRequest
      */
-    private $request;
+    private RequestInterface $request;
 
     private Response $response;
 

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Language;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockLanguage;
-use Config\Services;
 use MessageFormatter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -296,7 +295,7 @@ final class LanguageTest extends CIUnitTestCase
 
     public function testGetLocale(): void
     {
-        $this->lang = Services::language('en', false);
+        $this->lang = service('language', 'en', false);
         $this->assertSame('en', $this->lang->getLocale());
     }
 
@@ -353,7 +352,7 @@ final class LanguageTest extends CIUnitTestCase
 
     public function testBaseFallbacks(): void
     {
-        $this->lang = Services::language('en-ZZ', false);
+        $this->lang = service('language', 'en-ZZ', false);
         // key is in both base and variant; should pick variant
         $this->assertSame("It's made of cheese", $this->lang->getLine('More.notaMoon'));
 
@@ -372,7 +371,7 @@ final class LanguageTest extends CIUnitTestCase
      */
     public function testLangKeepLocale(): void
     {
-        $this->lang = Services::language('en', true);
+        $this->lang = service('language', 'en', true);
 
         lang('Language.languageGetLineInvalidArgumentException');
         $this->assertSame('en', $this->lang->getLocale());
@@ -399,7 +398,7 @@ final class LanguageTest extends CIUnitTestCase
      */
     public function testAllTheWayFallbacks(): void
     {
-        $this->lang = Services::language('ab-CD', false);
+        $this->lang = service('language', 'ab-CD', false);
         $this->assertSame('Allin.none', $this->lang->getLine('Allin.none'));
         $this->assertSame('Pyramid of Giza', $this->lang->getLine('Allin.one'));
         $this->assertSame('gluttony', $this->lang->getLine('Allin.two'));

--- a/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
+++ b/tests/system/Log/Handlers/ChromeLoggerHandlerTest.php
@@ -56,7 +56,7 @@ final class ChromeLoggerHandlerTest extends CIUnitTestCase
         $logger = new ChromeLoggerHandler($config->handlers['CodeIgniter\Log\Handlers\TestHandler']);
         $logger->sendLogs();
 
-        $response = Services::response(null, true);
+        $response = service('response', null, true);
 
         $this->assertTrue($response->hasHeader('X-ChromeLogger-Data'));
     }

--- a/tests/system/Models/ValidationModelRuleGroupTest.php
+++ b/tests/system/Models/ValidationModelRuleGroupTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Models;
 
 use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Model;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use Tests\Support\Config\Validation;
@@ -40,7 +39,7 @@ final class ValidationModelRuleGroupTest extends LiveModelTestCase
     protected function createModel(string $modelName, ?BaseConnection $db = null): Model
     {
         $config     = new Validation();
-        $validation = new \CodeIgniter\Validation\Validation($config, Services::renderer());
+        $validation = new \CodeIgniter\Validation\Validation($config, service('renderer'));
 
         $this->db    = $db ?? $this->db;
         $this->model = new $modelName($this->db, $validation);

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -64,7 +64,7 @@ final class PagerTest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         $this->config = new PagerConfig();
-        $this->pager  = new Pager($this->config, Services::renderer());
+        $this->pager  = new Pager($this->config, service('renderer'));
     }
 
     public function testSetPathRemembersPath(): void
@@ -493,7 +493,7 @@ final class PagerTest extends CIUnitTestCase
         Services::injectMock('request', $request);
 
         $this->config = new PagerConfig();
-        $this->pager  = new Pager($this->config, Services::renderer());
+        $this->pager  = new Pager($this->config, service('renderer'));
 
         $_GET['page_foo'] = 2;
 

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -69,14 +69,14 @@ final class ResourceControllerTest extends CIUnitTestCase
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 
         // Inject mock router.
-        $this->routes = Services::routes();
+        $this->routes = service('routes');
         $this->routes->resource('work', ['controller' => '\\' . Worker::class]);
         Services::injectMock('routes', $this->routes);
 
         $config            = new App();
         $this->codeigniter = new MockCodeIgniter($config);
 
-        $response = Services::response();
+        $response = service('response');
         $response->pretend();
     }
 

--- a/tests/system/RESTful/ResourcePresenterTest.php
+++ b/tests/system/RESTful/ResourcePresenterTest.php
@@ -63,7 +63,7 @@ final class ResourcePresenterTest extends CIUnitTestCase
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 
         // Inject mock router.
-        $this->routes = Services::routes();
+        $this->routes = service('routes');
         $this->routes->presenter('work', ['controller' => '\\' . Worker2::class]);
         Services::injectMock('routes', $this->routes);
 

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Router;
 
 use CodeIgniter\Config\Factories;
-use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Router\Controllers\BlogController;
@@ -42,7 +41,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
 
         $moduleConfig          = new Modules();
         $moduleConfig->enabled = false;
-        $this->collection      = new RouteCollection(Services::locator(), $moduleConfig, new Routing());
+        $this->collection      = new RouteCollection(service('locator'), $moduleConfig, new Routing());
     }
 
     private function createNewAutoRouter(string $namespace = 'CodeIgniter\Router\Controllers'): AutoRouterImproved

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Modules;
@@ -34,9 +33,9 @@ final class DefinedRouteCollectorTest extends CIUnitTestCase
         ];
         $config = array_merge($config, $defaults);
 
-        Services::autoloader()->addNamespace($config);
+        service('autoloader')->addNamespace($config);
 
-        $loader = Services::locator();
+        $loader = service('locator');
 
         if ($moduleConfig === null) {
             $moduleConfig          = new Modules();

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Router;
 
-use CodeIgniter\Config\Services;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\Router\Exceptions\RouterException;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -44,9 +43,9 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
         ];
         $config = array_merge($config, $defaults);
 
-        Services::autoloader()->addNamespace($config);
+        service('autoloader')->addNamespace($config);
 
-        $loader = Services::locator();
+        $loader = service('locator');
 
         if ($moduleConfig === null) {
             $moduleConfig          = new Modules();

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Router;
 
 use App\Controllers\Product;
-use CodeIgniter\Config\Services;
 use CodeIgniter\controller;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Method;
@@ -47,9 +46,9 @@ final class RouteCollectionTest extends CIUnitTestCase
         ];
         $config = array_merge($config, $defaults);
 
-        Services::autoloader()->addNamespace($config);
+        service('autoloader')->addNamespace($config);
 
-        $loader = Services::locator();
+        $loader = service('locator');
 
         if ($moduleConfig === null) {
             $moduleConfig          = new Modules();
@@ -148,7 +147,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testAddWorksWithCurrentHTTPMethods(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -180,7 +179,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testMatchIgnoresInvalidHTTPMethods(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -193,7 +192,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testAddWorksWithArrayOFHTTPMethods(): void
     {
-        Services::request()->setMethod(Method::POST);
+        service('request')->setMethod(Method::POST);
 
         $routes = $this->getCollector();
 
@@ -714,7 +713,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithCustomController(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['controller' => '<script>gallery']);
@@ -731,7 +730,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithCustomPlaceholder(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['placeholder' => ':num']);
@@ -748,7 +747,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithDefaultPlaceholder(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->setDefaultConstraint('num');
@@ -766,7 +765,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithBogusDefaultPlaceholder(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->setDefaultConstraint(':num');
@@ -784,7 +783,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithOnly(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['only' => 'index']);
@@ -798,7 +797,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testResourcesWithExcept(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->resource('photos', ['except' => 'edit,new']);
@@ -829,7 +828,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testMatchSupportsMultipleMethods(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -837,7 +836,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
 
-        Services::request()->setMethod(Method::POST);
+        service('request')->setMethod(Method::POST);
         $routes = $this->getCollector();
         $routes->match(['GET', 'POST'], 'here', 'there');
         $this->assertSame($expected, $routes->getRoutes());
@@ -845,7 +844,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testGet(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -967,7 +966,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     {
         // ENVIRONMENT should be 'testing'
 
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $expected = ['here' => '\there'];
@@ -1450,7 +1449,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testRouteGroupWithFilterSimple(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->group(
@@ -1469,7 +1468,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testRouteGroupWithFilterWithParams(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->group(
@@ -1487,7 +1486,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideNot(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $this->assertNull($routes->get404Override());
@@ -1495,7 +1494,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideString(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->set404Override('Explode');
@@ -1504,7 +1503,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function test404OverrideCallable(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->set404Override(static function (): void {
@@ -1515,7 +1514,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testOffsetParameters(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
         $routes->get('users/(:num)', 'users/show/$1', ['offset' => 1]);
@@ -1531,7 +1530,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1543,7 +1542,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1555,7 +1554,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1567,7 +1566,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1579,7 +1578,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1591,7 +1590,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithGenericSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1603,7 +1602,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainMatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1615,7 +1614,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainMismatch(): void
     {
         $_SERVER['HTTP_HOST'] = 'dev.example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1627,7 +1626,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteToWithoutSubdomainNot(): void
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
 
@@ -1644,10 +1643,10 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingDifferentSubdomains(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $routes->setDefaultNamespace('App\Controllers');
         $routes->setDefaultController('Home');
@@ -1665,10 +1664,10 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingTwoRules(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $routes->setDefaultNamespace('App\Controllers');
         $routes->setDefaultController('Home');
@@ -1686,10 +1685,10 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingTwoRulesLastApplies(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $routes->setDefaultNamespace('App\Controllers');
         $routes->setDefaultController('Home');
@@ -1706,10 +1705,10 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingMatchingSubdomain(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $routes->setDefaultNamespace('App\Controllers');
         $routes->setDefaultController('Home');
@@ -1726,10 +1725,10 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testRouteOverwritingMatchingHost(): void
     {
         $_SERVER['HTTP_HOST'] = 'doc.domain.com';
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
 
         $routes = $this->getCollector();
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $routes->setDefaultNamespace('App\Controllers');
         $routes->setDefaultController('Home');
@@ -1750,9 +1749,9 @@ final class RouteCollectionTest extends CIUnitTestCase
      */
     public function testRouteDefaultNameSpace(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $routes->setDefaultNamespace('App\Controllers');
         $routes->get('/', 'Core\Home::index');
@@ -1764,9 +1763,9 @@ final class RouteCollectionTest extends CIUnitTestCase
 
     public function testZeroAsURIPath(): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $routes->setDefaultNamespace('App\Controllers');
         $routes->get('/0', 'Core\Home::index');
@@ -1796,7 +1795,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         copy(TESTPATH . '_support/_controller/Product.php', APPPATH . 'Controllers/Product.php');
 
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
         $router->handle('/product');
 
         unlink(APPPATH . 'Controllers/Product.php');
@@ -1810,7 +1809,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     #[DataProvider('provideRouteDefaultNamespace')]
     public function testRoutesControllerNameReturnsFQCN($namespace): void
     {
-        Services::request()->setMethod(Method::GET);
+        service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
         $routes->setAutoRoute(false);
         $routes->setDefaultNamespace($namespace);
@@ -1818,7 +1817,7 @@ final class RouteCollectionTest extends CIUnitTestCase
 
         copy(TESTPATH . '_support/_controller/Product.php', APPPATH . 'Controllers/Product.php');
 
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
         $router->handle('/product');
 
         unlink(APPPATH . 'Controllers/Product.php');
@@ -1957,7 +1956,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->useSupportedLocalesOnly(true);
         $routes->get('{locale}/products', 'Products::list');
 
-        $router = new Router($routes, Services::request());
+        $router = new Router($routes, service('request'));
 
         $this->expectException(PageNotFoundException::class);
         $router->handle('fr/products');

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Router;
 
 use Closure;
 use CodeIgniter\Config\Factories;
-use CodeIgniter\Config\Services;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Exceptions\BadRequestException;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
@@ -45,7 +44,7 @@ final class RouterTest extends CIUnitTestCase
 
         $this->createRouteCollection();
 
-        $this->request = Services::request();
+        $this->request = service('request');
         $this->request->setMethod(Method::GET);
     }
 
@@ -57,7 +56,7 @@ final class RouterTest extends CIUnitTestCase
         $routingConfig ??= new Routing();
         $routingConfig->defaultNamespace = '\\';
 
-        $this->collection = new RouteCollection(Services::locator(), $moduleConfig, $routingConfig);
+        $this->collection = new RouteCollection(service('locator'), $moduleConfig, $routingConfig);
 
         $routes = [
             '/'                                               => 'Home::index',

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -171,7 +171,7 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
     #[WithoutErrorHandler]
     public function testCSRFVerifyPostInvalidToken(): void
     {
-        Services::exceptions()->initialize();
+        service('exceptions')->initialize();
 
         $this->expectException(SecurityException::class);
         $this->expectExceptionMessage('The action you requested is not allowed.');

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -23,7 +23,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockAppConfig;
 use CodeIgniter\Test\Mock\MockSecurity;
 use Config\Security as SecurityConfig;
-use Config\Services;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -80,7 +79,7 @@ final class SecurityTest extends CIUnitTestCase
 
         $security->verify(new Request(new MockAppConfig()));
 
-        $cookie = Services::response()->getCookie('csrf_cookie_name');
+        $cookie = service('response')->getCookie('csrf_cookie_name');
         $this->assertSame($security->getHash(), $cookie->getValue());
     }
 

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -19,7 +19,6 @@ use CodeIgniter\Controller;
 use CodeIgniter\Log\Logger;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use Config\App;
-use Config\Services;
 use Exception;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -139,8 +138,8 @@ final class ControllerTestTraitTest extends CIUnitTestCase
 
         $result = $this->withURI('http://example.com')
             ->withConfig($config)
-            ->withRequest(Services::request($config))
-            ->withResponse(Services::response($config))
+            ->withRequest(service('request', $config))
+            ->withResponse(service('response', $config))
             ->withLogger($logger)
             ->withBody($body)
             ->controller(Popcorn::class)

--- a/tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
+++ b/tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
@@ -46,7 +46,7 @@ final class FeatureTestAutoRoutingImprovedTest extends CIUnitTestCase
 
     private static function initializeRouter(): void
     {
-        $routes = Services::routes();
+        $routes = service('routes');
         $routes->resetRoutes();
         $routes->loadRoutes();
 
@@ -56,7 +56,7 @@ final class FeatureTestAutoRoutingImprovedTest extends CIUnitTestCase
         $namespace = 'Tests\Support\Controllers';
         $routes->setDefaultNamespace($namespace);
 
-        $router = Services::router($routes);
+        $router = service('router', $routes);
 
         Services::injectMock('router', $router);
     }

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -21,7 +21,6 @@ use CodeIgniter\HTTP\Response;
 use CodeIgniter\Test\Mock\MockCodeIgniter;
 use Config\App;
 use Config\Routing;
-use Config\Services;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -153,10 +152,10 @@ final class FeatureTestTraitTest extends CIUnitTestCase
                 'POST',
                 'section/create',
                 static function (): string {
-                    $validation = Services::validation();
+                    $validation = service('validation');
                     $validation->setRule('title', 'title', 'required|min_length[3]');
 
-                    $post = Services::request()->getPost();
+                    $post = service('request')->getPost();
 
                     if ($validation->run($post)) {
                         return 'Okay';
@@ -370,7 +369,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage('Cannot access CLI Route: ');
 
-        $collection = Services::routes();
+        $collection = service('routes');
         $collection->setAutoRoute(true);
         $collection->setDefaultNamespace('Tests\Support\Controllers');
 
@@ -407,7 +406,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'GET',
                 'home',
-                static fn () => json_encode(Services::request()->getGet()),
+                static fn () => json_encode(service('request')->getGet()),
             ],
         ]);
         $data = [
@@ -434,7 +433,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'GET',
                 'home',
-                static fn () => json_encode(Services::request()->fetchGlobal('request')),
+                static fn () => json_encode(service('request')->fetchGlobal('request')),
             ],
         ]);
         $data = [
@@ -461,7 +460,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'POST',
                 'home',
-                static fn () => json_encode(Services::request()->getPost()),
+                static fn () => json_encode(service('request')->getPost()),
             ],
         ]);
         $data = [
@@ -488,7 +487,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'POST',
                 'home',
-                static fn () => json_encode(Services::request()->fetchGlobal('request')),
+                static fn () => json_encode(service('request')->fetchGlobal('request')),
             ],
         ]);
         $data = [
@@ -539,7 +538,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
             [
                 'PUT',
                 'home',
-                static fn () => json_encode(Services::request()->fetchGlobal('request')),
+                static fn () => json_encode(service('request')->fetchGlobal('request')),
             ],
         ]);
         $data = [

--- a/tests/system/Test/FilterTestTraitTest.php
+++ b/tests/system/Test/FilterTestTraitTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Test;
 
 use CodeIgniter\HTTP\RequestInterface;
-use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Filters\Customfilter;
 
@@ -98,7 +97,7 @@ final class FilterTestTraitTest extends CIUnitTestCase
         $result = $caller();
 
         $this->assertSame('http://hellowworld.com', $result->getBody());
-        $this->assertNull(Services::response()->getBody());
+        $this->assertNull(service('response')->getBody());
 
         $this->resetServices();
     }

--- a/tests/system/Test/TestResponseTest.php
+++ b/tests/system/Test/TestResponseTest.php
@@ -16,7 +16,6 @@ namespace CodeIgniter\Test;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
 use Config\App;
-use Config\Services;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -302,7 +301,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse('');
         $this->response->setJSON($data, true);
 
-        $formatter = Services::format()->getFormatter('application/json');
+        $formatter = service('format')->getFormatter('application/json');
         $this->assertSame($formatter->format($data), $this->testResponse->getJSON());
     }
 
@@ -349,7 +348,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse('');
         $this->response->setXML($data);
 
-        $formatter = Services::format()->getFormatter('application/xml');
+        $formatter = service('format')->getFormatter('application/xml');
         $this->assertSame($formatter->format($data), $this->testResponse->getXML());
     }
 
@@ -429,7 +428,7 @@ final class TestResponseTest extends CIUnitTestCase
         $this->getTestResponse('');
         $this->response->setJSON($data, true);
 
-        $formatter = Services::format()->getFormatter('application/json');
+        $formatter = service('format')->getFormatter('application/json');
         $this->testResponse->assertJSONExact($formatter->format($data));
     }
 

--- a/tests/system/Validation/CreditCardRulesTest.php
+++ b/tests/system/Validation/CreditCardRulesTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
@@ -47,7 +46,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, service('renderer'));
         $this->validation->reset();
     }
 

--- a/tests/system/Validation/FileRulesTest.php
+++ b/tests/system/Validation/FileRulesTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
@@ -49,7 +48,7 @@ final class FileRulesTest extends CIUnitTestCase
         $this->resetServices();
         parent::setUp();
 
-        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, service('renderer'));
         $this->validation->reset();
 
         $_FILES = [

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -53,7 +52,7 @@ class FormatRulesTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, service('renderer'));
         $this->validation->reset();
     }
 

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Validation;
 
 use CodeIgniter\Test\CIUnitTestCase;
-use Config\Services;
 use ErrorException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -52,7 +51,7 @@ class RulesTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, service('renderer'));
         $this->validation->reset();
     }
 

--- a/tests/system/Validation/StrictRules/CreditCardRulesTest.php
+++ b/tests/system/Validation/StrictRules/CreditCardRulesTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Validation\StrictRules;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Validation;
-use Config\Services;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
@@ -48,7 +47,7 @@ final class CreditCardRulesTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, service('renderer'));
         $this->validation->reset();
     }
 

--- a/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
+++ b/tests/system/Validation/StrictRules/DatabaseRelatedRulesTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Validation\Validation;
 use Config\Database;
-use Config\Services;
 use InvalidArgumentException;
 use LogicException;
 use PHPUnit\Framework\Attributes\Group;
@@ -55,7 +54,7 @@ class DatabaseRelatedRulesTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, service('renderer'));
         $this->validation->reset();
     }
 

--- a/tests/system/Validation/StrictRules/FileRulesTest.php
+++ b/tests/system/Validation/StrictRules/FileRulesTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\Validation\StrictRules;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Validation;
-use Config\Services;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Validation\TestRules;
@@ -50,7 +49,7 @@ final class FileRulesTest extends CIUnitTestCase
         $this->resetServices();
         parent::setUp();
 
-        $this->validation = new Validation((object) $this->config, Services::renderer());
+        $this->validation = new Validation((object) $this->config, service('renderer'));
         $this->validation->reset();
 
         $_FILES = [

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -20,7 +20,6 @@ use CodeIgniter\HTTP\UserAgent;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Validation\Exceptions\ValidationException;
 use Config\App;
-use Config\Services;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -80,7 +79,7 @@ class ValidationTest extends CIUnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->validation = new Validation((object) static::$config, Services::renderer());
+        $this->validation = new Validation((object) static::$config, service('renderer'));
         $this->validation->reset();
     }
 
@@ -225,7 +224,7 @@ class ValidationTest extends CIUnitTestCase
 
         yield 'fail-deep-object' => [
             false,
-            new Validation((object) static::$config, Services::renderer()),
+            new Validation((object) static::$config, service('renderer')),
         ];
 
         yield 'pass-multiple-string' => [
@@ -1010,7 +1009,7 @@ class ValidationTest extends CIUnitTestCase
             $rulesets = static::$config['ruleSets'];
 
             static::$config['ruleSets'] = null;
-            (new Validation((object) static::$config, Services::renderer()))
+            (new Validation((object) static::$config, service('renderer')))
                 ->reset()
                 ->run(['foo' => '']);
 

--- a/tests/system/View/DecoratorsTest.php
+++ b/tests/system/View/DecoratorsTest.php
@@ -15,7 +15,6 @@ namespace CodeIgniter\View;
 
 use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Config\Factories;
-use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
 use PHPUnit\Framework\Attributes\Group;
@@ -36,7 +35,7 @@ final class DecoratorsTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->loader   = Services::locator();
+        $this->loader   = service('locator');
         $this->viewsDir = __DIR__ . '/Views';
         $this->config   = config('View');
     }

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\View;
 
 use CodeIgniter\Autoloader\FileLocator;
-use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\View;
 use PHPUnit\Framework\Attributes\Group;
@@ -33,7 +32,7 @@ final class ParserFilterTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->loader   = Services::locator();
+        $this->loader   = service('locator');
         $this->viewsDir = __DIR__ . '/Views';
         $this->config   = new View();
     }

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -36,8 +36,8 @@ final class ParserPluginTest extends CIUnitTestCase
 
         Services::reset(true);
 
-        $this->parser    = Services::parser();
-        $this->validator = Services::validation();
+        $this->parser    = service('parser');
+        $this->validator = service('validation');
     }
 
     public function testCurrentURL(): void

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -337,9 +337,12 @@ final class ParserTest extends CIUnitTestCase
     public function testParseLoopEntityProperties(): void
     {
         $power = new class () extends Entity {
-            public $foo    = 'bar';
-            protected $bar = 'baz';
+            public string $foo    = 'bar';
+            protected string $bar = 'baz';
 
+            /**
+             * @return array<string, mixed>
+             */
             public function toArray(bool $onlyChanged = false, bool $cast = true, bool $recursive = false): array
             {
                 return [

--- a/tests/system/View/ParserTest.php
+++ b/tests/system/View/ParserTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\Autoloader\FileLocator;
 use CodeIgniter\Entity\Entity;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
-use Config\Services;
 use Config\View as ViewConfig;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -38,7 +37,7 @@ final class ParserTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->loader   = Services::locator();
+        $this->loader   = service('locator');
         $this->viewsDir = __DIR__ . '/Views';
         $this->config   = new ViewConfig();
         $this->parser   = new Parser($this->config, $this->viewsDir, $this->loader);

--- a/tests/system/View/ViewTest.php
+++ b/tests/system/View/ViewTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace CodeIgniter\View;
 
 use CodeIgniter\Autoloader\FileLocator;
-use CodeIgniter\Config\Services;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\View\Exceptions\ViewException;
 use Config;
@@ -35,7 +34,7 @@ final class ViewTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->loader   = Services::locator();
+        $this->loader   = service('locator');
         $this->viewsDir = __DIR__ . '/Views';
         $this->config   = new Config\View();
     }


### PR DESCRIPTION
**Description**
Replace the use of `Services::some()` with `service('some')`. In theory, for large queries (> 100,000), the difference in execution will be noticeable.
https://github.com/codeigniter4/CodeIgniter4/pull/8607 https://github.com/codeigniter4/CodeIgniter4/pull/8623
All texts are executed, there should be no problems.

I left it unchanged **tests/system/Config/ServicesTest.php**
The examples in the documentation have not been changed.

It is not possible to call `Services::createRequest()`as a `service ('createRequest`)', **rector** says:
```console
 ------ --------------------------------------------------------------------------------------------------------------- 
  Line   tests/system/Helpers/URLHelper/MiscUrlTest.php                                                                 
 ------ --------------------------------------------------------------------------------------------------------------- 
  :937   The method 'createRequest' is reserved for service location internals and cannot be used as a service method.  
         🪪  codeigniter.reservedServiceName                                                                            
 ------ --------------------------------------------------------------------------------------------------------------- 
 ```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
