### PR TITLE
docs: Improve `Validation` docs

### DIFF
--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -203,6 +203,60 @@ Then add validation rules in the controller (**Form.php**):
 
 If you submit the form you should see the success page or the form with error messages.
 
+****************************
+Working with different types
+****************************
+
+Since the input value is not limited to scalar types, you can check various objects, enumerations or global data (see :ref:`rules-for-file-uploads`).
+Working with the validator is no different, you only need to add custom rules.
+This behavior can be useful when creating entities.
+
+An example for validation can be ``DateTime`` for the creation date, ``URI`` for the profile link, ``SplFileInfo`` for the avatar file.
+
+Let's check the input data before creating a new user, with a file structure:
+
+.. code-block:: text
+
+    app/
+    ├── Config
+    │   └── Validation.php:
+    ├── Controllers
+    │   └── UserController.php
+    ├── Entity
+    │   └── User.php
+    ├── Validation
+    │   └── UserRules.php
+    └── ValueObject
+        └── Name.php
+
+Add custom value-object ``Name``. It is required when working with the ``User``:
+
+.. literalinclude:: validation/048.php
+    :lines: 2-
+
+Create rule. We want to make sure that the username will be of the specified type and have a non-empty value:
+
+.. literalinclude:: validation/049.php
+    :lines: 2-
+
+Add rule to list in **app/Config/Validation.php**:
+
+.. literalinclude:: validation/050.php
+   :lines: 2-
+
+We can check the data manually. It looks more efficiently with the ``Validator``:
+
+
+.. literalinclude:: validation/051.php
+   :lines: 2-
+
+.. note:: Additionally, some basic rules can be applied, such as ``required``, ``permit_empty``, ``field_exists``, ``if_exist``.
+
+Try to create a ``User`` in the controller. Depending on the result, we can throw an exception or handle errors:
+
+.. literalinclude:: validation/052.php
+   :lines: 2-
+
 *********************
 Config for Validation
 *********************

--- a/user_guide_src/source/libraries/validation/048.php
+++ b/user_guide_src/source/libraries/validation/048.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\ValueObject;
+
+class Name
+{
+    public function __construct(public string $value = '')
+    {
+    }
+}

--- a/user_guide_src/source/libraries/validation/049.php
+++ b/user_guide_src/source/libraries/validation/049.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Validation;
+
+use App\ValueObject\Name;
+
+class UserRules
+{
+    public function valid_name($name, ?string &$error = null)
+    {
+        if (! $name instanceof Name) {
+            $error = 'The name should be Name::class.';
+
+            return false;
+        }
+
+        if ($name->value === '') {
+            $error = 'The name should not be empty.';
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/user_guide_src/source/libraries/validation/050.php
+++ b/user_guide_src/source/libraries/validation/050.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Config;
+
+use App\Validation\UserRules;
+use CodeIgniter\Config\BaseConfig;
+
+class Validation extends BaseConfig
+{
+    public array $ruleSets = [
+        // ...
+        UserRules::class,
+    ];
+
+    // ...
+}

--- a/user_guide_src/source/libraries/validation/051.php
+++ b/user_guide_src/source/libraries/validation/051.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Entity;
+
+use App\ValueObject\Name;
+use DomainException;
+
+class User
+{
+    public Name $name;
+    public string $createdAt;
+
+    public function __construct(array $data = [])
+    {
+        if (! service('validation')
+            ->setRules([
+                'name'       => 'required|valid_name',
+                'created_at' => 'valid_date[d/m/Y]',
+            ])
+            ->run($data)
+        ) {
+            // The validation failed
+            throw new DomainException('Invalid data for "User"');
+        }
+
+        // Working with allowed data
+        $this->name      = $data['name'];
+        $this->createdAt = $data['created_at'];
+    }
+}

--- a/user_guide_src/source/libraries/validation/052.php
+++ b/user_guide_src/source/libraries/validation/052.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Entity\User;
+use App\ValueObject\Name;
+use DomainException;
+
+class UserController
+{
+    public function index(): string
+    {
+        $data = [
+            'name'       => new Name('Ivan'),
+            'created_at' => '01/01/2000',
+        ];
+
+        try {
+            $user = new User($data);
+
+            // Hi, Ivan
+            return 'Hi, ' . $user->name->value;
+        } catch (DomainException $e) {
+            echo 'Found errors: ';
+
+            print_r(service('validation')->getErrors());
+        }
+    }
+}


### PR DESCRIPTION
**Description**
I do not know, is this more of a "bug or a feature"? It looks like a hidden feature.

I think few people use validation with objects. Do you think it's worth updating the documentation? If so, please check the translation.

I can't say exactly which version this will work from, but the current 4.5 branch shouldn't have any problems. I tested on **4.5.5** and **4.2.12**

- [x] Show an example of object validation
- [x] Show how an object can be validated before creation
- [ ] Add note. With the addition of `DataCaster` in the `Model`, the validation of objects is relevant
- [ ] Show examples of storing rules in objects instead of the `Validation` property
- [ ] Feature PR. Pass `setRules(), check(), run() [class, method]` or invokable `class-string` to the validator instead of an array.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
