### PR TITLE
fix: gather affected rows after query call failed

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -2198,7 +2198,7 @@ class BaseBuilder
      *
      * @param array|object|null $set a dataset
      *
-     * @return false|int|list<string> Number of rows inserted or FALSE on failure, SQL array when testMode
+     * @return false|int|list<string> Number of rows inserted or FALSE on no data to perform an insert operation, SQL array when testMode
      */
     public function insertBatch($set = null, ?bool $escape = null, int $batchSize = 100)
     {

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -227,6 +227,10 @@ class Connection extends BaseConnection
      */
     public function affectedRows(): int
     {
+        if ($this->resultID === false) {
+            return 0;
+        }
+
         return pg_affected_rows($this->resultID);
     }
 

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -444,6 +444,10 @@ class Connection extends BaseConnection
      */
     public function affectedRows(): int
     {
+        if ($this->resultID === false) {
+            return 0;
+        }
+
         return sqlsrv_rows_affected($this->resultID);
     }
 

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -106,7 +106,7 @@ final class InsertTest extends CIUnitTestCase
 
         if ($this->db->DBDriver === 'MySQLi') {
             // strict mode is required for MySQLi to throw an exception here
-            $config                   = config('Database');
+            $config                    = config('Database');
             $config->tests['strictOn'] = true;
 
             $db = Database::connect($config->tests);

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Forge;
 use CodeIgniter\Database\RawSql;
 use CodeIgniter\Test\CIUnitTestCase;
@@ -79,11 +80,29 @@ final class InsertTest extends CIUnitTestCase
             ],
         ];
 
-        $this->db->table($table)->insertBatch($data);
+        $count = $this->db->table($table)->insertBatch($data);
+
+        $this->assertSame(2, $count);
 
         $expected = $data;
         $this->seeInDatabase($table, $expected[0]);
         $this->seeInDatabase($table, $expected[1]);
+    }
+
+    public function testInsertBatchFailed(): void
+    {
+        $this->expectException(DatabaseException::class);
+
+        $data = [
+            [
+                'name' => 'Grocery Sales',
+            ],
+            [
+                'name' => null,
+            ],
+        ];
+
+        $this->db->table('job')->insertBatch($data);
     }
 
     public function testReplaceWithNoMatchingData(): void

--- a/tests/system/Database/Live/InsertTest.php
+++ b/tests/system/Database/Live/InsertTest.php
@@ -102,7 +102,17 @@ final class InsertTest extends CIUnitTestCase
             ],
         ];
 
-        $this->db->table('job')->insertBatch($data);
+        $db = $this->db;
+
+        if ($this->db->DBDriver === 'MySQLi') {
+            // strict mode is required for MySQLi to throw an exception here
+            $config                   = config('Database');
+            $config->tests['strictOn'] = true;
+
+            $db = Database::connect($config->tests);
+        }
+
+        $db->table('job')->insertBatch($data);
     }
 
     public function testReplaceWithNoMatchingData(): void

--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -259,7 +259,7 @@ final class TransactionTest extends CIUnitTestCase
 
         $this->assertFalse($this->db->transStatus());
 
-        $this->db->transRollback();
+        $this->db->transComplete();
 
         $this->dontSeeInDatabase('job', ['name' => 'Grocery Sales']);
     }

--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -254,7 +254,7 @@ final class TransactionTest extends CIUnitTestCase
             ],
         ];
 
-        $this->db->transBegin();
+        $this->db->transStrict(false)->transBegin();
         $this->db->table('job')->insertBatch($data);
 
         $this->assertFalse($this->db->transStatus());

--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -258,7 +258,7 @@ final class TransactionTest extends CIUnitTestCase
 
         if ($this->db->DBDriver === 'MySQLi') {
             // strict mode is required for MySQLi to throw an exception here
-            $config                   = config('Database');
+            $config                    = config('Database');
             $config->tests['strictOn'] = true;
 
             $db = Database::connect($config->tests);

--- a/tests/system/Database/Live/TransactionTest.php
+++ b/tests/system/Database/Live/TransactionTest.php
@@ -239,4 +239,28 @@ final class TransactionTest extends CIUnitTestCase
 
         $this->enableDBDebug();
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/9362
+     */
+    public function testTransInsertBatchFailed(): void
+    {
+        $data = [
+            [
+                'name' => 'Grocery Sales',
+            ],
+            [
+                'name' => null,
+            ],
+        ];
+
+        $this->db->transBegin();
+        $this->db->table('job')->insertBatch($data);
+
+        $this->assertFalse($this->db->transStatus());
+
+        $this->db->transRollback();
+
+        $this->dontSeeInDatabase('job', ['name' => 'Grocery Sales']);
+    }
 }

--- a/user_guide_src/source/changelogs/v4.5.8.rst
+++ b/user_guide_src/source/changelogs/v4.5.8.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Database:** Fixed a bug where ``Builder::affectedRows()`` threw an error when the previous query call failed in ``Postgre`` and ``SQLSRV`` drivers.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1870,7 +1870,7 @@ Class Reference
         :param array $set: Data to insert
         :param bool $escape: Whether to escape values
         :param int $batch_size: Count of rows to insert at once
-        :returns: Number of rows inserted or ``false`` on failure
+        :returns: Number of rows inserted or ``false`` on no data to perform an insert operation
         :rtype:    int|false
 
         Compiles and executes batch ``INSERT`` statements.


### PR DESCRIPTION
**Description**
This PR fixes a bug in the `Postgre` and `SQLSRV` handlers when calling `Builder::affectedRows()` after a failed query.

This is because when `Builder::affectedRows()` is called after a failed query, the `$resultID` is set to `false`, and a boolean value is not acceptable for either `pg_affected_rows()` or `sqlsrv_rows_affected()`.

Fixes #9362

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
