### PR TITLE
refactor: Fix phpstan return.type

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -652,7 +652,7 @@ class RouteCollection implements RouteCollectionInterface
      * It does not allow any options to be set on the route, or to
      * define the method used.
      */
-    public function map(array $routes = [], ?array $options = null): static
+    public function map(array $routes = [], ?array $options = null): RouteCollectionInterface
     {
         foreach ($routes as $from => $to) {
             $this->add($from, $to, $options);

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -652,7 +652,7 @@ class RouteCollection implements RouteCollectionInterface
      * It does not allow any options to be set on the route, or to
      * define the method used.
      */
-    public function map(array $routes = [], ?array $options = null): RouteCollectionInterface
+    public function map(array $routes = [], ?array $options = null): static
     {
         foreach ($routes as $from => $to) {
             $this->add($from, $to, $options);

--- a/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
+++ b/tests/system/Commands/Utilities/Routes/FilterFinderTest.php
@@ -21,6 +21,7 @@ use CodeIgniter\Filters\InvalidChars;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Router\RouteCollection;
+use CodeIgniter\Router\RouteCollectionInterface;
 use CodeIgniter\Router\Router;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ConfigFromArrayTrait;
@@ -53,7 +54,7 @@ final class FilterFinderTest extends CIUnitTestCase
         $this->moduleConfig->enabled = false;
     }
 
-    private function createRouteCollection(array $routes = []): RouteCollection
+    private function createRouteCollection(array $routes = []): RouteCollectionInterface
     {
         $collection = new RouteCollection(service('locator'), $this->moduleConfig, new Routing());
 
@@ -66,7 +67,7 @@ final class FilterFinderTest extends CIUnitTestCase
         return $collection->map($routes);
     }
 
-    private function createRouter(RouteCollection $collection): Router
+    private function createRouter(RouteCollectionInterface $collection): Router
     {
         return new Router($collection, $this->request);
     }
@@ -101,6 +102,9 @@ final class FilterFinderTest extends CIUnitTestCase
 
     public function testFindGlobalsFilters(): void
     {
+        /**
+         * @var RouteCollection $collection
+         */
         $collection = $this->createRouteCollection();
         $router     = $this->createRouter($collection);
         $filters    = $this->createFilters();
@@ -118,6 +122,9 @@ final class FilterFinderTest extends CIUnitTestCase
 
     public function testFindGlobalsFiltersWithRedirectRoute(): void
     {
+        /**
+         * @var RouteCollection $collection
+         */
         $collection = $this->createRouteCollection();
         $collection->addRedirect('users/about', 'profile');
 
@@ -137,6 +144,9 @@ final class FilterFinderTest extends CIUnitTestCase
 
     public function testFindGlobalsAndRouteFilters(): void
     {
+        /**
+         * @var RouteCollection $collection
+         */
         $collection = $this->createRouteCollection();
         $collection->get('admin', ' AdminController::index', ['filter' => 'honeypot']);
         $router  = $this->createRouter($collection);
@@ -155,6 +165,9 @@ final class FilterFinderTest extends CIUnitTestCase
 
     public function testFindGlobalsAndRouteClassnameFilters(): void
     {
+        /**
+         * @var RouteCollection $collection
+         */
         $collection = $this->createRouteCollection();
         $collection->get('admin', ' AdminController::index', ['filter' => InvalidChars::class]);
         $router  = $this->createRouter($collection);
@@ -173,6 +186,9 @@ final class FilterFinderTest extends CIUnitTestCase
 
     public function testFindGlobalsAndRouteMultipleFilters(): void
     {
+        /**
+         * @var RouteCollection $collection
+         */
         $collection = $this->createRouteCollection();
         $collection->get('admin', ' AdminController::index', ['filter' => ['honeypot', InvalidChars::class]]);
         $router  = $this->createRouter($collection);
@@ -191,6 +207,9 @@ final class FilterFinderTest extends CIUnitTestCase
 
     public function testFilterOrder(): void
     {
+        /**
+         * @var RouteCollection $collection
+         */
         $collection = $this->createRouteCollection([]);
         $collection->get('/', ' Home::index', ['filter' => ['route1', 'route2']]);
         $router  = $this->createRouter($collection);
@@ -256,6 +275,9 @@ final class FilterFinderTest extends CIUnitTestCase
         $feature                 = config(Feature::class);
         $feature->oldFilterOrder = true;
 
+        /**
+         * @var RouteCollection $collection
+         */
         $collection = $this->createRouteCollection([]);
         $collection->get('/', ' Home::index', ['filter' => ['route1', 'route2']]);
         $router  = $this->createRouter($collection);

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -45,7 +45,6 @@ includes:
     - property.readOnlyByPhpDocDefaultValue.neon
     - property.unusedType.neon
     - return.missing.neon
-    - return.type.neon
     - return.unusedType.neon
     - staticMethod.notFound.neon
     - ternary.shortNotAllowed.neon

--- a/utils/phpstan-baseline/return.type.neon
+++ b/utils/phpstan-baseline/return.type.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Method CodeIgniter\\Commands\\Utilities\\Routes\\FilterFinderTest\:\:createRouteCollection\(\) should return CodeIgniter\\Router\\RouteCollection but returns CodeIgniter\\Router\\RouteCollectionInterface\.$#'
-            count: 1
-            path: ../../tests/system/Commands/Utilities/Routes/FilterFinderTest.php


### PR DESCRIPTION
**Description**
`static` or `self` will decide what is returned.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
