### PR TITLE
refactor: enable FlipTypeControlToUseExclusiveTypeRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -19,6 +19,7 @@ use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
 use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\SingleInArrayToCompareRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector;
 use Rector\CodeQuality\Rector\If_\CombineIfRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
@@ -213,6 +214,7 @@ return RectorConfig::configure()
         TypedPropertyFromAssignsRector::class,
         ClosureReturnTypeRector::class,
         SimplifyBoolIdenticalTrueRector::class,
+        FlipTypeControlToUseExclusiveTypeRector::class,
     ])
     ->withConfiguredRule(StringClassNameToClassConstantRector::class, [
         // keep '\\' prefix string on string '\Foo\Bar'

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -819,7 +819,7 @@ class CodeIgniter
     {
         $this->benchmark->start('routing');
 
-        if ($routes === null) {
+        if (! $routes instanceof RouteCollectionInterface) {
             $routes = service('routes')->loadRoutes();
         }
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -869,7 +869,7 @@ if (! function_exists('_solidus')) {
     {
         static $docTypes = null;
 
-        if ($docTypesConfig !== null) {
+        if ($docTypesConfig instanceof DocTypes) {
             $docTypes = $docTypesConfig;
         }
 

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -684,7 +684,7 @@ abstract class BaseConnection implements ConnectionInterface
                 // Let others do something with this query.
                 Events::trigger('DBQuery', $query);
 
-                if ($exception !== null) {
+                if ($exception instanceof DatabaseException) {
                     throw new DatabaseException(
                         $exception->getMessage(),
                         $exception->getCode(),

--- a/system/Database/Migration.php
+++ b/system/Database/Migration.php
@@ -45,7 +45,7 @@ abstract class Migration
     {
         if (isset($this->DBGroup)) {
             $this->forge = Database::forge($this->DBGroup);
-        } elseif ($forge !== null) {
+        } elseif ($forge instanceof Forge) {
             $this->forge = $forge;
         } else {
             $this->forge = Database::forge(config(Database::class)->defaultGroup);

--- a/system/Database/Seeder.php
+++ b/system/Database/Seeder.php
@@ -105,7 +105,7 @@ class Seeder
      */
     public static function faker(): ?Generator
     {
-        if (self::$faker === null && class_exists(Factory::class)) {
+        if (! self::$faker instanceof Generator && class_exists(Factory::class)) {
             self::$faker = Factory::create();
         }
 

--- a/system/HTTP/DownloadResponse.php
+++ b/system/HTTP/DownloadResponse.php
@@ -85,7 +85,7 @@ class DownloadResponse extends Response
      */
     public function setBinary(string $binary)
     {
-        if ($this->file !== null) {
+        if ($this->file instanceof File) {
             throw DownloadException::forCannotSetBinary();
         }
 
@@ -309,7 +309,7 @@ class DownloadResponse extends Response
             return $this->sendBodyByBinary();
         }
 
-        if ($this->file !== null) {
+        if ($this->file instanceof File) {
             return $this->sendBodyByFilePath();
         }
 

--- a/system/HTTP/Exceptions/RedirectException.php
+++ b/system/HTTP/Exceptions/RedirectException.php
@@ -69,7 +69,7 @@ class RedirectException extends Exception implements ResponsableInterface, HTTPE
 
     public function getResponse(): ResponseInterface
     {
-        if (null === $this->response) {
+        if (! $this->response instanceof ResponseInterface) {
             $this->response = service('response')
                 ->redirect(base_url($this->getMessage()), 'auto', $this->getCode());
         }

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -39,7 +39,7 @@ class Negotiate
      */
     public function __construct(?RequestInterface $request = null)
     {
-        if ($request !== null) {
+        if ($request instanceof RequestInterface) {
             assert($request instanceof IncomingRequest);
 
             $this->request = $request;

--- a/system/HTTP/SiteURI.php
+++ b/system/HTTP/SiteURI.php
@@ -421,7 +421,7 @@ class SiteURI extends URI
         $relativePath = $this->stringifyRelativePath($relativePath);
 
         // Check current host.
-        $host = $config === null ? $this->getHost() : null;
+        $host = ! $config instanceof App ? $this->getHost() : null;
 
         $config ??= config(App::class);
 

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -156,7 +156,7 @@ class ChromeLoggerHandler extends BaseHandler
      */
     public function sendLogs(?ResponseInterface &$response = null)
     {
-        if ($response === null) {
+        if (! $response instanceof ResponseInterface) {
             $response = Services::response(null, true);
         }
 

--- a/system/Validation/FileRules.php
+++ b/system/Validation/FileRules.php
@@ -38,7 +38,7 @@ class FileRules
      */
     public function __construct(?RequestInterface $request = null)
     {
-        if ($request === null) {
+        if (! $request instanceof RequestInterface) {
             $request = service('request');
         }
 

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -87,7 +87,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $config = $this->createAppConfig();
         $this->createCookieConfig();
 
-        if ($this->request === null) {
+        if (! $this->request instanceof MockIncomingRequest) {
             $this->request = new MockIncomingRequest(
                 $config,
                 new SiteURI($config, $routePath),

--- a/utils/src/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/src/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -164,7 +164,7 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
 
     private function updateDocblock(string $variableName, string $camelCaseName, ?FunctionLike $functionLike): void
     {
-        if ($functionLike === null) {
+        if (! $functionLike instanceof FunctionLike) {
             return;
         }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

enable FlipTypeControlToUseExclusiveTypeRector to flip type control from null compare to use exclusive instanceof object for more verbose check.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
