### PR TITLE
refactor: use more strict result check on preg_match_all() result

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -348,7 +348,7 @@ class CLI
             // return the prompt again if $input contain(s) non-numeric character, except a comma.
             // And if max from $options less than max from input,
             // it means user tried to access null value in $options
-            if ($pattern === 0 || $maxOptions < $maxInput) {
+            if ($pattern < 1 || $maxOptions < $maxInput) {
                 static::error('Please select correctly.');
                 CLI::newLine();
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -663,7 +663,7 @@ class BaseBuilder
         } else {
             // Split multiple conditions
             // @TODO This does not parse `BETWEEN a AND b` correctly.
-            if (preg_match_all('/\sAND\s|\sOR\s/i', $cond, $joints, PREG_OFFSET_CAPTURE)) {
+            if (preg_match_all('/\sAND\s|\sOR\s/i', $cond, $joints, PREG_OFFSET_CAPTURE) >= 1) {
                 $conditions = [];
                 $joints     = $joints[0];
                 array_unshift($joints, ['', 0]);
@@ -3470,7 +3470,7 @@ class BaseBuilder
             '/' . implode('|', $this->pregOperators) . '/i',
             $str,
             $match
-        ) ? ($list ? $match[0] : $match[0][0]) : false;
+        ) >= 1 ? ($list ? $match[0] : $match[0][0]) : false;
     }
 
     /**
@@ -3501,7 +3501,7 @@ class BaseBuilder
             '/' . implode('|', $pregOperators) . '/i',
             $whereKey,
             $match
-        ) ? $match[0] : false;
+        ) >= 1 ? $match[0] : false;
     }
 
     /**

--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -342,7 +342,7 @@ class Query implements QueryInterface, Stringable
      */
     protected function matchSimpleBinds(string $sql, array $binds, int $bindCount, int $ml): string
     {
-        if ($c = preg_match_all("/'[^']*'/", $sql, $matches)) {
+        if ($c = preg_match_all("/'[^']*'/", $sql, $matches) >= 1) {
             $c = preg_match_all('/' . preg_quote($this->bindMarker, '/') . '/i', str_replace($matches[0], str_replace($this->bindMarker, str_repeat(' ', $ml), $matches[0]), $sql, $c), $matches, PREG_OFFSET_CAPTURE);
 
             // Bind values' count must match the count of markers in the query

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -122,7 +122,7 @@ class Builder extends BaseBuilder
             $cond = ' ON ' . $cond;
         } else {
             // Split multiple conditions
-            if (preg_match_all('/\sAND\s|\sOR\s/i', $cond, $joints, PREG_OFFSET_CAPTURE)) {
+            if (preg_match_all('/\sAND\s|\sOR\s/i', $cond, $joints, PREG_OFFSET_CAPTURE) >= 1) {
                 $conditions = [];
                 $joints     = $joints[0];
                 array_unshift($joints, ['', 0]);

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1031,7 +1031,7 @@ class Email
 
         $unwrap = [];
 
-        if (preg_match_all('|\{unwrap\}(.+?)\{/unwrap\}|s', $str, $matches)) {
+        if (preg_match_all('|\{unwrap\}(.+?)\{/unwrap\}|s', $str, $matches) >= 1) {
             for ($i = 0, $c = count($matches[0]); $i < $c; $i++) {
                 $unwrap[] = $matches[1][$i];
                 $str      = str_replace($matches[0][$i], '{{unwrapped' . $i . '}}', $str);

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -131,7 +131,7 @@ if (! function_exists('entities_to_ascii')) {
      */
     function entities_to_ascii(string $str, bool $all = true): string
     {
-        if (preg_match_all('/\&#(\d+)\;/', $str, $matches)) {
+        if (preg_match_all('/\&#(\d+)\;/', $str, $matches) >= 1) {
             for ($i = 0, $s = count($matches[0]); $i < $s; $i++) {
                 $digits = (int) $matches[1][$i];
                 $out    = '';
@@ -195,7 +195,7 @@ if (! function_exists('word_censor')) {
                     "\\1{$replacement}\\3",
                     $str
                 );
-            } elseif (preg_match_all("/{$delim}(" . $badword . "){$delim}/i", $str, $matches, PREG_PATTERN_ORDER | PREG_OFFSET_CAPTURE)) {
+            } elseif (preg_match_all("/{$delim}(" . $badword . "){$delim}/i", $str, $matches, PREG_PATTERN_ORDER | PREG_OFFSET_CAPTURE) >= 1) {
                 $matches = $matches[1];
 
                 for ($i = count($matches) - 1; $i >= 0; $i--) {
@@ -351,7 +351,7 @@ if (! function_exists('word_wrap')) {
         // strip the entire chunk and replace it with a marker.
         $unwrap = [];
 
-        if (preg_match_all('|\{unwrap\}(.+?)\{/unwrap\}|s', $str, $matches)) {
+        if (preg_match_all('|\{unwrap\}(.+?)\{/unwrap\}|s', $str, $matches) >= 1) {
             for ($i = 0, $c = count($matches[0]); $i < $c; $i++) {
                 $unwrap[] = $matches[1][$i];
                 $str      = str_replace($matches[0][$i], '{{unwrapped' . $i . '}}', $str);

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -360,7 +360,7 @@ if (! function_exists('auto_link')) {
                 $str,
                 $matches,
                 PREG_OFFSET_CAPTURE | PREG_SET_ORDER
-            )
+            ) >= 1
         ) {
             // Set our target HTML if using popup links.
             $target = ($popup) ? ' target="_blank"' : '';
@@ -387,7 +387,7 @@ if (! function_exists('auto_link')) {
                 $str,
                 $matches,
                 PREG_OFFSET_CAPTURE
-            )
+            ) >= 1
         ) {
             foreach (array_reverse($matches[0]) as $match) {
                 if (filter_var($match[0], FILTER_VALIDATE_EMAIL) !== false) {

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -98,7 +98,7 @@ class MemcachedHandler extends BaseHandler
                 $this->savePath,
                 $matches,
                 PREG_SET_ORDER
-            ) === 0
+            ) < 1
         ) {
             $this->memcached = null;
             $this->logger->error('Session: Invalid Memcached save path format: ' . $this->savePath);

--- a/system/Typography/Typography.php
+++ b/system/Typography/Typography.php
@@ -96,7 +96,7 @@ class Typography
 
         // HTML comment tags don't conform to patterns of normal tags, so pull them out separately, only if needed
         $htmlComments = [];
-        if (str_contains($str, '<!--') && preg_match_all('#(<!\-\-.*?\-\->)#s', $str, $matches)) {
+        if (str_contains($str, '<!--') && preg_match_all('#(<!\-\-.*?\-\->)#s', $str, $matches) >= 1) {
             for ($i = 0, $total = count($matches[0]); $i < $total; $i++) {
                 $htmlComments[] = $matches[0][$i];
                 $str            = str_replace($matches[0][$i], '{@HC' . $i . '}', $str);

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -419,7 +419,7 @@ class Parser extends View
          * $matches[][0] is the raw match
          * $matches[][1] is the contents
          */
-        if (preg_match_all($pattern, $template, $matches, PREG_SET_ORDER)) {
+        if (preg_match_all($pattern, $template, $matches, PREG_SET_ORDER) >= 1) {
             foreach ($matches as $match) {
                 // Create a hash of the contents to insert in its place.
                 $hash                       = md5($match[1]);
@@ -691,7 +691,7 @@ class Parser extends View
              *   $matches[1] = all parameters string in opening tag
              *   $matches[2] = content between the tags to send to the plugin.
              */
-            if (preg_match_all($pattern, $template, $matches, PREG_SET_ORDER) === 0) {
+            if (preg_match_all($pattern, $template, $matches, PREG_SET_ORDER) < 1) {
                 continue;
             }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**

Continue of PR: 

- https://github.com/codeigniter4/CodeIgniter4/pull/9339

this ensure `preg_match_all()` which with falsy check ensure got exact equal result, wich compare to `>=1` or `<1` which can be false or 0.


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
