### PR TITLE
refactor: Breaking: Differentiate between kilobyte/kibibyte and megabyte/mebibyte

### DIFF
--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -72,14 +72,18 @@ class File extends SplFileInfo
 
     /**
      * Retrieve the file size by unit.
+     * Supports the metric units "kb" and "mb"
+     * and the IEC units "kib" and "mib".
      *
      * @return false|int|string
      */
     public function getSizeByUnit(string $unit = 'b')
     {
         return match (strtolower($unit)) {
-            'kb'    => number_format($this->getSize() / 1024, 3),
-            'mb'    => number_format(($this->getSize() / 1024) / 1024, 3),
+            'kb'    => number_format($this->getSize() / 1000, 3),
+            'kib'   => number_format($this->getSize() / 1024, 3),
+            'mb'    => number_format(($this->getSize() / 1000) / 1000, 3),
+            'mib'   => number_format(($this->getSize() / 1024) / 1024, 3),
             default => $this->getSize(),
         };
     }

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -92,17 +92,31 @@ final class FileTest extends CIUnitTestCase
         $this->assertSame('file', $file->getType());
     }
 
-    public function testGetSizeReturnsKB(): void
+    public function testGetSizeReturnsKiB(): void
     {
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = number_format(filesize(SYSTEMPATH . 'Common.php') / 1024, 3);
+        $this->assertSame($size, $file->getSizeByUnit('kib'));
+    }
+
+    public function testGetSizeReturnsKB(): void
+    {
+        $file = new File(SYSTEMPATH . 'Common.php');
+        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / 1000, 3);
         $this->assertSame($size, $file->getSizeByUnit('kb'));
+    }
+
+    public function testGetSizeReturnsMiB(): void
+    {
+        $file = new File(SYSTEMPATH . 'Common.php');
+        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / 1024 / 1024, 3);
+        $this->assertSame($size, $file->getSizeByUnit('mib'));
     }
 
     public function testGetSizeReturnsMB(): void
     {
         $file = new File(SYSTEMPATH . 'Common.php');
-        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / 1024 / 1024, 3);
+        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / 1000 / 1000, 3);
         $this->assertSame($size, $file->getSizeByUnit('mb'));
     }
 


### PR DESCRIPTION
**Description**
Noticed that the file size calculation mixes up the SI unit prefixes with the NIST/IEC unit prefixes, by taking "kb" and "mb" but calculating "kib" and "mib". 
Fixed by providing both possibilities. 

This therefore will break existing code!

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
