### PR TITLE
refactor: Fix phpstan function.notFound

### DIFF
--- a/tests/system/CommonHelperTest.php
+++ b/tests/system/CommonHelperTest.php
@@ -148,7 +148,7 @@ final class CommonHelperTest extends CIUnitTestCase
             }
         }
 
-        $this->assertSame($this->dummyHelpers[0], foo_bar_baz());
+        $this->assertSame($this->dummyHelpers[0], foo_bar_baz()); // @phpstan-ignore-line function.notFound
     }
 
     public function testNamespacedHelperNotFound(): void

--- a/utils/phpstan-baseline/function.notFound.neon
+++ b/utils/phpstan-baseline/function.notFound.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Function foo_bar_baz not found\.$#'
-            count: 1
-            path: ../../tests/system/CommonHelperTest.php

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -18,7 +18,6 @@ includes:
     - expr.resultUnused.neon
     - function.alreadyNarrowedType.neon
     - function.inner.neon
-    - function.notFound.neon
     - generator.returnType.neon
     - generator.valueType.neon
     - greaterOrEqual.invalid.neon


### PR DESCRIPTION
**Description**
Only ignore this error.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
