### PR TITLE
fix: `Forge::dropColumn()` always returns `false` on SQLite3 driver

### DIFF
--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -778,7 +778,7 @@ class Forge
     }
 
     /**
-     * @param array|string $columnNames column names to DROP
+     * @param list<string>|string $columnNames column names to DROP
      *
      * @return bool
      *

--- a/system/Database/SQLite3/Forge.php
+++ b/system/Database/SQLite3/Forge.php
@@ -111,6 +111,31 @@ class Forge extends BaseForge
     }
 
     /**
+     * @param list<string>|string $columnNames
+     *
+     * @throws DatabaseException
+     */
+    public function dropColumn(string $table, $columnNames): bool
+    {
+        $columns = is_array($columnNames) ? $columnNames : array_map(trim(...), explode(',', $columnNames));
+        $result  = (new Table($this->db, $this))
+            ->fromTable($this->db->DBPrefix . $table)
+            ->dropColumn($columns)
+            ->run();
+
+        if (! $result && $this->db->DBDebug) {
+            throw new DatabaseException(sprintf(
+                'Failed to drop column%s "%s" on "%s" table.',
+                count($columns) > 1 ? 's' : '',
+                implode('", "', $columns),
+                $table,
+            ));
+        }
+
+        return $result;
+    }
+
+    /**
      * @param array|string $processedFields Processed column definitions
      *                                      or column names to DROP
      *
@@ -121,17 +146,6 @@ class Forge extends BaseForge
     protected function _alterTable(string $alterType, string $table, $processedFields)
     {
         switch ($alterType) {
-            case 'DROP':
-                $columnNamesToDrop = $processedFields;
-
-                $sqlTable = new Table($this->db, $this);
-
-                $sqlTable->fromTable($table)
-                    ->dropColumn($columnNamesToDrop)
-                    ->run();
-
-                return ''; // Why empty string?
-
             case 'CHANGE':
                 $fieldsToModify = [];
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1319,8 +1319,7 @@ final class ForgeTest extends CIUnitTestCase
         $this->forge->createTable('forge_test_two');
 
         $this->assertTrue($this->db->fieldExists('name', 'forge_test_two'));
-
-        $this->forge->dropColumn('forge_test_two', 'name');
+        $this->assertTrue($this->forge->dropColumn('forge_test_two', 'name'));
 
         $this->db->resetDataCache();
 

--- a/user_guide_src/source/changelogs/v4.5.7.rst
+++ b/user_guide_src/source/changelogs/v4.5.7.rst
@@ -31,6 +31,7 @@ Bugs Fixed
 **********
 
 - **Common:** Fixed a bug where the ``helper()`` method may throw `FileNotFoundException` on valid namespaced helper.
+- **Forge:** Fixed an issue where `SQLite3`'s Forge always returns `false` when calling ``dropColumn()``.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1686 errors
+# total 1685 errors
 
 parameters:
     ignoreErrors:
@@ -1694,11 +1694,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Database\\Forge\:\:createTable\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Database/Forge.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\Forge\:\:dropColumn\(\) has parameter \$columnNames with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Database/Forge.php
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Fixes #8849 
Replaces and closes #8931

Changes are coming from the original PR. Not sure if there's anymore needed for this fix.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
