### PR TITLE
fix: primary key mapping in the model for the entity

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -15836,12 +15836,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Models/PaginateModelTest.php',
 ];
 $ignoreErrors[] = [
-	// identifier: method.notFound
-	'message' => '#^Call to an undefined method class@anonymous/tests/system/Models/SaveModelTest\\.php\\:288\\:\\:truncate\\(\\)\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Models/SaveModelTest.php',
-];
-$ignoreErrors[] = [
 	// identifier: property.nonObject
 	'message' => '#^Cannot access property \\$description on array\\.$#',
 	'count' => 3,

--- a/system/Model.php
+++ b/system/Model.php
@@ -593,7 +593,7 @@ class Model extends BaseModel
     public function getIdValue($row)
     {
         if (is_object($row)) {
-            // Get the raw primary key value of the Entity.
+            // Get the raw or mapped primary key value of the Entity.
             if ($row instanceof Entity && $row->{$this->primaryKey} !== null) {
                 $cast = $row->cast();
 

--- a/system/Model.php
+++ b/system/Model.php
@@ -592,9 +592,9 @@ class Model extends BaseModel
      */
     public function getIdValue($row)
     {
-        if (is_object($row) && isset($row->{$this->primaryKey})) {
+        if (is_object($row)) {
             // Get the raw primary key value of the Entity.
-            if ($row instanceof Entity) {
+            if ($row instanceof Entity && $row->{$this->primaryKey} !== null) {
                 $cast = $row->cast();
 
                 // Disable Entity casting, because raw primary key value is needed for database.
@@ -608,7 +608,9 @@ class Model extends BaseModel
                 return $primaryKey;
             }
 
-            return $row->{$this->primaryKey};
+            if (! $row instanceof Entity && isset($row->{$this->primaryKey})) {
+                return $row->{$this->primaryKey};
+            }
         }
 
         if (is_array($row) && isset($row[$this->primaryKey])) {

--- a/tests/system/Models/SaveModelTest.php
+++ b/tests/system/Models/SaveModelTest.php
@@ -301,7 +301,7 @@ final class SaveModelTest extends LiveModelTestCase
 
         $this->setPrivateProperty($testModel, 'useTimestamps', true);
         $this->assertTrue($testModel->save($entity));
-        $testModel->truncate();
+        $testModel->db->table('empty')->truncate();
     }
 
     public function testInvalidAllowedFieldException(): void
@@ -372,7 +372,7 @@ final class SaveModelTest extends LiveModelTestCase
     public function testSaveNewEntityWithMappedPrimaryKey(): void
     {
         $entity = new class () extends Entity {
-            protected $name;
+            protected string $name;
             protected $attributes = [
                 'id'   => null,
                 'name' => null,
@@ -403,6 +403,6 @@ final class SaveModelTest extends LiveModelTestCase
         $this->assertTrue($testModel->save($entity));
 
         $this->seeInDatabase('empty', ['id' => 1, 'name' => 'Updated']);
-        $testModel->truncate();
+        $testModel->db->table('empty')->truncate();
     }
 }

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -38,10 +38,10 @@ Bugs Fixed
 - **DownloadResponse:** Fixed a bug that prevented setting custom cache headers. We can now also use the ``setCache()`` method.
 - **DownloadResponse:** Fixed a bug involving sending a custom "Expires-Disposition" header.
 - **Routing:** Fixed a TypeError in `str_replace()` when `Routing::$translateURIDashes` is set to `true` and a route is defined using a closure.
-
 - **Validation:** Fixed a bug where complex language strings were not properly handled.
 - **CURLRequest:** Added support for handling proxy responses using HTTP versions other than 1.1.
 - **Database:** Fixed a bug that caused ``Postgre\Connection::reconnect()`` method to throw an error when the connection had not yet been established.
+- **Model** Fixed a bug that caused the ``Model::getIdValue()`` method to not correctly recognize the primary key in the ``Entity`` object if a data mapping for the primary key was used.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug that caused the `Model::getIdValue()` to not correctly recognize the primary key in the ``Entity`` object if a data mapping for the primary key was used.

Fixes: #9306

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
