### PR TITLE
fix: check if defined `WRITEPATH` exists

### DIFF
--- a/system/Boot.php
+++ b/system/Boot.php
@@ -199,6 +199,7 @@ class Boot
             if (($writePath = realpath(rtrim($paths->writableDirectory, '\\/ '))) === false) {
                 header('HTTP/1.1 503 Service Unavailable.', true, 503);
                 echo 'The WRITEPATH is not set correctly.';
+
                 // EXIT_ERROR is not yet defined
                 exit(1);
             }

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -196,10 +196,12 @@ class Boot
 
         // The path to the writable directory.
         if (! defined('WRITEPATH')) {
-            if (($writePath = realpath(rtrim($paths->writableDirectory, '\\/ '))) === false) {
+
+            $writePath = realpath(rtrim($paths->writableDirectory, '\\/ '));
+        
+            if ($writePath === false) {
                 header('HTTP/1.1 503 Service Unavailable.', true, 503);
                 echo 'The WRITEPATH is not set correctly.';
-
                 // EXIT_ERROR is not yet defined
                 exit(1);
             }

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -196,7 +196,13 @@ class Boot
 
         // The path to the writable directory.
         if (! defined('WRITEPATH')) {
-            define('WRITEPATH', realpath(rtrim($paths->writableDirectory, '\\/ ')) . DIRECTORY_SEPARATOR);
+            if (($writePath = realpath(rtrim($paths->writableDirectory, '\\/ '))) === false) {
+                header('HTTP/1.1 503 Service Unavailable.', true, 503);
+                echo 'The WRITEPATH is not set correctly.';
+                // EXIT_ERROR is not yet defined
+                exit(1);
+            }
+            define('WRITEPATH', $writePath . DIRECTORY_SEPARATOR);
         }
 
         // The path to the tests directory

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -196,12 +196,12 @@ class Boot
 
         // The path to the writable directory.
         if (! defined('WRITEPATH')) {
-
             $writePath = realpath(rtrim($paths->writableDirectory, '\\/ '));
-        
+
             if ($writePath === false) {
                 header('HTTP/1.1 503 Service Unavailable.', true, 503);
                 echo 'The WRITEPATH is not set correctly.';
+
                 // EXIT_ERROR is not yet defined
                 exit(1);
             }


### PR DESCRIPTION
**Description**
This PR adds a check that `WRITEPATH` is defined correctly.

Fixes: #9309

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
