### PR TITLE
refactor: explicitly declare $methods property as array in Filters configuration

### DIFF
--- a/user_guide_src/source/tutorial/create_news_items/001.php
+++ b/user_guide_src/source/tutorial/create_news_items/001.php
@@ -8,7 +8,7 @@ class Filters extends BaseConfig
 {
     // ...
 
-    public $methods = [
+    public array $methods = [
         'POST' => ['csrf'],
     ];
 


### PR DESCRIPTION
Resolved a fatal error:
Type of Config\Filters::$methods must be array (as in class CodeIgniter\Config\Filters)
by explicitly declaring $methods as an array to ensure compatibility with strict typing.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide