### PR TITLE
refactor: fix `method.nameCase` errors

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -13070,12 +13070,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Database/Live/GetTest.php',
 ];
 $ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:getWhere\\(\\) with incorrect case\\: getwhere$#',
-	'count' => 4,
-	'path' => __DIR__ . '/tests/system/Database/Live/InsertTest.php',
-];
-$ignoreErrors[] = [
 	// identifier: property.phpDocType
 	'message' => '#^PHPDoc type string of property CodeIgniter\\\\Database\\\\Live\\\\MetadataTest\\:\\:\\$seed is not the same as PHPDoc type array\\<int, class\\-string\\<CodeIgniter\\\\Database\\\\Seeder\\>\\>\\|class\\-string\\<CodeIgniter\\\\Database\\\\Seeder\\> of overridden property CodeIgniter\\\\Test\\\\CIUnitTestCase\\:\\:\\$seed\\.$#',
 	'count' => 1,
@@ -13176,12 +13170,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Database\\\\Live\\\\UpdateTest\\:\\:testUpdateBatch\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Database/Live/UpdateTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method CodeIgniter\\\\Database\\\\BaseBuilder\\:\\:getWhere\\(\\) with incorrect case\\: getwhere$#',
-	'count' => 9,
-	'path' => __DIR__ . '/tests/system/Database/Live/UpsertTest.php',
 ];
 $ignoreErrors[] = [
 	// identifier: argument.type
@@ -13544,12 +13532,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Filters/fixtures/InvalidClass.php',
 ];
 $ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with incorrect case\\: assertInstanceof$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/Format/FormatTest.php',
-];
-$ignoreErrors[] = [
 	// identifier: missingType.iterableValue
 	'message' => '#^Method CodeIgniter\\\\Format\\\\XMLFormatterTest\\:\\:provideValidatingInvalidTags\\(\\) return type has no value type specified in iterable type iterable\\.$#',
 	'count' => 1,
@@ -13674,12 +13656,6 @@ $ignoreErrors[] = [
 	'message' => '#^Assigning \'Mozilla/5\\.0 \\(Linux; U; Android 2\\.0\\.3; ja\\-jp; SC\\-02C Build/IML74K\\) AppleWebKit/534\\.30 \\(KHTML, like Gecko\\) Version/4\\.0 Mobile Safari/534\\.30\' directly on offset \'HTTP_USER_AGENT\' of \\$_SERVER is discouraged\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/HTTP/DownloadResponseTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with incorrect case\\: AssertNull$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/system/HTTP/Files/FileCollectionTest.php',
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.return
@@ -16844,12 +16820,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/system/Test/ControllerTestTraitTest.php',
 ];
 $ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method CodeIgniter\\\\Test\\\\ControllerTestTraitTest\\:\\:withUri\\(\\) with incorrect case\\: withURI$#',
-	'count' => 17,
-	'path' => __DIR__ . '/tests/system/Test/ControllerTestTraitTest.php',
-];
-$ignoreErrors[] = [
 	// identifier: class.notFound
 	'message' => '#^Class App\\\\Controllers\\\\NeverHeardOfIt not found\\.$#',
 	'count' => 1,
@@ -17316,12 +17286,6 @@ $ignoreErrors[] = [
 	'message' => '#^Property CodeIgniter\\\\Validation\\\\FileRulesTest\\:\\:\\$config type has no value type specified in iterable type array\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/system/Validation/FileRulesTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with incorrect case\\: assertsame$#',
-	'count' => 2,
-	'path' => __DIR__ . '/tests/system/Validation/FormatRulesTest.php',
 ];
 $ignoreErrors[] = [
 	// identifier: missingType.iterableValue

--- a/system/Test/ControllerTestTrait.php
+++ b/system/Test/ControllerTestTrait.php
@@ -31,7 +31,7 @@ use Throwable;
  *
  *  $this->withRequest($request)
  *       ->withResponse($response)
- *       ->withURI($uri)
+ *       ->withUri($uri)
  *       ->withBody($body)
  *       ->controller('App\Controllers\Home')
  *       ->execute('methodName');

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -97,7 +97,7 @@ final class InsertTest extends CIUnitTestCase
         $this->db->table('job')->replace($data);
 
         $row = $this->db->table('job')
-            ->getwhere(['id' => 5])
+            ->getWhere(['id' => 5])
             ->getRow();
 
         $this->assertSame('Cab Driver', $row->name);
@@ -114,7 +114,7 @@ final class InsertTest extends CIUnitTestCase
         $this->db->table('job')->replace($data);
 
         $row = $this->db->table('job')
-            ->getwhere(['id' => 1])
+            ->getWhere(['id' => 1])
             ->getRow();
 
         $this->assertSame('Cab Driver', $row->name);
@@ -135,7 +135,7 @@ final class InsertTest extends CIUnitTestCase
         $builder->replace($data);
 
         $row = $this->db->table('job')
-            ->getwhere(['id' => 1])
+            ->getWhere(['id' => 1])
             ->getRow();
         $this->assertSame('John Smith', $row->name);
 
@@ -147,7 +147,7 @@ final class InsertTest extends CIUnitTestCase
         $builder->replace($data);
 
         $row = $this->db->table('job')
-            ->getwhere(['id' => 2])
+            ->getWhere(['id' => 2])
             ->getRow();
         $this->assertSame('Hans Schmidt', $row->name);
     }

--- a/tests/system/Database/Live/UpsertTest.php
+++ b/tests/system/Database/Live/UpsertTest.php
@@ -190,7 +190,7 @@ final class UpsertTest extends CIUnitTestCase
                 ->upsert($userData);
 
             $new = $this->db->table('user')
-                ->getwhere(['email' => 'ahmadinejad@world.com'])
+                ->getWhere(['email' => 'ahmadinejad@world.com'])
                 ->getRow();
 
             $this->assertSame(5, (int) $new->id);
@@ -460,7 +460,7 @@ final class UpsertTest extends CIUnitTestCase
         $this->db->table('user')->upsert($data);
 
         $original = $this->db->table('user')
-            ->getwhere(['id' => 6])
+            ->getWhere(['id' => 6])
             ->getRow();
 
         $data = [
@@ -474,7 +474,7 @@ final class UpsertTest extends CIUnitTestCase
 
         // get by id
         $row = $this->db->table('user')
-            ->getwhere(['id' => 6])
+            ->getWhere(['id' => 6])
             ->getRow();
 
         $this->assertSame('Random Name 356', $row->name);
@@ -508,17 +508,17 @@ final class UpsertTest extends CIUnitTestCase
 
         // get by id
         $row1 = $this->db->table('user')
-            ->getwhere(['id' => 1])
+            ->getWhere(['id' => 1])
             ->getRow();
 
         // get by id
         $row2 = $this->db->table('user')
-            ->getwhere(['id' => 2])
+            ->getWhere(['id' => 2])
             ->getRow();
 
         // get by id
         $row3 = $this->db->table('user')
-            ->getwhere(['id' => 3])
+            ->getWhere(['id' => 3])
             ->getRow();
 
         $this->assertSame('Upsert One On Id', $row1->name);
@@ -553,17 +553,17 @@ final class UpsertTest extends CIUnitTestCase
 
         // get by id
         $row1 = $this->db->table('user')
-            ->getwhere(['email' => 'nullone@domain.com'])
+            ->getWhere(['email' => 'nullone@domain.com'])
             ->getRow();
 
         // get by id
         $row2 = $this->db->table('user')
-            ->getwhere(['email' => 'nulltwo@domain.com'])
+            ->getWhere(['email' => 'nulltwo@domain.com'])
             ->getRow();
 
         // get by id
         $row3 = $this->db->table('user')
-            ->getwhere(['email' => 'nullthree@domain.com'])
+            ->getWhere(['email' => 'nullthree@domain.com'])
             ->getRow();
 
         $this->assertSame('Null One', $row1->name);

--- a/tests/system/Format/FormatTest.php
+++ b/tests/system/Format/FormatTest.php
@@ -42,7 +42,7 @@ final class FormatTest extends CIUnitTestCase
 
     public function testGetFormatter(): void
     {
-        $this->assertInstanceof(FormatterInterface::class, $this->format->getFormatter('application/json'));
+        $this->assertInstanceOf(FormatterInterface::class, $this->format->getFormatter('application/json'));
     }
 
     public function testGetFormatterExpectsExceptionOnUndefinedMime(): void

--- a/tests/system/HTTP/Files/FileCollectionTest.php
+++ b/tests/system/HTTP/Files/FileCollectionTest.php
@@ -524,7 +524,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
         $collection = new FileCollection();
         $file       = $collection->getFile('fileuser');
-        $this->AssertNull($file);
+        $this->assertNull($file);
     }
 
     public function testFileReturnValidMultipleFiles(): void

--- a/tests/system/Test/ControllerTestTraitTest.php
+++ b/tests/system/Test/ControllerTestTraitTest.php
@@ -49,7 +49,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     {
         $this->expectException('InvalidArgumentException');
         $logger = new Logger(new LoggerConfig());
-        $this->withURI('http://example.com')
+        $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(NeverHeardOfIt::class)
             ->execute('index');
@@ -59,7 +59,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     {
         $this->expectException('InvalidArgumentException');
         $logger = new Logger(new LoggerConfig());
-        $this->withURI('http://example.com')
+        $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Home::class)
             ->execute('nothere');
@@ -68,7 +68,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testController(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Home::class)
             ->execute('index');
@@ -78,7 +78,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
 
     public function testControllerWithoutLogger(): void
     {
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->controller(Home::class)
             ->execute('index');
 
@@ -88,7 +88,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testPopcornIndex(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('index');
@@ -99,7 +99,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testPopcornIndex2(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('index');
@@ -111,7 +111,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testPopcornFailure(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('pop');
@@ -122,7 +122,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testPopcornException(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('popper');
@@ -136,7 +136,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
         $config = new App();
         $body   = '';
 
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withConfig($config)
             ->withRequest(service('request', $config))
             ->withResponse(service('response', $config))
@@ -152,7 +152,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testRequestPassthrough(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('popper');
@@ -164,7 +164,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testFailureResponse(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('oops');
@@ -176,7 +176,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testEmptyResponse(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('weasel');
@@ -189,7 +189,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testRedirect(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('goaway');
@@ -200,7 +200,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testDOMParserForward(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('index');
@@ -211,7 +211,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
     public function testFailsForward(): void
     {
         $logger = new Logger(new LoggerConfig());
-        $result = $this->withURI('http://example.com')
+        $result = $this->withUri('http://example.com')
             ->withLogger($logger)
             ->controller(Popcorn::class)
             ->execute('index');
@@ -225,7 +225,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
      */
     public function testResponseOverriding(): void
     {
-        $result = $this->withURI('http://example.com/rest/')
+        $result = $this->withUri('http://example.com/rest/')
             ->controller(Popcorn::class)
             ->execute('index3');
 
@@ -271,7 +271,7 @@ final class ControllerTestTraitTest extends CIUnitTestCase
 
     public function testWithUriUpdatesUriStringAndCurrentUrlValues(): void
     {
-        $result = $this->withURI('http://example.com/foo/bar/1/2/3')
+        $result = $this->withUri('http://example.com/foo/bar/1/2/3')
             ->controller(Newautorouting::class)
             ->execute('postSave', '1', '2', '3');
 

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -789,7 +789,7 @@ class FormatRulesTest extends CIUnitTestCase
         $data = [
             'foo' => $value,
         ];
-        $this->assertsame($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     /**
@@ -807,7 +807,7 @@ class FormatRulesTest extends CIUnitTestCase
         $data = [
             'foo' => $value,
         ];
-        $this->assertsame($expected, $this->validation->run($data));
+        $this->assertSame($expected, $this->validation->run($data));
     }
 
     public static function provideInvalidIntegerType(): iterable

--- a/user_guide_src/source/testing/controllers.rst
+++ b/user_guide_src/source/testing/controllers.rst
@@ -90,7 +90,7 @@ Allows you to provide a **Logger** instance:
 If you do not provide one, a new Logger instance with the default configuration values will be passed
 into your controller.
 
-withURI(string $uri)
+withUri(string $uri)
 --------------------
 
 Allows you to provide a new URI that simulates the URL the client was visiting when this controller was run.

--- a/user_guide_src/source/testing/controllers/002.php
+++ b/user_guide_src/source/testing/controllers/002.php
@@ -13,7 +13,7 @@ class ForumControllerTest extends CIUnitTestCase
 
     public function testShowCategories()
     {
-        $result = $this->withURI('http://example.com/categories')
+        $result = $this->withUri('http://example.com/categories')
             ->controller(ForumController::class)
             ->execute('showCategories');
 

--- a/user_guide_src/source/testing/controllers/009.php
+++ b/user_guide_src/source/testing/controllers/009.php
@@ -1,5 +1,5 @@
 <?php
 
-$results = $this->withURI('http://example.com/forums/categories')
+$results = $this->withUri('http://example.com/forums/categories')
     ->controller(\App\Controllers\ForumController::class)
     ->execute('showCategories');


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Yes, we have these kind of errors in our baseline 🤷🏻‍♂️ 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
