### PR TITLE
refactor: Fix phpstan isset offset

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3175,6 +3175,7 @@ class BaseBuilder
                     ) {
                         continue;
                     }
+
                     // $matches = [
                     //  0 => '(test <= foo)',   /* the whole thing */
                     //  1 => '(',               /* optional */
@@ -3184,7 +3185,7 @@ class BaseBuilder
                     //  5 => ')'                /* optional */
                     // ];
 
-                    if (isset($matches[4]) && $matches[4] !== '') {
+                    if ($matches[4] !== '') {
                         $protectIdentifiers = false;
                         if (str_contains($matches[4], '.')) {
                             $protectIdentifiers = true;

--- a/utils/phpstan-baseline/isset.offset.neon
+++ b/utils/phpstan-baseline/isset.offset.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Offset 4 on array\{string, string, string, string, string, string\} in isset\(\) always exists and is not nullable\.$#'
-            count: 1
-            path: ../../system/Database/BaseBuilder.php

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -17,7 +17,6 @@ includes:
     - expr.resultUnused.neon
     - function.alreadyNarrowedType.neon
     - generator.valueType.neon
-    - isset.offset.neon
     - isset.property.neon
     - method.alreadyNarrowedType.neon
     - method.childParameterType.neon


### PR DESCRIPTION
**Description**
It seems `$matches` always has `6` keys. In addition, other indexes are not checked - they are expected to exist.
```console
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ $matches                                                                                                                                                                                            │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
array (6) [
    0 => string (34) " j.name  LIKE :j.name: ESCAPE '!' "
    1 => string (0) ""
    2 => string (7) " j.name"
    3 => string (27) "  LIKE :j.name: ESCAPE '!' "
    4 => string (0) ""
    5 => string (0) ""
]
```
**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
