### PR TITLE
fix: Path checking for the existence of a namespaced helper file

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -598,7 +598,7 @@ if (! function_exists('helper')) {
             if (str_contains($filename, '\\')) {
                 $path = $loader->locateFile($filename, 'Helpers');
 
-                if ($path !== '') {
+                if (!$path) {
                     throw FileNotFoundException::forFileNotFound($filename);
                 }
 


### PR DESCRIPTION
**Description**
The update in version 4.5.6 caused an error in the logic check line for the path of the namespaced helper file. The return value of `$loader->locateFile` is a string containing the file path if found, and `false` if not found. The `FileNotFoundException` should be executed if `$path` is `false`.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
