### PR TITLE
refactor: Fix phpstan if.condNotBoolean

### DIFF
--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -289,7 +289,7 @@ class CLI
 
         CLI::isZeroOptions($options);
 
-        if ($line = array_shift($text)) {
+        if (($line = array_shift($text)) !== null) {
             CLI::write($line);
         }
 

--- a/utils/phpstan-baseline/if.condNotBoolean.neon
+++ b/utils/phpstan-baseline/if.condNotBoolean.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
-            count: 1
-            path: ../../system/CLI/CLI.php

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -22,7 +22,6 @@ includes:
     - generator.returnType.neon
     - generator.valueType.neon
     - greaterOrEqual.invalid.neon
-    - if.condNotBoolean.neon
     - isset.offset.neon
     - isset.property.neon
     - method.alreadyNarrowedType.neon


### PR DESCRIPTION
**Description**
This is a rare case, but there are no tests for wrong `$options` values (`"", null, []` ...). Leaving it?

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
