### PR TITLE
feat: uniform rendering of stack trace from failed DB operations

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -913,6 +913,57 @@ if (! function_exists('remove_invisible_characters')) {
     }
 }
 
+if (! function_exists('render_backtrace')) {
+    /**
+     * Renders a backtrace in a nice string format.
+     *
+     * @param list<array{
+     *  file?: string,
+     *  line?: int,
+     *  class?: string,
+     *  type?: string,
+     *  function: string,
+     *  args?: list<mixed>
+     * }> $backtrace
+     */
+    function render_backtrace(array $backtrace): string
+    {
+        $backtraces = [];
+
+        foreach ($backtrace as $index => $trace) {
+            $frame = $trace + ['file' => '[internal function]', 'line' => 0, 'class' => '', 'type' => '', 'args' => []];
+
+            if ($frame['file'] !== '[internal function]') {
+                $frame['file'] = sprintf('%s(%s)', $frame['file'], $frame['line']);
+            }
+
+            unset($frame['line']);
+            $idx = $index;
+            $idx = str_pad((string) ++$idx, 2, ' ', STR_PAD_LEFT);
+
+            $args = implode(', ', array_map(static fn ($value): string => match (true) {
+                is_object($value)   => sprintf('Object(%s)', $value::class),
+                is_array($value)    => $value !== [] ? '[...]' : '[]',
+                $value === null     => 'null',
+                is_resource($value) => sprintf('resource (%s)', get_resource_type($value)),
+                default             => var_export($value, true),
+            }, $frame['args']));
+
+            $backtraces[] = sprintf(
+                '%s %s: %s%s%s(%s)',
+                $idx,
+                clean_path($frame['file']),
+                $frame['class'],
+                $frame['type'],
+                $frame['function'],
+                $args
+            );
+        }
+
+        return implode("\n", $backtraces);
+    }
+}
+
 if (! function_exists('request')) {
     /**
      * Returns the shared Request.

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -326,7 +326,12 @@ class Connection extends BaseConnection
         try {
             return $this->connID->query($this->prepQuery($sql), $this->resultMode);
         } catch (mysqli_sql_exception $e) {
-            log_message('error', (string) $e);
+            log_message('error', "{message}\nin {exFile} on line {exLine}.\n{trace}", [
+                'message' => $e->getMessage(),
+                'exFile'  => clean_path($e->getFile()),
+                'exLine'  => $e->getLine(),
+                'trace'   => render_backtrace($e->getTrace()),
+            ]);
 
             if ($this->DBDebug) {
                 throw new DatabaseException($e->getMessage(), $e->getCode(), $e);

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -226,7 +226,14 @@ class Connection extends BaseConnection
 
             return $result;
         } catch (ErrorException $e) {
-            log_message('error', (string) $e);
+            $trace = array_slice($e->getTrace(), 2); // remove call to error handler
+
+            log_message('error', "{message}\nin {exFile} on line {exLine}.\n{trace}", [
+                'message' => $e->getMessage(),
+                'exFile'  => clean_path($e->getFile()),
+                'exLine'  => $e->getLine(),
+                'trace'   => render_backtrace($trace),
+            ]);
 
             if ($this->DBDebug) {
                 throw new DatabaseException($e->getMessage(), $e->getCode(), $e);

--- a/system/Database/Postgre/Connection.php
+++ b/system/Database/Postgre/Connection.php
@@ -205,7 +205,14 @@ class Connection extends BaseConnection
         try {
             return pg_query($this->connID, $sql);
         } catch (ErrorException $e) {
-            log_message('error', (string) $e);
+            $trace = array_slice($e->getTrace(), 2); // remove the call to error handler
+
+            log_message('error', "{message}\nin {exFile} on line {exLine}.\n{trace}", [
+                'message' => $e->getMessage(),
+                'exFile'  => clean_path($e->getFile()),
+                'exLine'  => $e->getLine(),
+                'trace'   => render_backtrace($trace),
+            ]);
 
             if ($this->DBDebug) {
                 throw new DatabaseException($e->getMessage(), $e->getCode(), $e);

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -155,8 +155,12 @@ class Connection extends BaseConnection
         $errors = [];
 
         foreach (sqlsrv_errors() as $error) {
-            $errors[] = $error['message']
-                . ' SQLSTATE: ' . $error['SQLSTATE'] . ', code: ' . $error['code'];
+            $errors[] = sprintf(
+                '%s SQLSTATE: %s, code: %s',
+                $error['message'],
+                $error['SQLSTATE'],
+                $error['code']
+            );
         }
 
         return implode("\n", $errors);
@@ -488,17 +492,23 @@ class Connection extends BaseConnection
      */
     protected function execute(string $sql)
     {
-        $stmt = ($this->scrollable === false || $this->isWriteType($sql)) ?
-            sqlsrv_query($this->connID, $sql) :
-            sqlsrv_query($this->connID, $sql, [], ['Scrollable' => $this->scrollable]);
+        $stmt = ($this->scrollable === false || $this->isWriteType($sql))
+            ? sqlsrv_query($this->connID, $sql)
+            : sqlsrv_query($this->connID, $sql, [], ['Scrollable' => $this->scrollable]);
 
         if ($stmt === false) {
-            $error = $this->error();
+            $trace = debug_backtrace();
+            $first = array_shift($trace);
 
-            log_message('error', $error['message']);
+            log_message('error', "{message}\nin {exFile} on line {exLine}.\n{trace}", [
+                'message' => $this->getAllErrorMessages(),
+                'exFile'  => clean_path($first['file']),
+                'exLine'  => $first['line'],
+                'trace'   => render_backtrace($trace),
+            ]);
 
             if ($this->DBDebug) {
-                throw new DatabaseException($error['message']);
+                throw new DatabaseException($this->getAllErrorMessages());
             }
         }
 

--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -175,7 +175,12 @@ class Connection extends BaseConnection
                 ? $this->connID->exec($sql)
                 : $this->connID->query($sql);
         } catch (Exception $e) {
-            log_message('error', (string) $e);
+            log_message('error', "{message}\nin {exFile} on line {exLine}.\n{trace}", [
+                'message' => $e->getMessage(),
+                'exFile'  => clean_path($e->getFile()),
+                'exLine'  => $e->getLine(),
+                'trace'   => render_backtrace($e->getTrace()),
+            ]);
 
             if ($this->DBDebug) {
                 throw new DatabaseException($e->getMessage(), $e->getCode(), $e);

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -136,7 +136,7 @@ class Exceptions
                 'routeInfo' => $routeInfo,
                 'exFile'    => clean_path($exception->getFile()), // {file} refers to THIS file
                 'exLine'    => $exception->getLine(), // {line} refers to THIS line
-                'trace'     => self::renderBacktrace($exception->getTrace()),
+                'trace'     => render_backtrace($exception->getTrace()),
             ]);
 
             // Get the first exception.
@@ -149,7 +149,7 @@ class Exceptions
                     'message' => $prevException->getMessage(),
                     'exFile'  => clean_path($prevException->getFile()), // {file} refers to THIS file
                     'exLine'  => $prevException->getLine(), // {line} refers to THIS line
-                    'trace'   => self::renderBacktrace($prevException->getTrace()),
+                    'trace'   => render_backtrace($prevException->getTrace()),
                 ]);
             }
         }
@@ -527,7 +527,7 @@ class Exceptions
                 'message' => $message,
                 'errFile' => clean_path($file ?? ''),
                 'errLine' => $line ?? 0,
-                'trace'   => self::renderBacktrace($trace),
+                'trace'   => render_backtrace($trace),
             ]
         );
 
@@ -645,42 +645,5 @@ class Exceptions
         }
 
         return '<pre><code>' . $out . '</code></pre>';
-    }
-
-    private static function renderBacktrace(array $backtrace): string
-    {
-        $backtraces = [];
-
-        foreach ($backtrace as $index => $trace) {
-            $frame = $trace + ['file' => '[internal function]', 'line' => '', 'class' => '', 'type' => '', 'args' => []];
-
-            if ($frame['file'] !== '[internal function]') {
-                $frame['file'] = sprintf('%s(%s)', $frame['file'], $frame['line']);
-            }
-
-            unset($frame['line']);
-            $idx = $index;
-            $idx = str_pad((string) ++$idx, 2, ' ', STR_PAD_LEFT);
-
-            $args = implode(', ', array_map(static fn ($value): string => match (true) {
-                is_object($value)   => sprintf('Object(%s)', $value::class),
-                is_array($value)    => $value !== [] ? '[...]' : '[]',
-                $value === null     => 'null',
-                is_resource($value) => sprintf('resource (%s)', get_resource_type($value)),
-                default             => var_export($value, true),
-            }, $frame['args']));
-
-            $backtraces[] = sprintf(
-                '%s %s: %s%s%s(%s)',
-                $idx,
-                clean_path($frame['file']),
-                $frame['class'],
-                $frame['type'],
-                $frame['function'],
-                $args
-            );
-        }
-
-        return implode("\n", $backtraces);
     }
 }

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -805,4 +805,14 @@ final class CommonFunctionsTest extends CIUnitTestCase
         $this->assertSame(str_contains(php_uname(), 'Windows'), is_windows());
         $this->assertSame(defined('PHP_WINDOWS_VERSION_MAJOR'), is_windows());
     }
+
+    public function testRenderBacktrace(): void
+    {
+        $trace   = (new RuntimeException('Test exception'))->getTrace();
+        $renders = explode("\n", render_backtrace($trace));
+
+        foreach ($renders as $render) {
+            $this->assertMatchesRegularExpression('/^\s*\d* .+(?:\(\d+\))?: \S+(?:(?:\->|::)\S+)?\(.*\)$/', $render);
+        }
+    }
 }

--- a/tests/system/Database/Live/ExecuteLogMessageFormatTest.php
+++ b/tests/system/Database/Live/ExecuteLogMessageFormatTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Database\Live;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\TestLogger;
+use Config\Database;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * @internal
+ */
+#[Group('DatabaseLive')]
+final class ExecuteLogMessageFormatTest extends TestCase
+{
+    public function testLogMessageWhenExecuteFailsShowFullStructuredBacktrace(): void
+    {
+        $db = Database::connect((new Database)->tests, false);
+        (new ReflectionProperty($db, 'DBDebug'))->setValue($db, false);
+
+        $sql = 'SELECT * FROM some_table WHERE id = ? AND status = ? AND author = ?';
+        $db->query($sql, [3, 'live', 'Rick']);
+
+        $message = match ($db->DBDriver) {
+            'MySQLi'  => 'Table \'test.some_table\' doesn\'t exist',
+            'Postgre' => 'pg_query(): Query failed: ERROR:  relation "some_table" does not exist',
+            'SQLite3' => 'Unable to prepare statement: no such table: some_table',
+            'OCI8'    => 'oci_execute(): ORA-00942: table or view does not exist',
+            'SQLSRV'  => '[Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Invalid object name \'some_table\'. SQLSTATE: 42S02, code: 208',
+            default   => 'Unknown DB error',
+        };
+        $messageFromLogs = explode("\n", (new ReflectionProperty(TestLogger::class, 'op_logs'))->getValue()[0]['message']);
+
+        $this->assertSame($message, array_shift($messageFromLogs));
+
+        if ($db->DBDriver === 'Postgre') {
+            $messageFromLogs = array_slice($messageFromLogs, 2);
+        } elseif ($db->DBDriver === 'OCI8') {
+            $messageFromLogs = array_slice($messageFromLogs, 1);
+        }
+
+        $this->assertMatchesRegularExpression('/^in \S+ on line \d+\.$/', array_shift($messageFromLogs));
+
+        foreach ($messageFromLogs as $line) {
+            $this->assertMatchesRegularExpression('/^\s*\d* .+(?:\(\d+\))?: \S+(?:(?:\->|::)\S+)?\(.*\)$/', $line);
+        }
+    }
+}

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -128,22 +128,6 @@ final class ExceptionsTest extends CIUnitTestCase
         $this->assertSame([500, EXIT_DATABASE], $determineCodes(new DatabaseException('This.')));
     }
 
-    public function testRenderBacktrace(): void
-    {
-        $renderer  = self::getPrivateMethodInvoker(Exceptions::class, 'renderBacktrace');
-        $exception = new RuntimeException('This.');
-
-        $renderedBacktrace = $renderer($exception->getTrace());
-        $renderedBacktrace = explode("\n", $renderedBacktrace);
-
-        foreach ($renderedBacktrace as $trace) {
-            $this->assertMatchesRegularExpression(
-                '/^\s*\d* .+(?:\(\d+\))?: \S+(?:(?:\->|::)\S+)?\(.*\)$/',
-                $trace
-            );
-        }
-    }
-
     public function testMaskSensitiveData(): void
     {
         $maskSensitiveData = $this->getPrivateMethodInvoker($this->exception, 'maskSensitiveData');

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1672 errors
+# total 1670 errors
 
 parameters:
     ignoreErrors:
@@ -2414,11 +2414,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Debug\\Exceptions\:\:maskSensitiveData\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Debug/Exceptions.php
-
-        -
-            message: '#^Method CodeIgniter\\Debug\\Exceptions\:\:renderBacktrace\(\) has parameter \$backtrace with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Debug/Exceptions.php
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Closes #9338 

All DB drivers except SQL Server logs (with 'error' level) a full stack trace of any failed DB executions via the thrown exception. For SQL Server, the log only includes the message produced by `sqlsrv_errors()`. Moreover, there's inconsistency with regard to Postgre and OCI8 drivers. Since `pg_query()` and `oci8_execute()` only throws because of our error handler, the stack trace also includes the error handler (the `[internal function]` stack).

This PR aims to make consistent the log output of these drivers by using the same trace rendering. This is already achieved by the private `Exceptions::renderBacktrace()` method for the thrown exceptions, so this PR extracts it to a new function `render_backtrace` and uses that to format the trace. Also, trace coming from the error handler are removed.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
