### PR TITLE
feat: Differentiate between kilobyte/kibibyte and megabyte/mebibyte

### DIFF
--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -74,6 +74,7 @@ class File extends SplFileInfo
      * Retrieve the file size by unit, calculated in IEC standards with 1024 as base value.
      *
      * @phpstan-param positive-int $precision
+     *
      * @return false|int|string
      */
     public function getSizeByUnitBinary(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)
@@ -85,6 +86,7 @@ class File extends SplFileInfo
      * Retrieve the file size by unit, calculated in metric standards with 1000 as base value.
      *
      * @phpstan-param positive-int $precision
+     *
      * @return false|int|string
      */
     public function getSizeByUnitMetric(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)
@@ -223,7 +225,7 @@ class File extends SplFileInfo
         $divider  = $fileSizeBase ** $exponent;
         $size     = $this->getSize() / $divider;
 
-        if($unit !== FileSizeUnit::B) {
+        if ($unit !== FileSizeUnit::B) {
             $size = number_format($size, $precision);
         }
 

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -73,7 +73,6 @@ class File extends SplFileInfo
     /**
      * Retrieve the file size by unit, calculated in IEC standards with 1024 as base value.
      *
-     * @param FileSizeUnit $unit
      * @phpstan-param positive-int $precision
      * @return false|int|string
      */
@@ -85,7 +84,6 @@ class File extends SplFileInfo
     /**
      * Retrieve the file size by unit, calculated in metric standards with 1000 as base value.
      *
-     * @param FileSizeUnit $unit
      * @phpstan-param positive-int $precision
      * @return false|int|string
      */
@@ -222,12 +220,10 @@ class File extends SplFileInfo
     protected function getSizeByUnitInternal(int $fileSizeBase, FileSizeUnit $unit, int $precision)
     {
         $exponent = $unit->value;
-        $divider = $fileSizeBase ** $exponent;
+        $divider  = $fileSizeBase ** $exponent;
+        $size     = $this->getSize() / $divider;
 
-        $size = $this->getSize() / $divider;
-
-        if($unit !== FileSizeUnit::B)
-        {
+        if($unit !== FileSizeUnit::B) {
             $size = number_format($size, $precision);
         }
 

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -222,7 +222,7 @@ class File extends SplFileInfo
     protected function getSizeByUnitInternal(int $fileSizeBase, FileSizeUnit $unit, int $precision)
     {
         $exponent = $unit->value;
-        $divider = pow($fileSizeBase, $exponent);
+        $divider = $fileSizeBase ** $exponent;
 
         $size = $this->getSize() / $divider;
 

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -216,6 +216,9 @@ class File extends SplFileInfo
         return $destination;
     }
 
+    /**
+     * @return false|int|string
+     */
     protected function getSizeByUnitInternal(int $fileSizeBase, FileSizeUnit $unit, int $precision)
     {
         $exponent = $unit->value;

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -71,16 +71,38 @@ class File extends SplFileInfo
     }
 
     /**
+     * Retrieve the file size by unit, calculated in IEC standards with 1024 as base value.
+     *
+     * @return false|int|string
+     */
+    public function getSizeByUnitBinary(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)
+    {
+        return $this->getSizeByUnitInternal(1024, $unit, $precision);
+    }
+
+    /**
+     * Retrieve the file size by unit, calculated in metric standards with 1000 as base value.
+     *
+     * @return false|int|string
+     */
+    public function getSizeByUnitMetric(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)
+    {
+        return $this->getSizeByUnitInternal(1000, $unit, $precision);
+    }
+
+    /**
      * Retrieve the file size by unit.
+     *
+     * @deprecated Use getSizeByUnitBinary or getSizeByUnitMetric instead
      *
      * @return false|int|string
      */
     public function getSizeByUnit(string $unit = 'b')
     {
         return match (strtolower($unit)) {
-            'kb'    => number_format($this->getSize() / 1024, 3),
-            'mb'    => number_format(($this->getSize() / 1024) / 1024, 3),
-            default => $this->getSize(),
+            'kb'    => $this->getSizeByUnitBinary(FileSizeUnit::KB),
+            'mb'    => $this->getSizeByUnitBinary(FileSizeUnit::MB),
+            default => $this->getSizeByUnitBinary(FileSizeUnit::B)
         };
     }
 
@@ -188,5 +210,20 @@ class File extends SplFileInfo
         }
 
         return $destination;
+    }
+
+    protected function getSizeByUnitInternal(int $fileSizeBase, FileSizeUnit $unit, int $precision)
+    {
+        $exponent = $unit->value;
+        $divider = pow($fileSizeBase, $exponent);
+
+        $size = $this->getSize() / $divider;
+
+        if($unit !== FileSizeUnit::B)
+        {
+            $size = number_format($size, $precision);
+        }
+
+        return $size;
     }
 }

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -97,7 +97,7 @@ class File extends SplFileInfo
     /**
      * Retrieve the file size by unit.
      *
-     * @deprecated Use getSizeByUnitBinary or getSizeByUnitMetric instead
+     * @deprecated 4.6.0 Use getSizeByUnitBinary() or getSizeByUnitMetric() instead
      *
      * @return false|int|string
      */

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -74,10 +74,8 @@ class File extends SplFileInfo
      * Retrieve the file size by unit, calculated in IEC standards with 1024 as base value.
      *
      * @phpstan-param positive-int $precision
-     *
-     * @return false|int|string
      */
-    public function getSizeByUnitBinary(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)
+    public function getSizeByBinaryUnit(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3): int|string
     {
         return $this->getSizeByUnitInternal(1024, $unit, $precision);
     }
@@ -86,10 +84,8 @@ class File extends SplFileInfo
      * Retrieve the file size by unit, calculated in metric standards with 1000 as base value.
      *
      * @phpstan-param positive-int $precision
-     *
-     * @return false|int|string
      */
-    public function getSizeByUnitMetric(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)
+    public function getSizeByMetricUnit(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3): int|string
     {
         return $this->getSizeByUnitInternal(1000, $unit, $precision);
     }
@@ -97,15 +93,15 @@ class File extends SplFileInfo
     /**
      * Retrieve the file size by unit.
      *
-     * @deprecated 4.6.0 Use getSizeByUnitBinary() or getSizeByUnitMetric() instead
+     * @deprecated 4.6.0 Use getSizeByBinaryUnit() or getSizeByMetricUnit() instead
      *
      * @return false|int|string
      */
     public function getSizeByUnit(string $unit = 'b')
     {
         return match (strtolower($unit)) {
-            'kb'    => $this->getSizeByUnitBinary(FileSizeUnit::KB),
-            'mb'    => $this->getSizeByUnitBinary(FileSizeUnit::MB),
+            'kb'    => $this->getSizeByBinaryUnit(FileSizeUnit::KB),
+            'mb'    => $this->getSizeByBinaryUnit(FileSizeUnit::MB),
             default => $this->getSize()
         };
     }
@@ -216,10 +212,7 @@ class File extends SplFileInfo
         return $destination;
     }
 
-    /**
-     * @return false|int|string
-     */
-    protected function getSizeByUnitInternal(int $fileSizeBase, FileSizeUnit $unit, int $precision)
+    private function getSizeByUnitInternal(int $fileSizeBase, FileSizeUnit $unit, int $precision): int|string
     {
         $exponent = $unit->value;
         $divider  = $fileSizeBase ** $exponent;

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -73,6 +73,8 @@ class File extends SplFileInfo
     /**
      * Retrieve the file size by unit, calculated in IEC standards with 1024 as base value.
      *
+     * @param FileSizeUnit $unit
+     * @phpstan-param positive-int $precision
      * @return false|int|string
      */
     public function getSizeByUnitBinary(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)
@@ -83,6 +85,8 @@ class File extends SplFileInfo
     /**
      * Retrieve the file size by unit, calculated in metric standards with 1000 as base value.
      *
+     * @param FileSizeUnit $unit
+     * @phpstan-param positive-int $precision
      * @return false|int|string
      */
     public function getSizeByUnitMetric(FileSizeUnit $unit = FileSizeUnit::B, int $precision = 3)

--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -106,7 +106,7 @@ class File extends SplFileInfo
         return match (strtolower($unit)) {
             'kb'    => $this->getSizeByUnitBinary(FileSizeUnit::KB),
             'mb'    => $this->getSizeByUnitBinary(FileSizeUnit::MB),
-            default => $this->getSizeByUnitBinary(FileSizeUnit::B)
+            default => $this->getSize()
         };
     }
 

--- a/system/Files/FileSizeUnit.php
+++ b/system/Files/FileSizeUnit.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Files;
+
+enum FileSizeUnit : int
+{
+    case B  = 0;
+    case KB = 1;
+    case MB = 2;
+    case GB = 3;
+    case TB = 4;
+}

--- a/system/Files/FileSizeUnit.php
+++ b/system/Files/FileSizeUnit.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Files;
 
-enum FileSizeUnit : int
+enum FileSizeUnit: int
 {
     case B  = 0;
     case KB = 1;

--- a/system/Files/FileSizeUnit.php
+++ b/system/Files/FileSizeUnit.php
@@ -20,4 +20,16 @@ enum FileSizeUnit: int
     case MB = 2;
     case GB = 3;
     case TB = 4;
+
+    public static function fromString(string $unit): self
+    {
+        return match (strtolower($unit)) {
+            'b'  => self::B,
+            'kb' => self::KB,
+            'mb' => self::MB,
+            'gb' => self::GB,
+            'tb' => self::TB,
+            default => throw new InvalidArgumentException("Invalid unit: $unit"),
+        };
+    }
 }

--- a/system/Files/FileSizeUnit.php
+++ b/system/Files/FileSizeUnit.php
@@ -13,23 +13,30 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Files;
 
+use InvalidArgumentException;
+
 enum FileSizeUnit: int
 {
+    /**
+     * Allows the creation of a FileSizeUnit from Strings like "kb" or "mb"
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function fromString(string $unit): self
+    {
+        return match (strtolower($unit)) {
+            'b'     => self::B,
+            'kb'    => self::KB,
+            'mb'    => self::MB,
+            'gb'    => self::GB,
+            'tb'    => self::TB,
+            default => throw new InvalidArgumentException("Invalid unit: {$unit}"),
+        };
+    }
+
     case B  = 0;
     case KB = 1;
     case MB = 2;
     case GB = 3;
     case TB = 4;
-
-    public static function fromString(string $unit): self
-    {
-        return match (strtolower($unit)) {
-            'b'  => self::B,
-            'kb' => self::KB,
-            'mb' => self::MB,
-            'gb' => self::GB,
-            'tb' => self::TB,
-            default => throw new InvalidArgumentException("Invalid unit: $unit"),
-        };
-    }
 }

--- a/system/Files/FileSizeUnit.php
+++ b/system/Files/FileSizeUnit.php
@@ -13,10 +13,16 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Files;
 
-use InvalidArgumentException;
+use CodeIgniter\Exceptions\InvalidArgumentException;
 
 enum FileSizeUnit: int
 {
+    case B  = 0;
+    case KB = 1;
+    case MB = 2;
+    case GB = 3;
+    case TB = 4;
+
     /**
      * Allows the creation of a FileSizeUnit from Strings like "kb" or "mb"
      *
@@ -33,10 +39,4 @@ enum FileSizeUnit: int
             default => throw new InvalidArgumentException("Invalid unit: {$unit}"),
         };
     }
-
-    case B  = 0;
-    case KB = 1;
-    case MB = 2;
-    case GB = 3;
-    case TB = 4;
 }

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -172,6 +172,9 @@ final class FileTest extends CIUnitTestCase
         unlink(SYSTEMPATH . 'Common_Copy_5.php');
     }
 
+    /**
+     * @return Array<string, Array<int>>
+     */
     public static function provideGetSizeData()
     {
         return [

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -113,9 +113,7 @@ final class FileTest extends CIUnitTestCase
         $this->assertSame($size, $file->getSizeByUnit('b'));
     }
 
-    /**
-     * @dataProvider provideGetSizeData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetSizeData')]
     public function testGetSizeBinary(FileSizeUnit $unit): void
     {
         $divider = 1024 ** $unit->value;
@@ -131,9 +129,7 @@ final class FileTest extends CIUnitTestCase
         $this->assertSame($size, $file->getSizeByUnitBinary(FileSizeUnit::B));
     }
 
-    /**
-     * @dataProvider provideGetSizeData
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetSizeData')]
     public function testGetSizeMetric(FileSizeUnit $unit): void
     {
         $divider = 1000 ** $unit->value;
@@ -173,22 +169,22 @@ final class FileTest extends CIUnitTestCase
     }
 
     /**
-     * @return Array<string, Array<int>>
+     * @return @return array<string, list<int>>
      */
-    public static function provideGetSizeData()
+    public static function provideGetSizeData(): iterable
     {
         return [
             'returns KB binary' => [
-                FileSizeUnit::KB
+                FileSizeUnit::KB,
             ],
             'returns MB binary' => [
-                FileSizeUnit::KB
+                FileSizeUnit::MB,
             ],
             'returns GB binary' => [
-                FileSizeUnit::KB
+                FileSizeUnit::GB,
             ],
             'returns TB binary' => [
-                FileSizeUnit::KB
+                FileSizeUnit::TB,
             ],
         ];
     }

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Files;
 
 use CodeIgniter\Files\Exceptions\FileNotFoundException;
 use CodeIgniter\Test\CIUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use ZipArchive;
 
@@ -113,12 +114,12 @@ final class FileTest extends CIUnitTestCase
         $this->assertSame($size, $file->getSizeByUnit('b'));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetSizeData')]
+    #[DataProvider('provideGetSizeData')]
     public function testGetSizeBinary(FileSizeUnit $unit): void
     {
         $divider = 1024 ** $unit->value;
-        $file = new File(SYSTEMPATH . 'Common.php');
-        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
+        $file    = new File(SYSTEMPATH . 'Common.php');
+        $size    = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
         $this->assertSame($size, $file->getSizeByUnitBinary($unit));
     }
 
@@ -129,12 +130,12 @@ final class FileTest extends CIUnitTestCase
         $this->assertSame($size, $file->getSizeByUnitBinary(FileSizeUnit::B));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetSizeData')]
+    #[DataProvider('provideGetSizeData')]
     public function testGetSizeMetric(FileSizeUnit $unit): void
     {
         $divider = 1000 ** $unit->value;
-        $file = new File(SYSTEMPATH . 'Common.php');
-        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
+        $file    = new File(SYSTEMPATH . 'Common.php');
+        $size    = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
         $this->assertSame($size, $file->getSizeByUnitMetric($unit));
     }
 
@@ -169,9 +170,9 @@ final class FileTest extends CIUnitTestCase
     }
 
     /**
-     * @return @return array<string, list<int>>
+     * @return array<string, list<int>>
      */
-    public static function provideGetSizeData(): iterable
+    public static function provideGetSizeData()
     {
         return [
             'returns KB binary' => [

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -120,14 +120,14 @@ final class FileTest extends CIUnitTestCase
         $divider = 1024 ** $unit->value;
         $file    = new File(SYSTEMPATH . 'Common.php');
         $size    = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
-        $this->assertSame($size, $file->getSizeByUnitBinary($unit));
+        $this->assertSame($size, $file->getSizeByBinaryUnit($unit));
     }
 
     public function testGetSizeBinaryBytes(): void
     {
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = filesize(SYSTEMPATH . 'Common.php');
-        $this->assertSame($size, $file->getSizeByUnitBinary(FileSizeUnit::B));
+        $this->assertSame($size, $file->getSizeByBinaryUnit(FileSizeUnit::B));
     }
 
     #[DataProvider('provideGetSizeData')]
@@ -136,14 +136,14 @@ final class FileTest extends CIUnitTestCase
         $divider = 1000 ** $unit->value;
         $file    = new File(SYSTEMPATH . 'Common.php');
         $size    = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
-        $this->assertSame($size, $file->getSizeByUnitMetric($unit));
+        $this->assertSame($size, $file->getSizeByMetricUnit($unit));
     }
 
     public function testGetSizeMetricBytes(): void
     {
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = filesize(SYSTEMPATH . 'Common.php');
-        $this->assertSame($size, $file->getSizeByUnitMetric(FileSizeUnit::B));
+        $this->assertSame($size, $file->getSizeByMetricUnit(FileSizeUnit::B));
     }
 
     public function testThrowsExceptionIfNotAFile(): void

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -113,6 +113,42 @@ final class FileTest extends CIUnitTestCase
         $this->assertSame($size, $file->getSizeByUnit('b'));
     }
 
+    /**
+     * @dataProvider provideGetSizeData
+     */
+    public function testGetSizeBinary(FileSizeUnit $unit): void
+    {
+        $divider = pow(1024, $unit->value);
+        $file = new File(SYSTEMPATH . 'Common.php');
+        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
+        $this->assertSame($size, $file->getSizeByUnitBinary($unit));
+    }
+
+    public function testGetSizeBinaryBytes(): void
+    {
+        $file = new File(SYSTEMPATH . 'Common.php');
+        $size = filesize(SYSTEMPATH . 'Common.php');
+        $this->assertSame($size, $file->getSizeByUnitBinary(FileSizeUnit::B));
+    }
+
+    /**
+     * @dataProvider provideGetSizeData
+     */
+    public function testGetSizeMetric(FileSizeUnit $unit): void
+    {
+        $divider = pow(1000, $unit->value);
+        $file = new File(SYSTEMPATH . 'Common.php');
+        $size = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
+        $this->assertSame($size, $file->getSizeByUnitMetric($unit));
+    }
+
+    public function testGetSizeMetricBytes(): void
+    {
+        $file = new File(SYSTEMPATH . 'Common.php');
+        $size = filesize(SYSTEMPATH . 'Common.php');
+        $this->assertSame($size, $file->getSizeByUnitMetric(FileSizeUnit::B));
+    }
+
     public function testThrowsExceptionIfNotAFile(): void
     {
         $this->expectException(FileNotFoundException::class);
@@ -134,5 +170,23 @@ final class FileTest extends CIUnitTestCase
 
         unlink(SYSTEMPATH . 'Common_Copy.php');
         unlink(SYSTEMPATH . 'Common_Copy_5.php');
+    }
+
+    public static function provideGetSizeData()
+    {
+        return [
+            'returns KB binary' => [
+                FileSizeUnit::KB
+            ],
+            'returns MB binary' => [
+                FileSizeUnit::KB
+            ],
+            'returns GB binary' => [
+                FileSizeUnit::KB
+            ],
+            'returns TB binary' => [
+                FileSizeUnit::KB
+            ],
+        ];
     }
 }

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -170,7 +170,7 @@ final class FileTest extends CIUnitTestCase
     }
 
     /**
-     * @return array<string, array<int, CodeIgniter\Files\FileSizeUnit>>
+     * @return array<string, array<int, FileSizeUnit>>
      */
     public static function provideGetSizeData()
     {

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -170,7 +170,7 @@ final class FileTest extends CIUnitTestCase
     }
 
     /**
-     * @return array<string, list<int>>
+     * @return array<string, array<int, CodeIgniter\Files\FileSizeUnit>>
      */
     public static function provideGetSizeData()
     {

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -118,7 +118,7 @@ final class FileTest extends CIUnitTestCase
      */
     public function testGetSizeBinary(FileSizeUnit $unit): void
     {
-        $divider = pow(1024, $unit->value);
+        $divider = 1024 ** $unit->value;
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
         $this->assertSame($size, $file->getSizeByUnitBinary($unit));
@@ -136,7 +136,7 @@ final class FileTest extends CIUnitTestCase
      */
     public function testGetSizeMetric(FileSizeUnit $unit): void
     {
-        $divider = pow(1000, $unit->value);
+        $divider = 1000 ** $unit->value;
         $file = new File(SYSTEMPATH . 'Common.php');
         $size = number_format(filesize(SYSTEMPATH . 'Common.php') / $divider, 3);
         $this->assertSame($size, $file->getSizeByUnitMetric($unit));

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -215,6 +215,8 @@ Model
 Libraries
 =========
 
+- **File:** Added ``getSizeByBinaryUnit()`` and ``getSizeByMetricUnit()`` to ``File`` class.
+  See :ref:`File::getSizeByBinaryUnit() <file-get-size-by-binary-unit>` and :ref:`File::getSizeByMetricUnit() <file-get-size-by-metric-unit>`.
 - **FileCollection:** Added ``retainMultiplePatterns()`` to ``FileCollection`` class.
   See :ref:`FileCollection::retainMultiplePatterns() <file-collections-retain-multiple-patterns>`.
 - **Validation:** Added ``min_dims`` validation rule to ``FileRules`` class. See

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -279,7 +279,7 @@ Deprecations
     - The ``Filters::getArguments()`` method has been deprecated. No longer used.
 - **File:**
     - The function ``getSizeByUnit()`` of ``File`` has been deprecated.
-      Use either ``getSizeByUnitBinary()`` or ``getSizeByUnitMetric()`` instead.
+      Use either ``getSizeByBinaryUnit()`` or ``getSizeByMetricUnit()`` instead.
 
 **********
 Bugs Fixed

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -278,8 +278,8 @@ Deprecations
       been deprecated. No longer used.
     - The ``Filters::getArguments()`` method has been deprecated. No longer used.
 - **File:**
-    - The function ``getSizeByUnit`` of ``File`` has been deprecated.
-      Use either ``getSizeByUnitBinary`` or ``getSizeByUnitMetric`` instead.
+    - The function ``getSizeByUnit()`` of ``File`` has been deprecated.
+      Use either ``getSizeByUnitBinary()`` or ``getSizeByUnitMetric()`` instead.
 
 **********
 Bugs Fixed

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -277,6 +277,9 @@ Deprecations
     - The properties ``$arguments`` and ``$argumentsClass`` of ``Filters`` have
       been deprecated. No longer used.
     - The ``Filters::getArguments()`` method has been deprecated. No longer used.
+- **File:**
+    - The function ``getSizeByUnit`` of ``File`` has been deprecated.
+      Use either ``getSizeByUnitBinary`` or ``getSizeByUnitMetric`` instead.
 
 **********
 Bugs Fixed

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -56,10 +56,36 @@ A ``RuntimeException`` will be thrown if the file does not exist or an error occ
 getSizeByUnit()
 ===============
 
+.. deprecated:: 4.6.0
+
 Returns the size of the file default in bytes. You can pass in either ``'kb'`` or ``'mb'`` as the first parameter to get
-the results in kilobytes or megabytes, respectively:
+the results in kibibytes or mebibytes, respectively:
 
 .. literalinclude:: files/005.php
+    :lines: 2-
+
+A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
+
+getSizeByUnitBinary()
+===============
+
+Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get
+the results in kibibytes, mebibytes etc. respectively. You can pass in a precision value as the second parameter to define
+the amount of decimal places.
+
+.. literalinclude:: files/017.php
+    :lines: 2-
+
+A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
+
+getSizeByUnitMetric()
+===============
+
+Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get
+the results in kilobytes, megabytes etc. respectively. You can pass in a precision value as the second parameter to define
+the amount of decimal places.
+
+.. literalinclude:: files/018.php
     :lines: 2-
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -66,8 +66,13 @@ the results in kibibytes or mebibytes, respectively:
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
+
+.. _file-get-size-by-binary-unit:
+
 getSizeByBinaryUnit()
 =====================
+
+.. versionadded:: 4.6.0
 
 Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get
 the results in kibibytes, mebibytes etc. respectively. You can pass in a precision value as the second parameter to define
@@ -78,8 +83,13 @@ the amount of decimal places.
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
+
+.. _file-get-size-by-metric-unit:
+
 getSizeByMetricUnit()
 =====================
+
+.. versionadded:: 4.6.0
 
 Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get
 the results in kilobytes, megabytes etc. respectively. You can pass in a precision value as the second parameter to define

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -67,7 +67,7 @@ the results in kibibytes or mebibytes, respectively:
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
 getSizeByUnitBinary()
-===============
+=====================
 
 Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get
 the results in kibibytes, mebibytes etc. respectively. You can pass in a precision value as the second parameter to define
@@ -79,7 +79,7 @@ the amount of decimal places.
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
 getSizeByUnitMetric()
-===============
+=====================
 
 Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get
 the results in kilobytes, megabytes etc. respectively. You can pass in a precision value as the second parameter to define

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -74,7 +74,7 @@ the results in kibibytes, mebibytes etc. respectively. You can pass in a precisi
 the amount of decimal places.
 
 .. literalinclude:: files/017.php
-    :lines: 2-
+    :lines: 3-
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
@@ -86,7 +86,7 @@ the results in kilobytes, megabytes etc. respectively. You can pass in a precisi
 the amount of decimal places.
 
 .. literalinclude:: files/018.php
-    :lines: 2-
+    :lines: 3-
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -74,7 +74,7 @@ the results in kibibytes, mebibytes etc. respectively. You can pass in a precisi
 the amount of decimal places.
 
 .. literalinclude:: files/017.php
-    :lines: 3-
+    :lines: 4-
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
@@ -86,7 +86,7 @@ the results in kilobytes, megabytes etc. respectively. You can pass in a precisi
 the amount of decimal places.
 
 .. literalinclude:: files/018.php
-    :lines: 3-
+    :lines: 4-
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 

--- a/user_guide_src/source/libraries/files.rst
+++ b/user_guide_src/source/libraries/files.rst
@@ -66,7 +66,7 @@ the results in kibibytes or mebibytes, respectively:
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
-getSizeByUnitBinary()
+getSizeByBinaryUnit()
 =====================
 
 Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get
@@ -78,7 +78,7 @@ the amount of decimal places.
 
 A ``RuntimeException`` will be thrown if the file does not exist or an error occurs.
 
-getSizeByUnitMetric()
+getSizeByMetricUnit()
 =====================
 
 Returns the size of the file default in bytes. You can pass in different FileSizeUnit values as the first parameter to get

--- a/user_guide_src/source/libraries/files/017.php
+++ b/user_guide_src/source/libraries/files/017.php
@@ -1,4 +1,5 @@
 <?php
+use CodeIgniter\Files\FileSizeUnit;
 
 $bytes     = $file->getSizeByUnitBinary(); // 256901
 $kibibytes = $file->getSizeByUnitBinary(FileSizeUnit::KB); // 250.880

--- a/user_guide_src/source/libraries/files/017.php
+++ b/user_guide_src/source/libraries/files/017.php
@@ -2,6 +2,6 @@
 
 use CodeIgniter\Files\FileSizeUnit;
 
-$bytes     = $file->getSizeByUnitBinary(); // 256901
-$kibibytes = $file->getSizeByUnitBinary(FileSizeUnit::KB); // 250.880
-$mebibytes = $file->getSizeByUnitBinary(FileSizeUnit::MB); // 0.245
+$bytes     = $file->getSizeByBinaryUnit(); // 256901
+$kibibytes = $file->getSizeByBinaryUnit(FileSizeUnit::KB); // 250.880
+$mebibytes = $file->getSizeByBinaryUnit(FileSizeUnit::MB); // 0.245

--- a/user_guide_src/source/libraries/files/017.php
+++ b/user_guide_src/source/libraries/files/017.php
@@ -1,0 +1,5 @@
+<?php
+
+$bytes     = $file->getSizeByUnitBinary(); // 256901
+$kibibytes = $file->getSizeByUnitBinary(FileSizeUnit::KB); // 250.880
+$mebibytes = $file->getSizeByUnitBinary(FileSizeUnit::MB); // 0.245

--- a/user_guide_src/source/libraries/files/017.php
+++ b/user_guide_src/source/libraries/files/017.php
@@ -1,4 +1,5 @@
 <?php
+
 use CodeIgniter\Files\FileSizeUnit;
 
 $bytes     = $file->getSizeByUnitBinary(); // 256901

--- a/user_guide_src/source/libraries/files/018.php
+++ b/user_guide_src/source/libraries/files/018.php
@@ -1,4 +1,5 @@
 <?php
+
 use CodeIgniter\Files\FileSizeUnit;
 
 $bytes     = $file->getSizeByUnitMetric(); // 256901

--- a/user_guide_src/source/libraries/files/018.php
+++ b/user_guide_src/source/libraries/files/018.php
@@ -1,4 +1,5 @@
 <?php
+use CodeIgniter\Files\FileSizeUnit;
 
 $bytes     = $file->getSizeByUnitMetric(); // 256901
 $kilobytes = $file->getSizeByUnitMetric(FileSizeUnit::KB); // 256.901

--- a/user_guide_src/source/libraries/files/018.php
+++ b/user_guide_src/source/libraries/files/018.php
@@ -1,0 +1,5 @@
+<?php
+
+$bytes     = $file->getSizeByUnitMetric(); // 256901
+$kilobytes = $file->getSizeByUnitMetric(FileSizeUnit::KB); // 256.901
+$megabytes = $file->getSizeByUnitMetric(FileSizeUnit::MB); // 0.256

--- a/user_guide_src/source/libraries/files/018.php
+++ b/user_guide_src/source/libraries/files/018.php
@@ -2,6 +2,6 @@
 
 use CodeIgniter\Files\FileSizeUnit;
 
-$bytes     = $file->getSizeByUnitMetric(); // 256901
-$kilobytes = $file->getSizeByUnitMetric(FileSizeUnit::KB); // 256.901
-$megabytes = $file->getSizeByUnitMetric(FileSizeUnit::MB); // 0.256
+$bytes     = $file->getSizeByMetricUnit(); // 256901
+$kilobytes = $file->getSizeByMetricUnit(FileSizeUnit::KB); // 256.901
+$megabytes = $file->getSizeByMetricUnit(FileSizeUnit::MB); // 0.256


### PR DESCRIPTION
**Notice** 
This originated from another PR: https://github.com/codeigniter4/CodeIgniter4/pull/9271

**Description**
Noticed that the file size calculation mixes up the SI unit prefixes with the NIST/IEC unit prefixes, by taking "kb" and "mb" but calculating "kib" and "mib". 
Fixed by providing both possibilities. 

This therefore will break existing code!

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [X] User guide updated
- [X] Conforms to style guide