### PR TITLE
feat: Strict locale negotiation

### DIFF
--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -26,4 +26,10 @@ class Feature extends BaseConfig
      * If false, `limit(0)` returns no records. (the behavior of 3.1.9 or later in version 3.x.)
      */
     public bool $limitZeroAsAll = true;
+
+    /**
+     * Use an strict localization comparison (with territory en-*) instead of an abbreviated value
+     * Previously, the territory was cut off (en-* as en) before localization comparing
+     */
+    public bool $simpleNegotiateLocale = true;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -28,8 +28,10 @@ class Feature extends BaseConfig
     public bool $limitZeroAsAll = true;
 
     /**
-     * Set `false` to use strict localization comparison (with territory en-*) instead of an abbreviated value.
-     * Set `true`, so territory was cut off (en-* as en) before localization comparing.
+     * Use strict location negotiation.
+     *
+     * By default, the locale is selected based on a loose comparison of the language code (ISO 639-1)
+     * Enabling strict comparison will also consider the region code (ISO 3166-1 alpha-2).
      */
-    public bool $looseLocaleNegotiation = true;
+    public bool $strictLocaleNegotiation = false;
 }

--- a/app/Config/Feature.php
+++ b/app/Config/Feature.php
@@ -28,8 +28,8 @@ class Feature extends BaseConfig
     public bool $limitZeroAsAll = true;
 
     /**
-     * Use an strict localization comparison (with territory en-*) instead of an abbreviated value
-     * Previously, the territory was cut off (en-* as en) before localization comparing
+     * Set `false` to use strict localization comparison (with territory en-*) instead of an abbreviated value.
+     * Set `true`, so territory was cut off (en-* as en) before localization comparing.
      */
-    public bool $simpleNegotiateLocale = true;
+    public bool $looseLocaleNegotiation = true;
 }

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -227,7 +227,7 @@ class Negotiate
             }
 
             // if acceptable value is "anything", return the first available
-            if ($accept['value'] === '*' || $accept['value'] === '*/*') {
+            if ($accept['value'] === '*') {
                 return $supportedLocales[0];
             }
 

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\HTTP;
 
 use CodeIgniter\HTTP\Exceptions\HTTPException;
+use Config\Feature;
 
 /**
  * Class Negotiate
@@ -127,7 +128,7 @@ class Negotiate
      */
     public function language(array $supported): string
     {
-        return $this->getBestMatch($supported, $this->request->getHeaderLine('accept-language'), false, false, true);
+        return $this->getBestMatch($supported, $this->request->getHeaderLine('accept-language'), false, false, config(Feature::class)->simpleNegotiateLocale);
     }
 
     // --------------------------------------------------------------------

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -122,7 +122,7 @@ final class NegotiateTest extends CIUnitTestCase
         $this->assertSame('en-us', $this->negotiate->language(['en-us', 'en-gb', 'en']));
         $this->assertSame('en', $this->negotiate->language(['en', 'en-us', 'en-gb']));
 
-        config(Feature::class)->simpleNegotiateLocale = false;
+        config(Feature::class)->looseLocaleNegotiation = false;
 
         $this->assertSame('da', $this->negotiate->language(['da', 'en']));
         $this->assertSame('en-gb', $this->negotiate->language(['en-gb', 'en']));
@@ -142,13 +142,15 @@ final class NegotiateTest extends CIUnitTestCase
         $this->assertSame('fr-FR', $this->negotiate->language(['fr-FR', 'fr', 'en']));
         $this->assertSame('fr-BE', $this->negotiate->language(['fr-BE', 'fr', 'en']));
         $this->assertSame('en', $this->negotiate->language(['en', 'en-US']));
+        $this->assertSame('fr-BE', $this->negotiate->language(['ru', 'en-GB', 'fr-BE']));
 
-        config(Feature::class)->simpleNegotiateLocale = false;
+        config(Feature::class)->looseLocaleNegotiation = false;
 
         $this->assertSame('fr-FR', $this->negotiate->language(['fr', 'fr-FR', 'en']));
         $this->assertSame('fr-FR', $this->negotiate->language(['fr-FR', 'fr', 'en']));
         $this->assertSame('fr', $this->negotiate->language(['fr-BE', 'fr', 'en']));
         $this->assertSame('en-US', $this->negotiate->language(['en', 'en-US']));
+        $this->assertSame('fr-BE', $this->negotiate->language(['ru', 'en-GB', 'fr-BE']));
     }
 
     public function testBestMatchEmpty(): void

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -16,6 +16,7 @@ namespace CodeIgniter\HTTP;
 use CodeIgniter\HTTP\Exceptions\HTTPException;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\App;
+use Config\Feature;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -111,11 +112,23 @@ final class NegotiateTest extends CIUnitTestCase
 
     public function testAcceptLanguageBasics(): void
     {
-        $this->request->setHeader('Accept-Language', 'da, en-gb;q=0.8, en;q=0.7');
+        $this->request->setHeader('Accept-Language', 'da, en-gb, en-us;q=0.8, en;q=0.7');
 
         $this->assertSame('da', $this->negotiate->language(['da', 'en']));
         $this->assertSame('en-gb', $this->negotiate->language(['en-gb', 'en']));
         $this->assertSame('en', $this->negotiate->language(['en']));
+
+        // Will find the first locale instead of "en-gb"
+        $this->assertSame('en-us', $this->negotiate->language(['en-us', 'en-gb', 'en']));
+        $this->assertSame('en', $this->negotiate->language(['en', 'en-us', 'en-gb']));
+
+        config(Feature::class)->simpleNegotiateLocale = false;
+
+        $this->assertSame('da', $this->negotiate->language(['da', 'en']));
+        $this->assertSame('en-gb', $this->negotiate->language(['en-gb', 'en']));
+        $this->assertSame('en', $this->negotiate->language(['en']));
+        $this->assertSame('en-gb', $this->negotiate->language(['en-us', 'en-gb', 'en']));
+        $this->assertSame('en-gb', $this->negotiate->language(['en', 'en-us', 'en-gb']));
     }
 
     /**
@@ -125,7 +138,17 @@ final class NegotiateTest extends CIUnitTestCase
     {
         $this->request->setHeader('Accept-Language', 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7');
 
-        $this->assertSame('fr', $this->negotiate->language(['fr', 'en']));
+        $this->assertSame('fr', $this->negotiate->language(['fr', 'fr-FR', 'en']));
+        $this->assertSame('fr-FR', $this->negotiate->language(['fr-FR', 'fr', 'en']));
+        $this->assertSame('fr-BE', $this->negotiate->language(['fr-BE', 'fr', 'en']));
+        $this->assertSame('en', $this->negotiate->language(['en', 'en-US']));
+
+        config(Feature::class)->simpleNegotiateLocale = false;
+
+        $this->assertSame('fr-FR', $this->negotiate->language(['fr', 'fr-FR', 'en']));
+        $this->assertSame('fr-FR', $this->negotiate->language(['fr-FR', 'fr', 'en']));
+        $this->assertSame('fr', $this->negotiate->language(['fr-BE', 'fr', 'en']));
+        $this->assertSame('en-US', $this->negotiate->language(['en', 'en-US']));
     }
 
     public function testBestMatchEmpty(): void

--- a/tests/system/HTTP/NegotiateTest.php
+++ b/tests/system/HTTP/NegotiateTest.php
@@ -122,7 +122,7 @@ final class NegotiateTest extends CIUnitTestCase
         $this->assertSame('en-us', $this->negotiate->language(['en-us', 'en-gb', 'en']));
         $this->assertSame('en', $this->negotiate->language(['en', 'en-us', 'en-gb']));
 
-        config(Feature::class)->looseLocaleNegotiation = false;
+        config(Feature::class)->strictLocaleNegotiation = true;
 
         $this->assertSame('da', $this->negotiate->language(['da', 'en']));
         $this->assertSame('en-gb', $this->negotiate->language(['en-gb', 'en']));
@@ -144,7 +144,7 @@ final class NegotiateTest extends CIUnitTestCase
         $this->assertSame('en', $this->negotiate->language(['en', 'en-US']));
         $this->assertSame('fr-BE', $this->negotiate->language(['ru', 'en-GB', 'fr-BE']));
 
-        config(Feature::class)->looseLocaleNegotiation = false;
+        config(Feature::class)->strictLocaleNegotiation = true;
 
         $this->assertSame('fr-FR', $this->negotiate->language(['fr', 'fr-FR', 'en']));
         $this->assertSame('fr-FR', $this->negotiate->language(['fr-FR', 'fr', 'en']));

--- a/user_guide_src/source/changelogs/v4.5.8.rst
+++ b/user_guide_src/source/changelogs/v4.5.8.rst
@@ -18,6 +18,17 @@ BREAKING
 Message Changes
 ***************
 
+************
+Enhancements
+************
+
+Negotiator
+==========
+
+- Added a feature flag ``Feature::$simpleNegotiateLocale`` fix simple locale comparison.
+  Previously, response with language headers ``Accept-language: en-US,en-GB;q=0.9`` returned the first allowed language ``en`` could instead of the exact language ``en-US`` or ``en-GB``.
+  Set the value to ``false`` to be able to get ``en-*``
+
 *******
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.5.8.rst
+++ b/user_guide_src/source/changelogs/v4.5.8.rst
@@ -18,17 +18,6 @@ BREAKING
 Message Changes
 ***************
 
-************
-Enhancements
-************
-
-Negotiator
-==========
-
-- Added a feature flag ``Feature::$simpleNegotiateLocale`` fix simple locale comparison.
-  Previously, response with language headers ``Accept-language: en-US,en-GB;q=0.9`` returned the first allowed language ``en`` could instead of the exact language ``en-US`` or ``en-GB``.
-  Set the value to ``false`` to be able to get ``en-*``
-
 *******
 Changes
 *******

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -239,6 +239,13 @@ Routing
 
 - Now you can specify multiple hostnames when restricting routes.
 
+Negotiator
+==========
+
+- Added a feature flag ``Feature::$looseLocaleNegotiation`` fix simple locale comparison.
+  Previously, response with language headers ``Accept-language: en-US,en-GB;q=0.9`` returned the first allowed language ``en`` could instead of the exact language ``en-US`` or ``en-GB``.
+  Set the value to ``false`` to be able to get ``en-*``
+
 Testing
 =======
 

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -242,9 +242,9 @@ Routing
 Negotiator
 ==========
 
-- Added a feature flag ``Feature::$looseLocaleNegotiation`` fix simple locale comparison.
+- Added a feature flag ``Feature::$strictLocaleNegotiation`` to enable strict locale comparision.
   Previously, response with language headers ``Accept-language: en-US,en-GB;q=0.9`` returned the first allowed language ``en`` could instead of the exact language ``en-US`` or ``en-GB``.
-  Set the value to ``false`` to be able to get ``en-*``
+  Set the value to ``true`` to enable comparison not only by language code ('en' - ISO 639-1) but also by regional code ('en-US' - ISO 639-1 plus ISO 3166-1 alpha).
 
 Testing
 =======

--- a/user_guide_src/source/incoming/content_negotiation.rst
+++ b/user_guide_src/source/incoming/content_negotiation.rst
@@ -121,24 +121,15 @@ that the strict comparison will be made in the first place.
     if you have your own translation files, you **must also change** the folder names for CodeIgniter's translation files to match
     what you put in the ``$supportedLocales`` array.
 
-    Now let's consider the below example. The browser's preferred language will be set as this::
+Now let's consider the below example. The browser's preferred language will be set as this::
 
     GET /foo HTTP/1.1
     Accept-Language: fr; q=1.0, en-GB; q=0.5
 
-In this example, the browser would prefer French, with a second choice of English (United Kingdom). Your website on another hand will
+In this example, the browser would prefer French, with a second choice of English (United Kingdom). Your website on another hand
 supports German and English (United States):
 
-.. code-block:: php
-
-    $supported = [
-        'de',
-        'en-US',
-    ];
-
-    $lang = $request->negotiate('language', $supported);
-    // or
-    $lang = $negotiate->language($supported);
+.. literalinclude:: content_negotiation/008.php
 
 In this example, 'en-US' would be returned as the current language. If no match is found, it will return the first element
 in the ``$supported`` array. Here is how exactly the locale selection process works.

--- a/user_guide_src/source/incoming/content_negotiation.rst
+++ b/user_guide_src/source/incoming/content_negotiation.rst
@@ -102,6 +102,11 @@ and German you would do something like:
 In this example, 'en' would be returned as the current language. If no match is found, it will return the first element
 in the ``$supported`` array, so that should always be the preferred language.
 
+.. versionadded:: 4.6.0
+
+Disabling the ``Config\Feature::$looseLocaleNegotiation`` value allows you to strictly search for the requested language from the specified territory (``en-*``).
+In the case of a non-strict search, the language may be limited only by the country ``en``. Don't forget to create files for the ``en-*`` locale if you need a translation.
+
 Encoding
 ========
 

--- a/user_guide_src/source/incoming/content_negotiation/008.php
+++ b/user_guide_src/source/incoming/content_negotiation/008.php
@@ -1,0 +1,10 @@
+<?php
+
+$supported = [
+    'de',
+    'en-US',
+];
+
+$lang = $request->negotiate('language', $supported);
+// or
+$lang = $negotiate->language($supported);

--- a/user_guide_src/source/installation/upgrade_458.rst
+++ b/user_guide_src/source/installation/upgrade_458.rst
@@ -44,10 +44,7 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
-app/Config/Feature.php
-^^^^^^^^^^^^^^^^^^^^^^
-
-- ``Config\Feature::$simpleNegotiateLocale`` has been added.
+- @TODO
 
 All Changes
 ===========
@@ -55,4 +52,4 @@ All Changes
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- app/Config/Feature.php
+- @TODO

--- a/user_guide_src/source/installation/upgrade_458.rst
+++ b/user_guide_src/source/installation/upgrade_458.rst
@@ -44,7 +44,10 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
-- @TODO
+app/Config/Feature.php
+^^^^^^^^^^^^^^^^^^^^^^
+
+- ``Config\Feature::$simpleNegotiateLocale`` has been added.
 
 All Changes
 ===========
@@ -52,4 +55,4 @@ All Changes
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
+- app/Config/Feature.php

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -211,13 +211,14 @@ Config
 
 - app/Config/Feature.php
     - ``Config\Feature::$autoRoutesImproved`` has been changed to ``true``.
+    - ``Config\Feature::$looseLocaleNegotiation`` has been added.
 - app/Config/Routing.php
     - ``Config\Routing::$translateUriToCamelCase`` has been changed to ``true``.
-
 All Changes
 ===========
 
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
+- app/Config/Feature.php
 - @TODO

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -211,9 +211,10 @@ Config
 
 - app/Config/Feature.php
     - ``Config\Feature::$autoRoutesImproved`` has been changed to ``true``.
-    - ``Config\Feature::$looseLocaleNegotiation`` has been added.
+    - ``Config\Feature::$strictLocaleNegotiation`` has been added.
 - app/Config/Routing.php
     - ``Config\Routing::$translateUriToCamelCase`` has been changed to ``true``.
+
 All Changes
 ===========
 
@@ -221,4 +222,3 @@ This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
 - app/Config/Feature.php
-- @TODO


### PR DESCRIPTION
**Description**
See #9256
I added a setting for the desired behavior.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide
- [x] User guide updated
