### PR TITLE
style: enable `get_class_to_class_keyword` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -39,7 +39,9 @@ $finder = Finder::create()
         __DIR__ . '/spark',
     ]);
 
-$overrides = [];
+$overrides = [
+    'get_class_to_class_keyword' => true,
+];
 
 $options = [
     'cacheFile'    => 'build/.php-cs-fixer.cache',

--- a/user_guide_src/source/libraries/publisher/005.php
+++ b/user_guide_src/source/libraries/publisher/005.php
@@ -7,6 +7,6 @@ foreach (Publisher::discover() as $publisher) {
     $result = $publisher->publish();
 
     if ($result === false) {
-        CLI::error(get_class($publisher) . ' failed to publish!', 'red');
+        CLI::error($publisher::class . ' failed to publish!', 'red');
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
```console
❯ utils/vendor/bin/php-cs-fixer describe get_class_to_class_keyword
PHP CS Fixer 3.67.0 Persian Successor by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.15
Description of the `get_class_to_class_keyword` rule.

Replace `get_class` calls on object variables with class keyword syntax.

Fixer applying this rule is RISKY.
Risky if the `get_class` function is overridden.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -get_class($a);
   +$a::class;
   
   ----------- end diff -----------

 * Example #2.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,4 +1,4 @@
    <?php
    
    $date = new \DateTimeImmutable();
   -$class = get_class($date);
   +$class = $date::class;
   
   ----------- end diff -----------

Fixer is part of the following rule sets:
* @PHP80Migration:risky with default config
* @PHP82Migration:risky with default config
* @Symfony:risky with default config
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
