### PR TITLE
refactor: Fix phpstan codeigniter.modelArgumentInstanceOf

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -218,6 +218,7 @@ parameters:
     RESTful:
       - +API
       - +Controller
+      - +Model
     Router:
       - HTTP
     Security:

--- a/system/RESTful/BaseResource.php
+++ b/system/RESTful/BaseResource.php
@@ -18,6 +18,7 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\Model;
 use Psr\Log\LoggerInterface;
 
 abstract class BaseResource extends Controller
@@ -30,12 +31,12 @@ abstract class BaseResource extends Controller
     protected $request;
 
     /**
-     * @var string|null The model that holding this resource's data
+     * @var class-string<Model>|string|null The model that holding this resource's data
      */
     protected $modelName;
 
     /**
-     * @var object|null The model that holding this resource's data
+     * @var Model|object|null The model that holding this resource's data
      */
     protected $model;
 
@@ -55,7 +56,7 @@ abstract class BaseResource extends Controller
      * Set or change the model this controller is bound to.
      * Given either the name or the object, determine the other.
      *
-     * @param object|string|null $which
+     * @param class-string<Model>|Model|object|string|null $which
      *
      * @return void
      */
@@ -63,7 +64,7 @@ abstract class BaseResource extends Controller
     {
         if ($which !== null) {
             $this->model     = is_object($which) ? $which : null;
-            $this->modelName = is_object($which) ? null : $which;
+            $this->modelName = is_object($which) ? '' : $which;
         }
 
         if (empty($this->model) && ! empty($this->modelName) && class_exists($this->modelName)) {

--- a/system/RESTful/BaseResource.php
+++ b/system/RESTful/BaseResource.php
@@ -64,7 +64,7 @@ abstract class BaseResource extends Controller
     {
         if ($which !== null) {
             $this->model     = is_object($which) ? $which : null;
-            $this->modelName = is_object($which) ? '' : $which;
+            $this->modelName = is_object($which) ? null : $which;
         }
 
         if (empty($this->model) && ! empty($this->modelName) && class_exists($this->modelName)) {

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -400,7 +400,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
     public function testModelNotExists(): void
     {
-        $this->assertNull(model(UnexsistenceClass::class)); // @phpstan-ignore class.notFound
+        $this->assertNull(model(UnexsistenceClass::class)); // @phpstan-ignore class.notFound, codeigniter.modelArgumentInstanceof
     }
 
     public function testModelExistsBasename(): void

--- a/utils/phpstan-baseline/codeigniter.modelArgumentInstanceof.neon
+++ b/utils/phpstan-baseline/codeigniter.modelArgumentInstanceof.neon
@@ -1,4 +1,4 @@
-# total 2 errors
+# total 1 error
 
 parameters:
     ignoreErrors:
@@ -6,8 +6,3 @@ parameters:
             message: '#^Argument \#1 \$name \(class\-string\) passed to function model does not extend CodeIgniter\\\\Model\.$#'
             count: 1
             path: ../../system/RESTful/BaseResource.php
-
-        -
-            message: '#^Argument \#1 \$name \(''CodeIgniter\\\\UnexsistenceClass''\) passed to function model does not extend CodeIgniter\\\\Model\.$#'
-            count: 1
-            path: ../../tests/system/CommonFunctionsTest.php


### PR DESCRIPTION
**Description**
I need help.
I still don't understand how to work with generics. I can add simple hints, but any condition raises questions.

How do I specify here "If $which is `class-string<Model> ? class-string<Model> : Model|object|string|null`" and then update the hint for `model($this->modelName)`

The **phpstan** documentation is small. There is no description of most use cases. Did I miss something?

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
