### PR TITLE
refactor: Fix phpstan when delete string key

### DIFF
--- a/system/Test/Mock/MockCache.php
+++ b/system/Test/Mock/MockCache.php
@@ -31,7 +31,7 @@ class MockCache extends BaseHandler implements CacheInterface
     /**
      * Expiration times.
      *
-     * @var ?list<int>
+     * @var array<string, int|null>
      */
     protected $expirations = [];
 

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -53,6 +53,5 @@ includes:
     - return.unusedType.neon
     - staticMethod.notFound.neon
     - ternary.shortNotAllowed.neon
-    - unset.offset.neon
     - varTag.type.neon
     - variable.undefined.neon

--- a/utils/phpstan-baseline/unset.offset.neon
+++ b/utils/phpstan-baseline/unset.offset.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Cannot unset offset string on list\<int\>\|null\.$#'
-            count: 2
-            path: ../../system/Test/Mock/MockCache.php


### PR DESCRIPTION
**Description**
Wrong PHPDoc type `$expirations`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
