### PR TITLE
refactor: Fix phpstan booleanAnd.rightAlwaysTrue

### DIFF
--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -96,7 +96,7 @@ if (! function_exists('directory_mirror')) {
                 if (! is_dir($target)) {
                     mkdir($target, 0755);
                 }
-            } elseif (! is_file($target) || ($overwrite && is_file($target))) {
+            } elseif ($overwrite || ! is_file($target)) {
                 copy($origin, $target);
             }
         }

--- a/utils/phpstan-baseline/booleanAnd.rightAlwaysTrue.neon
+++ b/utils/phpstan-baseline/booleanAnd.rightAlwaysTrue.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Right side of && is always true\.$#'
-            count: 1
-            path: ../../system/Helpers/filesystem_helper.php

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,7 +1,6 @@
 includes:
     - argument.type.neon
     - assign.propertyType.neon
-    - booleanAnd.rightAlwaysTrue.neon
     - codeigniter.cacheHandlerInstance.neon
     - codeigniter.configArgumentInstanceof.neon
     - codeigniter.frameworkExceptionInstance.neon


### PR DESCRIPTION
**Description**
`is_file($target)` not needed, as it will be overwritten anyway.
Question: Is it worth checking copy() and throwing an exception?

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
