### PR TITLE
refactor: Fix phpstan return.missing

### DIFF
--- a/system/Test/Mock/MockResult.php
+++ b/system/Test/Mock/MockResult.php
@@ -77,6 +77,7 @@ class MockResult extends BaseResult
      */
     protected function fetchAssoc()
     {
+        return [];
     }
 
     /**

--- a/utils/phpstan-baseline/return.missing.neon
+++ b/utils/phpstan-baseline/return.missing.neon
@@ -1,4 +1,4 @@
-# total 2 errors
+# total 1 error
 
 parameters:
     ignoreErrors:
@@ -6,8 +6,3 @@ parameters:
             message: '#^Method CodeIgniter\\Images\\Handlers\\BaseHandler\:\:__call\(\) should return mixed but return statement is missing\.$#'
             count: 1
             path: ../../system/Images/Handlers/BaseHandler.php
-
-        -
-            message: '#^Method CodeIgniter\\Test\\Mock\\MockResult\:\:fetchAssoc\(\) should return mixed but return statement is missing\.$#'
-            count: 1
-            path: ../../system/Test/Mock/MockResult.php


### PR DESCRIPTION
**Description**
Don't you think `MockResult` is a dead class? It is not used anywhere.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
