### PR TITLE
refactor: Fix phpstan function.inner

### DIFF
--- a/tests/system/CommonHelperTest.php
+++ b/tests/system/CommonHelperTest.php
@@ -142,13 +142,13 @@ final class CommonHelperTest extends CIUnitTestCase
 
         // this chunk is not needed really; just added so that IDEs will be happy
         if (! function_exists('foo_bar_baz')) {
-            function foo_bar_baz(): string
+            function foo_bar_baz(): string // @phpstan-ignore function.inner
             {
                 return __FILE__;
             }
         }
 
-        $this->assertSame($this->dummyHelpers[0], foo_bar_baz()); // @phpstan-ignore-line function.notFound
+        $this->assertSame($this->dummyHelpers[0], foo_bar_baz()); // @phpstan-ignore function.notFound
     }
 
     public function testNamespacedHelperNotFound(): void

--- a/utils/phpstan-baseline/function.inner.neon
+++ b/utils/phpstan-baseline/function.inner.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Inner named functions are not supported by PHPStan\. Consider refactoring to an anonymous function, class method, or a top\-level\-defined function\. See issue \#165 \(https\://github\.com/phpstan/phpstan/issues/165\) for more details\.$#'
-            count: 1
-            path: ../../tests/system/CommonHelperTest.php

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -17,7 +17,6 @@ includes:
     - empty.property.neon
     - expr.resultUnused.neon
     - function.alreadyNarrowedType.neon
-    - function.inner.neon
     - generator.valueType.neon
     - isset.offset.neon
     - isset.property.neon


### PR DESCRIPTION
**Description**
Just ignoring it.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
