### PR TITLE
feat: Support start/stop slave's replication and create temporary table in database

### DIFF
--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -900,8 +900,7 @@ class CodeIgniter
     {
         assert(is_string($this->controller));
 
-        $class = new $this->controller();
-        $class->initController($this->request, $this->response, Services::logger());
+        $class = new $this->controller($this->request, $this->response, Services::logger());
 
         $this->benchmark->stop('controller_constructor');
 

--- a/system/Controller.php
+++ b/system/Controller.php
@@ -72,12 +72,19 @@ class Controller
      */
     protected $validator;
 
+    public function __construct(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
+    {
+        $this->initController($request, $response, $logger);
+    }
+
     /**
      * Constructor.
      *
      * @return void
      *
      * @throws HTTPException
+     * 
+     * @deprecated  4.6.0 No longer used.
      */
     public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
     {

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3433,6 +3433,14 @@ class BaseBuilder
         ]);
     }
 
+    public function selectIntoTemporaryTable(?string $tb=NULL)
+    {
+        $tempTable = $this->db->createTemporaryTable($this->compileSelect(), $tb, $this->binds, false);
+        $this->resetSelect();
+        $this->binds = [];
+        return $tempTable;
+    }
+
     /**
      * Tests whether the string has an SQL operator
      */


### PR DESCRIPTION
**Description**
About database:
Add methods `createTemporaryTable`/`stopReplicating`/`startReplicating` to Database\BaseConnection class.
Add method `selectIntoTemporaryTable` to Database\BaseBuilder class.
Reset some states in Database\BaseConnection class's `__destruct` method such as transDepth.
Reason for temporary table: When we use temporary table, we may just want to get a random table name that was not exist, this process should be a packaged method for DB connection instance.  To satisfy the scene that name of temporary table should be defined explicitly, this method also provide a pass in param `$name` which's default value is null.
Reason for replicating: When we use "Read/ Write Splitting" database, some "write statement" may be required not to be re executed in slaves such as `grant powers to a DB user only exists in master`.
Reason for reset: Someone like me may run this framework in "Resident Process" such as [Swoole](https://github.com/swoole), which is necessary to reset it's states before put a connection back to the pool.

About controller:
Pass `$this->request`, `$this->response`, `Services::logger()` to `new $this->controller()` instead of call `$class->initController()` in CodeIgniter's `createController` method.
Call `$this->initController` in Controller's `__construct` method (For backward compatibility).
Reason:  `__construct` method is the official initiator,use it may be more intuitive.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide

I'm sorry that I can't submit a feature request to the [forum](https://forum.codeigniter.com/forum-29.html) because I can't register it successfully. The screen  displays `Please solve the reCAPTCHA to verify that you're not a robot.`. The console of my chrome browser displays:
Refused to execute script from 'https://forum.codeigniter.com/jscripts/theme-effects.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled. @`member.php:1`
Failed to load resource: net::ERR_CONNECTION_TIMED_OUT. @`www.google.com/recaptcha/api.js?onload=captchaOnloadCallback&render=explicit:1`