### PR TITLE
fix: baseURI for curlrequest and image/jpg for jpg mime

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -199,6 +199,7 @@ class Mimes
         ],
         'gif' => 'image/gif',
         'jpg' => [
+            'image/jpg',
             'image/jpeg',
             'image/pjpeg',
         ],

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -211,7 +211,7 @@ class Services extends BaseService
 
         return new CURLRequest(
             $config,
-            new URI($options['base_uri'] ?? null),
+            new URI($options['baseURI'] ?? null),
             $response,
             $options
         );


### PR DESCRIPTION
#9265
**Description**
Use 'baseURI' instead of 'base_uri' as the manual described.
Add 'image/jpg' mime for file extension jpg.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
