### PR TITLE
refactor: [BaseBuilder] Removed redundant `|| $val instanceof RawSql` check from the `foreach` loop.

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3297,7 +3297,7 @@ class BaseBuilder
         $array = [];
 
         foreach (get_object_vars($object) as $key => $val) {
-            if ((! is_object($val) || $val instanceof RawSql) && ! is_array($val)) {
+            if ((! is_object($val)) && ! is_array($val)) {
                 $array[$key] = $val;
             }
         }


### PR DESCRIPTION
**Description**

The redundant || $val instanceof RawSql check has been removed from the foreach loop because the preceding code already ensures that $object cannot be an instance of RawSql. This makes the condition unnecessary and simplifies the logic.

https://github.com/codeigniter4/CodeIgniter4/blob/b0b7ecbac2871f2eb95af0451f8fb6bc3998ccf7/system/Database/BaseBuilder.php#L3293

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
