### PR TITLE
fix: ensure csrf token is string

### DIFF
--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -307,7 +307,7 @@ class Security implements SecurityInterface
         // Does the token exist in POST, HEADER or optionally php:://input - json data or PUT, DELETE, PATCH - raw data.
 
         if ($tokenValue = $request->getPost($this->config->tokenName)) {
-            return $tokenValue;
+            return is_string($tokenValue) ? $tokenValue : null;
         }
 
         if ($request->hasHeader($this->config->headerName)

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -313,7 +313,7 @@ class Security implements SecurityInterface
         if ($request->hasHeader($this->config->headerName)) {
             $tokenValue = $request->header($this->config->headerName)->getValue();
 
-            return ($tokenValue !== '' && $tokenValue !== [] && is_string($tokenValue)) ? $tokenValue : null;
+            return (is_string($tokenValue) && $tokenValue !== '') ? $tokenValue : null;
         }
 
         $body = (string) $request->getBody();

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -327,8 +327,9 @@ class Security implements SecurityInterface
             }
 
             parse_str($body, $parsed);
+            $tokenValue = $parsed[$this->config->tokenName] ?? null;
 
-            return $parsed[$this->config->tokenName] ?? null;
+            return is_string($tokenValue) ? $tokenValue : null;
         }
 
         return null;

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -321,7 +321,9 @@ class Security implements SecurityInterface
         if ($body !== '') {
             $json = json_decode($body);
             if ($json !== null && json_last_error() === JSON_ERROR_NONE) {
-                return $json->{$this->config->tokenName} ?? null;
+                $tokenValue = $json->{$this->config->tokenName} ?? null;
+
+                return is_string($tokenValue) ? $tokenValue : null;
             }
 
             parse_str($body, $parsed);

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -310,10 +310,10 @@ class Security implements SecurityInterface
             return is_string($tokenValue) ? $tokenValue : null;
         }
 
-        if ($request->hasHeader($this->config->headerName)
-            && $request->header($this->config->headerName)->getValue() !== ''
-            && $request->header($this->config->headerName)->getValue() !== []) {
-            return $request->header($this->config->headerName)->getValue();
+        if ($request->hasHeader($this->config->headerName)) {
+            $tokenValue = $request->header($this->config->headerName)->getValue();
+
+            return ($tokenValue !== '' && $tokenValue !== [] && is_string($tokenValue)) ? $tokenValue : null;
         }
 
         $body = (string) $request->getBody();

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -359,12 +359,12 @@ final class SecurityTest extends CIUnitTestCase
         $method    = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
         $testCases = [
             'empty_post'            => $this->createIncomingRequest(),
-            'malicious_post'        => $this->createIncomingRequest()->setGlobal('post', ['csrf_test_name' => ['malicious' => 'data']]),
+            'invalid_post_data'     => $this->createIncomingRequest()->setGlobal('post', ['csrf_test_name' => ['invalid' => 'data']]),
             'empty_header'          => $this->createIncomingRequest()->setHeader('X-CSRF-TOKEN', ''),
-            'malicious_json'        => $this->createIncomingRequest()->setBody(json_encode(['csrf_test_name' => ['malicious' => 'data']])),
+            'invalid_json_data'     => $this->createIncomingRequest()->setBody(json_encode(['csrf_test_name' => ['invalid' => 'data']])),
             'invalid_json'          => $this->createIncomingRequest()->setBody('{invalid json}'),
             'missing_token_in_body' => $this->createIncomingRequest()->setBody('other=value&another=test'),
-            'malicious_form'        => $this->createIncomingRequest()->setBody('csrf_test_name[]=malicious'),
+            'invalid_form_data'     => $this->createIncomingRequest()->setBody('csrf_test_name[]=invalid'),
         ];
 
         foreach ($testCases as $case => $request) {

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -342,4 +342,34 @@ final class SecurityTest extends CIUnitTestCase
 
         $this->assertNull($method($request));
     }
+
+    public function testGetPostedTokenReturnsTokenFromJsonInput(): void
+    {
+        $_POST    = [];
+        $jsonBody = json_encode(['csrf_test_name' => '8b9218a55906f9dcc1dc263dce7f005a']);
+        $request  = $this->createIncomingRequest()->setBody($jsonBody);
+        $method   = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+
+        $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method($request));
+    }
+
+    public function testGetPostedTokenReturnsTokenFromFormEncodedInput(): void
+    {
+        $_POST    = [];
+        $formBody = 'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a';
+        $request  = $this->createIncomingRequest()->setBody($formBody);
+        $method   = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+
+        $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method($request));
+    }
+
+    public function testGetPostedTokenReturnsNullFromMaliciousJsonInput(): void
+    {
+        $_POST         = [];
+        $maliciousJson = json_encode(['csrf_test_name' => ['malicious' => 'data']]);
+        $request       = $this->createIncomingRequest()->setBody($maliciousJson);
+        $method        = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+
+        $this->assertNull($method($request));
+    }
 }

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -25,8 +25,6 @@ use CodeIgniter\Test\Mock\MockSecurity;
 use Config\Security as SecurityConfig;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
-use ReflectionMethod;
 
 /**
  * @internal
@@ -49,16 +47,6 @@ final class SecurityTest extends CIUnitTestCase
         $config ??= new SecurityConfig();
 
         return new MockSecurity($config);
-    }
-
-    private function getPostedTokenMethod(): ReflectionMethod
-    {
-        $reflection = new ReflectionClass(Security::class);
-        $method     = $reflection->getMethod('getPostedToken');
-
-        $method->setAccessible(true);
-
-        return $method;
     }
 
     public function testBasicConfigIsSaved(): void
@@ -330,34 +318,28 @@ final class SecurityTest extends CIUnitTestCase
 
     public function testGetPostedTokenReturnsTokenWhenValid(): void
     {
-        $method   = $this->getPostedTokenMethod();
-        $security = $this->createMockSecurity();
-
         $_POST['csrf_test_name'] = '8b9218a55906f9dcc1dc263dce7f005a';
         $request                 = $this->createIncomingRequest();
+        $method                  = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
-        $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method->invoke($security, $request));
+        $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method($request));
     }
 
     public function testGetPostedTokenReturnsNullWhenEmpty(): void
     {
-        $method   = $this->getPostedTokenMethod();
-        $security = $this->createMockSecurity();
-
         $_POST   = [];
         $request = $this->createIncomingRequest();
+        $method  = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
-        $this->assertNull($method->invoke($security, $request));
+        $this->assertNull($method($request));
     }
 
     public function testGetPostedTokenReturnsNullWhenMaliciousData(): void
     {
-        $method   = $this->getPostedTokenMethod();
-        $security = $this->createMockSecurity();
-
         $_POST['csrf_test_name'] = ['malicious' => 'data'];
         $request                 = $this->createIncomingRequest();
+        $method                  = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
-        $this->assertNull($method->invoke($security, $request));
+        $this->assertNull($method($request));
     }
 }

--- a/user_guide_src/source/changelogs/v4.5.8.rst
+++ b/user_guide_src/source/changelogs/v4.5.8.rst
@@ -39,7 +39,7 @@ Bugs Fixed
 **********
 
 - **Database:** Fixed a bug where ``Builder::affectedRows()`` threw an error when the previous query call failed in ``Postgre`` and ``SQLSRV`` drivers.
-- **Security** Fixed a security issue in `Security` class where CSRF token validation might fail in specific malformed request inputs.
+- **Security** Fixed a bug where the CSRF token validation could fail on malformed input, causing a generic 500 error instead of handling the input gracefully.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.5.8.rst
+++ b/user_guide_src/source/changelogs/v4.5.8.rst
@@ -39,7 +39,7 @@ Bugs Fixed
 **********
 
 - **Database:** Fixed a bug where ``Builder::affectedRows()`` threw an error when the previous query call failed in ``Postgre`` and ``SQLSRV`` drivers.
-- **Security** Fixed a bug where the CSRF token validation could fail on malformed input, causing a generic 500 error instead of handling the input gracefully.
+- **Security:** Fixed a bug where the CSRF token validation could fail on malformed input, causing a generic HTTP 500 status code instead of handling the input gracefully.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.5.8.rst
+++ b/user_guide_src/source/changelogs/v4.5.8.rst
@@ -39,6 +39,7 @@ Bugs Fixed
 **********
 
 - **Database:** Fixed a bug where ``Builder::affectedRows()`` threw an error when the previous query call failed in ``Postgre`` and ``SQLSRV`` drivers.
+- **Security** Fixed a security issue in `Security` class where CSRF token validation might fail in specific malformed request inputs.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Make sure the CSRF token must be a string, because hackers can fake the request and pass csrf_main as an array, the system will break 500.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
