### PR TITLE
feat: add image/jpg to jpg file's mime

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -199,6 +199,7 @@ class Mimes
         ],
         'gif' => 'image/gif',
         'jpg' => [
+            'image/jpg',
             'image/jpeg',
             'image/pjpeg',
         ],


### PR DESCRIPTION
#9300
image/jpg is one type of .jpg file.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
