### PR TITLE
refactor: Move property to local variable on usage only in setUp() method in tests

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -16431,12 +16431,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue
-	'message' => '#^Property CodeIgniter\\\\Publisher\\\\PublisherOutputTest\\:\\:\\$structure type has no value type specified in iterable type array\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Publisher/PublisherOutputTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Publisher\\\\PublisherRestrictionsTest\\:\\:provideDefaultPublicRestrictions\\(\\) return type has no value type specified in iterable type iterable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Publisher/PublisherRestrictionsTest.php',

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -30,14 +30,12 @@ final class ConsoleTest extends CIUnitTestCase
 {
     use StreamFilterTrait;
 
-    private DotEnv $env;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->env = new DotEnv(ROOTPATH);
-        $this->env->load();
+        $env = new DotEnv(ROOTPATH);
+        $env->load();
 
         // Set environment values that would otherwise stop the framework from functioning during tests.
         if (! isset($_SERVER['app.baseURL'])) {

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -25,8 +25,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('CacheLive')]
 final class MemcachedHandlerTest extends AbstractHandlerTestCase
 {
-    private Cache $config;
-
     private static function getKeyArray()
     {
         return [
@@ -44,9 +42,9 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
             $this->markTestSkipped('Memcached extension not loaded.');
         }
 
-        $this->config = new Cache();
+        $config = new Cache();
 
-        $this->handler = new MemcachedHandler($this->config);
+        $this->handler = new MemcachedHandler($config);
 
         $this->handler->initialize();
     }

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -47,7 +47,6 @@ use Tests\Support\Filters\RedirectFilter;
 final class CodeIgniterTest extends CIUnitTestCase
 {
     private CodeIgniter $codeigniter;
-    protected $routes;
 
     #[WithoutErrorHandler]
     protected function setUp(): void

--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -32,7 +32,6 @@ use TypeError;
 final class DotEnvTest extends CIUnitTestCase
 {
     private ?vfsStreamDirectory $root;
-    private string $path;
     private string $fixturesFolder;
 
     #[WithoutErrorHandler]
@@ -42,8 +41,8 @@ final class DotEnvTest extends CIUnitTestCase
 
         $this->root           = vfsStream::setup();
         $this->fixturesFolder = $this->root->url();
-        $this->path           = TESTPATH . 'system/Config/fixtures';
-        vfsStream::copyFromFileSystem($this->path, $this->root);
+        $path                 = TESTPATH . 'system/Config/fixtures';
+        vfsStream::copyFromFileSystem($path, $this->root);
 
         $file = 'unreadable.env';
         $path = rtrim($this->fixturesFolder, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $file;

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -40,7 +40,6 @@ use Psr\Log\LoggerInterface;
 #[Group('Others')]
 final class ControllerTest extends CIUnitTestCase
 {
-    private App $config;
     private ?Controller $controller = null;
 
     /**
@@ -59,9 +58,9 @@ final class ControllerTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->config   = new App();
-        $this->request  = new IncomingRequest($this->config, new SiteURI($this->config), null, new UserAgent());
-        $this->response = new Response($this->config);
+        $config         = new App();
+        $this->request  = new IncomingRequest($config, new SiteURI($config), null, new UserAgent());
+        $this->response = new Response($config);
         $this->logger   = Services::logger();
     }
 

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -26,7 +26,6 @@ final class FileWithVfsTest extends CIUnitTestCase
 {
     // For VFS stuff
     private ?vfsStreamDirectory $root = null;
-    private string $path;
     private string $start;
     private File $file;
 
@@ -35,8 +34,8 @@ final class FileWithVfsTest extends CIUnitTestCase
         parent::setUp();
 
         $this->root = vfsStream::setup();
-        $this->path = '_support/Files/';
-        vfsStream::copyFromFileSystem(TESTPATH . $this->path, $this->root);
+        $path       = '_support/Files/';
+        vfsStream::copyFromFileSystem(TESTPATH . $path, $this->root);
         $this->start = $this->root->url() . '/';
         $this->file  = new File($this->start . 'able/apple.php');
     }

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -26,8 +26,6 @@ use PHPUnit\Framework\Attributes\Group;
 final class FileMovingTest extends CIUnitTestCase
 {
     private ?vfsStreamDirectory $root;
-    private string $path;
-    private string $start;
     private string $destination;
 
     protected function setUp(): void
@@ -35,11 +33,11 @@ final class FileMovingTest extends CIUnitTestCase
         parent::setUp();
 
         $this->root = vfsStream::setup();
-        $this->path = '_support/Files/';
-        vfsStream::copyFromFileSystem(TESTPATH . $this->path, $this->root);
-        $this->start = $this->root->url() . '/';
+        $path       = '_support/Files/';
+        vfsStream::copyFromFileSystem(TESTPATH . $path, $this->root);
+        $start = $this->root->url() . '/';
 
-        $this->destination = $this->start . 'destination';
+        $this->destination = $start . 'destination';
         if (is_dir($this->destination)) {
             rmdir($this->destination);
         }

--- a/tests/system/Helpers/CookieHelperTest.php
+++ b/tests/system/Helpers/CookieHelperTest.php
@@ -33,7 +33,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class CookieHelperTest extends CIUnitTestCase
 {
-    private IncomingRequest $request;
     private string $name;
     private string $value;
     private int $expire;
@@ -51,8 +50,8 @@ final class CookieHelperTest extends CIUnitTestCase
 
         Services::injectMock('response', new MockResponse(new App()));
         $this->response = Services::response();
-        $this->request  = new IncomingRequest(new App(), new SiteURI(new App()), null, new UserAgent());
-        Services::injectMock('request', $this->request);
+        $request        = new IncomingRequest(new App(), new SiteURI(new App()), null, new UserAgent());
+        Services::injectMock('request', $request);
 
         helper('cookie');
     }

--- a/tests/system/Images/BaseHandlerTest.php
+++ b/tests/system/Images/BaseHandlerTest.php
@@ -19,7 +19,6 @@ use CodeIgniter\Images\Exceptions\ImageException;
 use CodeIgniter\Images\Handlers\BaseHandler;
 use CodeIgniter\Test\CIUnitTestCase;
 use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -35,7 +34,6 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class BaseHandlerTest extends CIUnitTestCase
 {
-    private vfsStreamDirectory $root;
     private string $origin;
     private string $start;
     private string $path;
@@ -47,10 +45,10 @@ final class BaseHandlerTest extends CIUnitTestCase
         }
 
         // create virtual file system
-        $this->root = vfsStream::setup();
+        $root = vfsStream::setup();
         // copy our support files
         $this->origin = SUPPORTPATH . 'Images/';
-        vfsStream::copyFromFileSystem($this->origin, $this->root);
+        vfsStream::copyFromFileSystem($this->origin, $root);
         // make subfolders
         $structure = [
             'work'     => [],
@@ -58,10 +56,10 @@ final class BaseHandlerTest extends CIUnitTestCase
         ];
         vfsStream::create($structure);
         // with one of them read only
-        $this->root->getChild('wontwork')->chmod(0400);
+        $root->getChild('wontwork')->chmod(0400);
 
         // for VFS tests
-        $this->start = $this->root->url() . '/';
+        $this->start = $root->url() . '/';
         $this->path  = $this->start . 'ci-logo.png';
     }
 

--- a/tests/system/Images/ImageTest.php
+++ b/tests/system/Images/ImageTest.php
@@ -26,7 +26,6 @@ use PHPUnit\Framework\Attributes\Group;
 final class ImageTest extends CIUnitTestCase
 {
     private vfsStreamDirectory $root;
-    private string $origin;
     private string $start;
     private Image $image;
 
@@ -35,8 +34,8 @@ final class ImageTest extends CIUnitTestCase
         // create virtual file system
         $this->root = vfsStream::setup();
         // copy our support files
-        $this->origin = '_support/Images/';
-        vfsStream::copyFromFileSystem(TESTPATH . $this->origin, $this->root);
+        $origin = '_support/Images/';
+        vfsStream::copyFromFileSystem(TESTPATH . $origin, $this->root);
         // make subfolders
         $structure = [
             'work'     => [],

--- a/tests/system/Log/Handlers/FileHandlerTest.php
+++ b/tests/system/Log/Handlers/FileHandlerTest.php
@@ -17,7 +17,6 @@ use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockFileLogger;
 use CodeIgniter\Test\Mock\MockLogger as LoggerConfig;
 use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\Log\Handlers\TestHandler;
 
@@ -27,14 +26,13 @@ use Tests\Support\Log\Handlers\TestHandler;
 #[Group('Others')]
 final class FileHandlerTest extends CIUnitTestCase
 {
-    private vfsStreamDirectory $root;
     private string $start;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->root  = vfsStream::setup('root');
-        $this->start = $this->root->url() . '/';
+        $root        = vfsStream::setup('root');
+        $this->start = $root->url() . '/';
     }
 
     public function testHandle(): void

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -25,11 +25,6 @@ use PHPUnit\Framework\Attributes\Group;
 final class PublisherOutputTest extends CIUnitTestCase
 {
     /**
-     * Files to seed to VFS
-     */
-    private array $structure;
-
-    /**
      * Virtual destination
      */
     private vfsStreamDirectory $root;
@@ -60,7 +55,7 @@ final class PublisherOutputTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        $this->structure = [
+        $structure = [
             'able' => [
                 'apple.php' => 'Once upon a midnight dreary',
                 'bazam'     => 'While I pondered weak and weary',
@@ -74,7 +69,7 @@ final class PublisherOutputTest extends CIUnitTestCase
             '.hidden'       => 'There is no spoon',
         ];
 
-        $this->root = vfsStream::setup('root', null, $this->structure);
+        $this->root = vfsStream::setup('root', null, $structure);
 
         // Add root to the list of allowed destinations
         config('Publisher')->restrictions[$this->root->url()] = '*';

--- a/tests/system/Publisher/PublisherOutputTest.php
+++ b/tests/system/Publisher/PublisherOutputTest.php
@@ -55,6 +55,9 @@ final class PublisherOutputTest extends CIUnitTestCase
     {
         parent::setUp();
 
+        /**
+         * Files to seed to VFS
+         */
         $structure = [
             'able' => [
                 'apple.php' => 'Once upon a midnight dreary',

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -25,15 +25,14 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class CellTest extends CIUnitTestCase
 {
-    private MockCache $cache;
     private Cell $cell;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->cache = new MockCache();
-        $this->cell  = new Cell($this->cache);
+        $cache      = new MockCache();
+        $this->cell = new Cell($cache);
     }
 
     public function testPrepareParamsReturnsEmptyArrayWithInvalidParam(): void


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

Use local variable when only used on `setUp()` method.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
