### PR TITLE
fix: `fetchGlobal()` with numeric key

### DIFF
--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -249,7 +249,7 @@ trait RequestTrait
      *
      * @param         string                                   $name   Supergrlobal name (lowercase)
      * @phpstan-param 'get'|'post'|'request'|'cookie'|'server' $name
-     * @param         array|string|null                        $index
+     * @param         array|int|string|null                    $index
      * @param         int|null                                 $filter Filter constant
      * @param         array|int|null                           $flags  Options
      *
@@ -290,7 +290,7 @@ trait RequestTrait
         }
 
         // Does the index contain array notation?
-        if (($count = preg_match_all('/(?:^[^\[]+)|\[[^]]*\]/', $index, $matches)) > 1) {
+        if (is_string($index) && ($count = preg_match_all('/(?:^[^\[]+)|\[[^]]*\]/', $index, $matches)) > 1) {
             $value = $this->globals[$name];
 
             for ($i = 0; $i < $count; $i++) {

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -196,6 +196,21 @@ final class RequestTest extends CIUnitTestCase
         $this->assertCount(2, $result['ANNOUNCEMENTS']);
     }
 
+    public function testFetchGlobalReturnsWithListValues(): void
+    {
+        $post = [
+            ['foo' => 0],
+            ['bar' => 1],
+            ['baz' => 2],
+        ];
+
+        $this->request->setGlobal('post', $post);
+        $result = $this->request->fetchGlobal('post');
+
+        $this->assertIsList($result);
+        $this->assertSame($post, $result);
+    }
+
     public function testFetchGlobalWithArrayTop(): void
     {
         $post = [

--- a/tests/system/HTTP/RequestTest.php
+++ b/tests/system/HTTP/RequestTest.php
@@ -199,9 +199,9 @@ final class RequestTest extends CIUnitTestCase
     public function testFetchGlobalReturnsWithListValues(): void
     {
         $post = [
-            ['foo' => 0],
-            ['bar' => 1],
-            ['baz' => 2],
+            0 => ['foo' => 0],
+            1 => ['bar' => 1],
+            2 => ['baz' => 2],
         ];
 
         $this->request->setGlobal('post', $post);

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -580,6 +580,26 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $response->assertJSONExact($data);
     }
 
+    public function testCallWithListJsonRequest(): void
+    {
+        $this->withRoutes([
+            [
+                'POST',
+                'home',
+                '\Tests\Support\Controllers\Popcorn::echoJson',
+            ],
+        ]);
+        $data = [
+            ['one' => 1, 'two' => 2],
+            ['one' => 3, 'two' => 4],
+        ];
+        $response = $this->withBodyFormat('json')
+            ->call(Method::POST, 'home', $data);
+
+        $response->assertOK();
+        $response->assertJSONExact($data);
+    }
+
     public function testSetupRequestBodyWithParams(): void
     {
         $request = $this->setupRequest('post', 'home');

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -29,6 +29,10 @@ Deprecations
 **********
 Bugs Fixed
 **********
+- **FeatureTestTrait:** Allows `#call` and `#post` to process JSON lists. It failed because `RequestTrait#fetchGlobal` expected the second parameter ($index) to be an associative array.
+
+- **RequestTrait:** Allows to get a value by a numeric key if the data is stored as a list and not an associative array.
+
 - **Session Library:** The session initialization debug message now uses the correct log type "debug" instead of "info".
 
 - **Validation:** Fixed the `getValidated()` method that did not return valid data when validation rules used multiple asterisks.

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -29,13 +29,12 @@ Deprecations
 **********
 Bugs Fixed
 **********
-- **FeatureTestTrait:** Allows `#call` and `#post` to process JSON lists. It failed because `RequestTrait#fetchGlobal` expected the second parameter ($index) to be an associative array.
-
-- **RequestTrait:** Allows to get a value by a numeric key if the data is stored as a list and not an associative array.
+- **RequestTrait:** Fixed a bug where the ``fetchGlobal()`` method did not allow handling data by numeric key when stored as a list.
 
 - **Session Library:** The session initialization debug message now uses the correct log type "debug" instead of "info".
 
 - **Validation:** Fixed the `getValidated()` method that did not return valid data when validation rules used multiple asterisks.
+
 - **Database:** Fixed the case insensitivity option in the ``like()`` method when dealing with accented characters.
 
 - **Parser:** Fixed bug that caused equal key names to be replaced by the key name defined first.


### PR DESCRIPTION
**Description**
Closes  #9204, #9211
Before that, the method could not get a value if the POST, GET... data is stored as a list.
This affected FeatureTestTrait

> I think there is a potential error in fetchGlobal() - it does not understand the numeric keys $_GET[0]['one'] = 1

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
