### PR TITLE
refactor: `Reflection*::setAccessible()` is now no-op in PHP 8.1

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1799,8 +1799,6 @@ abstract class BaseModel
             // Loop over each property,
             // saving the name/value in a new array we can return.
             foreach ($props as $prop) {
-                // Must make protected values accessible.
-                $prop->setAccessible(true);
                 $properties[$prop->getName()] = $prop->getValue($object);
             }
         }

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -39,8 +39,7 @@ trait ReflectionHelper
     public static function getPrivateMethodInvoker($obj, $method)
     {
         $refMethod = new ReflectionMethod($obj, $method);
-        $refMethod->setAccessible(true);
-        $obj = (gettype($obj) === 'object') ? $obj : null;
+        $obj       = (gettype($obj) === 'object') ? $obj : null;
 
         return static fn (...$args) => $refMethod->invokeArgs($obj, $args);
     }
@@ -59,10 +58,7 @@ trait ReflectionHelper
     {
         $refClass = is_object($obj) ? new ReflectionObject($obj) : new ReflectionClass($obj);
 
-        $refProperty = $refClass->getProperty($property);
-        $refProperty->setAccessible(true);
-
-        return $refProperty;
+        return $refClass->getProperty($property);
     }
 
     /**

--- a/system/Traits/PropertiesTrait.php
+++ b/system/Traits/PropertiesTrait.php
@@ -71,7 +71,6 @@ trait PropertiesTrait
                 continue;
             }
 
-            $property->setAccessible(true);
             $properties[] = $property;
         }
 

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -549,13 +549,11 @@ final class CLITest extends CIUnitTestCase
     public function testWindow(): void
     {
         $height = new ReflectionProperty(CLI::class, 'height');
-        $height->setAccessible(true);
         $height->setValue(null, null);
 
         $this->assertIsInt(CLI::getHeight());
 
         $width = new ReflectionProperty(CLI::class, 'width');
-        $width->setAccessible(true);
         $width->setValue(null, null);
 
         $this->assertIsInt(CLI::getWidth());


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Refer: https://wiki.php.net/rfc/make-reflection-setaccessible-no-op

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
