### PR TITLE
docs: add missing info about exceptions for non-HTML responses

### DIFF
--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -183,6 +183,8 @@ The following new Exception interfaces have been added:
 - ``CodeIgniter\HTTP\Exceptions\ExceptionInterface``
 - ``CodeIgniter\Router\Exceptions\ExceptionInterface``
 
+Displaying exceptions for non-HTML responses now rely on the PHP ``display_errors`` setting instead of hardcoded environments.
+
 Commands
 ========
 


### PR DESCRIPTION
**Description**
This PR adds missing info about changes in handling exceptions for non-HTML responses.

See: #9308

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
