### PR TITLE
chore: Optimize the usage of option 'baseURI' for CURLRequest

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -197,6 +197,7 @@ class Services extends BaseService
     /**
      * The CURL Request class acts as a simple HTTP client for interacting
      * with other servers, typically through APIs.
+     * The option 'base_uri' is deprecated and will be remove soon.
      *
      * @return CURLRequest
      */
@@ -208,10 +209,12 @@ class Services extends BaseService
 
         $config ??= config(App::class);
         $response ??= new Response($config);
+        $uri = new URI($options['baseURI'] ?? ($options['base_uri'] ?? null));
+        unset($options['baseURI']);
 
         return new CURLRequest(
             $config,
-            new URI($options['base_uri'] ?? null),
+            $uri,
             $response,
             $options
         );

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -209,7 +209,7 @@ class Services extends BaseService
 
         $config ??= config(App::class);
         $response ??= new Response($config);
-        $uri = new URI($options['baseURI'] ?? ($options['base_uri'] ?? null));
+        $uri = new URI($options['baseURI'] ?? $options['base_uri'] ?? null);
         unset($options['baseURI']);
 
         return new CURLRequest(

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -139,7 +139,7 @@ class CURLRequest extends OutgoingRequest
             $uri = new URI($options['baseURI']);
             $uri->useRawQueryString();
             unset($options['baseURI']);
-        }else{
+        } else {
             $uri = $this->uri;
         }
         $this->parseOptions($options);

--- a/system/Test/Mock/MockCURLRequest.php
+++ b/system/Test/Mock/MockCURLRequest.php
@@ -45,12 +45,6 @@ class MockCURLRequest extends CURLRequest
     }
 
     // for testing purposes only
-    public function getBaseURI()
-    {
-        return $this->baseURI;
-    }
-
-    // for testing purposes only
     public function getDelay()
     {
         return $this->delay;


### PR DESCRIPTION
#9265
**Description**
Use option 'baseURI' first in Config\Services->curlrequest.
Use the property 'uri' of OutgoingRequest as default baseURI instead of the property 'baseURI' of CURLRequest.
Remove the property 'baseURI' of CURLRequest.
Nolonger parse 'baseURI' in 'parseOptions' method.
If 'baseURI' exists in 'request' method's options, create a new URI instance with it. Otherwise, use the property 'uri' of OutgoingRequest.
Use the param '$uri' passed in rather than the property 'baseURI' of CURLRequest in 'prepareURL' method.
Remove 'getBaseURI' method from Test/Mock/MockCURLRequest.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
