### PR TITLE
fix: exceptions for non-HTML responses

### DIFF
--- a/system/Debug/ExceptionHandler.php
+++ b/system/Debug/ExceptionHandler.php
@@ -76,7 +76,11 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
             }
 
             if (! str_contains($request->getHeaderLine('accept'), 'text/html')) {
-                $data = (ENVIRONMENT === 'development' || ENVIRONMENT === 'testing')
+                $data = in_array(
+                    strtolower(ini_get('display_errors')),
+                    ['1', 'true', 'on', 'yes'],
+                    true
+                )
                     ? $this->collectVars($exception, $statusCode)
                     : '';
 

--- a/user_guide_src/source/changelogs/v4.5.6.rst
+++ b/user_guide_src/source/changelogs/v4.5.6.rst
@@ -42,6 +42,7 @@ Bugs Fixed
 - **Validation:** Fixed a bug where complex language strings were not properly handled.
 - **CURLRequest:** Added support for handling proxy responses using HTTP versions other than 1.1.
 - **Database:** Fixed a bug that caused ``Postgre\Connection::reconnect()`` method to throw an error when the connection had not yet been established.
+- **Exception:** Fixed a bug where exceptions for non-HTML responses were not relying on the PHP ``display_errors`` setting.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug where exceptions for non-HTML responses did not rely on the `display_errors` setting.

Fixes: #9242

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
