### PR TITLE
chore: add more trailing commas in more places

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,6 +44,7 @@ $overrides = [
     'trailing_comma_in_multiline' => [
         'after_heredoc' => true,
         'elements'      => [
+            'array_destructuring',
             'arrays',
             'parameters',
         ],

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -40,7 +40,14 @@ $finder = Finder::create()
     ]);
 
 $overrides = [
-    'get_class_to_class_keyword' => true,
+    'get_class_to_class_keyword'  => true,
+    'trailing_comma_in_multiline' => [
+        'after_heredoc' => true,
+        'elements'      => [
+            'arrays',
+            'parameters',
+        ],
+    ],
 ];
 
 $options = [

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,6 +44,7 @@ $overrides = [
     'trailing_comma_in_multiline' => [
         'after_heredoc' => true,
         'elements'      => [
+            'arguments',
             'array_destructuring',
             'arrays',
             'match',
@@ -64,5 +65,5 @@ $options = [
 return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
     'CodeIgniter 4 framework',
     'CodeIgniter Foundation',
-    'admin@codeigniter.com'
+    'admin@codeigniter.com',
 );

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,6 +46,7 @@ $overrides = [
         'elements'      => [
             'array_destructuring',
             'arrays',
+            'match',
             'parameters',
         ],
     ],

--- a/admin/create-new-changelog.php
+++ b/admin/create-new-changelog.php
@@ -47,7 +47,7 @@ if ($isMinorUpdate) {
 replace_file_content(
     $changelogIndex,
     '/\.\. toctree::\n    :titlesonly:\n/u',
-    ".. toctree::\n    :titlesonly:\n\n    v{$version}"
+    ".. toctree::\n    :titlesonly:\n\n    v{$version}",
 );
 // Replace {version}
 $length    = mb_strlen("Version {$version}");
@@ -55,12 +55,12 @@ $underline = str_repeat('#', $length);
 replace_file_content(
     $changelog,
     '/#################\nVersion {version}\n#################/u',
-    "{$underline}\nVersion {$version}\n{$underline}"
+    "{$underline}\nVersion {$version}\n{$underline}",
 );
 replace_file_content(
     $changelog,
     '/{version}/u',
-    "{$version}"
+    "{$version}",
 );
 
 // Copy upgrading
@@ -72,7 +72,7 @@ copy('./admin/next-upgrading-guide.rst', $upgrading);
 replace_file_content(
     $upgradingIndex,
     '/    backward_compatibility_notes\n/u',
-    "    backward_compatibility_notes\n\n    upgrade_{$versionWithoutDots}"
+    "    backward_compatibility_notes\n\n    upgrade_{$versionWithoutDots}",
 );
 // Replace {version}
 $length    = mb_strlen("Upgrading from {$versionCurrent} to {$version}");
@@ -80,7 +80,7 @@ $underline = str_repeat('#', $length);
 replace_file_content(
     $upgrading,
     '/##############################\nUpgrading from {version} to {version}\n##############################/u',
-    "{$underline}\nUpgrading from {$versionCurrent} to {$version}\n{$underline}"
+    "{$underline}\nUpgrading from {$versionCurrent} to {$version}\n{$underline}",
 );
 
 // Commits

--- a/admin/prepare-release.php
+++ b/admin/prepare-release.php
@@ -33,31 +33,31 @@ system('git switch -c release-' . $version);
 replace_file_content(
     './system/CodeIgniter.php',
     '/public const CI_VERSION = \'.*?\';/u',
-    "public const CI_VERSION = '{$version}';"
+    "public const CI_VERSION = '{$version}';",
 );
 
 // Updates version number in "conf.py".
 replace_file_content(
     './user_guide_src/source/conf.py',
     '/^version = \'.*?\'/mu',
-    "version = '{$minor}'"
+    "version = '{$minor}'",
 );
 replace_file_content(
     './user_guide_src/source/conf.py',
     '/^release = \'.*?\'/mu',
-    "release = '{$version}'"
+    "release = '{$version}'",
 );
 
 // Updates version number in "phpdoc.dist.xml".
 replace_file_content(
     './phpdoc.dist.xml',
     '!<title>CodeIgniter v.*? API</title>!mu',
-    "<title>CodeIgniter v{$minor} API</title>"
+    "<title>CodeIgniter v{$minor} API</title>",
 );
 replace_file_content(
     './phpdoc.dist.xml',
     '/<version number=".*?">/mu',
-    "<version number=\"{$version}\">"
+    "<version number=\"{$version}\">",
 );
 
 // Updates release date in changelogs.
@@ -65,7 +65,7 @@ $date = date('F j, Y');
 replace_file_content(
     "./user_guide_src/source/changelogs/v{$version}.rst",
     '/^Release Date: .*/mu',
-    "Release Date: {$date}"
+    "Release Date: {$date}",
 );
 
 // Commits

--- a/admin/starter/tests/unit/HealthTest.php
+++ b/admin/starter/tests/unit/HealthTest.php
@@ -32,7 +32,7 @@ final class HealthTest extends CIUnitTestCase
             $config = new App();
             $this->assertTrue(
                 $validation->check($config->baseURL, 'valid_url'),
-                'baseURL "' . $config->baseURL . '" in .env is not valid URL'
+                'baseURL "' . $config->baseURL . '" in .env is not valid URL',
             );
         }
 
@@ -43,7 +43,7 @@ final class HealthTest extends CIUnitTestCase
         // BaseURL in app/Config/App.php is a valid URL?
         $this->assertTrue(
             $validation->check($reader->baseURL, 'valid_url'),
-            'baseURL "' . $reader->baseURL . '" in app/Config/App.php is not valid URL'
+            'baseURL "' . $reader->baseURL . '" in app/Config/App.php is not valid URL',
         );
     }
 }

--- a/preload.php
+++ b/preload.php
@@ -86,7 +86,7 @@ class preload
             $phpFiles  = new RegexIterator(
                 $fullTree,
                 '/.+((?<!Test)+\.php$)/i',
-                RecursiveRegexIterator::GET_MATCH
+                RecursiveRegexIterator::GET_MATCH,
             );
 
             foreach ($phpFiles as $key => $file) {

--- a/public/index.php
+++ b/public/index.php
@@ -11,7 +11,7 @@ if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
     $message = sprintf(
         'Your PHP version must be %s or higher to run CodeIgniter. Current version: %s',
         $minPhpVersion,
-        PHP_VERSION
+        PHP_VERSION,
     );
 
     header('HTTP/1.1 503 Service Unavailable.', true, 503);

--- a/rector.php
+++ b/rector.php
@@ -62,7 +62,7 @@ return RectorConfig::configure()
     ->withCache(
         // Github action cache or local
         is_dir('/tmp') ? '/tmp/rector' : null,
-        FileCacheStorage::class
+        FileCacheStorage::class,
     )
     // paths to refactor; solid alternative to CLI arguments
     ->withPaths([

--- a/spark
+++ b/spark
@@ -40,7 +40,7 @@ if (version_compare(PHP_VERSION, $minPhpVersion, '<')) {
     $message = sprintf(
         'Your PHP version must be %s or higher to run CodeIgniter. Current version: %s',
         $minPhpVersion,
-        PHP_VERSION
+        PHP_VERSION,
     );
 
     exit($message);

--- a/system/API/ResponseTrait.php
+++ b/system/API/ResponseTrait.php
@@ -319,7 +319,7 @@ trait ResponseTrait
             $mime = $this->request->negotiate(
                 'media',
                 $format->getConfig()->supportedResponseFormats,
-                false
+                false,
             );
         }
 

--- a/system/Autoloader/Autoloader.php
+++ b/system/Autoloader/Autoloader.php
@@ -347,7 +347,7 @@ class Autoloader
 
             throw new InvalidArgumentException(
                 'The file path contains special characters "' . $chars
-                . '" that are not allowed: "' . $filename . '"'
+                . '" that are not allowed: "' . $filename . '"',
             );
         }
         if ($result === false) {
@@ -386,7 +386,7 @@ class Autoloader
             throw new RuntimeException(
                 'Your Composer version is too old.'
                 . ' Please update Composer (run `composer self-update`) to v2.0.14 or later'
-                . ' and remove your vendor/ directory, and run `composer update`.'
+                . ' and remove your vendor/ directory, and run `composer update`.',
             );
         }
         // This method requires Composer 2.0.14 or later.

--- a/system/Autoloader/FileLocator.php
+++ b/system/Autoloader/FileLocator.php
@@ -295,9 +295,9 @@ class FileLocator implements FileLocatorInterface
                         str_replace(
                             '/',
                             '\\',
-                            mb_substr($path, mb_strlen($namespace['path']))
+                            mb_substr($path, mb_strlen($namespace['path'])),
                         ),
-                        '\\'
+                        '\\',
                     );
                 // Remove the file extension (.php)
                 $className = mb_substr($className, 0, -4);

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -379,7 +379,7 @@ abstract class BaseModel
             $this->converter = new DataConverter(
                 $this->casts,
                 $this->castHandlers,
-                $this->db
+                $this->db,
             );
         }
     }
@@ -1081,7 +1081,7 @@ abstract class BaseModel
                 if ($updateIndex === null) {
                     throw new InvalidArgumentException(
                         'The index ("' . $index . '") for updateBatch() is missing in the data: '
-                        . json_encode($row)
+                        . json_encode($row),
                     );
                 }
 

--- a/system/Boot.php
+++ b/system/Boot.php
@@ -288,7 +288,7 @@ class Boot
 
         $message = sprintf(
             'The framework needs the following extension(s) installed and loaded: %s.',
-            implode(', ', $missingExtensions)
+            implode(', ', $missingExtensions),
         );
 
         header('HTTP/1.1 503 Service Unavailable.', true, 503);

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -610,11 +610,11 @@ class CLI
             $nonColoredText = preg_replace(
                 $pattern,
                 '<<__colored_string__>>',
-                $text
+                $text,
             );
             $nonColoredChunks = preg_split(
                 '/<<__colored_string__>>/u',
-                $nonColoredText
+                $nonColoredText,
             );
 
             foreach ($nonColoredChunks as $i => $chunk) {

--- a/system/CLI/Console.php
+++ b/system/CLI/Console.php
@@ -63,7 +63,7 @@ class Console
             'CodeIgniter v%s Command Line Tool - Server Time: %s UTC%s',
             CodeIgniter::CI_VERSION,
             date('Y-m-d H:i:s'),
-            date('P')
+            date('P'),
         ), 'green');
         CLI::newLine();
     }

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -370,7 +370,7 @@ trait GeneratorTrait
         string $class,
         array $search = [],
         array $replace = [],
-        array $data = []
+        array $data = [],
     ): string {
         // Retrieves the namespace part from the fully qualified class name.
         $namespace = trim(

--- a/system/CLI/GeneratorTrait.php
+++ b/system/CLI/GeneratorTrait.php
@@ -171,7 +171,7 @@ trait GeneratorTrait
                 CLI::prompt(
                     'Are you sure you want to continue?',
                     ['y', 'n'],
-                    'required'
+                    'required',
                 ) === 'n'
             ) {
                 CLI::newLine();
@@ -193,7 +193,7 @@ trait GeneratorTrait
             CLI::error(
                 lang('CLI.generator.fileExist', [clean_path($target)]),
                 'light_gray',
-                'red'
+                'red',
             );
             CLI::newLine();
 
@@ -216,7 +216,7 @@ trait GeneratorTrait
             CLI::error(
                 lang('CLI.generator.fileError', [clean_path($target)]),
                 'light_gray',
-                'red'
+                'red',
             );
             CLI::newLine();
 
@@ -227,7 +227,7 @@ trait GeneratorTrait
         if ($this->getOption('force') && $isFile) {
             CLI::write(
                 lang('CLI.generator.fileOverwrite', [clean_path($target)]),
-                'yellow'
+                'yellow',
             );
             CLI::newLine();
 
@@ -236,7 +236,7 @@ trait GeneratorTrait
 
         CLI::write(
             lang('CLI.generator.fileCreate', [clean_path($target)]),
-            'green'
+            'green',
         );
         CLI::newLine();
     }
@@ -326,10 +326,10 @@ trait GeneratorTrait
                 '\\',
                 array_map(
                     pascalize(...),
-                    explode('\\', str_replace('/', '\\', trim($class)))
-                )
+                    explode('\\', str_replace('/', '\\', trim($class))),
+                ),
             ),
-            '\\/'
+            '\\/',
         );
     }
 
@@ -351,7 +351,7 @@ trait GeneratorTrait
             return view(
                 "CodeIgniter\\Commands\\Generators\\Views\\{$this->template}",
                 $data,
-                ['debug' => false]
+                ['debug' => false],
             );
         }
     }
@@ -376,9 +376,9 @@ trait GeneratorTrait
         $namespace = trim(
             implode(
                 '\\',
-                array_slice(explode('\\', $class), 0, -1)
+                array_slice(explode('\\', $class), 0, -1),
             ),
-            '\\'
+            '\\',
         );
         $search[]  = '<@php';
         $search[]  = '{namespace}';
@@ -404,7 +404,7 @@ trait GeneratorTrait
             && preg_match(
                 '/(?P<imports>(?:^use [^;]+;$\n?)+)/m',
                 $template,
-                $match
+                $match,
             )
         ) {
             $imports = explode("\n", trim($match['imports']));
@@ -432,7 +432,7 @@ trait GeneratorTrait
             CLI::error(
                 lang('CLI.namespaceNotDefined', [$namespace]),
                 'light_gray',
-                'red'
+                'red',
             );
             CLI::newLine();
 
@@ -446,7 +446,7 @@ trait GeneratorTrait
             . str_replace(
                 '\\',
                 DIRECTORY_SEPARATOR,
-                trim(str_replace($namespace . '\\', '', $class), '\\')
+                trim(str_replace($namespace . '\\', '', $class), '\\'),
             ) . '.php';
 
         return implode(
@@ -454,8 +454,8 @@ trait GeneratorTrait
             array_slice(
                 explode(DIRECTORY_SEPARATOR, $file),
                 0,
-                -1
-            )
+                -1,
+            ),
         ) . DIRECTORY_SEPARATOR . $this->basename($file);
     }
 
@@ -470,9 +470,9 @@ trait GeneratorTrait
             str_replace(
                 '/',
                 '\\',
-                $this->getOption('namespace') ?? APP_NAMESPACE
+                $this->getOption('namespace') ?? APP_NAMESPACE,
             ),
-            '\\'
+            '\\',
         );
     }
 

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -85,7 +85,7 @@ class MemcachedHandler extends BaseHandler
                 $this->memcached->addServer(
                     $this->config['host'],
                     $this->config['port'],
-                    $this->config['weight']
+                    $this->config['weight'],
                 );
 
                 // attempt to get status of servers
@@ -103,7 +103,7 @@ class MemcachedHandler extends BaseHandler
                 // Check if we can connect to the server
                 $canConnect = $this->memcached->connect(
                     $this->config['host'],
-                    $this->config['port']
+                    $this->config['port'],
                 );
 
                 // If we can't connect, throw a CriticalError exception
@@ -116,7 +116,7 @@ class MemcachedHandler extends BaseHandler
                     $this->config['host'],
                     $this->config['port'],
                     true,
-                    $this->config['weight']
+                    $this->config['weight'],
                 );
             } else {
                 throw new CriticalError('Cache: Not support Memcache(d) extension.');

--- a/system/Cache/Handlers/PredisHandler.php
+++ b/system/Cache/Handlers/PredisHandler.php
@@ -82,7 +82,7 @@ class PredisHandler extends BaseHandler
 
         $data = array_combine(
             ['__ci_type', '__ci_value'],
-            $this->redis->hmget($key, ['__ci_type', '__ci_value'])
+            $this->redis->hmget($key, ['__ci_type', '__ci_value']),
         );
 
         if (! isset($data['__ci_type'], $data['__ci_value']) || $data['__ci_value'] === false) {

--- a/system/Cache/ResponseCache.php
+++ b/system/Cache/ResponseCache.php
@@ -112,7 +112,7 @@ final class ResponseCache
         return $this->cache->save(
             $this->generateCacheKey($request),
             serialize(['headers' => $headers, 'output' => $response->getBody()]),
-            $this->ttl
+            $this->ttl,
         );
     }
 

--- a/system/CodeIgniter.php
+++ b/system/CodeIgniter.php
@@ -325,7 +325,7 @@ class CodeIgniter
         if ($this->context === null) {
             throw new LogicException(
                 'Context must be set before run() is called. If you are upgrading from 4.1.x, '
-                . 'you need to merge `public/index.php` and `spark` file from `vendor/codeigniter4/framework`.'
+                . 'you need to merge `public/index.php` and `spark` file from `vendor/codeigniter4/framework`.',
             );
         }
 
@@ -799,7 +799,7 @@ class CodeIgniter
         return str_replace(
             ['{elapsed_time}', '{memory_usage}'],
             [(string) $this->totalTime, number_format(memory_get_peak_usage() / 1024 / 1024, 3)],
-            $output
+            $output,
         );
     }
 
@@ -979,7 +979,7 @@ class CodeIgniter
 
         // Throws new PageNotFoundException and remove exception message on production.
         throw PageNotFoundException::forPageNotFound(
-            (ENVIRONMENT !== 'production' || ! $this->isWeb()) ? $e->getMessage() : null
+            (ENVIRONMENT !== 'production' || ! $this->isWeb()) ? $e->getMessage() : null,
         );
     }
 
@@ -1064,7 +1064,7 @@ class CodeIgniter
                 $uri->getAuthority(),
                 $uri->getPath(),
                 $uri->getQuery(),
-                $uri->getFragment()
+                $uri->getFragment(),
             ));
         }
     }

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -144,7 +144,7 @@ class ShowTableInfo extends BaseCommand
             $tableNameNo = CLI::promptByKey(
                 ['Here is the list of your database tables:', 'Which table do you want to see?'],
                 $tables,
-                'required'
+                'required',
             );
             CLI::newLine();
 
@@ -174,7 +174,7 @@ class ShowTableInfo extends BaseCommand
         ]];
         CLI::table(
             $data,
-            ['hostname', 'database', 'username', 'DBDriver', 'DBPrefix', 'port']
+            ['hostname', 'database', 'username', 'DBDriver', 'DBPrefix', 'port'],
         );
     }
 
@@ -290,7 +290,7 @@ class ShowTableInfo extends BaseCommand
                 static fn ($item): string => mb_strlen((string) $item) > $limitFieldValue
                     ? mb_substr((string) $item, 0, $limitFieldValue) . '...'
                     : (string) $item,
-                $row
+                $row,
             );
             $this->tbody[] = $row;
         }

--- a/system/Commands/Database/ShowTableInfo.php
+++ b/system/Commands/Database/ShowTableInfo.php
@@ -272,7 +272,7 @@ class ShowTableInfo extends BaseCommand
         string $tableName,
         int $limitRows,
         int $limitFieldValue,
-        ?string $sortField = null
+        ?string $sortField = null,
     ): array {
         $this->tbody = [];
 

--- a/system/Commands/Encryption/GenerateKey.php
+++ b/system/Commands/Encryption/GenerateKey.php
@@ -182,7 +182,7 @@ class GenerateKey extends BaseCommand
             $newFileContents = preg_replace(
                 '/^[#\s]*encryption.key[=\s]*(?:hex2bin\:[a-f0-9]{64}|base64\:(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?)$/m',
                 $replacementKey,
-                $oldFileContents
+                $oldFileContents,
             );
         }
 

--- a/system/Commands/Generators/CellGenerator.php
+++ b/system/Commands/Generators/CellGenerator.php
@@ -96,7 +96,7 @@ class CellGenerator extends BaseCommand
         $viewName  = preg_replace(
             '/([a-z][a-z0-9_\/\\\\]+)(_cell)$/i',
             '$1',
-            $viewName
+            $viewName,
         ) ?? $viewName;
         $namespace = substr($className, 0, strrpos($className, '\\') + 1);
 

--- a/system/Commands/Generators/CommandGenerator.php
+++ b/system/Commands/Generators/CommandGenerator.php
@@ -115,7 +115,7 @@ class CommandGenerator extends BaseCommand
             $class,
             ['{group}', '{command}'],
             [$group, $command],
-            ['type' => $type]
+            ['type' => $type],
         );
     }
 }

--- a/system/Commands/Generators/ControllerGenerator.php
+++ b/system/Commands/Generators/ControllerGenerator.php
@@ -130,7 +130,7 @@ class ControllerGenerator extends BaseCommand
             $class,
             ['{useStatement}', '{extends}'],
             [$useStatement, $extends],
-            ['type' => $rest]
+            ['type' => $rest],
         );
     }
 }

--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -102,9 +102,9 @@ class TestGenerator extends BaseCommand
                 str_replace(
                     '/',
                     '\\',
-                    $this->getOption('namespace')
+                    $this->getOption('namespace'),
                 ),
-                '\\'
+                '\\',
             );
         }
 
@@ -143,7 +143,7 @@ class TestGenerator extends BaseCommand
             CLI::error(
                 lang('CLI.namespaceNotDefined', [$namespace]),
                 'light_gray',
-                'red'
+                'red',
             );
             CLI::newLine();
 
@@ -157,7 +157,7 @@ class TestGenerator extends BaseCommand
             . str_replace(
                 '\\',
                 DIRECTORY_SEPARATOR,
-                trim(str_replace($namespace . '\\', '', $class), '\\')
+                trim(str_replace($namespace . '\\', '', $class), '\\'),
             ) . '.php';
 
         return implode(
@@ -165,8 +165,8 @@ class TestGenerator extends BaseCommand
             array_slice(
                 explode(DIRECTORY_SEPARATOR, $file),
                 0,
-                -1
-            )
+                -1,
+            ),
         ) . DIRECTORY_SEPARATOR . $this->basename($file);
     }
 

--- a/system/Commands/Translation/LocalizationFinder.php
+++ b/system/Commands/Translation/LocalizationFinder.php
@@ -70,7 +70,7 @@ class LocalizationFinder extends BaseCommand
             if (! in_array($optionLocale, config(App::class)->supportedLocales, true)) {
                 CLI::error(
                     'Error: "' . $optionLocale . '" is not supported. Supported locales: '
-                    . implode(', ', config(App::class)->supportedLocales)
+                    . implode(', ', config(App::class)->supportedLocales),
                 );
 
                 return EXIT_USER_INPUT;

--- a/system/Commands/Translation/LocalizationFinder.php
+++ b/system/Commands/Translation/LocalizationFinder.php
@@ -116,7 +116,7 @@ class LocalizationFinder extends BaseCommand
         [
             'foundLanguageKeys' => $foundLanguageKeys,
             'badLanguageKeys'   => $badLanguageKeys,
-            'countFiles'        => $countFiles
+            'countFiles'        => $countFiles,
         ] = $this->findLanguageKeysInFiles($files);
 
         ksort($foundLanguageKeys);

--- a/system/Commands/Utilities/ConfigCheck.php
+++ b/system/Commands/Utilities/ConfigCheck.php
@@ -109,7 +109,7 @@ final class ConfigCheck extends BaseCommand
             CLI::write($this->getKintD($config));
         } else {
             CLI::write(
-                CLI::color($this->getVarDump($config), 'cyan')
+                CLI::color($this->getVarDump($config), 'cyan'),
             );
         }
 
@@ -150,7 +150,7 @@ final class ConfigCheck extends BaseCommand
         return preg_replace(
             '!.*system/Commands/Utilities/ConfigCheck.php.*\n!u',
             '',
-            $output
+            $output,
         );
     }
 }

--- a/system/Commands/Utilities/Environment.php
+++ b/system/Commands/Utilities/Environment.php
@@ -151,7 +151,7 @@ final class Environment extends BaseCommand
 
         return file_put_contents(
             $envFile,
-            preg_replace($pattern, "\nCI_ENVIRONMENT = {$newEnv}", file_get_contents($envFile), -1, $count)
+            preg_replace($pattern, "\nCI_ENVIRONMENT = {$newEnv}", file_get_contents($envFile), -1, $count),
         ) !== false && $count > 0;
     }
 }

--- a/system/Commands/Utilities/FilterCheck.php
+++ b/system/Commands/Utilities/FilterCheck.php
@@ -100,7 +100,7 @@ class FilterCheck extends BaseCommand
                 CLI::color(
                     '"' . strtoupper($method) . ' ' . $route . '"',
                     'black',
-                    'light_gray'
+                    'light_gray',
                 ),
             );
 

--- a/system/Commands/Utilities/Optimize.php
+++ b/system/Commands/Utilities/Optimize.php
@@ -110,13 +110,13 @@ final class Optimize extends BaseCommand
             [
                 'public bool $configCacheEnabled = false;'  => 'public bool $configCacheEnabled = true;',
                 'public bool $locatorCacheEnabled = false;' => 'public bool $locatorCacheEnabled = true;',
-            ]
+            ],
         );
 
         if ($result) {
             CLI::write(
                 'Config Caching and FileLocator Caching are enabled in "app/Config/Optimize.php".',
-                'green'
+                'green',
             );
 
             return;

--- a/system/Commands/Utilities/Routes.php
+++ b/system/Commands/Utilities/Routes.php
@@ -133,7 +133,7 @@ class Routes extends BaseCommand
                     $collection->getDefaultController(),
                     $collection->getDefaultMethod(),
                     $methods,
-                    $collection->getRegisteredControllers('*')
+                    $collection->getRegisteredControllers('*'),
                 );
 
                 $autoRoutes = $autoRouteCollector->get();
@@ -149,7 +149,7 @@ class Routes extends BaseCommand
                             $collection->getDefaultMethod(),
                             $methods,
                             $collection->getRegisteredControllers('*'),
-                            $uri
+                            $uri,
                         );
 
                         $autoRoutes = [...$autoRoutes, ...$autoRouteCollector->get()];
@@ -159,7 +159,7 @@ class Routes extends BaseCommand
                 $autoRouteCollector = new AutoRouteCollector(
                     $collection->getDefaultNamespace(),
                     $collection->getDefaultController(),
-                    $collection->getDefaultMethod()
+                    $collection->getDefaultMethod(),
                 );
 
                 $autoRoutes = $autoRouteCollector->get();

--- a/system/Commands/Utilities/Routes/AutoRouteCollector.php
+++ b/system/Commands/Utilities/Routes/AutoRouteCollector.php
@@ -41,7 +41,7 @@ final class AutoRouteCollector
             $output = $reader->read(
                 $class,
                 $this->defaultController,
-                $this->defaultMethod
+                $this->defaultMethod,
             );
 
             foreach ($output as $item) {

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php
@@ -59,7 +59,7 @@ final class AutoRouteCollector
             $routes = $reader->read(
                 $class,
                 $this->defaultController,
-                $this->defaultMethod
+                $this->defaultMethod,
             );
 
             if ($routes === []) {

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/AutoRouteCollector.php
@@ -36,7 +36,7 @@ final class AutoRouteCollector
         private readonly string $defaultMethod,
         private readonly array $httpMethods,
         private readonly array $protectedControllers,
-        private readonly string $prefix = ''
+        private readonly string $prefix = '',
     ) {
     }
 

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -78,7 +78,7 @@ final class ControllerMethodReader
                             $classname,
                             $methodName,
                             $httpVerb,
-                            $method
+                            $method,
                         );
 
                         if ($routeForDefaultController !== []) {
@@ -193,7 +193,7 @@ final class ControllerMethodReader
     {
         if ($this->translateUriToCamelCase) {
             $string = strtolower(
-                preg_replace('/([a-z\d])([A-Z])/', '$1-$2', $string)
+                preg_replace('/([a-z\d])([A-Z])/', '$1-$2', $string),
             );
         } elseif ($this->translateURIDashes) {
             $string = str_replace('_', '-', $string);

--- a/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReader.php
@@ -33,7 +33,7 @@ final class ControllerMethodReader
      */
     public function __construct(
         private readonly string $namespace,
-        private readonly array $httpMethods
+        private readonly array $httpMethods,
     ) {
         $config                        = config(Routing::class);
         $this->translateURIDashes      = $config->translateURIDashes;
@@ -214,7 +214,7 @@ final class ControllerMethodReader
         string $classname,
         string $methodName,
         string $httpVerb,
-        ReflectionMethod $method
+        ReflectionMethod $method,
     ): array {
         $output = [];
 

--- a/system/Commands/Utilities/Routes/ControllerFinder.php
+++ b/system/Commands/Utilities/Routes/ControllerFinder.php
@@ -28,7 +28,7 @@ final class ControllerFinder
      * @param string $namespace namespace to search
      */
     public function __construct(
-        private readonly string $namespace
+        private readonly string $namespace,
     ) {
         $this->locator = service('locator');
     }

--- a/system/Commands/Utilities/Routes/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/ControllerMethodReader.php
@@ -57,7 +57,7 @@ final class ControllerMethodReader
                 $defaultController,
                 $uriByClass,
                 $classname,
-                $methodName
+                $methodName,
             );
             $output = [...$output, ...$routeWithoutController];
 
@@ -89,7 +89,7 @@ final class ControllerMethodReader
                     $defaultController,
                     $uriByClass,
                     $classname,
-                    $methodName
+                    $methodName,
                 );
                 $output = [...$output, ...$routeWithoutController];
 

--- a/system/Commands/Utilities/Routes/ControllerMethodReader.php
+++ b/system/Commands/Utilities/Routes/ControllerMethodReader.php
@@ -153,7 +153,7 @@ final class ControllerMethodReader
         string $defaultController,
         string $uriByClass,
         string $classname,
-        string $methodName
+        string $methodName,
     ): array {
         if ($classShortname !== $defaultController) {
             return [];

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -32,7 +32,7 @@ final class FilterCollector
          *
          * If set to true, route filters are not found.
          */
-        private readonly bool $resetRoutes = false
+        private readonly bool $resetRoutes = false,
     ) {
     }
 

--- a/system/Commands/Utilities/Routes/FilterCollector.php
+++ b/system/Commands/Utilities/Routes/FilterCollector.php
@@ -50,7 +50,7 @@ final class FilterCollector
             @trigger_error(
                 'Passing lowercase HTTP method "' . $method . '" is deprecated.'
                 . ' Use uppercase HTTP method like "' . strtoupper($method) . '".',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
         }
 

--- a/system/Commands/Utilities/Routes/SampleURIGenerator.php
+++ b/system/Commands/Utilities/Routes/SampleURIGenerator.php
@@ -57,7 +57,7 @@ final class SampleURIGenerator
             $sampleUri = str_replace(
                 '{locale}',
                 config(App::class)->defaultLocale,
-                $routeKey
+                $routeKey,
             );
         }
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -146,7 +146,7 @@ if (! function_exists('command')) {
                 // @codeCoverageIgnoreStart
                 throw new InvalidArgumentException(sprintf(
                     'Unable to parse input near "... %s ...".',
-                    substr($command, $cursor, 10)
+                    substr($command, $cursor, 10),
                 ));
                 // @codeCoverageIgnoreEnd
             }
@@ -1065,7 +1065,7 @@ if (! function_exists('slash_item')) {
                 'Cannot convert "%s::$%s" of type "%s" to type "string".',
                 App::class,
                 $item,
-                gettype($configItem)
+                gettype($configItem),
             ));
         }
 

--- a/system/Common.php
+++ b/system/Common.php
@@ -470,7 +470,7 @@ if (! function_exists('force_https')) {
     function force_https(
         int $duration = 31_536_000,
         ?RequestInterface $request = null,
-        ?ResponseInterface $response = null
+        ?ResponseInterface $response = null,
     ): void {
         $request ??= service('request');
 

--- a/system/ComposerScripts.php
+++ b/system/ComposerScripts.php
@@ -102,7 +102,7 @@ final class ComposerScripts
         /** @var SplFileInfo $file */
         foreach (new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator(rtrim($directory, '\\/'), FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         ) as $file) {
             $path = $file->getPathname();
 
@@ -146,7 +146,7 @@ final class ComposerScripts
         /** @var SplFileInfo $file */
         foreach (new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($originDir, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::SELF_FIRST
+            RecursiveIteratorIterator::SELF_FIRST,
         ) as $file) {
             $origin = $file->getPathname();
             $target = $targetDir . substr($origin, $dirLen);

--- a/system/Config/DotEnv.php
+++ b/system/Config/DotEnv.php
@@ -164,7 +164,7 @@ class DotEnv
                 %1$s          # and the closing quote
                 .*$           # and discard any string after the closing quote
                 /mx',
-                $quote
+                $quote,
             );
 
             $value = preg_replace($regexPattern, '$1', $value);
@@ -206,7 +206,7 @@ class DotEnv
 
                     return $nestedVariable;
                 },
-                $value
+                $value,
             );
         }
 

--- a/system/Config/Factories.php
+++ b/system/Config/Factories.php
@@ -106,7 +106,7 @@ final class Factories
             }
 
             throw new InvalidArgumentException(
-                'Already defined in Factories: ' . $component . ' ' . $alias . ' -> ' . self::$aliases[$component][$alias]
+                'Already defined in Factories: ' . $component . ' ' . $alias . ' -> ' . self::$aliases[$component][$alias],
             );
         }
 
@@ -448,7 +448,7 @@ final class Factories
                 self::$options[$component],
                 self::$aliases[$component],
                 self::$instances[$component],
-                self::$updated[$component]
+                self::$updated[$component],
             );
 
             return;

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -267,7 +267,7 @@ class Services extends BaseService
      */
     public static function exceptions(
         ?ExceptionsConfig $config = null,
-        bool $getShared = true
+        bool $getShared = true,
     ) {
         if ($getShared) {
             return static::getSharedInstance('exceptions', $config);
@@ -721,7 +721,7 @@ class Services extends BaseService
     public static function siteurifactory(
         ?App $config = null,
         ?Superglobals $superglobals = null,
-        bool $getShared = true
+        bool $getShared = true,
     ) {
         if ($getShared) {
             return static::getSharedInstance('siteurifactory', $config, $superglobals);
@@ -741,7 +741,7 @@ class Services extends BaseService
     public static function superglobals(
         ?array $server = null,
         ?array $get = null,
-        bool $getShared = true
+        bool $getShared = true,
     ) {
         if ($getShared) {
             return static::getSharedInstance('superglobals', $server, $get);

--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -213,7 +213,7 @@ class Services extends BaseService
             $config,
             new URI($options['baseURI'] ?? null),
             $response,
-            $options
+            $options,
         );
     }
 
@@ -569,7 +569,7 @@ class Services extends BaseService
             $config,
             AppServices::get('uri'),
             'php://input',
-            new UserAgent()
+            new UserAgent(),
         );
     }
 
@@ -689,7 +689,7 @@ class Services extends BaseService
         if (! class_exists($driverName) || ! is_a($driverName, SessionBaseHandler::class, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid session handler "%s" provided.',
-                $driverName
+                $driverName,
             ));
         }
 

--- a/system/DataCaster/Cast/ArrayCast.php
+++ b/system/DataCaster/Cast/ArrayCast.php
@@ -24,7 +24,7 @@ class ArrayCast extends BaseCast implements CastInterface
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): array {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -40,7 +40,7 @@ class ArrayCast extends BaseCast implements CastInterface
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         return serialize($value);
     }

--- a/system/DataCaster/Cast/BaseCast.php
+++ b/system/DataCaster/Cast/BaseCast.php
@@ -20,7 +20,7 @@ abstract class BaseCast implements CastInterface
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): mixed {
         return $value;
     }
@@ -28,7 +28,7 @@ abstract class BaseCast implements CastInterface
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): mixed {
         return $value;
     }

--- a/system/DataCaster/Cast/BooleanCast.php
+++ b/system/DataCaster/Cast/BooleanCast.php
@@ -24,7 +24,7 @@ class BooleanCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): bool {
         // For PostgreSQL
         if ($value === 't') {

--- a/system/DataCaster/Cast/CSVCast.php
+++ b/system/DataCaster/Cast/CSVCast.php
@@ -24,7 +24,7 @@ class CSVCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): array {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -36,7 +36,7 @@ class CSVCast extends BaseCast
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         if (! is_array($value)) {
             self::invalidTypeValueError($value);

--- a/system/DataCaster/Cast/CastInterface.php
+++ b/system/DataCaster/Cast/CastInterface.php
@@ -27,7 +27,7 @@ interface CastInterface
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): mixed;
 
     /**
@@ -42,6 +42,6 @@ interface CastInterface
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): mixed;
 }

--- a/system/DataCaster/Cast/DatetimeCast.php
+++ b/system/DataCaster/Cast/DatetimeCast.php
@@ -28,7 +28,7 @@ class DatetimeCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): Time {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -56,7 +56,7 @@ class DatetimeCast extends BaseCast
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         if (! $value instanceof Time) {
             self::invalidTypeValueError($value);

--- a/system/DataCaster/Cast/FloatCast.php
+++ b/system/DataCaster/Cast/FloatCast.php
@@ -24,7 +24,7 @@ class FloatCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): float {
         if (! is_float($value) && ! is_string($value)) {
             self::invalidTypeValueError($value);

--- a/system/DataCaster/Cast/IntBoolCast.php
+++ b/system/DataCaster/Cast/IntBoolCast.php
@@ -24,7 +24,7 @@ final class IntBoolCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): bool {
         if (! is_int($value) && ! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -36,7 +36,7 @@ final class IntBoolCast extends BaseCast
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): int {
         if (! is_bool($value)) {
             self::invalidTypeValueError($value);

--- a/system/DataCaster/Cast/IntegerCast.php
+++ b/system/DataCaster/Cast/IntegerCast.php
@@ -24,7 +24,7 @@ class IntegerCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): int {
         if (! is_string($value) && ! is_int($value)) {
             self::invalidTypeValueError($value);

--- a/system/DataCaster/Cast/JsonCast.php
+++ b/system/DataCaster/Cast/JsonCast.php
@@ -28,7 +28,7 @@ class JsonCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): array|stdClass {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -50,7 +50,7 @@ class JsonCast extends BaseCast
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         try {
             $output = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);

--- a/system/DataCaster/Cast/TimestampCast.php
+++ b/system/DataCaster/Cast/TimestampCast.php
@@ -26,7 +26,7 @@ class TimestampCast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): Time {
         if (! is_int($value) && ! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -38,7 +38,7 @@ class TimestampCast extends BaseCast
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): int {
         if (! $value instanceof Time) {
             self::invalidTypeValueError($value);

--- a/system/DataCaster/Cast/URICast.php
+++ b/system/DataCaster/Cast/URICast.php
@@ -26,7 +26,7 @@ class URICast extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): URI {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -38,7 +38,7 @@ class URICast extends BaseCast
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         if (! $value instanceof URI) {
             self::invalidTypeValueError($value);

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -83,7 +83,7 @@ final class DataCaster
                     && ! is_subclass_of($handler, EntityCastInterface::class)
                 ) {
                     throw new InvalidArgumentException(
-                        'Invalid class type. It must implement CastInterface. class: ' . $handler
+                        'Invalid class type. It must implement CastInterface. class: ' . $handler,
                     );
                 }
             }
@@ -169,7 +169,7 @@ final class DataCaster
 
         if (! isset($handlers[$type])) {
             throw new InvalidArgumentException(
-                'No such handler for "' . $field . '". Invalid type: ' . $type
+                'No such handler for "' . $field . '". Invalid type: ' . $type,
             );
         }
 

--- a/system/DataCaster/DataCaster.php
+++ b/system/DataCaster/DataCaster.php
@@ -68,7 +68,7 @@ final class DataCaster
         ?array $castHandlers = null,
         ?array $types = null,
         private readonly ?object $helper = null,
-        private readonly bool $strict = true
+        private readonly bool $strict = true,
     ) {
         $this->castHandlers = array_merge($this->castHandlers, $castHandlers);
 

--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -807,7 +807,7 @@ class BaseBuilder
                     '/\s*(!?=|<>|IS(?:\s+NOT)?)\s*$/i',
                     $k,
                     $match,
-                    PREG_OFFSET_CAPTURE
+                    PREG_OFFSET_CAPTURE,
                 )
             ) {
                 $k  = substr($k, 0, $match[0][1]);
@@ -2022,8 +2022,8 @@ class BaseBuilder
                         ' = ' . $value :
                         ' = VALUES(' . $value . ')'),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -2291,10 +2291,10 @@ class BaseBuilder
                 $this->removeAlias($this->QBFrom[0]),
                 true,
                 null,
-                false
+                false,
             ),
             array_keys($this->QBSet),
-            array_values($this->QBSet)
+            array_values($this->QBSet),
         );
 
         if ($reset) {
@@ -2328,10 +2328,10 @@ class BaseBuilder
                 $this->removeAlias($this->QBFrom[0]),
                 true,
                 $escape,
-                false
+                false,
             ),
             array_keys($this->QBSet),
-            array_values($this->QBSet)
+            array_values($this->QBSet),
         );
 
         if (! $this->testMode) {
@@ -2653,8 +2653,8 @@ class BaseBuilder
                         ' = ' . $value :
                         ' = ' . $alias . '.' . $value),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             ) . "\n";
 
             $sql .= "FROM (\n{:_table_:}";
@@ -2678,8 +2678,8 @@ class BaseBuilder
                         )
                     ),
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -2694,10 +2694,10 @@ class BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . "\n";
         }
 
@@ -2924,8 +2924,8 @@ class BaseBuilder
                         )
                     ),
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             );
 
             // convert binds in where
@@ -2949,10 +2949,10 @@ class BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . "\n";
         }
 
@@ -3160,7 +3160,7 @@ class BaseBuilder
                     '/((?:^|\s+)AND\s+|(?:^|\s+)OR\s+)/i',
                     $qbkey['condition'],
                     -1,
-                    PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+                    PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY,
                 );
 
                 foreach ($conditions as &$condition) {
@@ -3170,7 +3170,7 @@ class BaseBuilder
                         || preg_match(
                             '/^(\(?)(.*)(' . preg_quote($op, '/') . ')\s*(.*(?<!\)))?(\)?)$/i',
                             $condition,
-                            $matches
+                            $matches,
                         ) !== 1
                     ) {
                         continue;
@@ -3436,7 +3436,7 @@ class BaseBuilder
     {
         return preg_match(
             '/(<|>|!|=|\sIS NULL|\sIS NOT NULL|\sEXISTS|\sBETWEEN|\sLIKE|\sIN\s*\(|\s)/i',
-            trim($str)
+            trim($str),
         ) === 1;
     }
 
@@ -3470,7 +3470,7 @@ class BaseBuilder
         return preg_match_all(
             '/' . implode('|', $this->pregOperators) . '/i',
             $str,
-            $match
+            $match,
         ) >= 1 ? ($list ? $match[0] : $match[0][0]) : false;
     }
 
@@ -3501,7 +3501,7 @@ class BaseBuilder
         return preg_match_all(
             '/' . implode('|', $pregOperators) . '/i',
             $whereKey,
-            $match
+            $match,
         ) >= 1 ? $match[0] : false;
     }
 

--- a/system/Database/BaseConnection.php
+++ b/system/Database/BaseConnection.php
@@ -424,7 +424,7 @@ abstract class BaseConnection implements ConnectionInterface
             $connectionErrors[] = sprintf(
                 'Main connection [%s]: %s',
                 $this->DBDriver,
-                $e->getMessage()
+                $e->getMessage(),
             );
             log_message('error', 'Error connecting to the database: ' . $e);
         }
@@ -450,7 +450,7 @@ abstract class BaseConnection implements ConnectionInterface
                             'Failover #%d [%s]: %s',
                             ++$index,
                             $this->DBDriver,
-                            $e->getMessage()
+                            $e->getMessage(),
                         );
                         log_message('error', 'Error connecting to the database: ' . $e);
                     }
@@ -467,7 +467,7 @@ abstract class BaseConnection implements ConnectionInterface
                 throw new DatabaseException(sprintf(
                     'Unable to connect to the database.%s%s',
                     PHP_EOL,
-                    implode(PHP_EOL, $connectionErrors)
+                    implode(PHP_EOL, $connectionErrors),
                 ));
             }
         }
@@ -688,7 +688,7 @@ abstract class BaseConnection implements ConnectionInterface
                     throw new DatabaseException(
                         $exception->getMessage(),
                         $exception->getCode(),
-                        $exception
+                        $exception,
                     );
                 }
 
@@ -1220,7 +1220,7 @@ abstract class BaseConnection implements ConnectionInterface
             . str_replace(
                 $this->escapeChar,
                 $this->escapeChar . $this->escapeChar,
-                $item
+                $item,
             )
             . $this->escapeChar;
     }
@@ -1277,7 +1277,7 @@ abstract class BaseConnection implements ConnectionInterface
                 return preg_replace(
                     '/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?\./i',
                     $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '.',
-                    $item
+                    $item,
                 );
             }
         }
@@ -1286,7 +1286,7 @@ abstract class BaseConnection implements ConnectionInterface
         return preg_replace(
             '/' . $this->pregEscapeChar[0] . '?([^' . $this->pregEscapeChar[1] . '\.]+)' . $this->pregEscapeChar[1] . '?(\.)?/i',
             $this->pregEscapeChar[2] . '$1' . $this->pregEscapeChar[3] . '$2',
-            $item
+            $item,
         );
     }
 
@@ -1386,7 +1386,7 @@ abstract class BaseConnection implements ConnectionInterface
                     $this->likeEscapeChar . '%',
                     $this->likeEscapeChar . '_',
                 ],
-                $str
+                $str,
             );
         }
 
@@ -1522,7 +1522,7 @@ abstract class BaseConnection implements ConnectionInterface
             $key = array_search(
                 strtolower($tableName),
                 array_map(strtolower(...), $this->dataCache['table_names']),
-                true
+                true,
             );
 
             // table doesn't exist but still in cache - lets reset cache, it can be rebuilt later

--- a/system/Database/BaseUtils.php
+++ b/system/Database/BaseUtils.php
@@ -217,7 +217,7 @@ abstract class BaseUtils
                 $line[] = $enclosure . str_replace(
                     $enclosure,
                     $enclosure . $enclosure,
-                    (string) $item
+                    (string) $item,
                 ) . $enclosure;
             }
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -234,8 +234,8 @@ class Forge
                     $ifNotExists ? $this->createDatabaseIfStr : $this->createDatabaseStr,
                     $this->db->escapeIdentifier($dbName),
                     $this->db->charset,
-                    $this->db->DBCollat
-                )
+                    $this->db->DBCollat,
+                ),
             )) {
                 // @codeCoverageIgnoreStart
                 if ($this->db->DBDebug) {
@@ -294,7 +294,7 @@ class Forge
         }
 
         if (! $this->db->query(
-            sprintf($this->dropDatabaseStr, $this->db->escapeIdentifier($dbName))
+            sprintf($this->dropDatabaseStr, $this->db->escapeIdentifier($dbName)),
         )) {
             if ($this->db->DBDebug) {
                 throw new DatabaseException('Unable to drop the specified database.');
@@ -307,7 +307,7 @@ class Forge
             $key = array_search(
                 strtolower($dbName),
                 array_map(strtolower(...), $this->db->dataCache['db_names']),
-                true
+                true,
             );
             if ($key !== false) {
                 unset($this->db->dataCache['db_names'][$key]);
@@ -525,7 +525,7 @@ class Forge
         $sql = sprintf(
             (string) $this->dropConstraintStr,
             $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
-            $this->db->escapeIdentifiers($foreignName)
+            $this->db->escapeIdentifiers($foreignName),
         );
 
         if ($sql === '') {
@@ -618,7 +618,7 @@ class Forge
             'CREATE TABLE',
             $this->db->escapeIdentifiers($table),
             $processedFields,
-            $this->_createTableAttributes($attributes)
+            $this->_createTableAttributes($attributes),
         );
     }
 
@@ -668,7 +668,7 @@ class Forge
             $key = array_search(
                 strtolower($this->db->DBPrefix . $tableName),
                 array_map(strtolower(...), $this->db->dataCache['table_names']),
-                true
+                true,
             );
 
             if ($key !== false) {
@@ -723,14 +723,14 @@ class Forge
         $result = $this->db->query(sprintf(
             $this->renameTableStr,
             $this->db->escapeIdentifiers($this->db->DBPrefix . $tableName),
-            $this->db->escapeIdentifiers($this->db->DBPrefix . $newTableName)
+            $this->db->escapeIdentifiers($this->db->DBPrefix . $newTableName),
         ));
 
         if ($result && ! empty($this->db->dataCache['table_names'])) {
             $key = array_search(
                 strtolower($this->db->DBPrefix . $tableName),
                 array_map(strtolower(...), $this->db->dataCache['table_names']),
-                true
+                true,
             );
 
             if ($key !== false) {
@@ -1112,7 +1112,7 @@ class Forge
 
             $this->fields = array_combine(
                 array_map(static fn ($columnName) => $columnName->name, $fieldData),
-                array_fill(0, count($fieldData), [])
+                array_fill(0, count($fieldData), []),
             );
         }
 

--- a/system/Database/Forge.php
+++ b/system/Database/Forge.php
@@ -425,7 +425,7 @@ class Forge
         $tableField = '',
         string $onUpdate = '',
         string $onDelete = '',
-        string $fkName = ''
+        string $fkName = '',
     ): Forge {
         $fieldName  = (array) $fieldName;
         $tableField = (array) $tableField;

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -605,7 +605,7 @@ class MigrationRunner
                 CLI::color(lang('Migrations.added'), 'yellow'),
                 $migration->namespace,
                 $migration->version,
-                $migration->class
+                $migration->class,
             );
         }
     }
@@ -625,7 +625,7 @@ class MigrationRunner
                 CLI::color(lang('Migrations.removed'), 'yellow'),
                 $history->namespace,
                 $history->version,
-                $history->class
+                $history->class,
             );
         }
     }

--- a/system/Database/MySQLi/Builder.php
+++ b/system/Database/MySQLi/Builder.php
@@ -106,8 +106,8 @@ class Builder extends BaseBuilder
                         )
                     ),
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             ) . "\n";
 
             $sql .= "SET\n";
@@ -119,8 +119,8 @@ class Builder extends BaseBuilder
                         ' = ' . $value :
                         ' = ' . $alias . '.' . $value),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -135,10 +135,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . "\n";
         }
 

--- a/system/Database/MySQLi/Connection.php
+++ b/system/Database/MySQLi/Connection.php
@@ -116,7 +116,7 @@ class Connection extends BaseConnection
             if ($this->strictOn) {
                 $this->mysqli->options(
                     MYSQLI_INIT_COMMAND,
-                    "SET SESSION sql_mode = CONCAT(@@sql_mode, ',', 'STRICT_ALL_TABLES')"
+                    "SET SESSION sql_mode = CONCAT(@@sql_mode, ',', 'STRICT_ALL_TABLES')",
                 );
             } else {
                 $this->mysqli->options(
@@ -128,7 +128,7 @@ class Connection extends BaseConnection
                                 'STRICT_ALL_TABLES', ''),
                             'STRICT_TRANS_TABLES,', ''),
                         ',STRICT_TRANS_TABLES', ''),
-                    'STRICT_TRANS_TABLES', '')"
+                    'STRICT_TRANS_TABLES', '')",
                 );
             }
         }
@@ -175,7 +175,7 @@ class Connection extends BaseConnection
                     $ssl['cert'] ?? null,
                     $ssl['ca'] ?? null,
                     $ssl['capath'] ?? null,
-                    $ssl['cipher'] ?? null
+                    $ssl['cipher'] ?? null,
                 );
             }
 
@@ -190,7 +190,7 @@ class Connection extends BaseConnection
                 $this->database,
                 $port,
                 $socket,
-                $clientFlags
+                $clientFlags,
             )) {
                 // Prior to version 5.7.3, MySQL silently downgrades to an unencrypted connection if SSL setup fails
                 if (($clientFlags & MYSQLI_CLIENT_SSL) !== 0 && version_compare($this->mysqli->client_info, 'mysqlnd 5.7.3', '<=')
@@ -381,7 +381,7 @@ class Connection extends BaseConnection
         return str_replace(
             [$this->likeEscapeChar, '%', '_'],
             ['\\' . $this->likeEscapeChar, '\\%', '\\_'],
-            $str
+            $str,
         );
     }
 

--- a/system/Database/MySQLi/Forge.php
+++ b/system/Database/MySQLi/Forge.php
@@ -258,7 +258,7 @@ class Forge extends BaseForge
     {
         $sql = sprintf(
             'ALTER TABLE %s DROP PRIMARY KEY',
-            $this->db->escapeIdentifiers($this->db->DBPrefix . $table)
+            $this->db->escapeIdentifiers($this->db->DBPrefix . $table),
         );
 
         return $this->db->query($sql);

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -92,10 +92,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . " FROM DUAL\n";
         }
 
@@ -287,8 +287,8 @@ class Builder extends BaseBuilder
                         )
                     ),
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             ) . ")\n";
 
             $sql .= "WHEN MATCHED THEN UPDATE\n";
@@ -302,8 +302,8 @@ class Builder extends BaseBuilder
                     ' = ' . $value :
                     ' = ' . $alias . '.' . $value),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -318,10 +318,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )) . ' FROM DUAL',
-                    $values
-                )
+                    $values,
+                ),
             ) . "\n";
         }
 
@@ -392,8 +392,8 @@ class Builder extends BaseBuilder
                         )
                     ),
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             ) . ")\n";
 
             $sql .= "WHEN MATCHED THEN UPDATE SET\n";
@@ -405,8 +405,8 @@ class Builder extends BaseBuilder
                     " = {$value}" :
                     " = {$alias}.{$value}"),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             );
 
             $sql .= "\nWHEN NOT MATCHED THEN INSERT (" . implode(', ', $keys) . ")\nVALUES ";
@@ -427,10 +427,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . " FROM DUAL\n";
         }
 
@@ -477,8 +477,8 @@ class Builder extends BaseBuilder
                         )
                     ),
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             );
 
             // convert binds in where
@@ -491,7 +491,7 @@ class Builder extends BaseBuilder
             $sql .= ' ' . str_replace(
                 'WHERE ',
                 'AND ',
-                $this->compileWhereHaving('QBWhere')
+                $this->compileWhereHaving('QBWhere'),
             ) . ')';
 
             $this->QBOptions['sql'] = $sql;
@@ -506,10 +506,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . " FROM DUAL\n";
         }
 

--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -523,7 +523,7 @@ class Connection extends BaseConnection
         $sql = sprintf(
             'BEGIN %s (' . substr(str_repeat(',%s', count($params)), 1) . '); END;',
             $procedureName,
-            ...array_map(static fn ($row) => $row['name'], $params)
+            ...array_map(static fn ($row) => $row['name'], $params),
         );
 
         $this->resetStmtId = false;
@@ -554,7 +554,7 @@ class Connection extends BaseConnection
                 $param['name'],
                 $param['value'],
                 $param['length'] ?? -1,
-                $param['type'] ?? SQLT_CHR
+                $param['type'] ?? SQLT_CHR,
             );
         }
     }

--- a/system/Database/OCI8/Forge.php
+++ b/system/Database/OCI8/Forge.php
@@ -112,7 +112,7 @@ class Forge extends BaseForge
 
             $fields = array_map(
                 fn ($field) => $this->db->escapeIdentifiers(trim($field)),
-                is_string($columnNamesToDrop) ? explode(',', $columnNamesToDrop) : $columnNamesToDrop
+                is_string($columnNamesToDrop) ? explode(',', $columnNamesToDrop) : $columnNamesToDrop,
             );
 
             return $sql . ' DROP (' . implode(',', $fields) . ') CASCADE CONSTRAINT INVALIDATE';

--- a/system/Database/Postgre/Builder.php
+++ b/system/Database/Postgre/Builder.php
@@ -357,8 +357,8 @@ class Builder extends BaseBuilder
                             ' = ' . $value :
                             ' = ' . $that->cast($alias . '.' . $value, $that->getFieldType($table, $key))),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             ) . "\n";
 
             $sql .= "FROM (\n{:_table_:}";
@@ -381,8 +381,8 @@ class Builder extends BaseBuilder
                             . $that->cast($alias . '.' . $value, $that->getFieldType($table, $value));
                     },
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -397,10 +397,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . "\n";
         }
 
@@ -528,8 +528,8 @@ class Builder extends BaseBuilder
                     " = {$value}" :
                     " = {$alias}.{$value}"),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -584,15 +584,15 @@ class Builder extends BaseBuilder
                             return $table . '.' . $key . ' = '
                                 . $that->cast(
                                     $alias . '.' . $value,
-                                    $that->getFieldType($table, $key)
+                                    $that->getFieldType($table, $key),
                                 );
                         }
 
                         return $table . '.' . $value . ' = ' . $alias . '.' . $value;
                     },
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             );
 
             // convert binds in where
@@ -605,7 +605,7 @@ class Builder extends BaseBuilder
             $sql .= ' ' . str_replace(
                 'WHERE ',
                 'AND ',
-                $this->compileWhereHaving('QBWhere')
+                $this->compileWhereHaving('QBWhere'),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -620,10 +620,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . "\n";
         }
 

--- a/system/Database/SQLSRV/Builder.php
+++ b/system/Database/SQLSRV/Builder.php
@@ -764,8 +764,8 @@ class Builder extends BaseBuilder
                         )
                     ),
                     array_keys($constraints),
-                    $constraints
-                )
+                    $constraints,
+                ),
             ) . ")\n";
 
             $sql .= "WHEN MATCHED THEN UPDATE SET\n";
@@ -777,8 +777,8 @@ class Builder extends BaseBuilder
                         ' = ' . $value :
                     " = {$alias}.{$value}"),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             );
 
             $sql .= "\nWHEN NOT MATCHED THEN INSERT (" . implode(', ', $keys) . ")\nVALUES ";
@@ -792,8 +792,8 @@ class Builder extends BaseBuilder
                     . 'isnull(IDENT_CURRENT(\'' . $fullTableName . '\')+IDENT_INCR(\''
                     . $fullTableName . "'),1)) ELSE {$alias}.{$columnName} END"
                     : "{$alias}.{$columnName}",
-                        $keys
-                    )
+                        $keys,
+                    ),
                 ) . ');'
             );
 

--- a/system/Database/SQLSRV/Forge.php
+++ b/system/Database/SQLSRV/Forge.php
@@ -134,12 +134,12 @@ class Forge extends BaseForge
             $sql = sprintf(
                 $this->createDatabaseIfStr,
                 $dbName,
-                $this->db->escapeIdentifier($dbName)
+                $this->db->escapeIdentifier($dbName),
             );
         } else {
             $sql = sprintf(
                 $this->createDatabaseStr,
-                $this->db->escapeIdentifier($dbName)
+                $this->db->escapeIdentifier($dbName),
             );
         }
 
@@ -381,8 +381,8 @@ class Forge extends BaseForge
                 $maxLength = max(
                     array_map(
                         static fn ($value): int => strlen($value),
-                        $attributes['CONSTRAINT']
-                    )
+                        $attributes['CONSTRAINT'],
+                    ),
                 );
 
                 $attributes['TYPE']       = 'VARCHAR';

--- a/system/Database/SQLite3/Builder.php
+++ b/system/Database/SQLite3/Builder.php
@@ -196,8 +196,8 @@ class Builder extends BaseBuilder
                         " = {$value}" :
                         " = {$alias}.{$value}"),
                     array_keys($updateFields),
-                    $updateFields
-                )
+                    $updateFields,
+                ),
             );
 
             $this->QBOptions['sql'] = $sql;
@@ -268,10 +268,10 @@ class Builder extends BaseBuilder
                     static fn ($value): string => 'SELECT ' . implode(', ', array_map(
                         static fn ($key, $index): string => $index . ' ' . $key,
                         $keys,
-                        $value
+                        $value,
                     )),
-                    $values
-                )
+                    $values,
+                ),
             ) . "\n";
         }
 

--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -308,7 +308,7 @@ class Table
 
         $this->keys = array_filter(
             $this->keys,
-            static fn ($index): bool => count(array_intersect($index['fields'], $fieldNames)) === count($index['fields'])
+            static fn ($index): bool => count(array_intersect($index['fields'], $fieldNames)) === count($index['fields']),
         );
 
         // Unique/Index keys
@@ -334,7 +334,7 @@ class Table
             $this->forge->addForeignKey(
                 $foreignKey->column_name,
                 trim($foreignKey->foreign_table_name, $this->db->DBPrefix),
-                $foreignKey->foreign_column_name
+                $foreignKey->foreign_column_name,
             );
         }
 
@@ -358,15 +358,15 @@ class Table
 
         $exFields = implode(
             ', ',
-            array_map(fn ($item) => $this->db->protectIdentifiers($item), $exFields)
+            array_map(fn ($item) => $this->db->protectIdentifiers($item), $exFields),
         );
         $newFields = implode(
             ', ',
-            array_map(fn ($item) => $this->db->protectIdentifiers($item), $newFields)
+            array_map(fn ($item) => $this->db->protectIdentifiers($item), $newFields),
         );
 
         $this->db->query(
-            "INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}"
+            "INSERT INTO {$this->prefixedTableName}({$newFields}) SELECT {$exFields} FROM {$this->db->DBPrefix}temp_{$this->tableName}",
         );
     }
 

--- a/system/Debug/BaseExceptionHandler.php
+++ b/system/Debug/BaseExceptionHandler.php
@@ -61,7 +61,7 @@ abstract class BaseExceptionHandler
         RequestInterface $request,
         ResponseInterface $response,
         int $statusCode,
-        int $exitCode
+        int $exitCode,
     );
 
     /**

--- a/system/Debug/BaseExceptionHandler.php
+++ b/system/Debug/BaseExceptionHandler.php
@@ -221,7 +221,7 @@ abstract class BaseExceptionHandler
                     "<span class='line highlight'><span class='number'>{$format}</span> %s\n</span>%s",
                     $n + $start + 1,
                     strip_tags($row),
-                    implode('', $tags[0])
+                    implode('', $tags[0]),
                 );
             } else {
                 $out .= sprintf('<span class="line"><span class="number">' . $format . '</span> %s', $n + $start + 1, $row) . "\n";

--- a/system/Debug/ExceptionHandler.php
+++ b/system/Debug/ExceptionHandler.php
@@ -68,10 +68,10 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
                         'HTTP/%s %s %s',
                         $request->getProtocolVersion(),
                         $response->getStatusCode(),
-                        $response->getReasonPhrase()
+                        $response->getReasonPhrase(),
                     ),
                     true,
-                    $statusCode
+                    $statusCode,
                 );
             }
 
@@ -138,7 +138,7 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
             in_array(
                 strtolower(ini_get('display_errors')),
                 ['1', 'true', 'on', 'yes'],
-                true
+                true,
             )
         ) {
             $view = 'error_exception.php';

--- a/system/Debug/ExceptionHandler.php
+++ b/system/Debug/ExceptionHandler.php
@@ -47,7 +47,7 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
         RequestInterface $request,
         ResponseInterface $response,
         int $statusCode,
-        int $exitCode
+        int $exitCode,
     ): void {
         // ResponseTrait needs these properties.
         $this->request  = $request;
@@ -129,7 +129,7 @@ final class ExceptionHandler extends BaseExceptionHandler implements ExceptionHa
     protected function determineView(
         Throwable $exception,
         string $templatePath,
-        int $statusCode = 500
+        int $statusCode = 500,
     ): string {
         // Production environments should have a custom exception file.
         $view = 'production.php';

--- a/system/Debug/ExceptionHandlerInterface.php
+++ b/system/Debug/ExceptionHandlerInterface.php
@@ -27,6 +27,6 @@ interface ExceptionHandlerInterface
         RequestInterface $request,
         ResponseInterface $response,
         int $statusCode,
-        int $exitCode
+        int $exitCode,
     ): void;
 }

--- a/system/Debug/Exceptions.php
+++ b/system/Debug/Exceptions.php
@@ -164,7 +164,7 @@ class Exceptions
                 $this->request,
                 $this->response,
                 $statusCode,
-                $exitCode
+                $exitCode,
             );
 
             return;
@@ -270,7 +270,7 @@ class Exceptions
             in_array(
                 strtolower(ini_get('display_errors')),
                 ['1', 'true', 'on', 'yes'],
-                true
+                true,
             )
         ) {
             $view = 'error_exception.php';
@@ -462,7 +462,7 @@ class Exceptions
                 'errFile' => clean_path($file ?? ''),
                 'errLine' => $line ?? 0,
                 'trace'   => self::renderBacktrace($trace),
-            ]
+            ],
         );
 
         return true;
@@ -567,7 +567,7 @@ class Exceptions
                     "<span class='line highlight'><span class='number'>{$format}</span> %s\n</span>%s",
                     $n + $start + 1,
                     strip_tags($row),
-                    implode('', $tags[0])
+                    implode('', $tags[0]),
                 );
             } else {
                 $out .= sprintf('<span class="line"><span class="number">' . $format . '</span> %s', $n + $start + 1, $row) . "\n";
@@ -611,7 +611,7 @@ class Exceptions
                 $frame['class'],
                 $frame['type'],
                 $frame['function'],
-                $args
+                $args,
             );
         }
 

--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -58,7 +58,7 @@ class Toolbar
                 log_message(
                     'critical',
                     'Toolbar collector does not exist (' . $collector . ').'
-                    . ' Please check $collectors in the app/Config/Toolbar.php file.'
+                    . ' Please check $collectors in the app/Config/Toolbar.php file.',
                 );
 
                 continue;
@@ -391,7 +391,7 @@ class Toolbar
                 $stats['startTime'],
                 $stats['totalTime'],
                 $request,
-                $response
+                $response,
             );
 
             helper('filesystem');
@@ -439,8 +439,8 @@ class Toolbar
                         '/<head>/',
                         '<head>' . $script,
                         $response->getBody(),
-                        1
-                    )
+                        1,
+                    ),
                 );
 
                 return;
@@ -516,7 +516,7 @@ class Toolbar
             $history = new History();
             $history->setFiles(
                 $debugbarTime[0],
-                $this->config->maxHistory
+                $this->config->maxHistory,
             );
 
             $data['collectors'][] = $history->getAsArray();

--- a/system/Debug/Toolbar/Collectors/Database.php
+++ b/system/Debug/Toolbar/Collectors/Database.php
@@ -228,7 +228,7 @@ class Database extends BaseCollector
             $uniqueCount,
             $uniqueCount > 1 ? 'of them' : '',
             $connectionCount,
-            $connectionCount > 1 ? 's' : ''
+            $connectionCount > 1 ? 's' : '',
         );
     }
 

--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -109,7 +109,7 @@ class Routes extends BaseCollector
                     ' <empty> | default: '
                     . var_export(
                         $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null,
-                        true
+                        true,
                     ),
             ];
         }

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1659,7 +1659,7 @@ class Email
         $this->finalBody = preg_replace_callback(
             '/\{unwrap\}(.*?)\{\/unwrap\}/si',
             $this->removeNLCallback(...),
-            $this->finalBody
+            $this->finalBody,
         );
     }
 
@@ -1900,7 +1900,7 @@ class Email
             $this->SMTPPort,
             $errno,
             $errstr,
-            $this->SMTPTimeout
+            $this->SMTPTimeout,
         );
 
         if (! is_resource($this->SMTPConnect)) {
@@ -1921,7 +1921,7 @@ class Email
                 STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT
                 | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
                 | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
-                | STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT
+                | STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT,
             );
 
             if ($crypto !== true) {

--- a/system/Entity/Entity.php
+++ b/system/Entity/Entity.php
@@ -138,7 +138,7 @@ class Entity implements JsonSerializable
             array_merge($this->defaultCastHandlers, $this->castHandlers),
             null,
             null,
-            false
+            false,
         );
 
         $this->syncOriginal();
@@ -185,7 +185,7 @@ class Entity implements JsonSerializable
 
         if (is_array($this->datamap)) {
             $keys = array_unique(
-                [...array_diff($keys, $this->datamap), ...array_keys($this->datamap)]
+                [...array_diff($keys, $this->datamap), ...array_keys($this->datamap)],
             );
         }
 

--- a/system/Events/Events.php
+++ b/system/Events/Events.php
@@ -212,7 +212,7 @@ class Events
             if ($check === $listener) {
                 unset(
                     static::$listeners[$eventName][1][$index],
-                    static::$listeners[$eventName][2][$index]
+                    static::$listeners[$eventName][2][$index],
                 );
 
                 return true;

--- a/system/Exceptions/FrameworkException.php
+++ b/system/Exceptions/FrameworkException.php
@@ -68,7 +68,7 @@ class FrameworkException extends RuntimeException implements ExceptionInterface
             // @codeCoverageIgnoreStart
             $message = sprintf(
                 'The framework needs the following extension(s) installed and loaded: %s.',
-                $extension
+                $extension,
             );
             // @codeCoverageIgnoreEnd
         } else {

--- a/system/Files/FileCollection.php
+++ b/system/Files/FileCollection.php
@@ -103,7 +103,7 @@ class FileCollection implements Countable, IteratorAggregate
             $pattern = str_replace(
                 ['#', '.', '*', '?'],
                 ['\#', '\.', '.*', '.'],
-                $pattern
+                $pattern,
             );
             $pattern = "#\\A{$pattern}\\z#";
         }

--- a/system/Filters/Filters.php
+++ b/system/Filters/Filters.php
@@ -202,7 +202,7 @@ class Filters
 
             $result = $class->before(
                 $this->request,
-                $this->argumentsClass[$className] ?? null
+                $this->argumentsClass[$className] ?? null,
             );
 
             if ($result instanceof RequestInterface) {
@@ -241,7 +241,7 @@ class Filters
             $result = $class->after(
                 $this->request,
                 $this->response,
-                $this->argumentsClass[$className] ?? null
+                $this->argumentsClass[$className] ?? null,
             );
 
             if ($result instanceof ResponseInterface) {
@@ -648,7 +648,7 @@ class Filters
             @trigger_error(
                 'Setting lowercase HTTP method key "' . strtolower($method) . '" is deprecated.'
                 . ' Use uppercase HTTP method like "' . strtoupper($method) . '".',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
 
             $found  = true;
@@ -744,7 +744,7 @@ class Filters
             if ($check && array_key_exists($name, $this->arguments)) {
                 throw new ConfigException(
                     '"' . $name . '" already has arguments: '
-                    . (($this->arguments[$name] === null) ? 'null' : implode(',', $this->arguments[$name]))
+                    . (($this->arguments[$name] === null) ? 'null' : implode(',', $this->arguments[$name])),
                 );
             }
 

--- a/system/Filters/PerformanceMetrics.php
+++ b/system/Filters/PerformanceMetrics.php
@@ -53,7 +53,7 @@ class PerformanceMetrics implements FilterInterface
                     (string) $benchmark->getElapsedTime('total_execution'),
                     number_format(memory_get_peak_usage() / 1024 / 1024, 3),
                 ],
-                $body
+                $body,
             );
 
             $response->setBody($output);

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -342,7 +342,7 @@ class CURLRequest extends OutgoingRequest
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 

--- a/system/HTTP/Cors.php
+++ b/system/HTTP/Cors.php
@@ -107,7 +107,7 @@ class Cors
         if (in_array('*', $this->config[$name], true) && $count > 1) {
             throw new ConfigException(
                 "If wildcard is specified, you must set `'{$name}' => ['*']`."
-                . ' But using wildcard is not recommended.'
+                . ' But using wildcard is not recommended.',
             );
         }
     }
@@ -121,7 +121,7 @@ class Cors
             throw new ConfigException(
                 'When responding to a credentialed request, '
                 . 'the server must not specify the "*" wildcard for the '
-                . $header . ' response-header value.'
+                . $header . ' response-header value.',
             );
         }
     }
@@ -176,7 +176,7 @@ class Cors
 
         $response->setHeader(
             'Access-Control-Allow-Headers',
-            implode(', ', $this->config['allowedHeaders'])
+            implode(', ', $this->config['allowedHeaders']),
         );
     }
 
@@ -187,7 +187,7 @@ class Cors
 
         $response->setHeader(
             'Access-Control-Allow-Methods',
-            implode(', ', $this->config['allowedMethods'])
+            implode(', ', $this->config['allowedMethods']),
         );
     }
 
@@ -223,7 +223,7 @@ class Cors
         if ($this->config['exposedHeaders'] !== []) {
             $response->setHeader(
                 'Access-Control-Expose-Headers',
-                implode(', ', $this->config['exposedHeaders'])
+                implode(', ', $this->config['exposedHeaders']),
             );
         }
     }

--- a/system/HTTP/Exceptions/RedirectException.php
+++ b/system/HTTP/Exceptions/RedirectException.php
@@ -45,7 +45,7 @@ class RedirectException extends Exception implements ResponsableInterface, HTTPE
             throw new InvalidArgumentException(
                 'RedirectException::__construct() first argument must be a string or ResponseInterface',
                 0,
-                $this
+                $this,
             );
         }
 
@@ -55,7 +55,7 @@ class RedirectException extends Exception implements ResponsableInterface, HTTPE
 
             if ($this->response->getHeaderLine('Location') === '' && $this->response->getHeaderLine('Refresh') === '') {
                 throw new LogicException(
-                    'The Response object passed to RedirectException does not contain a redirect address.'
+                    'The Response object passed to RedirectException does not contain a redirect address.',
                 );
             }
 
@@ -76,7 +76,7 @@ class RedirectException extends Exception implements ResponsableInterface, HTTPE
 
         service('logger')->info(
             'REDIRECTED ROUTE at '
-             . ($this->response->getHeaderLine('Location') ?: substr($this->response->getHeaderLine('Refresh'), 6))
+             . ($this->response->getHeaderLine('Location') ?: substr($this->response->getHeaderLine('Refresh'), 6)),
         );
 
         return $this->response;

--- a/system/HTTP/Files/FileCollection.php
+++ b/system/HTTP/Files/FileCollection.php
@@ -189,7 +189,7 @@ class FileCollection
             $array['type'] ?? null,
             ($array['size'] ?? null) === null ? null : (int) $array['size'],
             $array['error'] ?? null,
-            $array['full_path'] ?? null
+            $array['full_path'] ?? null,
         );
     }
 
@@ -219,7 +219,7 @@ class FileCollection
                 $stack    = [&$pointer];
                 $iterator = new RecursiveIteratorIterator(
                     new RecursiveArrayIterator($value),
-                    RecursiveIteratorIterator::SELF_FIRST
+                    RecursiveIteratorIterator::SELF_FIRST,
                 );
 
                 foreach ($iterator as $key => $val) {

--- a/system/HTTP/Message.php
+++ b/system/HTTP/Message.php
@@ -119,7 +119,7 @@ class Message implements MessageInterface
         if ($this->hasMultipleHeaders($name)) {
             throw new InvalidArgumentException(
                 'The header "' . $name . '" already has multiple headers.'
-                . ' You cannot use getHeaderLine().'
+                . ' You cannot use getHeaderLine().',
             );
         }
 

--- a/system/HTTP/MessageTrait.php
+++ b/system/HTTP/MessageTrait.php
@@ -182,7 +182,7 @@ trait MessageTrait
         if ($this->hasMultipleHeaders($name)) {
             throw new InvalidArgumentException(
                 'The header "' . $name . '" already has multiple headers.'
-                . ' You cannot change them. If you really need to change, remove the header first.'
+                . ' You cannot change them. If you really need to change, remove the header first.',
             );
         }
     }

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -154,7 +154,7 @@ class Negotiate
         ?string $header = null,
         bool $enforceTypes = false,
         bool $strictMatch = false,
-        bool $matchLocales = false
+        bool $matchLocales = false,
     ): string {
         if ($supported === []) {
             throw HTTPException::forEmptySupportedNegotiations();

--- a/system/HTTP/Negotiate.php
+++ b/system/HTTP/Negotiate.php
@@ -90,7 +90,7 @@ class Negotiate
             $supported,
             $this->request->getHeaderLine('accept-charset'),
             false,
-            true
+            true,
         );
 
         // If no charset is shown as a match, ignore the directive
@@ -212,7 +212,7 @@ class Negotiate
                 if (preg_match(
                     '/^(?P<name>.+?)=(?P<quoted>"|\')?(?P<value>.*?)(?:\k<quoted>)?$/',
                     $pair,
-                    $param
+                    $param,
                 )) {
                     $parameters[trim($param['name'])] = trim($param['value']);
                 }

--- a/system/HTTP/OutgoingRequest.php
+++ b/system/HTTP/OutgoingRequest.php
@@ -43,7 +43,7 @@ class OutgoingRequest extends Message implements OutgoingRequestInterface
         ?URI $uri = null,
         array $headers = [],
         $body = null,
-        string $version = '1.1'
+        string $version = '1.1',
     ) {
         $this->method = $method;
         $this->uri    = $uri;

--- a/system/HTTP/RequestTrait.php
+++ b/system/HTTP/RequestTrait.php
@@ -72,7 +72,7 @@ trait RequestTrait
 
         if (! empty($proxyIPs) && (! is_array($proxyIPs) || is_int(array_key_first($proxyIPs)))) {
             throw new ConfigException(
-                'You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.'
+                'You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.',
             );
         }
 

--- a/system/HTTP/ResponseInterface.php
+++ b/system/HTTP/ResponseInterface.php
@@ -341,7 +341,7 @@ interface ResponseInterface extends MessageInterface
         $prefix = '',
         $secure = false,
         $httponly = false,
-        $samesite = null
+        $samesite = null,
     );
 
     /**

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -512,7 +512,7 @@ trait ResponseTrait
         $prefix = '',
         $secure = null,
         $httponly = null,
-        $samesite = null
+        $samesite = null,
     ) {
         if ($name instanceof Cookie) {
             $this->cookieStore = $this->cookieStore->put($name);

--- a/system/HTTP/ResponseTrait.php
+++ b/system/HTTP/ResponseTrait.php
@@ -407,14 +407,14 @@ trait ResponseTrait
                 header(
                     $name . ': ' . $value->getValueLine(),
                     false,
-                    $this->getStatusCode()
+                    $this->getStatusCode(),
                 );
             } else {
                 foreach ($value as $header) {
                     header(
                         $name . ': ' . $header->getValueLine(),
                         false,
-                        $this->getStatusCode()
+                        $this->getStatusCode(),
                     );
                 }
             }

--- a/system/HTTP/SiteURI.php
+++ b/system/HTTP/SiteURI.php
@@ -199,7 +199,7 @@ class SiteURI extends URI
         // Validate baseURL
         if (filter_var($baseURL, FILTER_VALIDATE_URL) === false) {
             throw new ConfigException(
-                'Config\App::$baseURL "' . $baseURL . '" is not a valid URL.'
+                'Config\App::$baseURL "' . $baseURL . '" is not a valid URL.',
             );
         }
 
@@ -266,7 +266,7 @@ class SiteURI extends URI
             $this->getAuthority(),
             $this->getPath(),
             $this->getQuery(),
-            $this->getFragment()
+            $this->getFragment(),
         );
     }
 

--- a/system/HTTP/SiteURI.php
+++ b/system/HTTP/SiteURI.php
@@ -95,7 +95,7 @@ class SiteURI extends URI
         App $configApp,
         string $relativePath = '',
         ?string $host = null,
-        ?string $scheme = null
+        ?string $scheme = null,
     ) {
         $this->indexPage = $configApp->indexPage;
 
@@ -142,7 +142,7 @@ class SiteURI extends URI
     private function determineBaseURL(
         App $configApp,
         ?string $host,
-        ?string $scheme
+        ?string $scheme,
     ): URI {
         $baseURL = $this->normalizeBaseURL($configApp);
 

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -638,7 +638,7 @@ class URI implements Stringable
             $this->getAuthority(),
             $path, // Absolute URIs should use a "/" for an empty path
             $this->getQuery(),
-            $this->getFragment()
+            $this->getFragment(),
         );
     }
 
@@ -1022,7 +1022,7 @@ class URI implements Stringable
         $path = preg_replace_callback(
             '/(?:[^' . static::CHAR_UNRESERVED . ':@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/',
             static fn (array $matches): string => rawurlencode($matches[0]),
-            $path
+            $path,
         );
 
         return $path;
@@ -1170,7 +1170,7 @@ class URI implements Stringable
         $params = array_map(static fn (string $chunk): ?string => preg_replace_callback(
             '/^(?<key>[^&=]+?)(?:\[[^&=]*\])?=(?<value>[^&=]+)/',
             static fn (array $match): string => str_replace($match['key'], bin2hex($match['key']), $match[0]),
-            urldecode($chunk)
+            urldecode($chunk),
         ), $query);
 
         $params = implode('&', $params);

--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -163,7 +163,7 @@ class URI implements Stringable
         ?string $authority = null,
         ?string $path = null,
         ?string $query = null,
-        ?string $fragment = null
+        ?string $fragment = null,
     ): string {
         $uri = '';
         if ($scheme !== null && $scheme !== '') {

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -210,7 +210,7 @@ final class ArrayHelper
         array $result,
         array $row,
         array $indexes,
-        bool $includeEmpty
+        bool $includeEmpty,
     ): array {
         if (($index = array_shift($indexes)) === null) {
             $result[] = $row;

--- a/system/Helpers/Array/ArrayHelper.php
+++ b/system/Helpers/Array/ArrayHelper.php
@@ -54,12 +54,12 @@ final class ArrayHelper
             '/(?<!\\\\)\./',
             rtrim($index, '* '),
             0,
-            PREG_SPLIT_NO_EMPTY
+            PREG_SPLIT_NO_EMPTY,
         );
 
         return array_map(
             static fn ($key): string => str_replace('\.', '.', $key),
-            $segments
+            $segments,
         );
     }
 
@@ -130,7 +130,7 @@ final class ArrayHelper
     {
         if (str_ends_with($index, '*') || str_contains($index, '*.*')) {
             throw new InvalidArgumentException(
-                'You must set key right after "*". Invalid index: "' . $index . '"'
+                'You must set key right after "*". Invalid index: "' . $index . '"',
             );
         }
 

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -46,7 +46,7 @@ if (! function_exists('set_cookie')) {
         string $prefix = '',
         ?bool $secure = null,
         ?bool $httpOnly = null,
-        ?string $sameSite = null
+        ?string $sameSite = null,
     ): void {
         $response = service('response');
         $response->setCookie($name, $value, $expire, $domain, $path, $prefix, $secure, $httpOnly, $sameSite);

--- a/system/Helpers/date_helper.php
+++ b/system/Helpers/date_helper.php
@@ -43,7 +43,7 @@ if (! function_exists('now')) {
             $year,
             $hour,
             $minute,
-            $second
+            $second,
         );
 
         return mktime($hour, $minute, $second, $month, $day, $year);

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -202,7 +202,7 @@ if (! function_exists('get_filenames')) {
         string $sourceDir,
         ?bool $includePath = false,
         bool $hidden = false,
-        bool $includeDir = true
+        bool $includeDir = true,
     ): array {
         $files = [];
 

--- a/system/Helpers/filesystem_helper.php
+++ b/system/Helpers/filesystem_helper.php
@@ -87,7 +87,7 @@ if (! function_exists('directory_mirror')) {
          */
         foreach (new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($originDir, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::SELF_FIRST
+            RecursiveIteratorIterator::SELF_FIRST,
         ) as $file) {
             $origin = $file->getPathname();
             $target = $targetDir . substr($origin, $dirLen);
@@ -159,7 +159,7 @@ if (! function_exists('delete_files')) {
         try {
             foreach (new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS),
-                RecursiveIteratorIterator::CHILD_FIRST
+                RecursiveIteratorIterator::CHILD_FIRST,
             ) as $object) {
                 $filename = $object->getFilename();
                 if (! $hidden && $filename[0] === '.') {
@@ -212,7 +212,7 @@ if (! function_exists('get_filenames')) {
         try {
             foreach (new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
-                RecursiveIteratorIterator::SELF_FIRST
+                RecursiveIteratorIterator::SELF_FIRST,
             ) as $name => $object) {
                 $basename = pathinfo($name, PATHINFO_BASENAME);
                 if (! $hidden && $basename[0] === '.') {

--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -741,7 +741,7 @@ if (! function_exists('validation_show_error')) {
 
         $errors = array_filter(validation_errors(), static fn ($key): bool => preg_match(
             '/^' . str_replace(['\.\*', '\*\.'], ['\..+', '.+\.'], preg_quote($field, '/')) . '$/',
-            $key
+            $key,
         ) === 1, ARRAY_FILTER_USE_KEY);
 
         if ($errors === []) {

--- a/system/Helpers/html_helper.php
+++ b/system/Helpers/html_helper.php
@@ -238,7 +238,7 @@ if (! function_exists('link_tag')) {
         string $title = '',
         string $media = '',
         bool $indexPage = false,
-        string $hreflang = ''
+        string $hreflang = '',
     ): string {
         $attributes = [];
         // extract fields if needed

--- a/system/Helpers/inflector_helper.php
+++ b/system/Helpers/inflector_helper.php
@@ -278,7 +278,7 @@ if (! function_exists('is_pluralizable')) {
                 'wisdom',
                 'work',
             ],
-            true
+            true,
         );
 
         return ! $uncountables;

--- a/system/Helpers/security_helper.php
+++ b/system/Helpers/security_helper.php
@@ -35,7 +35,7 @@ if (! function_exists('strip_image_tags')) {
                 '#<img[\s/]+.*?src\s*=\s*?(([^\s"\'=<>`]+)).*?\>#i',
             ],
             '\\2',
-            $str
+            $str,
         );
     }
 }

--- a/system/Helpers/text_helper.php
+++ b/system/Helpers/text_helper.php
@@ -152,7 +152,7 @@ if (! function_exists('entities_to_ascii')) {
             return str_replace(
                 ['&amp;', '&lt;', '&gt;', '&quot;', '&apos;', '&#45;'],
                 ['&', '<', '>', '"', "'", '-'],
-                $str
+                $str,
             );
         }
 
@@ -193,7 +193,7 @@ if (! function_exists('word_censor')) {
                 $str = preg_replace(
                     "/({$delim})(" . $badword . ")({$delim})/i",
                     "\\1{$replacement}\\3",
-                    $str
+                    $str,
                 );
             } elseif (preg_match_all("/{$delim}(" . $badword . "){$delim}/i", $str, $matches, PREG_PATTERN_ORDER | PREG_OFFSET_CAPTURE) >= 1) {
                 $matches = $matches[1];
@@ -205,7 +205,7 @@ if (! function_exists('word_censor')) {
                         $str,
                         str_repeat('#', $length),
                         $matches[$i][1],
-                        $length
+                        $length,
                     );
                 }
             }
@@ -235,7 +235,7 @@ if (! function_exists('highlight_code')) {
         $str = str_replace(
             ['&lt;', '&gt;', '<?', '?>', '<%', '%>', '\\', '</script>'],
             ['<', '>', 'phptagopen', 'phptagclose', 'asptagopen', 'asptagclose', 'backslashtmp', 'scriptclose'],
-            $str
+            $str,
         );
 
         // The highlight_string function requires that the text be surrounded
@@ -254,7 +254,7 @@ if (! function_exists('highlight_code')) {
                 "$1</span>\n</span>\n</code>",
                 '',
             ],
-            $str
+            $str,
         );
 
         // Replace our markers back to PHP tags.
@@ -275,7 +275,7 @@ if (! function_exists('highlight_code')) {
                 '\\',
                 '&lt;/script&gt;',
             ],
-            $str
+            $str,
         );
     }
 }
@@ -581,7 +581,7 @@ if (! function_exists('random_string')) {
             case 'crypto':
                 if ($len % 2 !== 0) {
                     throw new InvalidArgumentException(
-                        'You must set an even number to the second parameter when you use `crypto`.'
+                        'You must set an even number to the second parameter when you use `crypto`.',
                     );
                 }
 
@@ -611,7 +611,7 @@ if (! function_exists('_from_random')) {
     {
         if ($length <= 0) {
             throw new InvalidArgumentException(
-                sprintf('A strictly positive length is expected, "%d" given.', $length)
+                sprintf('A strictly positive length is expected, "%d" given.', $length),
             );
         }
 
@@ -619,7 +619,7 @@ if (! function_exists('_from_random')) {
         $bits     = (int) ceil(log($poolSize, 2.0));
         if ($bits <= 0 || $bits > 56) {
             throw new InvalidArgumentException(
-                'The length of the alphabet must in the [2^1, 2^56] range.'
+                'The length of the alphabet must in the [2^1, 2^56] range.',
             );
         }
 

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -359,7 +359,7 @@ if (! function_exists('auto_link')) {
                 '#([a-z][a-z0-9+\-.]*://|www\.)[a-z0-9]+(-+[a-z0-9]+)*(\.[a-z0-9]+(-+[a-z0-9]+)*)+(/([^\s()<>;]+\w)?/?)?#i',
                 $str,
                 $matches,
-                PREG_OFFSET_CAPTURE | PREG_SET_ORDER
+                PREG_OFFSET_CAPTURE | PREG_SET_ORDER,
             ) >= 1
         ) {
             // Set our target HTML if using popup links.
@@ -386,7 +386,7 @@ if (! function_exists('auto_link')) {
                 '#([\w\.\-\+]+@[a-z0-9\-]+\.[a-z0-9\-\.]+[^[:punct:]\s])#i',
                 $str,
                 $matches,
-                PREG_OFFSET_CAPTURE
+                PREG_OFFSET_CAPTURE,
             ) >= 1
         ) {
             foreach (array_reverse($matches[0]) as $match) {

--- a/system/Honeypot/Honeypot.php
+++ b/system/Honeypot/Honeypot.php
@@ -85,7 +85,7 @@ class Honeypot
             $this->config->container = str_ireplace(
                 '>{template}',
                 ' id="' . $this->config->containerId . '">{template}',
-                $this->config->container
+                $this->config->container,
             );
         }
 

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -222,7 +222,7 @@ trait TimeTrait
         ?int $minutes = null,
         ?int $seconds = null,
         $timezone = null,
-        ?string $locale = null
+        ?string $locale = null,
     ) {
         $year ??= date('Y');
         $month ??= date('m');

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -665,7 +665,7 @@ trait TimeTrait
             (int) $minute,
             (int) $second,
             $this->getTimezoneName(),
-            $this->locale
+            $this->locale,
         );
     }
 

--- a/system/Images/Handlers/GDHandler.php
+++ b/system/Images/Handlers/GDHandler.php
@@ -322,7 +322,7 @@ class GDHandler extends BaseHandler
             // if valid image type, make corresponding image resource
             $this->resource = $this->getImageResource(
                 $this->image()->getPathname(),
-                $this->image()->imageType
+                $this->image()->imageType,
             );
         }
     }

--- a/system/Language/Language.php
+++ b/system/Language/Language.php
@@ -206,11 +206,11 @@ class Language
 
             $argsString = implode(
                 ', ',
-                array_map(static fn ($element): string => '"' . $element . '"', $args)
+                array_map(static fn ($element): string => '"' . $element . '"', $args),
             );
             $argsUrlEncoded = implode(
                 ', ',
-                array_map(static fn ($element): string => '"' . rawurlencode($element) . '"', $args)
+                array_map(static fn ($element): string => '"' . rawurlencode($element) . '"', $args),
             );
 
             log_message(
@@ -218,7 +218,7 @@ class Language
                 'Language.invalidMessageFormat: $message: "' . $message
                 . '", $args: ' . $argsString
                 . ' (urlencoded: ' . $argsUrlEncoded . '),'
-                . ' MessageFormatter Error: ' . $fmtError
+                . ' MessageFormatter Error: ' . $fmtError,
             );
 
             return $message . "\n【Warning】Also, invalid string(s) was passed to the Language class. See log file for details.";

--- a/system/Log/Handlers/ChromeLoggerHandler.php
+++ b/system/Log/Handlers/ChromeLoggerHandler.php
@@ -160,7 +160,7 @@ class ChromeLoggerHandler extends BaseHandler
         }
 
         $data = base64_encode(
-            mb_convert_encoding(json_encode($this->json), 'UTF-8', mb_list_encodings())
+            mb_convert_encoding(json_encode($this->json), 'UTF-8', mb_list_encodings()),
         );
 
         $response->setHeader($this->header, $data);

--- a/system/Model.php
+++ b/system/Model.php
@@ -373,17 +373,17 @@ class Model extends BaseModel
                 $allFields = $this->db->protectIdentifiers(
                     array_map(
                         static fn ($row) => $row->name,
-                        $this->db->getFieldData($this->table)
+                        $this->db->getFieldData($this->table),
                     ),
                     false,
-                    true
+                    true,
                 );
 
                 $sql = sprintf(
                     'INSERT INTO %s (%s) VALUES (%s)',
                     $table,
                     implode(',', $allFields),
-                    substr(str_repeat(',DEFAULT', count($allFields)), 1)
+                    substr(str_repeat(',DEFAULT', count($allFields)), 1),
                 );
             } else {
                 $sql = 'INSERT INTO ' . $table . ' DEFAULT VALUES';
@@ -454,7 +454,7 @@ class Model extends BaseModel
 
         if ($builder->getCompiledQBWhere() === []) {
             throw new DatabaseException(
-                'Updates are not allowed unless they contain a "where" or "like" clause.'
+                'Updates are not allowed unless they contain a "where" or "like" clause.',
             );
         }
 
@@ -503,7 +503,7 @@ class Model extends BaseModel
         if ($this->useSoftDeletes && ! $purge) {
             if ($builder->getCompiledQBWhere() === []) {
                 throw new DatabaseException(
-                    'Deletes are not allowed unless they contain a "where" or "like" clause.'
+                    'Deletes are not allowed unless they contain a "where" or "like" clause.',
                 );
             }
 

--- a/system/Pager/Pager.php
+++ b/system/Pager/Pager.php
@@ -295,7 +295,7 @@ class Pager implements PagerInterface
                 $uri->getAuthority(),
                 $uri->getPath(),
                 $uri->getQuery(),
-                $uri->getFragment()
+                $uri->getFragment(),
             );
     }
 

--- a/system/Pager/PagerRenderer.php
+++ b/system/Pager/PagerRenderer.php
@@ -148,7 +148,7 @@ class PagerRenderer
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 
@@ -186,7 +186,7 @@ class PagerRenderer
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 
@@ -208,7 +208,7 @@ class PagerRenderer
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 
@@ -230,7 +230,7 @@ class PagerRenderer
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 
@@ -252,7 +252,7 @@ class PagerRenderer
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 
@@ -278,7 +278,7 @@ class PagerRenderer
                     $uri->getAuthority(),
                     $uri->getPath(),
                     $uri->getQuery(),
-                    $uri->getFragment()
+                    $uri->getFragment(),
                 ),
                 'title'  => $i,
                 'active' => ($i === $this->current),
@@ -341,7 +341,7 @@ class PagerRenderer
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 
@@ -379,7 +379,7 @@ class PagerRenderer
             $uri->getAuthority(),
             $uri->getPath(),
             $uri->getQuery(),
-            $uri->getFragment()
+            $uri->getFragment(),
         );
     }
 

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -118,19 +118,19 @@ final class AutoRouter implements AutoRouterInterface
                     // Like $routes->cli('hello/(:segment)', 'Home::$1')
                     if (str_contains($handler, '::$')) {
                         throw new PageNotFoundException(
-                            'Cannot access CLI Route: ' . $uri
+                            'Cannot access CLI Route: ' . $uri,
                         );
                     }
 
                     if (str_starts_with($handler, $controller . '::' . $methodName)) {
                         throw new PageNotFoundException(
-                            'Cannot access CLI Route: ' . $uri
+                            'Cannot access CLI Route: ' . $uri,
                         );
                     }
 
                     if ($handler === $controller) {
                         throw new PageNotFoundException(
-                            'Cannot access CLI Route: ' . $uri
+                            'Cannot access CLI Route: ' . $uri,
                         );
                     }
                 }
@@ -153,9 +153,9 @@ final class AutoRouter implements AutoRouterInterface
                 str_replace(
                     '/',
                     '\\',
-                    $this->defaultNamespace . $this->directory . $controllerName
+                    $this->defaultNamespace . $this->directory . $controllerName,
                 ),
-                '\\'
+                '\\',
             );
         }
 
@@ -199,7 +199,7 @@ final class AutoRouter implements AutoRouterInterface
 
         while ($c-- > 0) {
             $segmentConvert = ucfirst(
-                $this->translateURIDashes ? str_replace('-', '_', $segments[0]) : $segments[0]
+                $this->translateURIDashes ? str_replace('-', '_', $segments[0]) : $segments[0],
             );
             // as soon as we encounter any segment that is not PSR-4 compliant, stop searching
             if (! $this->isValidSegment($segmentConvert)) {

--- a/system/Router/AutoRouter.php
+++ b/system/Router/AutoRouter.php
@@ -51,7 +51,7 @@ final class AutoRouter implements AutoRouterInterface
          * Whether dashes in URI's should be converted
          * to underscores when determining method names.
          */
-        private bool $translateURIDashes
+        private bool $translateURIDashes,
     ) {
     }
 

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -210,7 +210,7 @@ final class AutoRouterImproved implements AutoRouterInterface
 
             $namespaces = array_map(
                 fn ($segment): string => $this->translateURI($segment),
-                $segments
+                $segments,
             );
 
             $controller = '\\' . $this->namespace
@@ -288,7 +288,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                 strtolower($baseControllerName) === strtolower($this->defaultController)
             ) {
                 throw new PageNotFoundException(
-                    'Cannot access the default controller "' . $this->controller . '" with the controller name URI path.'
+                    'Cannot access the default controller "' . $this->controller . '" with the controller name URI path.',
                 );
             }
         } elseif ($this->searchLastDefaultController()) {
@@ -329,14 +329,14 @@ final class AutoRouterImproved implements AutoRouterInterface
             // Prevent access to default controller's method
             if (strtolower($baseControllerName) === strtolower($this->defaultController)) {
                 throw new PageNotFoundException(
-                    'Cannot access the default controller "' . $this->controller . '::' . $this->method . '"'
+                    'Cannot access the default controller "' . $this->controller . '::' . $this->method . '"',
                 );
             }
 
             // Prevent access to default method path
             if (strtolower($this->method) === strtolower($defaultMethod)) {
                 throw new PageNotFoundException(
-                    'Cannot access the default method "' . $this->method . '" with the method name URI path.'
+                    'Cannot access the default method "' . $this->method . '" with the method name URI path.',
                 );
             }
         } elseif (method_exists($this->controller, $defaultMethod)) {
@@ -400,7 +400,7 @@ final class AutoRouterImproved implements AutoRouterInterface
         $dir = str_replace(
             '\\',
             '/',
-            ltrim(substr($namespaces, strlen($this->namespace)), '\\')
+            ltrim(substr($namespaces, strlen($this->namespace)), '\\'),
         );
 
         if ($dir !== '') {
@@ -417,7 +417,7 @@ final class AutoRouterImproved implements AutoRouterInterface
 
             if ($routeLowerCase === $controller) {
                 throw new PageNotFoundException(
-                    'Cannot access the controller in Defined Routes. Controller: ' . $controllerInRoutes
+                    'Cannot access the controller in Defined Routes. Controller: ' . $controllerInRoutes,
                 );
             }
         }
@@ -446,7 +446,7 @@ final class AutoRouterImproved implements AutoRouterInterface
             throw new PageNotFoundException(
                 'The param count in the URI are greater than the controller method params.'
                 . ' Handler:' . $this->controller . '::' . $this->method
-                . ', URI:' . $this->uri
+                . ', URI:' . $this->uri,
             );
         }
     }
@@ -459,7 +459,7 @@ final class AutoRouterImproved implements AutoRouterInterface
 
             throw new PageNotFoundException(
                 'AutoRouterImproved does not support `_remap()` method.'
-                . ' Controller:' . $this->controller
+                . ' Controller:' . $this->controller,
             );
         } catch (ReflectionException) {
             // Do nothing.
@@ -482,7 +482,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                     . ' when $translateURIDashes is enabled.'
                     . ' Please use the dash.'
                     . ' Handler:' . $this->controller . '::' . $this->method
-                    . ', URI:' . $this->uri
+                    . ', URI:' . $this->uri,
                 );
             }
         }
@@ -502,7 +502,7 @@ final class AutoRouterImproved implements AutoRouterInterface
 
         if (! in_array(ltrim($classname, '\\'), get_declared_classes(), true)) {
             throw new PageNotFoundException(
-                '"' . $classname . '" is not found.'
+                '"' . $classname . '" is not found.',
             );
         }
     }
@@ -531,7 +531,7 @@ final class AutoRouterImproved implements AutoRouterInterface
             && ! in_array($method, get_class_methods($this->controller), true)
         ) {
             throw new PageNotFoundException(
-                '"' . $this->controller . '::' . $method . '()" is not found.'
+                '"' . $this->controller . '::' . $method . '()" is not found.',
             );
         }
     }
@@ -558,7 +558,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                     . ' containing uppercase letters ("' . $segment . '")'
                     . ' when $translateUriToCamelCase is enabled.'
                     . ' Please use the dash.'
-                    . ' URI:' . $this->uri
+                    . ' URI:' . $this->uri,
                 );
             }
 
@@ -568,7 +568,7 @@ final class AutoRouterImproved implements AutoRouterInterface
                     . ' containing double dash ("' . $segment . '")'
                     . ' when $translateUriToCamelCase is enabled.'
                     . ' Please use the single dash.'
-                    . ' URI:' . $this->uri
+                    . ' URI:' . $this->uri,
                 );
             }
 
@@ -576,8 +576,8 @@ final class AutoRouterImproved implements AutoRouterInterface
                 ' ',
                 '',
                 ucwords(
-                    preg_replace('/[\-]+/', ' ', $segment)
-                )
+                    preg_replace('/[\-]+/', ' ', $segment),
+                ),
             );
         }
 

--- a/system/Router/AutoRouterImproved.php
+++ b/system/Router/AutoRouterImproved.php
@@ -121,7 +121,7 @@ final class AutoRouterImproved implements AutoRouterInterface
          * Whether dashes in URI's should be converted
          * to underscores when determining method names.
          */
-        private readonly bool $translateURIDashes
+        private readonly bool $translateURIDashes,
     ) {
         $this->namespace = rtrim($namespace, '\\');
 

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -634,7 +634,7 @@ class RouteCollection implements RouteCollectionInterface
             @trigger_error(
                 'Passing lowercase HTTP method "' . $verb . '" is deprecated.'
                 . ' Use uppercase HTTP method like "' . strtoupper($verb) . '".',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
         }
 
@@ -791,7 +791,7 @@ class RouteCollection implements RouteCollectionInterface
             // Merge options other than filters.
             $this->currentOptions = array_merge(
                 $this->currentOptions ?? [],
-                $options
+                $options,
             );
         }
 
@@ -1026,7 +1026,7 @@ class RouteCollection implements RouteCollectionInterface
                 @trigger_error(
                     'Passing lowercase HTTP method "' . $verb . '" is deprecated.'
                     . ' Use uppercase HTTP method like "' . strtoupper($verb) . '".',
-                    E_USER_DEPRECATED
+                    E_USER_DEPRECATED,
                 );
             }
 
@@ -1382,7 +1382,7 @@ class RouteCollection implements RouteCollectionInterface
         foreach ($placeholders as $index => $placeholder) {
             if (! isset($params[$index])) {
                 throw new InvalidArgumentException(
-                    'Missing argument for "' . $placeholder . '" in route "' . $from . '".'
+                    'Missing argument for "' . $placeholder . '" in route "' . $from . '".',
                 );
             }
 
@@ -1506,7 +1506,7 @@ class RouteCollection implements RouteCollectionInterface
                     '/\$X/',
                     static fn ($m): string => '$' . $i,
                     $to,
-                    1
+                    1,
                 );
             }
         }
@@ -1773,7 +1773,7 @@ class RouteCollection implements RouteCollectionInterface
             @trigger_error(
                 'Passing lowercase HTTP method "' . $verb . '" is deprecated.'
                 . ' Use uppercase HTTP method like "' . strtoupper($verb) . '".',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
         }
 

--- a/system/Router/Router.php
+++ b/system/Router/Router.php
@@ -167,7 +167,7 @@ class Router implements RouterInterface
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),
-                    $this->translateURIDashes
+                    $this->translateURIDashes,
                 );
             } else {
                 $this->autoRouter = new AutoRouter(
@@ -175,7 +175,7 @@ class Router implements RouterInterface
                     $this->collection->getDefaultNamespace(),
                     $this->collection->getDefaultController(),
                     $this->collection->getDefaultMethod(),
-                    $this->translateURIDashes
+                    $this->translateURIDashes,
                 );
             }
         }
@@ -221,7 +221,7 @@ class Router implements RouterInterface
         // want this, like in the case of API's.
         if (! $this->collection->shouldAutoRoute()) {
             throw new PageNotFoundException(
-                "Can't find a route for '{$this->collection->getHTTPVerb()}: {$uri}'."
+                "Can't find a route for '{$this->collection->getHTTPVerb()}: {$uri}'.",
             );
         }
 
@@ -442,7 +442,7 @@ class Router implements RouterInterface
 
                     throw new RedirectException(
                         preg_replace('#\A' . $routeKey . '\z#u', $redirectTo, $uri),
-                        $this->collection->getRedirectCode($routeKey)
+                        $this->collection->getRedirectCode($routeKey),
                     );
                 }
                 // Store our locale so CodeIgniter object can
@@ -451,7 +451,7 @@ class Router implements RouterInterface
                     preg_match(
                         '#^' . str_replace('{locale}', '(?<locale>[^/]+)', $matchedKey) . '$#u',
                         $uri,
-                        $matched
+                        $matched,
                     );
 
                     if ($this->collection->shouldUseSupportedLocalesOnly()
@@ -546,7 +546,7 @@ class Router implements RouterInterface
 
                 return $matches[$index] ?? '';
             },
-            $input
+            $input,
         );
     }
 
@@ -736,7 +736,7 @@ class Router implements RouterInterface
                 && preg_match('/\A[' . $this->permittedURIChars . ']+\z/iu', $segment) !== 1
             ) {
                 throw new BadRequestException(
-                    'The URI you submitted has disallowed characters: "' . $segment . '"'
+                    'The URI you submitted has disallowed characters: "' . $segment . '"',
                 );
             }
         }

--- a/system/Security/Exceptions/SecurityException.php
+++ b/system/Security/Exceptions/SecurityException.php
@@ -50,7 +50,7 @@ class SecurityException extends FrameworkException implements HTTPExceptionInter
     {
         return new static(
             'Invalid UTF-8 characters in ' . $source . ': ' . $string,
-            400
+            400,
         );
     }
 
@@ -66,7 +66,7 @@ class SecurityException extends FrameworkException implements HTTPExceptionInter
     {
         return new static(
             'Invalid Control characters in ' . $source . ': ' . $string,
-            400
+            400,
         );
     }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -530,7 +530,7 @@ class Security implements SecurityInterface
             $this->hash,
             [
                 'expires' => $this->config->expires === 0 ? 0 : Time::now()->getTimestamp() + $this->config->expires,
-            ]
+            ],
         );
 
         $response = service('response');

--- a/system/Session/Handlers/BaseHandler.php
+++ b/system/Session/Handlers/BaseHandler.php
@@ -132,7 +132,7 @@ abstract class BaseHandler implements SessionHandlerInterface
         return setcookie(
             $this->cookieName,
             '',
-            ['expires' => 1, 'path' => $this->cookiePath, 'domain' => $this->cookieDomain, 'secure' => $this->cookieSecure, 'httponly' => true]
+            ['expires' => 1, 'path' => $this->cookiePath, 'domain' => $this->cookieDomain, 'secure' => $this->cookieSecure, 'httponly' => true],
         );
     }
 

--- a/system/Session/Handlers/DatabaseHandler.php
+++ b/system/Session/Handlers/DatabaseHandler.php
@@ -285,7 +285,7 @@ class DatabaseHandler extends BaseHandler
         return $this->db->table($this->table)->where(
             'timestamp <',
             "now() - INTERVAL {$max_lifetime} second",
-            false
+            false,
         )->delete() ? 1 : $this->fail();
     }
 

--- a/system/Session/Handlers/FileHandler.php
+++ b/system/Session/Handlers/FileHandler.php
@@ -283,7 +283,7 @@ class FileHandler extends BaseHandler
 
         $pattern = sprintf(
             '#\A%s' . $pattern . $this->sessionIDRegex . '\z#',
-            preg_quote($this->cookieName, '#')
+            preg_quote($this->cookieName, '#'),
         );
 
         $collected = 0;

--- a/system/Session/Handlers/MemcachedHandler.php
+++ b/system/Session/Handlers/MemcachedHandler.php
@@ -97,7 +97,7 @@ class MemcachedHandler extends BaseHandler
                 '#,?([^,:]+)\:(\d{1,5})(?:\:(\d+))?#',
                 $this->savePath,
                 $matches,
-                PREG_SET_ORDER
+                PREG_SET_ORDER,
             ) < 1
         ) {
             $this->memcached = null;
@@ -110,7 +110,7 @@ class MemcachedHandler extends BaseHandler
             // If Memcached already has this server (or if the port is invalid), skip it
             if (in_array($match[1] . ':' . $match[2], $serverList, true)) {
                 $this->logger->debug(
-                    'Session: Memcached server pool already has ' . $match[1] . ':' . $match[2]
+                    'Session: Memcached server pool already has ' . $match[1] . ':' . $match[2],
                 );
 
                 continue;
@@ -118,7 +118,7 @@ class MemcachedHandler extends BaseHandler
 
             if (! $this->memcached->addServer($match[1], (int) $match[2], $match[3] ?? 0)) {
                 $this->logger->error(
-                    'Could not add ' . $match[1] . ':' . $match[2] . ' to Memcached server pool.'
+                    'Could not add ' . $match[1] . ':' . $match[2] . ' to Memcached server pool.',
                 );
             } else {
                 $serverList[] = $match[1] . ':' . $match[2];
@@ -275,7 +275,7 @@ class MemcachedHandler extends BaseHandler
 
             if (! $this->memcached->set($lockKey, Time::now()->getTimestamp(), 300)) {
                 $this->logger->error(
-                    'Session: Error while trying to obtain lock for ' . $this->keyPrefix . $sessionID
+                    'Session: Error while trying to obtain lock for ' . $this->keyPrefix . $sessionID,
                 );
 
                 return false;
@@ -287,7 +287,7 @@ class MemcachedHandler extends BaseHandler
 
         if ($attempt === 30) {
             $this->logger->error(
-                'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.'
+                'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID . ' after 30 attempts, aborting.',
             );
 
             return false;
@@ -309,7 +309,7 @@ class MemcachedHandler extends BaseHandler
                 && $this->memcached->getResultCode() !== Memcached::RES_NOTFOUND
             ) {
                 $this->logger->error(
-                    'Session: Error while trying to free lock for ' . $this->lockKey
+                    'Session: Error while trying to free lock for ' . $this->lockKey,
                 );
 
                 return false;

--- a/system/Session/Handlers/RedisHandler.php
+++ b/system/Session/Handlers/RedisHandler.php
@@ -180,7 +180,7 @@ class RedisHandler extends BaseHandler
             ! $redis->connect(
                 $this->savePath['host'],
                 $this->savePath['port'],
-                $this->savePath['timeout']
+                $this->savePath['timeout'],
             )
         ) {
             $this->logger->error('Session: Unable to connect to Redis with the configured settings.');
@@ -188,7 +188,7 @@ class RedisHandler extends BaseHandler
             $this->logger->error('Session: Unable to authenticate to Redis instance.');
         } elseif (isset($this->savePath['database']) && ! $redis->select($this->savePath['database'])) {
             $this->logger->error(
-                'Session: Unable to select Redis database with index ' . $this->savePath['database']
+                'Session: Unable to select Redis database with index ' . $this->savePath['database'],
             );
         } else {
             $this->redis = $redis;
@@ -318,7 +318,7 @@ class RedisHandler extends BaseHandler
         if (isset($this->redis, $this->lockKey)) {
             if (($result = $this->redis->del($this->keyPrefix . $id)) !== 1) {
                 $this->logger->debug(
-                    'Session: Redis::del() expected to return 1, got ' . var_export($result, true) . ' instead.'
+                    'Session: Redis::del() expected to return 1, got ' . var_export($result, true) . ' instead.',
                 );
             }
 
@@ -369,7 +369,7 @@ class RedisHandler extends BaseHandler
                 (string) Time::now()->getTimestamp(),
                 // NX -- Only set the key if it does not already exist.
                 // EX seconds -- Set the specified expire time, in seconds.
-                ['nx', 'ex' => 300]
+                ['nx', 'ex' => 300],
             );
 
             if (! $result) {
@@ -385,7 +385,7 @@ class RedisHandler extends BaseHandler
         if ($attempt === 300) {
             $this->logger->error(
                 'Session: Unable to obtain lock for ' . $this->keyPrefix . $sessionID
-                . ' after 300 attempts, aborting.'
+                . ' after 300 attempts, aborting.',
             );
 
             return false;

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -361,7 +361,7 @@ abstract class CIUnitTestCase extends TestCase
         $this->assertTrue($result, sprintf(
             'Failed asserting that expected message "%s" with level "%s" was logged.',
             $expectedMessage ?? '',
-            $level
+            $level,
         ));
 
         return $result;
@@ -377,8 +377,8 @@ abstract class CIUnitTestCase extends TestCase
             $message !== '' ? $message : sprintf(
                 'Failed asserting that logs have a record of message containing "%s" with level "%s".',
                 $logMessage,
-                $level
-            )
+                $level,
+            ),
         );
     }
 
@@ -417,7 +417,7 @@ abstract class CIUnitTestCase extends TestCase
     {
         $this->assertNotNull(
             $this->getHeaderEmitted($header, $ignoreCase, __METHOD__),
-            "Didn't find header for {$header}"
+            "Didn't find header for {$header}",
         );
     }
 
@@ -431,7 +431,7 @@ abstract class CIUnitTestCase extends TestCase
     {
         $this->assertNull(
             $this->getHeaderEmitted($header, $ignoreCase, __METHOD__),
-            "Found header for {$header}"
+            "Found header for {$header}",
         );
     }
 

--- a/system/Test/ConfigFromArrayTrait.php
+++ b/system/Test/ConfigFromArrayTrait.php
@@ -39,7 +39,7 @@ trait ConfigFromArrayTrait
             }
 
             throw new LogicException(
-                'No such property: ' . $classname . '::$' . $key
+                'No such property: ' . $classname . '::$' . $key,
             );
         }
 

--- a/system/Test/Constraints/SeeInDatabase.php
+++ b/system/Test/Constraints/SeeInDatabase.php
@@ -68,7 +68,7 @@ class SeeInDatabase extends Constraint
             "a row in the table [%s] matches the attributes \n%s\n\n%s",
             $table,
             $this->toString(false, JSON_PRETTY_PRINT),
-            $this->getAdditionalInfo($table)
+            $this->getAdditionalInfo($table),
         );
     }
 
@@ -81,7 +81,7 @@ class SeeInDatabase extends Constraint
 
         $similar = $builder->where(
             array_key_first($this->data),
-            $this->data[array_key_first($this->data)]
+            $this->data[array_key_first($this->data)],
         )->limit($this->show)->get()->getResultArray();
 
         if ($similar !== []) {

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -437,21 +437,21 @@ class Fabricator
                 if (isset($this->modifiedFields['unique'][$field])) {
                     $faker = $faker->unique(
                         $this->modifiedFields['unique'][$field]['reset'],
-                        $this->modifiedFields['unique'][$field]['maxRetries']
+                        $this->modifiedFields['unique'][$field]['maxRetries'],
                     );
                 }
 
                 if (isset($this->modifiedFields['optional'][$field])) {
                     $faker = $faker->optional(
                         $this->modifiedFields['optional'][$field]['weight'],
-                        $this->modifiedFields['optional'][$field]['default']
+                        $this->modifiedFields['optional'][$field]['default'],
                     );
                 }
 
                 if (isset($this->modifiedFields['valid'][$field])) {
                     $faker = $faker->valid(
                         $this->modifiedFields['valid'][$field]['validator'],
-                        $this->modifiedFields['valid'][$field]['maxRetries']
+                        $this->modifiedFields['valid'][$field]['maxRetries'],
                     );
                 }
 

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -58,7 +58,7 @@ trait FeatureTestTrait
                     @trigger_error(
                         'Passing lowercase HTTP method "' . $route[0] . '" is deprecated.'
                         . ' Use uppercase HTTP method like "' . strtoupper($route[0]) . '".',
-                        E_USER_DEPRECATED
+                        E_USER_DEPRECATED,
                     );
                 }
 
@@ -168,7 +168,7 @@ trait FeatureTestTrait
             @trigger_error(
                 'Passing lowercase HTTP method "' . $method . '" is deprecated.'
                 . ' Use uppercase HTTP method like "' . strtoupper($method) . '".',
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
         }
 
@@ -385,7 +385,7 @@ trait FeatureTestTrait
             $request->setGlobal($name, $params);
             $request->setGlobal(
                 'request',
-                $request->fetchGlobal('post') + $request->fetchGlobal('get')
+                $request->fetchGlobal('post') + $request->fetchGlobal('get'),
             );
         }
 

--- a/system/Test/Mock/MockInputOutput.php
+++ b/system/Test/Mock/MockInputOutput.php
@@ -74,7 +74,7 @@ final class MockInputOutput extends InputOutput
 
         throw new InvalidArgumentException(
             'No such index in output: ' . $index . ', the last index is: '
-            . (count($this->outputs) - 1)
+            . (count($this->outputs) - 1),
         );
     }
 
@@ -103,7 +103,7 @@ final class MockInputOutput extends InputOutput
     {
         if ($this->inputs === []) {
             throw new LogicException(
-                'No input data. Specifiy input data with `MockInputOutput::setInputs()`.'
+                'No input data. Specifiy input data with `MockInputOutput::setInputs()`.',
             );
         }
 

--- a/system/Test/TestResponse.php
+++ b/system/Test/TestResponse.php
@@ -153,7 +153,7 @@ class TestResponse
     {
         Assert::assertTrue(
             $this->isOK(),
-            "{$this->response->getStatusCode()} is not a successful status code, or Response has an empty body."
+            "{$this->response->getStatusCode()} is not a successful status code, or Response has an empty body.",
         );
     }
 
@@ -164,7 +164,7 @@ class TestResponse
     {
         Assert::assertFalse(
             $this->isOK(),
-            "{$this->response->getStatusCode()} is an unexpected successful status code, or Response body has content."
+            "{$this->response->getStatusCode()} is an unexpected successful status code, or Response body has content.",
         );
     }
 
@@ -287,7 +287,7 @@ class TestResponse
             Assert::assertSame(
                 $value,
                 $this->response->getHeaderLine($key),
-                "The value of '{$key}' header ({$this->response->getHeaderLine($key)}) does not match expected value."
+                "The value of '{$key}' header ({$this->response->getHeaderLine($key)}) does not match expected value.",
             );
         }
     }
@@ -331,7 +331,7 @@ class TestResponse
 
         Assert::assertGreaterThan(
             Time::now()->getTimestamp(),
-            $this->response->getCookie($key, $prefix)->getExpiresTimestamp()
+            $this->response->getCookie($key, $prefix)->getExpiresTimestamp(),
         );
     }
 
@@ -420,7 +420,7 @@ class TestResponse
     {
         Assert::assertTrue(
             $this->domParser->see($search, $element),
-            "Text '{$search}' is not seen in response."
+            "Text '{$search}' is not seen in response.",
         );
     }
 
@@ -431,7 +431,7 @@ class TestResponse
     {
         Assert::assertTrue(
             $this->domParser->dontSee($search, $element),
-            "Text '{$search}' is unexpectedly seen in response."
+            "Text '{$search}' is unexpectedly seen in response.",
         );
     }
 
@@ -442,7 +442,7 @@ class TestResponse
     {
         Assert::assertTrue(
             $this->domParser->seeElement($search),
-            "Element with selector '{$search}' is not seen in response."
+            "Element with selector '{$search}' is not seen in response.",
         );
     }
 
@@ -453,7 +453,7 @@ class TestResponse
     {
         Assert::assertTrue(
             $this->domParser->dontSeeElement($search),
-            "Element with selector '{$search}' is unexpectedly seen in response.'"
+            "Element with selector '{$search}' is unexpectedly seen in response.'",
         );
     }
 
@@ -464,7 +464,7 @@ class TestResponse
     {
         Assert::assertTrue(
             $this->domParser->seeLink($text, $details),
-            "Anchor tag with text '{$text}' is not seen in response."
+            "Anchor tag with text '{$text}' is not seen in response.",
         );
     }
 
@@ -475,7 +475,7 @@ class TestResponse
     {
         Assert::assertTrue(
             $this->domParser->seeInField($field, $value),
-            "Input named '{$field}' with value '{$value}' is not seen in response."
+            "Input named '{$field}' with value '{$value}' is not seen in response.",
         );
     }
 

--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -428,7 +428,7 @@ class FormatRules
         $scheme       = strtolower((string) parse_url($str, PHP_URL_SCHEME));
         $validSchemes = explode(
             ',',
-            strtolower($validSchemes ?? 'http,https')
+            strtolower($validSchemes ?? 'http,https'),
         );
 
         return in_array($scheme, $validSchemes, true)

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -386,7 +386,7 @@ class Rules
         ?string $otherFields = null,
         array $data = [],
         ?string $error = null,
-        ?string $field = null
+        ?string $field = null,
     ): bool {
         if ($otherFields === null || $data === []) {
             throw new InvalidArgumentException('You must supply the parameters: otherFields, data.');
@@ -447,7 +447,7 @@ class Rules
         ?string $param = null,
         array $data = [],
         ?string $error = null,
-        ?string $field = null
+        ?string $field = null,
     ): bool {
         if (str_contains($field, '.')) {
             return ArrayHelper::dotKeyExists($field, $data);

--- a/system/Validation/Rules.php
+++ b/system/Validation/Rules.php
@@ -125,7 +125,7 @@ class Rules
         [$field, $whereField, $whereValue] = array_pad(
             explode(',', $field),
             3,
-            null
+            null,
         );
 
         // Break the table and field apart
@@ -184,7 +184,7 @@ class Rules
         [$field, $ignoreField, $ignoreValue] = array_pad(
             explode(',', $field),
             3,
-            null
+            null,
         );
 
         sscanf($field, '%[^.].%[^.]', $table, $field);

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -149,7 +149,7 @@ class Rules
         [$field, $whereField, $whereValue] = array_pad(
             explode(',', $field),
             3,
-            null
+            null,
         );
 
         // Break the table and field apart
@@ -210,7 +210,7 @@ class Rules
         [$field, $ignoreField, $ignoreValue] = array_pad(
             explode(',', $field),
             3,
-            null
+            null,
         );
 
         sscanf($field, '%[^.].%[^.]', $table, $field);

--- a/system/Validation/StrictRules/Rules.php
+++ b/system/Validation/StrictRules/Rules.php
@@ -42,7 +42,7 @@ class Rules
         string $otherField,
         array $data,
         ?string $error = null,
-        ?string $field = null
+        ?string $field = null,
     ): bool {
         if (str_contains($otherField, '.')) {
             return $str !== dot_array_search($otherField, $data);
@@ -279,7 +279,7 @@ class Rules
         string $otherField,
         array $data,
         ?string $error = null,
-        ?string $field = null
+        ?string $field = null,
     ): bool {
         if (str_contains($otherField, '.')) {
             return $str === dot_array_search($otherField, $data);
@@ -410,7 +410,7 @@ class Rules
         ?string $otherFields = null,
         array $data = [],
         ?string $error = null,
-        ?string $field = null
+        ?string $field = null,
     ): bool {
         return $this->nonStrictRules->required_without($str, $otherFields, $data, $error, $field);
     }
@@ -428,7 +428,7 @@ class Rules
         ?string $param = null,
         array $data = [],
         ?string $error = null,
-        ?string $field = null
+        ?string $field = null,
     ): bool {
         if (str_contains($field, '.')) {
             return ArrayHelper::dotKeyExists($field, $data);

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -177,7 +177,7 @@ class Validation implements ValidationInterface
                 $values = array_filter(
                     $flattenedArray,
                     static fn ($key): bool => preg_match(self::getRegex($field), $key) === 1,
-                    ARRAY_FILTER_USE_KEY
+                    ARRAY_FILTER_USE_KEY,
                 );
 
                 // if keys not found
@@ -208,7 +208,7 @@ class Validation implements ValidationInterface
             // Store data that was actually validated.
             $this->validated = DotArrayFilter::run(
                 array_keys($this->rules),
-                $this->data
+                $this->data,
             );
 
             return true;
@@ -226,7 +226,7 @@ class Validation implements ValidationInterface
             . str_replace(
                 ['\.\*', '\*\.'],
                 ['\.[^.]+', '[^.]+\.'],
-                preg_quote($field, '/')
+                preg_quote($field, '/'),
             )
             . '\z/';
     }
@@ -248,11 +248,11 @@ class Validation implements ValidationInterface
             'check',
             null,
             $rules,
-            $errors
+            $errors,
         )->run(
             ['check' => $value],
             null,
-            $dbGroup
+            $dbGroup,
         );
     }
 
@@ -368,7 +368,7 @@ class Validation implements ValidationInterface
                     $label,
                     $param,
                     (string) $value,
-                    $originalField
+                    $originalField,
                 );
 
                 return false;
@@ -805,7 +805,7 @@ class Validation implements ValidationInterface
                             throw new LogicException(
                                 'No validation rules for the placeholder: "' . $field
                                 . '". You must set the validation rules for the field.'
-                                . ' See <https://codeigniter4.github.io/userguide/libraries/validation.html#validation-placeholders>.'
+                                . ' See <https://codeigniter4.github.io/userguide/libraries/validation.html#validation-placeholders>.',
                             );
                         }
 
@@ -813,7 +813,7 @@ class Validation implements ValidationInterface
                         foreach ($placeholderRules as $placeholderRule) {
                             if ($this->retrievePlaceholders($placeholderRule, $data) !== []) {
                                 throw new LogicException(
-                                    'The placeholder field cannot use placeholder: ' . $field
+                                    'The placeholder field cannot use placeholder: ' . $field,
                                 );
                             }
                         }
@@ -868,7 +868,7 @@ class Validation implements ValidationInterface
         $errors = array_filter(
             $this->getErrors(),
             static fn ($key): bool => preg_match(self::getRegex($field), $key) === 1,
-            ARRAY_FILTER_USE_KEY
+            ARRAY_FILTER_USE_KEY,
         );
 
         return $errors === [] ? '' : implode("\n", $errors);

--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -281,7 +281,7 @@ class Validation implements ValidationInterface
         $value,
         $rules = null,       // @TODO remove `= null`
         ?array $data = null, // @TODO remove `= null`
-        ?string $originalField = null
+        ?string $originalField = null,
     ): bool {
         if ($data === null) {
             throw new InvalidArgumentException('You must supply the parameter: data.');
@@ -914,7 +914,7 @@ class Validation implements ValidationInterface
         ?string $label = null,
         ?string $param = null,
         ?string $value = null,
-        ?string $originalField = null
+        ?string $originalField = null,
     ): string {
         $param ??= '';
 

--- a/system/View/Cells/Cell.php
+++ b/system/View/Cells/Cell.php
@@ -97,13 +97,13 @@ class Cell implements Stringable
 
         $candidateViews = array_filter(
             [$view, $possibleView1 ?? '', $possibleView2 ?? ''],
-            static fn (string $path): bool => $path !== '' && is_file($path)
+            static fn (string $path): bool => $path !== '' && is_file($path),
         );
 
         if ($candidateViews === []) {
             throw new LogicException(sprintf(
                 'Cannot locate the view file for the "%s" cell.',
-                static::class
+                static::class,
             ));
         }
 

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -86,7 +86,7 @@ class Parser extends View
         ?string $viewPath = null,
         $loader = null,
         ?bool $debug = null,
-        ?LoggerInterface $logger = null
+        ?LoggerInterface $logger = null,
     ) {
         // Ensure user plugins override core plugins.
         $this->plugins = $config->plugins;

--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -329,7 +329,7 @@ class Parser extends View
             $this->leftDelimiter . '\s*/' . preg_quote($variable, '#') . '\s*' . $this->rightDelimiter . '#us',
             $template,
             $matches,
-            PREG_SET_ORDER
+            PREG_SET_ORDER,
         );
 
         /*
@@ -484,12 +484,12 @@ class Parser extends View
         $template = preg_replace(
             '/' . $leftDelimiter . '\s*else\s*' . $rightDelimiter . '/ums',
             '<?php else: ?>',
-            $template
+            $template,
         );
         $template = preg_replace(
             '/' . $leftDelimiter . '\s*endif\s*' . $rightDelimiter . '/ums',
             '<?php endif; ?>',
-            $template
+            $template,
         );
 
         // Parse the PHP itself, or insert an error so they can debug

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -200,7 +200,7 @@ class View implements RendererInterface
                 $this->logPerformance(
                     $this->renderVars['start'],
                     microtime(true),
-                    $this->renderVars['view']
+                    $this->renderVars['view'],
                 );
 
                 return $output;
@@ -213,7 +213,7 @@ class View implements RendererInterface
             $this->renderVars['file'] = $this->loader->locateFile(
                 $this->renderVars['view'],
                 'Views',
-                ($fileExt === '') ? 'php' : $fileExt
+                ($fileExt === '') ? 'php' : $fileExt,
             );
         }
 
@@ -257,7 +257,7 @@ class View implements RendererInterface
         $this->logPerformance(
             $this->renderVars['start'],
             microtime(true),
-            $this->renderVars['view']
+            $this->renderVars['view'],
         );
 
         // Check if DebugToolbar is enabled.
@@ -292,7 +292,7 @@ class View implements RendererInterface
             cache()->save(
                 $this->renderVars['cacheName'],
                 $output,
-                (int) $this->renderVars['options']['cache']
+                (int) $this->renderVars['options']['cache'],
             );
         }
 

--- a/system/View/View.php
+++ b/system/View/View.php
@@ -147,7 +147,7 @@ class View implements RendererInterface
         ?string $viewPath = null,
         ?FileLocatorInterface $loader = null,
         ?bool $debug = null,
-        ?LoggerInterface $logger = null
+        ?LoggerInterface $logger = null,
     ) {
         $this->config   = $config;
         $this->viewPath = rtrim($viewPath, '\\/ ') . DIRECTORY_SEPARATOR;

--- a/system/rewrite.php
+++ b/system/rewrite.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 // @codeCoverageIgnoreStart
 $uri = urldecode(
-    parse_url('https://codeigniter.com' . $_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
+    parse_url('https://codeigniter.com' . $_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '',
 );
 
 // All request handle by index.php file.

--- a/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
+++ b/tests/_support/Database/Migrations/20160428212500_Create_test_tables.php
@@ -99,7 +99,7 @@ class Migration_Create_test_tables extends Migration
             unset(
                 $dataTypeFields['type_set'],
                 $dataTypeFields['type_mediumtext'],
-                $dataTypeFields['type_double']
+                $dataTypeFields['type_double'],
             );
         }
 

--- a/tests/_support/Database/Seeds/CITestSeeder.php
+++ b/tests/_support/Database/Seeds/CITestSeeder.php
@@ -151,7 +151,7 @@ class CITestSeeder extends Seeder
                 $data['type_test'][0]['type_real'],
                 $data['type_test'][0]['type_double'],
                 $data['type_test'][0]['type_decimal'],
-                $data['type_test'][0]['type_blob']
+                $data['type_test'][0]['type_blob'],
             );
         }
 
@@ -166,7 +166,7 @@ class CITestSeeder extends Seeder
                 $data['type_test'][0]['type_set'],
                 $data['type_test'][0]['type_mediumtext'],
                 $data['type_test'][0]['type_double'],
-                $data['type_test'][0]['type_blob']
+                $data['type_test'][0]['type_blob'],
             );
         }
 

--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -92,7 +92,7 @@ final class ResponseTraitTest extends CIUnitTestCase
                 $config,
                 new SiteURI($config, $routePath),
                 null,
-                new UserAgent()
+                new UserAgent(),
             );
             $this->response = new MockResponse($config);
         }
@@ -135,7 +135,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->formatter = null;
         $controller      = $this->makeController(
             '',
-            ['Accept' => 'application/json']
+            ['Accept' => 'application/json'],
         );
 
         $this->invoke($controller, 'respondCreated', [['id' => 3], 'A Custom Reason']);
@@ -156,7 +156,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->formatter = null;
         $controller      = $this->makeController(
             '',
-            ['Accept' => 'application/json']
+            ['Accept' => 'application/json'],
         );
 
         $this->invoke($controller, 'respondCreated', ['A Custom Reason']);
@@ -187,7 +187,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->assertSame('A Custom Reason', $this->response->getBody());
         $this->assertStringStartsWith(
             'text/html',
-            $this->response->getHeaderLine('Content-Type')
+            $this->response->getHeaderLine('Content-Type'),
         );
     }
 
@@ -279,7 +279,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->assertSame('"something"', $this->response->getBody());
         $this->assertStringStartsWith(
             'application/json',
-            $this->response->getHeaderLine('Content-Type')
+            $this->response->getHeaderLine('Content-Type'),
         );
         $this->assertSame('Created', $this->response->getReasonPhrase());
     }
@@ -460,7 +460,7 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->invoke(
             $controller,
             'failValidationErrors',
-            [['foo' => 'Nope', 'bar' => 'No way'], 'FAT CHANCE', 'A Custom Reason']
+            [['foo' => 'Nope', 'bar' => 'No way'], 'FAT CHANCE', 'A Custom Reason'],
         );
 
         $expected = [
@@ -571,14 +571,14 @@ final class ResponseTraitTest extends CIUnitTestCase
         $this->assertSame(
             $mimeType,
             $this->request->getHeaderLine('Accept'),
-            'Request header...'
+            'Request header...',
         );
 
         $this->response->setContentType($contentType);
         $this->assertSame(
             $contentType,
             $this->response->getHeaderLine('Content-Type'),
-            'Response header pre-response...'
+            'Response header pre-response...',
         );
 
         $_SERVER = $original;
@@ -637,7 +637,7 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $this->assertStringStartsWith(
             config('Format')->supportedResponseFormats[0],
-            $response->getHeaderLine('Content-Type')
+            $response->getHeaderLine('Content-Type'),
         );
     }
 
@@ -651,7 +651,7 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $this->assertStringStartsWith(
             'application/json',
-            $this->response->getHeaderLine('Content-Type')
+            $this->response->getHeaderLine('Content-Type'),
         );
         $this->assertSame($this->formatter->format($data), $this->response->getJSON());
 
@@ -660,7 +660,7 @@ final class ResponseTraitTest extends CIUnitTestCase
 
         $this->assertStringStartsWith(
             'application/xml',
-            $this->response->getHeaderLine('Content-Type')
+            $this->response->getHeaderLine('Content-Type'),
         );
     }
 

--- a/tests/system/AutoReview/ComposerJsonTest.php
+++ b/tests/system/AutoReview/ComposerJsonTest.php
@@ -62,7 +62,7 @@ final class ComposerJsonTest extends TestCase
                 $dependency,
                 $expectedVersion,
                 $fwRequireDev[$dependency],
-                clean_path(dirname(__DIR__, 3) . '/admin/framework/composer.json')
+                clean_path(dirname(__DIR__, 3) . '/admin/framework/composer.json'),
             ));
         }
     }
@@ -77,7 +77,7 @@ final class ComposerJsonTest extends TestCase
         $this->checkConfig(
             $this->devComposer['config'],
             $this->frameworkComposer['config'],
-            'framework'
+            'framework',
         );
     }
 
@@ -86,7 +86,7 @@ final class ComposerJsonTest extends TestCase
         $this->checkConfig(
             $this->devComposer['config'],
             $this->starterComposer['config'],
-            'starter'
+            'starter',
         );
     }
 
@@ -101,7 +101,7 @@ final class ComposerJsonTest extends TestCase
         $this->assertSame(
             $this->devComposer[$section],
             $sectionContent,
-            sprintf('The %s\'s "%s" section is not updated with the main composer.json', strtolower($component), $section)
+            sprintf('The %s\'s "%s" section is not updated with the main composer.json', strtolower($component), $section),
         );
     }
 
@@ -119,7 +119,7 @@ final class ComposerJsonTest extends TestCase
             $this->assertSame($expectedValue, $actualValue, sprintf(
                 '%s\'s value for config property "%s" is not same with the main composer.json\'s config.',
                 ucfirst($component),
-                $key
+                $key,
             ));
         }
     }
@@ -132,7 +132,7 @@ final class ComposerJsonTest extends TestCase
             $this->fail(sprintf(
                 'The composer.json at "%s" is not readable or does not exist. Error was "%s".',
                 clean_path($path),
-                $e->getMessage()
+                $e->getMessage(),
             ));
         }
     }

--- a/tests/system/AutoReview/FrameworkCodeTest.php
+++ b/tests/system/AutoReview/FrameworkCodeTest.php
@@ -66,7 +66,7 @@ final class FrameworkCodeTest extends TestCase
 
                 return $groupAttribute->name();
             }, $attributes),
-            self::$recognizedGroupAttributeNames
+            self::$recognizedGroupAttributeNames,
         );
         $this->assertEmpty($unrecognizedGroups, sprintf(
             "[%s] Unexpected #[Group] attribute%s:\n%s\nExpected group names to be in \"%s\".",
@@ -74,9 +74,9 @@ final class FrameworkCodeTest extends TestCase
             count($unrecognizedGroups) > 1 ? 's' : '',
             implode("\n", array_map(
                 static fn (string $group): string => sprintf('  * #[Group(\'%s\')]', $group),
-                $unrecognizedGroups
+                $unrecognizedGroups,
             )),
-            implode(', ', self::$recognizedGroupAttributeNames)
+            implode(', ', self::$recognizedGroupAttributeNames),
         ));
     }
 
@@ -100,9 +100,9 @@ final class FrameworkCodeTest extends TestCase
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator(
                 $directory,
-                FilesystemIterator::SKIP_DOTS
+                FilesystemIterator::SKIP_DOTS,
             ),
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
 
         $testClasses = array_map(
@@ -111,32 +111,32 @@ final class FrameworkCodeTest extends TestCase
                     $file->getPathname(),
                     '',
                     0,
-                    strlen($directory)
+                    strlen($directory),
                 );
                 $relativePath = substr_replace(
                     $relativePath,
                     '',
-                    strlen($relativePath) - strlen(DIRECTORY_SEPARATOR . $file->getBasename())
+                    strlen($relativePath) - strlen(DIRECTORY_SEPARATOR . $file->getBasename()),
                 );
 
                 return sprintf(
                     'CodeIgniter\\%s%s%s',
                     strtr($relativePath, DIRECTORY_SEPARATOR, '\\'),
                     $relativePath === '' ? '' : '\\',
-                    $file->getBasename('.' . $file->getExtension())
+                    $file->getBasename('.' . $file->getExtension()),
                 );
             },
             array_filter(
                 iterator_to_array($iterator, false),
                 static fn (SplFileInfo $file): bool => $file->isFile()
                     && ! str_contains($file->getPathname(), DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR)
-                    && ! str_contains($file->getPathname(), DIRECTORY_SEPARATOR . 'Views' . DIRECTORY_SEPARATOR)
-            )
+                    && ! str_contains($file->getPathname(), DIRECTORY_SEPARATOR . 'Views' . DIRECTORY_SEPARATOR),
+            ),
         );
 
         $testClasses = array_filter(
             $testClasses,
-            static fn (string $class): bool => is_subclass_of($class, TestCase::class)
+            static fn (string $class): bool => is_subclass_of($class, TestCase::class),
         );
 
         sort($testClasses);

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -202,7 +202,7 @@ final class AutoloaderTest extends CIUnitTestCase
 
         $this->assertSame(
             __FILE__,
-            ($this->classLoader)('App\Controllers\AutoloaderTest')
+            ($this->classLoader)('App\Controllers\AutoloaderTest'),
         );
     }
 
@@ -235,7 +235,7 @@ final class AutoloaderTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The file path contains special characters "${}!#" that are not allowed: "${../path}!#/to/some/file.php_"'
+            'The file path contains special characters "${}!#" that are not allowed: "${../path}!#/to/some/file.php_"',
         );
 
         $test = '${../path}!#/to/some/file.php_';
@@ -247,7 +247,7 @@ final class AutoloaderTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The characters ".-_" are not allowed in filename edges: "/path/to/some/file.php_"'
+            'The characters ".-_" are not allowed in filename edges: "/path/to/some/file.php_"',
         );
 
         $test = '/path/to/some/file.php_';

--- a/tests/system/Autoloader/FileLocatorTest.php
+++ b/tests/system/Autoloader/FileLocatorTest.php
@@ -218,7 +218,7 @@ class FileLocatorTest extends CIUnitTestCase
                 SYSTEMPATH . 'Language/en/Validation.php',
                 APPPATH . 'Language/en/Validation.php',
             ],
-            $foundFiles
+            $foundFiles,
         );
     }
 
@@ -243,7 +243,7 @@ class FileLocatorTest extends CIUnitTestCase
         $directory = str_replace(
             '/',
             DIRECTORY_SEPARATOR,
-            APPPATH . 'Config/Boot'
+            APPPATH . 'Config/Boot',
         );
         $this->assertNotContains($directory, $files);
     }
@@ -308,7 +308,7 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $this->assertSame(
             self::class,
-            $this->locator->getClassname(__FILE__)
+            $this->locator->getClassname(__FILE__),
         );
     }
 
@@ -316,7 +316,7 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $this->assertSame(
             '',
-            $this->locator->getClassname(SYSTEMPATH . 'bootstrap.php')
+            $this->locator->getClassname(SYSTEMPATH . 'bootstrap.php'),
         );
     }
 
@@ -324,7 +324,7 @@ class FileLocatorTest extends CIUnitTestCase
     {
         $this->assertSame(
             '',
-            $this->locator->getClassname(SYSTEMPATH)
+            $this->locator->getClassname(SYSTEMPATH),
         );
     }
 }

--- a/tests/system/CLI/CLITest.php
+++ b/tests/system/CLI/CLITest.php
@@ -283,7 +283,7 @@ final class CLITest extends CIUnitTestCase
 
         $this->assertSame(
             "\033[1;37m\033[42m\033[4mtest\033[0m",
-            CLI::color('test', 'white', 'green', 'underline')
+            CLI::color('test', 'white', 'green', 'underline'),
         );
     }
 
@@ -291,7 +291,7 @@ final class CLITest extends CIUnitTestCase
     {
         $this->assertSame(
             '',
-            CLI::color('', 'white', 'green', 'underline')
+            CLI::color('', 'white', 'green', 'underline'),
         );
     }
 
@@ -358,7 +358,7 @@ final class CLITest extends CIUnitTestCase
     {
         CLI::write(
             CLI::color('green', 'green') . ' red ' . CLI::color('green', 'green'),
-            'red'
+            'red',
         );
 
         $expected = "\033[0;32mgreen\033[0m\033[0;31m red \033[0m\033[0;32mgreen\033[0m" . PHP_EOL;
@@ -440,15 +440,15 @@ final class CLITest extends CIUnitTestCase
         $this->assertSame('', CLI::wrap(''));
         $this->assertSame(
             '1234' . PHP_EOL . ' 5678' . PHP_EOL . ' 90' . PHP_EOL . ' abc' . PHP_EOL . ' de' . PHP_EOL . ' fghij' . PHP_EOL . ' 0987654321',
-            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 5, 1)
+            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 5, 1),
         );
         $this->assertSame(
             '1234 5678 90' . PHP_EOL . '  abc de fghij' . PHP_EOL . '  0987654321',
-            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 999, 2)
+            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321', 999, 2),
         );
         $this->assertSame(
             '1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321',
-            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321')
+            CLI::wrap('1234 5678 90' . PHP_EOL . 'abc de fghij' . PHP_EOL . '0987654321'),
         );
     }
 

--- a/tests/system/CLI/ConsoleTest.php
+++ b/tests/system/CLI/ConsoleTest.php
@@ -54,8 +54,8 @@ final class ConsoleTest extends CIUnitTestCase
             0,
             strpos(
                 $this->getStreamFilterBuffer(),
-                sprintf('CodeIgniter v%s Command Line Tool', CodeIgniter::CI_VERSION)
-            )
+                sprintf('CodeIgniter v%s Command Line Tool', CodeIgniter::CI_VERSION),
+            ),
         );
     }
 
@@ -143,7 +143,7 @@ final class ConsoleTest extends CIUnitTestCase
         $this->assertStringContainsString('env [<environment>]', $this->getStreamFilterBuffer());
         $this->assertStringContainsString(
             'Retrieves the current environment, or set a new one.',
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
     }
 

--- a/tests/system/Cache/ResponseCacheTest.php
+++ b/tests/system/Cache/ResponseCacheTest.php
@@ -46,7 +46,7 @@ final class ResponseCacheTest extends CIUnitTestCase
     private function createIncomingRequest(
         string $uri = '',
         array $query = [],
-        ?AppConfig $appConfig = null
+        ?AppConfig $appConfig = null,
     ): IncomingRequest {
         $_POST = $_GET = $_SERVER = $_REQUEST = $_ENV = $_COOKIE = $_SESSION = [];
 

--- a/tests/system/Cache/ResponseCacheTest.php
+++ b/tests/system/Cache/ResponseCacheTest.php
@@ -65,7 +65,7 @@ final class ResponseCacheTest extends CIUnitTestCase
             $appConfig,
             $siteUri,
             null,
-            new UserAgent()
+            new UserAgent(),
         );
     }
 

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -843,7 +843,7 @@ final class CodeIgniterTest extends CIUnitTestCase
     public function testPageCacheWithCacheQueryString(
         $cacheQueryStringValue,
         int $expectedPagesInCache,
-        array $testingUrls
+        array $testingUrls,
     ): void {
         // Suppress command() output
         CITestStreamFilter::registration();

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -214,7 +214,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes = service('routes');
         $routes->add(
             'pages/(:segment)',
-            static fn ($segment): string => 'You want to see "' . esc($segment) . '" page.'
+            static fn ($segment): string => 'You want to see "' . esc($segment) . '" page.',
         );
         $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);
@@ -293,7 +293,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes->add(
             'pages/about',
             static fn () => service('incomingrequest')->getBody(),
-            ['filter' => Customfilter::class]
+            ['filter' => Customfilter::class],
         );
 
         $router = service('router', $routes, service('incomingrequest'));
@@ -324,7 +324,7 @@ final class CodeIgniterTest extends CIUnitTestCase
             'pages/about',
             static fn () => service('incomingrequest')->getBody(),
             // Set filter with no argument.
-            ['filter' => 'test-customfilter']
+            ['filter' => 'test-customfilter'],
         );
 
         $router = service('router', $routes, service('incomingrequest'));
@@ -358,7 +358,7 @@ final class CodeIgniterTest extends CIUnitTestCase
         $routes->add(
             'pages/about',
             static fn () => service('incomingrequest')->getBody(),
-            ['filter' => Customfilter::class]
+            ['filter' => Customfilter::class],
         );
         $router = service('router', $routes, service('incomingrequest'));
         Services::injectMock('router', $router);

--- a/tests/system/Commands/Database/MigrateStatusTest.php
+++ b/tests/system/Commands/Database/MigrateStatusTest.php
@@ -51,7 +51,7 @@ final class MigrateStatusTest extends CIUnitTestCase
         $contents = str_replace(
             'namespace Tests\Support\MigrationTestMigrations\Database\Migrations;',
             'namespace App\Database\Migrations;',
-            $contents
+            $contents,
         );
         file_put_contents($this->migrationFileTo, $contents);
 

--- a/tests/system/Commands/EnvironmentCommandTest.php
+++ b/tests/system/Commands/EnvironmentCommandTest.php
@@ -64,7 +64,7 @@ final class EnvironmentCommandTest extends CIUnitTestCase
         command('env testing');
         $this->assertStringContainsString(
             'The "testing" environment is reserved for PHPUnit testing.',
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
     }
 
@@ -83,7 +83,7 @@ final class EnvironmentCommandTest extends CIUnitTestCase
         $this->assertStringContainsString('Both default shipped', $this->getStreamFilterBuffer());
         $this->assertStringContainsString(
             'It is impossible to write the new environment type.',
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
     }
 

--- a/tests/system/Commands/FilterCheckTest.php
+++ b/tests/system/Commands/FilterCheckTest.php
@@ -48,7 +48,7 @@ final class FilterCheckTest extends CIUnitTestCase
 
         $this->assertStringContainsString(
             '| GET    | /     | forcehttps pagecache | pagecache performance toolbar |',
-            preg_replace('/\033\[.+?m/u', '', $this->getBuffer())
+            preg_replace('/\033\[.+?m/u', '', $this->getBuffer()),
         );
     }
 
@@ -61,8 +61,8 @@ final class FilterCheckTest extends CIUnitTestCase
             str_replace(
                 ["\033[0m", "\033[1;31m", "\033[0;30m", "\033[47m"],
                 '',
-                $this->getBuffer()
-            )
+                $this->getBuffer(),
+            ),
         );
     }
 }

--- a/tests/system/Commands/GenerateKeyTest.php
+++ b/tests/system/Commands/GenerateKeyTest.php
@@ -137,7 +137,7 @@ final class GenerateKeyTest extends CIUnitTestCase
             'encryption.key = ' . $key,
             '# encryption.key = ' . $key,
             file_get_contents($this->envPath),
-            $count
+            $count,
         ));
         $this->assertSame(1, $count, 'Failed commenting out the previously set application key.');
 
@@ -155,7 +155,7 @@ final class GenerateKeyTest extends CIUnitTestCase
             'encryption.key = ' . $key,
             '# encryption.key = ' . $key,
             file_get_contents($this->envPath),
-            $count
+            $count,
         ));
         $this->assertSame(1, $count, 'Failed commenting out the previously set application key.');
 

--- a/tests/system/Commands/MigrationIntegrationTest.php
+++ b/tests/system/Commands/MigrationIntegrationTest.php
@@ -61,7 +61,7 @@ final class MigrationIntegrationTest extends CIUnitTestCase
         command('migrate -n App');
         $this->assertStringContainsString(
             '(App) 20160428212500_App\Database\Migrations\Migration_Create_test_tables',
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
 
         $this->resetStreamFilterBuffer();
@@ -69,7 +69,7 @@ final class MigrationIntegrationTest extends CIUnitTestCase
         command('migrate:rollback -n App');
         $this->assertStringContainsString(
             '(App) 20160428212500_App\Database\Migrations\Migration_Create_test_tables',
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
     }
 }

--- a/tests/system/Commands/RoutesTest.php
+++ b/tests/system/Commands/RoutesTest.php
@@ -85,7 +85,7 @@ final class RoutesTest extends CIUnitTestCase
             EOL;
         $this->assertStringContainsString(
             $expected,
-            preg_replace('/\033\[.+?m/u', '', $this->getBuffer())
+            preg_replace('/\033\[.+?m/u', '', $this->getBuffer()),
         );
     }
 

--- a/tests/system/Commands/Utilities/ConfigCheckTest.php
+++ b/tests/system/Commands/Utilities/ConfigCheckTest.php
@@ -73,7 +73,7 @@ final class ConfigCheckTest extends CIUnitTestCase
                          config:check 'CodeIgniter\Shield\Config\Auth'
 
                 EOF,
-            str_replace("\n\n", "\n", $this->getStreamFilterBuffer())
+            str_replace("\n\n", "\n", $this->getStreamFilterBuffer()),
         );
     }
 
@@ -83,7 +83,7 @@ final class ConfigCheckTest extends CIUnitTestCase
 
         $this->assertSame(
             "No such Config class: Nonexistent\n",
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
     }
 
@@ -92,14 +92,14 @@ final class ConfigCheckTest extends CIUnitTestCase
         /** @var Closure(object): string $command */
         $command = $this->getPrivateMethodInvoker(
             new ConfigCheck(service('logger'), service('commands')),
-            'getKintD'
+            'getKintD',
         );
 
         command('config:check App');
 
         $this->assertSame(
             $command(config('App')) . "\n",
-            preg_replace('/\s+Config Caching: \S+/', '', $this->getStreamFilterBuffer())
+            preg_replace('/\s+Config Caching: \S+/', '', $this->getStreamFilterBuffer()),
         );
     }
 
@@ -108,12 +108,12 @@ final class ConfigCheckTest extends CIUnitTestCase
         /** @var Closure(object): string $command */
         $command = $this->getPrivateMethodInvoker(
             new ConfigCheck(service('logger'), service('commands')),
-            'getVarDump'
+            'getVarDump',
         );
         $clean = static fn (string $input): string => trim(preg_replace(
             '/(\033\[[0-9;]+m)|(\035\[[0-9;]+m)/u',
             '',
-            $input
+            $input,
         ));
 
         try {
@@ -122,7 +122,7 @@ final class ConfigCheckTest extends CIUnitTestCase
 
             $this->assertSame(
                 $clean($command(config('App'))),
-                $clean(preg_replace('/\s+Config Caching: \S+/', '', $this->getStreamFilterBuffer()))
+                $clean(preg_replace('/\s+Config Caching: \S+/', '', $this->getStreamFilterBuffer())),
             );
         } finally {
             Kint::$enabled_mode = true;

--- a/tests/system/Commands/Utilities/NamespacesTest.php
+++ b/tests/system/Commands/Utilities/NamespacesTest.php
@@ -73,15 +73,15 @@ final class NamespacesTest extends CIUnitTestCase
 
         $this->assertStringContainsString(
             '|CodeIgniter|ROOTPATH/system|Yes|',
-            str_replace(' ', '', $this->getBuffer())
+            str_replace(' ', '', $this->getBuffer()),
         );
         $this->assertStringContainsString(
             '|App|ROOTPATH/app|Yes|',
-            str_replace(' ', '', $this->getBuffer())
+            str_replace(' ', '', $this->getBuffer()),
         );
         $this->assertStringContainsString(
             '|Config|APPPATH/Config|Yes|',
-            str_replace(' ', '', $this->getBuffer())
+            str_replace(' ', '', $this->getBuffer()),
         );
     }
 }

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -79,7 +79,7 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
         Factories::injectMock('config', Routing::class, $config);
 
         $reader = $this->createControllerMethodReader(
-            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers'
+            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers',
         );
 
         $routes = $reader->read(Dash_controller::class);
@@ -116,7 +116,7 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
         Factories::injectMock('config', Routing::class, $config);
 
         $reader = $this->createControllerMethodReader(
-            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers'
+            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers',
         );
 
         $routes = $reader->read(BlogController::class);
@@ -147,7 +147,7 @@ final class ControllerMethodReaderTest extends CIUnitTestCase
     public function testReadDefaultController(): void
     {
         $reader = $this->createControllerMethodReader(
-            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers'
+            'CodeIgniter\Commands\Utilities\Routes\AutoRouterImproved\Controllers',
         );
 
         $routes = $reader->read(Home::class);

--- a/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
+++ b/tests/system/Commands/Utilities/Routes/AutoRouterImproved/ControllerMethodReaderTest.php
@@ -30,7 +30,7 @@ use Tests\Support\Controllers\Remap;
 final class ControllerMethodReaderTest extends CIUnitTestCase
 {
     private function createControllerMethodReader(
-        string $namespace = 'Tests\Support\Controllers'
+        string $namespace = 'Tests\Support\Controllers',
     ): ControllerMethodReader {
         $methods = [
             'get',

--- a/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
+++ b/tests/system/Commands/Utilities/Routes/SampleURIGeneratorTest.php
@@ -51,7 +51,7 @@ final class SampleURIGeneratorTest extends CIUnitTestCase
         $routes = service('routes');
         $routes->addPlaceholder(
             'uuid',
-            '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+            '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
         );
 
         $generator = new SampleURIGenerator();

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -338,7 +338,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         $this->assertSame(
             '/en/path/string/to/13',
-            route_to('path-to', 'string', 13, 'en')
+            route_to('path-to', 'string', 13, 'en'),
         );
     }
 
@@ -352,7 +352,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
 
         $this->assertSame(
             '/en/path/string/to/13',
-            route_to('path-to', 'string', 13, 'invalid')
+            route_to('path-to', 'string', 13, 'invalid'),
         );
     }
 
@@ -642,7 +642,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
             $this->assertInstanceOf(RedirectException::class, $e);
             $this->assertSame(
                 'https://example.com/index.php/',
-                $e->getResponse()->header('Location')->getValue()
+                $e->getResponse()->header('Location')->getValue(),
             );
             $this->assertFalse($e->getResponse()->hasCookie('force'));
             $this->assertSame('header', $e->getResponse()->getHeaderLine('Force'));
@@ -668,7 +668,7 @@ final class CommonFunctionsTest extends CIUnitTestCase
             $this->assertInstanceOf(RedirectException::class, $e);
             $this->assertSame(
                 'https://example.jp/codeIgniter/index.php/en/home?foo=bar',
-                $e->getResponse()->header('Location')->getValue()
+                $e->getResponse()->header('Location')->getValue(),
             );
         }
     }

--- a/tests/system/CommonHelperTest.php
+++ b/tests/system/CommonHelperTest.php
@@ -129,7 +129,7 @@ final class CommonHelperTest extends CIUnitTestCase
         foreach ($this->dummyHelpers as $helper) {
             $this->assertFileDoesNotExist($helper, sprintf(
                 'The dummy helper file "%s" should not be existing before it is tested.',
-                $helper
+                $helper,
             ));
         }
 

--- a/tests/system/Config/FactoriesTest.php
+++ b/tests/system/Config/FactoriesTest.php
@@ -338,18 +338,18 @@ final class FactoriesTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Already defined in Factories: models CodeIgniter\Shield\Models\UserModel -> Tests\Support\Models\UserModel'
+            'Already defined in Factories: models CodeIgniter\Shield\Models\UserModel -> Tests\Support\Models\UserModel',
         );
 
         Factories::define(
             'models',
             'CodeIgniter\Shield\Models\UserModel',
-            UserModel::class
+            UserModel::class,
         );
         Factories::define(
             'models',
             'CodeIgniter\Shield\Models\UserModel',
-            EntityModel::class
+            EntityModel::class,
         );
     }
 
@@ -358,12 +358,12 @@ final class FactoriesTest extends CIUnitTestCase
         Factories::define(
             'models',
             'CodeIgniter\Shield\Models\UserModel',
-            UserModel::class
+            UserModel::class,
         );
         Factories::define(
             'models',
             'CodeIgniter\Shield\Models\UserModel',
-            UserModel::class
+            UserModel::class,
         );
 
         $model = model('CodeIgniter\Shield\Models\UserModel');
@@ -379,7 +379,7 @@ final class FactoriesTest extends CIUnitTestCase
         Factories::define(
             'models',
             'CodeIgniter\Shield\Models\UserModel',
-            'App\Models\UserModel'
+            'App\Models\UserModel',
         );
     }
 
@@ -387,7 +387,7 @@ final class FactoriesTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Already defined in Factories: models Tests\Support\Models\UserModel -> Tests\Support\Models\UserModel'
+            'Already defined in Factories: models Tests\Support\Models\UserModel -> Tests\Support\Models\UserModel',
         );
 
         model(UserModel::class);
@@ -395,7 +395,7 @@ final class FactoriesTest extends CIUnitTestCase
         Factories::define(
             'models',
             UserModel::class,
-            'App\Models\UserModel'
+            'App\Models\UserModel',
         );
     }
 
@@ -404,7 +404,7 @@ final class FactoriesTest extends CIUnitTestCase
         Factories::define(
             'models',
             UserModel::class,
-            EntityModel::class
+            EntityModel::class,
         );
 
         $model = model(UserModel::class);
@@ -417,7 +417,7 @@ final class FactoriesTest extends CIUnitTestCase
         Factories::define(
             'models',
             UserModel::class,
-            EntityModel::class
+            EntityModel::class,
         );
 
         $model = Factories::get('models', UserModel::class);

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -195,7 +195,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->assertFalse($method($data, $rule));
         $this->assertSame(
             'The password field must be at least 10 characters in length.',
-            service('validation')->getError('password')
+            service('validation')->getError('password'),
         );
     }
 
@@ -224,11 +224,11 @@ final class ControllerTest extends CIUnitTestCase
         $this->assertFalse($method($data, $rules, $errors));
         $this->assertSame(
             '"username" must be 3 letters or longer.',
-            service('validation')->getError('username')
+            service('validation')->getError('username'),
         );
         $this->assertSame(
             'The password field must be at least 10 characters in length.',
-            service('validation')->getError('password')
+            service('validation')->getError('password'),
         );
     }
 
@@ -262,11 +262,11 @@ final class ControllerTest extends CIUnitTestCase
         $this->assertFalse($method($data, $rules));
         $this->assertSame(
             '"Username" must be 3 letters or longer.',
-            service('validation')->getError('username')
+            service('validation')->getError('username'),
         );
         $this->assertSame(
             'The Password field must be at least 10 characters in length.',
-            service('validation')->getError('password')
+            service('validation')->getError('password'),
         );
     }
 

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -93,7 +93,7 @@ final class CookieTest extends CIUnitTestCase
             'value',
             [
                 'prefix' => $optionPrefix,
-            ]
+            ],
         );
 
         $this->assertSame($expected, $cookie->getPrefixedName());
@@ -271,19 +271,19 @@ final class CookieTest extends CIUnitTestCase
 
         $this->assertSame(
             'cookie=lover; Path=/; HttpOnly; SameSite=Lax',
-            $a->toHeaderString()
+            $a->toHeaderString(),
         );
         $this->assertSame(
             "cookie=monster; Expires=Sun, 14-Feb-2021 00:00:00 GMT; Max-Age={$max}; Path=/web; Domain=localhost; HttpOnly; SameSite=Lax",
-            (string) $b
+            (string) $b,
         );
         $this->assertSame(
             'cookie=lover; Path=/; Secure; SameSite=Strict',
-            (string) $c
+            (string) $c,
         );
         $this->assertSame(
             'cookie=deleted; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly; SameSite=Lax',
-            (string) $d
+            (string) $d,
         );
 
         Cookie::setDefaults($old);

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -530,7 +530,7 @@ final class DataConverterTest extends CIUnitTestCase
         array $handlers = [],
         ?object $helper = null,
         Closure|string|null $reconstructor = 'reconstruct',
-        Closure|string|null $extractor = null
+        Closure|string|null $extractor = null,
     ): DataConverter {
         return new DataConverter($types, $handlers, $helper, $reconstructor, $extractor);
     }

--- a/tests/system/DataConverter/DataConverterTest.php
+++ b/tests/system/DataConverter/DataConverterTest.php
@@ -471,7 +471,7 @@ final class DataConverterTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            '[CodeIgniter\DataCaster\Cast\JsonCast] Invalid value type: bool, and its value: true'
+            '[CodeIgniter\DataCaster\Cast\JsonCast] Invalid value type: bool, and its value: true',
         );
 
         $types = [
@@ -491,7 +491,7 @@ final class DataConverterTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Invalid class type. It must implement CastInterface. class: CodeIgniter\DataConverter\DataConverter'
+            'Invalid class type. It must implement CastInterface. class: CodeIgniter\DataConverter\DataConverter',
         );
 
         $types = [

--- a/tests/system/Database/BaseConnectionTest.php
+++ b/tests/system/Database/BaseConnectionTest.php
@@ -188,7 +188,7 @@ final class BaseConnectionTest extends CIUnitTestCase
         bool $protectIdentifiers,
         bool $fieldExists,
         string $item,
-        string $expected
+        string $expected,
     ): void {
         $db = new MockConnection($this->options);
 

--- a/tests/system/Database/BaseQueryTest.php
+++ b/tests/system/Database/BaseQueryTest.php
@@ -251,7 +251,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setQuery(
             "SELECT mytable.id, DATE_FORMAT(mytable.created_at,'%d/%m/%Y %H:%i:%s') AS created_at_uk FROM mytable WHERE mytable.id = ?",
-            [1]
+            [1],
         );
 
         $expected = "SELECT mytable.id, DATE_FORMAT(mytable.created_at,'%d/%m/%Y %H:%i:%s') AS created_at_uk FROM mytable WHERE mytable.id = 1";
@@ -326,7 +326,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setQuery(
             'SELECT * FROM posts WHERE content = :content: OR foobar = :foobar:',
-            ['content' => 'a placeholder looks like :foobar:', 'foobar' => 'bazqux']
+            ['content' => 'a placeholder looks like :foobar:', 'foobar' => 'bazqux'],
         );
 
         $expected = "SELECT * FROM posts WHERE content = 'a placeholder looks like :foobar:' OR foobar = 'bazqux'";
@@ -381,7 +381,7 @@ final class BaseQueryTest extends CIUnitTestCase
         $query->setQuery(
             'SELECT * FROM product WHERE date_pickup < DateAdd(month, ?, Convert(date, GetDate())',
             [-6],
-            true
+            true,
         );
 
         $expected = 'SELECT * FROM product WHERE date_pickup < DateAdd(month, -6, Convert(date, GetDate())';
@@ -395,7 +395,7 @@ final class BaseQueryTest extends CIUnitTestCase
 
         $query->setQuery(
             'SELECT * FROM product WHERE date_pickup < DateAdd(month, :num:, Convert(date, GetDate())',
-            ['num' => -6]
+            ['num' => -6],
         );
 
         $expected = 'SELECT * FROM product WHERE date_pickup < DateAdd(month, -6, Convert(date, GetDate())';

--- a/tests/system/Database/Builder/InsertTest.php
+++ b/tests/system/Database/Builder/InsertTest.php
@@ -287,7 +287,7 @@ final class InsertTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'RawSql "expires = DATE_ADD(NOW(), INTERVAL 2 HOUR)" cannot be used here.'
+            'RawSql "expires = DATE_ADD(NOW(), INTERVAL 2 HOUR)" cannot be used here.',
         );
 
         $builder = $this->db->table('auth_bearer');

--- a/tests/system/Database/Builder/JoinTest.php
+++ b/tests/system/Database/Builder/JoinTest.php
@@ -90,7 +90,7 @@ final class JoinTest extends CIUnitTestCase
         $builder->join(
             'leases',
             'units.unit_id = leases.unit_id AND CURDATE() BETWEEN lease_start_date AND lease_exp_date',
-            'LEFT'
+            'LEFT',
         );
 
         // @TODO Should be `... CURDATE() BETWEEN "lease_start_date" AND "lease_exp_date"`

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -220,7 +220,7 @@ final class SelectTest extends CIUnitTestCase
 
         $builder->select(
             'REGEXP_SUBSTR(ral_anno,"[0-9]{1,2}([,.][0-9]{1,3})([,.][0-9]{1,3})") AS ral',
-            false
+            false,
         );
 
         $expected = <<<'SQL'
@@ -405,7 +405,7 @@ final class SelectTest extends CIUnitTestCase
         $sql = $builder->getCompiledSelect();
         $this->assertSame(
             'SELECT * FROM "users"',
-            str_replace("\n", ' ', $sql)
+            str_replace("\n", ' ', $sql),
         );
     }
 }

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -69,7 +69,7 @@ final class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
     {
         service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
-            SUPPORTPATH . 'MigrationTestMigrations'
+            SUPPORTPATH . 'MigrationTestMigrations',
         );
     }
 

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -69,7 +69,7 @@ final class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
     {
         service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
-            SUPPORTPATH . 'MigrationTestMigrations'
+            SUPPORTPATH . 'MigrationTestMigrations',
         );
     }
 

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -74,7 +74,7 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
     {
         service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
-            SUPPORTPATH . 'MigrationTestMigrations'
+            SUPPORTPATH . 'MigrationTestMigrations',
         );
     }
 

--- a/tests/system/Database/Live/AbstractGetFieldDataTestCase.php
+++ b/tests/system/Database/Live/AbstractGetFieldDataTestCase.php
@@ -138,7 +138,7 @@ abstract class AbstractGetFieldDataTestCase extends CIUnitTestCase
                 $fields['type_enum'],
                 $fields['type_set'],
                 $fields['type_mediumtext'],
-                $fields['type_double']
+                $fields['type_double'],
             );
         }
 
@@ -146,7 +146,7 @@ abstract class AbstractGetFieldDataTestCase extends CIUnitTestCase
             unset(
                 $fields['type_set'],
                 $fields['type_mediumtext'],
-                $fields['type_double']
+                $fields['type_double'],
             );
         }
 

--- a/tests/system/Database/Live/DbUtilsTest.php
+++ b/tests/system/Database/Live/DbUtilsTest.php
@@ -102,7 +102,7 @@ final class DbUtilsTest extends CIUnitTestCase
 
         if ($this->db->DBDriver === 'OCI8') {
             $this->markTestSkipped(
-                'Unsupported feature of the oracle database platform.'
+                'Unsupported feature of the oracle database platform.',
             );
         }
 
@@ -146,7 +146,7 @@ final class DbUtilsTest extends CIUnitTestCase
 
         if ($this->db->DBDriver === 'OCI8') {
             $this->markTestSkipped(
-                'Unsupported feature of the oracle database platform.'
+                'Unsupported feature of the oracle database platform.',
             );
         }
 

--- a/tests/system/Database/Live/DeleteTest.php
+++ b/tests/system/Database/Live/DeleteTest.php
@@ -134,15 +134,15 @@ final class DeleteTest extends CIUnitTestCase
 
         $this->dontSeeInDatabase(
             $table,
-            ['type_date' => '2023-12-01', 'type_varchar' => 'test1']
+            ['type_date' => '2023-12-01', 'type_varchar' => 'test1'],
         );
         $this->dontSeeInDatabase(
             $table,
-            ['type_date' => '2023-12-02', 'type_varchar' => 'test2']
+            ['type_date' => '2023-12-02', 'type_varchar' => 'test2'],
         );
         $this->seeInDatabase(
             $table,
-            ['type_date' => '2023-12-03', 'type_varchar' => 'test3']
+            ['type_date' => '2023-12-03', 'type_varchar' => 'test3'],
         );
     }
 

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -1457,7 +1457,7 @@ final class ForgeTest extends CIUnitTestCase
         $name = array_search(
             $column,
             array_column($fields, 'name'),
-            true
+            true,
         );
 
         if ($name === false) {
@@ -1707,7 +1707,7 @@ final class ForgeTest extends CIUnitTestCase
         $indexes = array_filter(
             $allIndexes,
             static fn ($index): bool => ($index->name === 'db_actions_name')
-                    && ($index->fields === [0 => 'name'])
+                    && ($index->fields === [0 => 'name']),
         );
         $this->assertCount(1, $indexes);
 
@@ -1715,14 +1715,14 @@ final class ForgeTest extends CIUnitTestCase
         $indexes = array_filter(
             $allIndexes,
             static fn ($index): bool => ($index->name === 'db_actions_category_name')
-                    && ($index->fields === [0 => 'category', 1 => 'name'])
+                    && ($index->fields === [0 => 'category', 1 => 'name']),
         );
         $this->assertCount(1, $indexes);
 
         // check that the primary key exists
         $indexes = array_filter(
             $allIndexes,
-            static fn ($index): bool => $index->type === 'PRIMARY'
+            static fn ($index): bool => $index->type === 'PRIMARY',
         );
         $this->assertCount(1, $indexes);
 
@@ -1755,7 +1755,7 @@ final class ForgeTest extends CIUnitTestCase
         $indexes = array_filter(
             $allIndexes,
             static fn ($index): bool => ($index->name === 'db_actions_name')
-                && ($index->fields === [0 => 'name'])
+                && ($index->fields === [0 => 'name']),
         );
         $this->assertCount(1, $indexes);
 
@@ -1780,7 +1780,7 @@ final class ForgeTest extends CIUnitTestCase
         // check that the primary key exists
         $indexes = array_filter(
             $allIndexes,
-            static fn ($index): bool => $index->type === 'PRIMARY'
+            static fn ($index): bool => $index->type === 'PRIMARY',
         );
         $this->assertCount(1, $indexes);
 

--- a/tests/system/Database/Live/OCI8/GetFieldDataTestCase.php
+++ b/tests/system/Database/Live/OCI8/GetFieldDataTestCase.php
@@ -41,7 +41,7 @@ final class GetFieldDataTestCase extends AbstractGetFieldDataTestCase
         $name = array_search(
             $column,
             array_column($fields, 'name'),
-            true
+            true,
         );
 
         if ($name === false) {

--- a/tests/system/Database/Live/Postgre/ConnectTest.php
+++ b/tests/system/Database/Live/Postgre/ConnectTest.php
@@ -40,7 +40,7 @@ final class ConnectTest extends CIUnitTestCase
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage(
             'Unable to connect to the database.
-Main connection [Postgre]: ERROR:  invalid value for parameter "client_encoding": "utf8mb4"'
+Main connection [Postgre]: ERROR:  invalid value for parameter "client_encoding": "utf8mb4"',
         );
 
         $config = config('Database');

--- a/tests/system/Database/Live/UpdateTest.php
+++ b/tests/system/Database/Live/UpdateTest.php
@@ -443,7 +443,7 @@ final class UpdateTest extends CIUnitTestCase
             null,
             ['id', new RawSql($this->db->protectIdentifiers('d')
             . '.' . $this->db->protectIdentifiers('country')
-            . " LIKE 'U%'")]
+            . " LIKE 'U%'")],
         );
 
         $this->seeInDatabase('user', [

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -61,7 +61,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         service('autoloader')->addNamespace(
             'Tests\Support\MigrationTestMigrations',
-            SUPPORTPATH . 'MigrationTestMigrations'
+            SUPPORTPATH . 'MigrationTestMigrations',
         );
     }
 
@@ -89,7 +89,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
         ) . $dbConfig->tests['database'];
         $this->assertSame(
             $database,
-            $this->getPrivateProperty($db, 'database')
+            $this->getPrivateProperty($db, 'database'),
         );
         $this->assertSame($dbConfig->tests['DBDriver'], $this->getPrivateProperty($db, 'DBDriver'));
     }
@@ -297,7 +297,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
         vfsStream::copyFromFileSystem(
             TESTPATH . '_support/MigrationTestMigrations/Database/Migrations',
-            $this->root
+            $this->root,
         );
 
         $this->expectException(ConfigException::class);

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -151,11 +151,11 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
         $this->assertStringContainsString(
             'ERROR: 404',
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
         $this->assertStringContainsString(
             'Controller or its method is not found: Foo::bar',
-            $this->getStreamFilterBuffer()
+            $this->getStreamFilterBuffer(),
         );
 
         $this->resetStreamFilterBuffer();

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -139,7 +139,7 @@ final class ExceptionsTest extends CIUnitTestCase
         foreach ($renderedBacktrace as $trace) {
             $this->assertMatchesRegularExpression(
                 '/^\s*\d* .+(?:\(\d+\))?: \S+(?:(?:\->|::)\S+)?\(.*\)$/',
-                $trace
+                $trace,
             );
         }
     }

--- a/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/DatabaseTest.php
@@ -48,7 +48,7 @@ final class DatabaseTest extends CIUnitTestCase
             $this->assertArrayHasKey('index', $trace);
             $this->assertSame(
                 sprintf('%s', $i + 1),
-                preg_replace(sprintf('/%s/', chr(0xC2) . chr(0xA0)), '', $trace['index'])
+                preg_replace(sprintf('/%s/', chr(0xC2) . chr(0xA0)), '', $trace['index']),
             );
 
             // since we merged file & line together

--- a/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
+++ b/tests/system/Debug/Toolbar/Collectors/HistoryTest.php
@@ -88,7 +88,7 @@ final class HistoryTest extends CIUnitTestCase
             $this->assertSame($request['time'], sprintf('%.6f', $time));
             $this->assertSame(
                 $request['datetime'],
-                DateTime::createFromFormat('U.u', $time)->format('Y-m-d H:i:s.u')
+                DateTime::createFromFormat('U.u', $time)->format('Y-m-d H:i:s.u'),
             );
             $this->assertSame($request['active'], ($time === $activeRowTime));
 

--- a/tests/system/Email/EmailTest.php
+++ b/tests/system/Email/EmailTest.php
@@ -182,11 +182,11 @@ final class EmailTest extends CIUnitTestCase
         $this->assertStringStartsWith('ci-logo.png@', $cid);
         $this->assertStringStartsWith(
             'ci-logo.png@',
-            $email->archive['attachments'][0]['cid']
+            $email->archive['attachments'][0]['cid'],
         );
         $this->assertMatchesRegularExpression(
             '/<img src="cid:ci-logo.png@(.+?)" alt="CI Logo">/u',
-            $email->archive['body']
+            $email->archive['body'],
         );
     }
 
@@ -208,11 +208,11 @@ final class EmailTest extends CIUnitTestCase
         $this->assertStringStartsWith('image001.png@', $cid);
         $this->assertStringStartsWith(
             'image001.png@',
-            $email->archive['attachments'][0]['cid']
+            $email->archive['attachments'][0]['cid'],
         );
         $this->assertMatchesRegularExpression(
             '/<img src="cid:image001.png@(.+?)" alt="CI Logo">/u',
-            $email->archive['body']
+            $email->archive['body'],
         );
     }
 }

--- a/tests/system/Filters/CorsTest.php
+++ b/tests/system/Filters/CorsTest.php
@@ -89,7 +89,7 @@ final class CorsTest extends CIUnitTestCase
                 'maxAge'              => 0,
                 'supportsCredentials' => false,
             ],
-            $options
+            $options,
         );
 
         return new Cors($passedOptions);
@@ -119,7 +119,7 @@ final class CorsTest extends CIUnitTestCase
 
         $this->assertHeader(
             'Access-Control-Allow-Origin',
-            'http://localhost'
+            'http://localhost',
         );
     }
 
@@ -208,7 +208,7 @@ final class CorsTest extends CIUnitTestCase
     {
         $this->expectException(ConfigException::class);
         $this->expectExceptionMessage(
-            'When responding to a credentialed request, the server must not specify the "*" wildcard for the Access-Control-Allow-Headers response-header value.'
+            'When responding to a credentialed request, the server must not specify the "*" wildcard for the Access-Control-Allow-Headers response-header value.',
         );
 
         $this->cors = $this->createCors(['allowedHeaders' => ['*'], 'supportsCredentials' => true]);
@@ -249,7 +249,7 @@ final class CorsTest extends CIUnitTestCase
         $this->assertTrue($response->hasHeader('Access-Control-Expose-Headers'));
         $this->assertHeader(
             'Access-Control-Expose-Headers',
-            'x-exposed-header, x-another-exposed-header'
+            'x-exposed-header, x-another-exposed-header',
         );
     }
 
@@ -257,7 +257,7 @@ final class CorsTest extends CIUnitTestCase
     {
         $this->expectException(ConfigException::class);
         $this->expectExceptionMessage(
-            'When responding to a credentialed request, the server must not specify the "*" wildcard for the Access-Control-Allow-Origin response-header value.'
+            'When responding to a credentialed request, the server must not specify the "*" wildcard for the Access-Control-Allow-Origin response-header value.',
         );
 
         $this->cors = $this->createCors([
@@ -273,7 +273,7 @@ final class CorsTest extends CIUnitTestCase
     {
         $this->expectException(ConfigException::class);
         $this->expectExceptionMessage(
-            'When responding to a credentialed request, the server must not specify the "*" wildcard for the Access-Control-Allow-Origin response-header value.'
+            'When responding to a credentialed request, the server must not specify the "*" wildcard for the Access-Control-Allow-Origin response-header value.',
         );
 
         $this->cors = $this->createCors([
@@ -303,7 +303,7 @@ final class CorsTest extends CIUnitTestCase
     {
         $this->expectException(ConfigException::class);
         $this->expectExceptionMessage(
-            "If wildcard is specified, you must set `'allowedOrigins' => ['*']`. But using wildcard is not recommended."
+            "If wildcard is specified, you must set `'allowedOrigins' => ['*']`. But using wildcard is not recommended.",
         );
 
         $this->cors = $this->createCors([

--- a/tests/system/Filters/FiltersTest.php
+++ b/tests/system/Filters/FiltersTest.php
@@ -97,7 +97,7 @@ final class FiltersTest extends CIUnitTestCase
         $filtersConfig = $this->createConfigFromArray(FiltersConfig::class, $config);
         $filters       = $this->createFilters(
             $filtersConfig,
-            new CLIRequest(new MockAppConfig())
+            new CLIRequest(new MockAppConfig()),
         );
 
         $expected = [

--- a/tests/system/Format/FormatTest.php
+++ b/tests/system/Format/FormatTest.php
@@ -56,7 +56,7 @@ final class FormatTest extends CIUnitTestCase
     {
         $this->format->getConfig()->formatters = array_merge(
             $this->format->getConfig()->formatters,
-            ['text/xml' => 'App\Foo']
+            ['text/xml' => 'App\Foo'],
         );
 
         $this->expectException(FormatException::class);
@@ -68,7 +68,7 @@ final class FormatTest extends CIUnitTestCase
     {
         $this->format->getConfig()->formatters = array_merge(
             $this->format->getConfig()->formatters,
-            ['text/xml' => URI::class]
+            ['text/xml' => URI::class],
         );
 
         $this->expectException(FormatException::class);

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -914,12 +914,12 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
         $this->assertCount(3, $setCookieHeaders);
         $this->assertSame(
             'logged_in=no; Path=/; Domain=github.com; Expires=Mon, 11 Nov 2024 02:27:05 GMT; HttpOnly; Secure; SameSite=Lax',
-            $setCookieHeaders[2]->getValue()
+            $setCookieHeaders[2]->getValue(),
         );
 
         $this->assertSame(
             '_octo=GH1.1.599292127.1699669625; Path=/; Domain=github.com; Expires=Mon, 11 Nov 2024 02:27:05 GMT; Secure; SameSite=Lax',
-            $setCookieHeaders[1]->getValueLine()
+            $setCookieHeaders[1]->getValueLine(),
         );
     }
 
@@ -1067,7 +1067,7 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
 
         $this->assertSame(
             http_build_query($params),
-            $this->request->curl_options[CURLOPT_POSTFIELDS]
+            $this->request->curl_options[CURLOPT_POSTFIELDS],
         );
 
         $params['afile'] = new CURLFile(__FILE__);
@@ -1076,7 +1076,7 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
 
         $this->assertSame(
             $params,
-            $this->request->curl_options[CURLOPT_POSTFIELDS]
+            $this->request->curl_options[CURLOPT_POSTFIELDS],
         );
     }
 
@@ -1098,7 +1098,7 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
         $expected = json_encode($params);
         $this->assertSame(
             $expected,
-            $this->request->curl_options[CURLOPT_POSTFIELDS]
+            $this->request->curl_options[CURLOPT_POSTFIELDS],
         );
     }
 
@@ -1116,11 +1116,11 @@ accept-ranges: bytes\x0d\x0a\x0d\x0a";
         $expected = json_encode($params);
         $this->assertSame(
             $expected,
-            $this->request->curl_options[CURLOPT_POSTFIELDS]
+            $this->request->curl_options[CURLOPT_POSTFIELDS],
         );
         $this->assertSame(
             'Content-Type: application/json',
-            $this->request->curl_options[CURLOPT_HTTPHEADER][0]
+            $this->request->curl_options[CURLOPT_HTTPHEADER][0],
         );
     }
 

--- a/tests/system/HTTP/ContentSecurityPolicyTest.php
+++ b/tests/system/HTTP/ContentSecurityPolicyTest.php
@@ -441,7 +441,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $result     = $this->work($body);
         $nonceStyle = array_filter(
             $this->getPrivateProperty($this->csp, 'styleSrc'),
-            static fn ($value): bool => str_starts_with($value, 'nonce-')
+            static fn ($value): bool => str_starts_with($value, 'nonce-'),
         );
 
         $this->assertStringContainsString('nonce=', $this->response->getBody());
@@ -516,7 +516,7 @@ final class ContentSecurityPolicyTest extends CIUnitTestCase
         $result      = $this->work($body);
         $nonceScript = array_filter(
             $this->getPrivateProperty($this->csp, 'scriptSrc'),
-            static fn ($value): bool => str_starts_with($value, 'nonce-')
+            static fn ($value): bool => str_starts_with($value, 'nonce-'),
         );
 
         $this->assertStringContainsString('nonce=', $this->response->getBody());

--- a/tests/system/HTTP/CorsTest.php
+++ b/tests/system/HTTP/CorsTest.php
@@ -109,20 +109,20 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'http://localhost:8080'
+            'http://localhost:8080',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Headers',
-            'X-API-KEY, X-Requested-With, Content-Type, Accept'
+            'X-API-KEY, X-Requested-With, Content-Type, Accept',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Methods',
-            'PUT'
+            'PUT',
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Credentials')
+            $response->hasHeader('Access-Control-Allow-Credentials'),
         );
     }
 
@@ -144,22 +144,22 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'https://api.example.com'
+            'https://api.example.com',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Headers',
-            'X-API-KEY, X-Requested-With, Content-Type, Accept'
+            'X-API-KEY, X-Requested-With, Content-Type, Accept',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Methods',
-            'PUT'
+            'PUT',
         );
         $this->assertHeader(
             $response,
             'Vary',
-            'Origin'
+            'Origin',
         );
     }
 
@@ -182,22 +182,22 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'https://api.example.com'
+            'https://api.example.com',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Headers',
-            'X-API-KEY, X-Requested-With, Content-Type, Accept'
+            'X-API-KEY, X-Requested-With, Content-Type, Accept',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Methods',
-            'PUT'
+            'PUT',
         );
         $this->assertHeader(
             $response,
             'Vary',
-            'Accept-Language, Origin'
+            'Accept-Language, Origin',
         );
     }
 
@@ -217,13 +217,13 @@ final class CorsTest extends CIUnitTestCase
         $response = $cors->handlePreflightRequest($request, $response);
 
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Origin')
+            $response->hasHeader('Access-Control-Allow-Origin'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Headers')
+            $response->hasHeader('Access-Control-Allow-Headers'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Methods')
+            $response->hasHeader('Access-Control-Allow-Methods'),
         );
     }
 
@@ -245,22 +245,22 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'https://api.example.com'
+            'https://api.example.com',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Headers',
-            'X-API-KEY, X-Requested-With, Content-Type, Accept'
+            'X-API-KEY, X-Requested-With, Content-Type, Accept',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Methods',
-            'PUT'
+            'PUT',
         );
         $this->assertHeader(
             $response,
             'Vary',
-            'Origin'
+            'Origin',
         );
     }
 
@@ -280,13 +280,13 @@ final class CorsTest extends CIUnitTestCase
         $response = $cors->handlePreflightRequest($request, $response);
 
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Origin')
+            $response->hasHeader('Access-Control-Allow-Origin'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Headers')
+            $response->hasHeader('Access-Control-Allow-Headers'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Methods')
+            $response->hasHeader('Access-Control-Allow-Methods'),
         );
     }
 
@@ -309,22 +309,22 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'http://localhost:8080'
+            'http://localhost:8080',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Headers',
-            'X-API-KEY, X-Requested-With, Content-Type, Accept'
+            'X-API-KEY, X-Requested-With, Content-Type, Accept',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Methods',
-            'PUT'
+            'PUT',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Credentials',
-            'true'
+            'true',
         );
     }
 
@@ -346,16 +346,16 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'http://localhost:8080'
+            'http://localhost:8080',
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Headers')
+            $response->hasHeader('Access-Control-Allow-Headers'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Methods')
+            $response->hasHeader('Access-Control-Allow-Methods'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Credentials')
+            $response->hasHeader('Access-Control-Allow-Credentials'),
         );
     }
 
@@ -377,7 +377,7 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'http://localhost:8080'
+            'http://localhost:8080',
         );
     }
 
@@ -401,12 +401,12 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'http://localhost:8080'
+            'http://localhost:8080',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Credentials',
-            'true'
+            'true',
         );
     }
 
@@ -429,12 +429,12 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'http://localhost:8080'
+            'http://localhost:8080',
         );
         $this->assertHeader(
             $response,
             'Access-Control-Expose-Headers',
-            'Content-Length, X-Kuma-Revision'
+            'Content-Length, X-Kuma-Revision',
         );
     }
 
@@ -455,18 +455,18 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'https://api.example.com'
+            'https://api.example.com',
         );
         $this->assertHeader(
             $response,
             'Vary',
-            'Origin'
+            'Origin',
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Headers')
+            $response->hasHeader('Access-Control-Allow-Headers'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Methods')
+            $response->hasHeader('Access-Control-Allow-Methods'),
         );
     }
 
@@ -488,12 +488,12 @@ final class CorsTest extends CIUnitTestCase
         $this->assertHeader(
             $response,
             'Access-Control-Allow-Origin',
-            'https://api.example.com'
+            'https://api.example.com',
         );
         $this->assertHeader(
             $response,
             'Vary',
-            'Accept-Language, Origin'
+            'Accept-Language, Origin',
         );
     }
 
@@ -512,13 +512,13 @@ final class CorsTest extends CIUnitTestCase
         $response = $cors->addResponseHeaders($request, $response);
 
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Origin')
+            $response->hasHeader('Access-Control-Allow-Origin'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Headers')
+            $response->hasHeader('Access-Control-Allow-Headers'),
         );
         $this->assertFalse(
-            $response->hasHeader('Access-Control-Allow-Methods')
+            $response->hasHeader('Access-Control-Allow-Methods'),
         );
     }
 }

--- a/tests/system/HTTP/IncomingRequestTest.php
+++ b/tests/system/HTTP/IncomingRequestTest.php
@@ -290,7 +290,7 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $this->assertSame(
             'utf-8',
-            $this->request->negotiate('charset', ['iso-8859', 'unicode-1-2'])
+            $this->request->negotiate('charset', ['iso-8859', 'unicode-1-2']),
         );
     }
 
@@ -299,7 +299,7 @@ final class IncomingRequestTest extends CIUnitTestCase
         $this->request->setHeader('Accept', 'text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
         $this->assertSame(
             'text/html',
-            $this->request->negotiate('media', ['text/html', 'text/x-c', 'text/x-dvi', 'text/plain'])
+            $this->request->negotiate('media', ['text/html', 'text/x-c', 'text/x-dvi', 'text/plain']),
         );
     }
 
@@ -436,17 +436,17 @@ final class IncomingRequestTest extends CIUnitTestCase
 
         $this->assertSame(
             $expected,
-            $request->getJsonVar(null, true, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION)
+            $request->getJsonVar(null, true, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION),
         );
 
         $this->assertSame(
             $expected['array'],
-            $request->getJsonVar('array', true, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION)
+            $request->getJsonVar('array', true, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION),
         );
 
         $this->assertSame(
             ['array' => $expected['array'], 'float' => $expected['float']],
-            $request->getJsonVar(['array', 'float'], true, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION)
+            $request->getJsonVar(['array', 'float'], true, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION),
         );
 
         $result = $request->getJsonVar(['array', 'float'], false, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
@@ -1165,7 +1165,7 @@ final class IncomingRequestTest extends CIUnitTestCase
     {
         $this->expectException(ConfigException::class);
         $this->expectExceptionMessage(
-            'You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.'
+            'You must set an array with Proxy IP address key and HTTP header name value in Config\App::$proxyIPs.',
         );
 
         $config           = new App();

--- a/tests/system/HTTP/MessageTest.php
+++ b/tests/system/HTTP/MessageTest.php
@@ -311,7 +311,7 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->message->addHeader(
             'Set-Cookie',
-            'logged_in=no; Path=/'
+            'logged_in=no; Path=/',
         );
 
         $header = $this->message->header('Set-Cookie');
@@ -324,11 +324,11 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->message->addHeader(
             'Set-Cookie',
-            'logged_in=no; Path=/'
+            'logged_in=no; Path=/',
         );
         $this->message->addHeader(
             'Set-Cookie',
-            'sessid=123456; Path=/'
+            'sessid=123456; Path=/',
         );
 
         $headers = $this->message->header('Set-Cookie');
@@ -342,16 +342,16 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The header "Set-Cookie" already has multiple headers. You cannot change them. If you really need to change, remove the header first.'
+            'The header "Set-Cookie" already has multiple headers. You cannot change them. If you really need to change, remove the header first.',
         );
 
         $this->message->addHeader(
             'Set-Cookie',
-            'logged_in=no; Path=/'
+            'logged_in=no; Path=/',
         );
         $this->message->addHeader(
             'Set-Cookie',
-            'sessid=123456; Path=/'
+            'sessid=123456; Path=/',
         );
 
         $this->message->appendHeader('Set-Cookie', 'HttpOnly');
@@ -361,16 +361,16 @@ final class MessageTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The header "Set-Cookie" already has multiple headers. You cannot use getHeaderLine().'
+            'The header "Set-Cookie" already has multiple headers. You cannot use getHeaderLine().',
         );
 
         $this->message->addHeader(
             'Set-Cookie',
-            'logged_in=no; Path=/'
+            'logged_in=no; Path=/',
         );
         $this->message->addHeader(
             'Set-Cookie',
-            'sessid=123456; Path=/'
+            'sessid=123456; Path=/',
         );
 
         $this->message->getHeaderLine('Set-Cookie');

--- a/tests/system/HTTP/RedirectExceptionTest.php
+++ b/tests/system/HTTP/RedirectExceptionTest.php
@@ -49,7 +49,7 @@ final class RedirectExceptionTest extends TestCase
             service('response')
                 ->redirect('redirect')
                 ->setCookie('cookie', 'value')
-                ->setHeader('Redirect-Header', 'value')
+                ->setHeader('Redirect-Header', 'value'),
         ))->getResponse();
 
         $this->assertSame('redirect', $response->getHeaderLine('location'));
@@ -62,7 +62,7 @@ final class RedirectExceptionTest extends TestCase
     {
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
-            'The Response object passed to RedirectException does not contain a redirect address.'
+            'The Response object passed to RedirectException does not contain a redirect address.',
         );
 
         new RedirectException(service('response'));

--- a/tests/system/HTTP/RedirectResponseTest.php
+++ b/tests/system/HTTP/RedirectResponseTest.php
@@ -61,7 +61,7 @@ final class RedirectResponseTest extends CIUnitTestCase
             $this->config,
             new SiteURI($this->config),
             null,
-            new UserAgent()
+            new UserAgent(),
         );
         Services::injectMock('request', $this->request);
     }

--- a/tests/system/HTTP/ResponseSendTest.php
+++ b/tests/system/HTTP/ResponseSendTest.php
@@ -173,7 +173,7 @@ final class ResponseSendTest extends CIUnitTestCase
             '',
             '/',
             '',
-            true
+            true,
         );
 
         // send it

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -276,7 +276,7 @@ final class ResponseTest extends CIUnitTestCase
         string $protocol,
         string $method,
         ?int $code,
-        int $expectedCode
+        int $expectedCode,
     ): void {
         $_SERVER['SERVER_SOFTWARE'] = $server;
         $_SERVER['SERVER_PROTOCOL'] = $protocol;
@@ -319,7 +319,7 @@ final class ResponseTest extends CIUnitTestCase
         string $protocol,
         string $method,
         ?int $code,
-        int $expectedCode
+        int $expectedCode,
     ): void {
         $_SERVER['SERVER_SOFTWARE'] = 'Microsoft-IIS';
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';

--- a/tests/system/HTTP/ResponseTest.php
+++ b/tests/system/HTTP/ResponseTest.php
@@ -175,7 +175,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $this->assertSame(
             '<http://example.com/test/index.php/?page=1>; rel="first",<http://example.com/test/index.php/?page=2>; rel="prev",<http://example.com/test/index.php/?page=4>; rel="next",<http://example.com/test/index.php/?page=20>; rel="last"',
-            $response->header('Link')->getValue()
+            $response->header('Link')->getValue(),
         );
 
         $pager->store('default', 1, 10, 200);
@@ -183,7 +183,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $this->assertSame(
             '<http://example.com/test/index.php/?page=2>; rel="next",<http://example.com/test/index.php/?page=20>; rel="last"',
-            $response->header('Link')->getValue()
+            $response->header('Link')->getValue(),
         );
 
         $pager->store('default', 20, 10, 200);
@@ -191,7 +191,7 @@ final class ResponseTest extends CIUnitTestCase
 
         $this->assertSame(
             '<http://example.com/test/index.php/?page=1>; rel="first",<http://example.com/test/index.php/?page=19>; rel="prev"',
-            $response->header('Link')->getValue()
+            $response->header('Link')->getValue(),
         );
     }
 

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -93,7 +93,7 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         string $uriString,
         string $expectUriString,
         string $expectedPath,
-        string $expectedRoutePath
+        string $expectedRoutePath,
     ): void {
         $factory = $this->createSiteURIFactory();
 
@@ -134,7 +134,7 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         string $uriString,
         string $expectUriString,
         string $expectedPath,
-        string $expectedRoutePath
+        string $expectedRoutePath,
     ): void {
         $config            = new App();
         $config->indexPage = '';

--- a/tests/system/HTTP/SiteURITest.php
+++ b/tests/system/HTTP/SiteURITest.php
@@ -40,7 +40,7 @@ final class SiteURITest extends CIUnitTestCase
         string $expectedQuery,
         string $expectedFragment,
         array $expectedSegments,
-        int $expectedTotalSegments
+        int $expectedTotalSegments,
     ): void {
         $config            = new App();
         $config->indexPage = $indexPage;
@@ -337,7 +337,7 @@ final class SiteURITest extends CIUnitTestCase
         string $expectedQuery,
         string $expectedFragment,
         array $expectedSegments,
-        int $expectedTotalSegments
+        int $expectedTotalSegments,
     ): void {
         $config            = new App();
         $config->indexPage = $indexPage;

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -953,15 +953,15 @@ final class URITest extends CIUnitTestCase
     {
         $this->assertSame(
             'http://entirely.different.com/subfolder',
-            (string) (new URI('entirely.different.com/subfolder'))
+            (string) (new URI('entirely.different.com/subfolder')),
         );
         $this->assertSame(
             'http://localhost/subfolder',
-            (string) (new URI('localhost/subfolder'))
+            (string) (new URI('localhost/subfolder')),
         );
         $this->assertSame(
             'http://localtest.me/subfolder',
-            (string) (new URI('localtest.me/subfolder'))
+            (string) (new URI('localtest.me/subfolder')),
         );
     }
 
@@ -1052,7 +1052,7 @@ final class URITest extends CIUnitTestCase
         // going through request
         $this->assertSame(
             'http://example.com/ci/v4/controller/method',
-            (string) $request->getUri()
+            (string) $request->getUri(),
         );
         $this->assertSame('/ci/v4/controller/method', $request->getUri()->getPath());
         $this->assertSame('controller/method', $request->getUri()->getRoutePath());
@@ -1086,18 +1086,18 @@ final class URITest extends CIUnitTestCase
         // going through request
         $this->assertSame(
             'http://example.com/ci/v4/index.php/controller/method',
-            (string) $request->getUri()
+            (string) $request->getUri(),
         );
         $this->assertSame(
             '/ci/v4/index.php/controller/method',
-            $request->getUri()->getPath()
+            $request->getUri()->getPath(),
         );
 
         // standalone
         $uri = new URI('http://example.com/ci/v4/index.php/controller/method');
         $this->assertSame(
             'http://example.com/ci/v4/index.php/controller/method',
-            (string) $uri
+            (string) $uri,
         );
         $this->assertSame('/ci/v4/index.php/controller/method', $uri->getPath());
 
@@ -1126,7 +1126,7 @@ final class URITest extends CIUnitTestCase
         // Detected by request
         $this->assertSame(
             'https://example.com/ci/v4/controller/method',
-            (string) $request->getUri()
+            (string) $request->getUri(),
         );
 
         // Standalone
@@ -1135,7 +1135,7 @@ final class URITest extends CIUnitTestCase
 
         $this->assertSame(
             trim($uri->getPath(), '/'),
-            trim($request->getUri()->getPath(), '/')
+            trim($request->getUri()->getPath(), '/'),
         );
     }
 

--- a/tests/system/Helpers/DateHelperTest.php
+++ b/tests/system/Helpers/DateHelperTest.php
@@ -46,7 +46,7 @@ final class DateHelperTest extends CIUnitTestCase
         // Chicago should be two hours ahead of Vancouver
         $this->assertSame(
             7200,
-            now('America/Chicago') - now('America/Vancouver')
+            now('America/Chicago') - now('America/Vancouver'),
         );
 
         Time::setTestNow();
@@ -84,7 +84,7 @@ final class DateHelperTest extends CIUnitTestCase
 
         $this->assertSame(
             $expected,
-            timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion)
+            timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion),
         );
     }
 
@@ -105,7 +105,7 @@ final class DateHelperTest extends CIUnitTestCase
 
         $this->assertSame(
             $expected,
-            timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion, $country)
+            timezone_select('custom-select', 'Asia/Jakarta', $spesificRegion, $country),
         );
     }
 }

--- a/tests/system/Helpers/FormHelperTest.php
+++ b/tests/system/Helpers/FormHelperTest.php
@@ -944,12 +944,12 @@ final class FormHelperTest extends CIUnitTestCase
 
         $this->assertSame(
             '',
-            set_checkbox('fruit', 'apple', true)
+            set_checkbox('fruit', 'apple', true),
         );
 
         $this->assertSame(
             '',
-            set_checkbox('fruit', 'apple')
+            set_checkbox('fruit', 'apple'),
         );
     }
 

--- a/tests/system/Helpers/HTMLHelperTest.php
+++ b/tests/system/Helpers/HTMLHelperTest.php
@@ -338,7 +338,7 @@ final class HTMLHelperTest extends CIUnitTestCase
 
         $this->assertMatchesRegularExpression(
             '!<script nonce="\w+?" src="http://site.com/js/mystyles.js".*?>!u',
-            $html
+            $html,
         );
 
         // Reset CSP object
@@ -414,7 +414,7 @@ final class HTMLHelperTest extends CIUnitTestCase
             'alternate',
             '',
             '',
-            'only screen and (max-width: 640px)'
+            'only screen and (max-width: 640px)',
         );
 
         $expected = '<link href="http://sp.example.com/" rel="alternate" media="only screen and (max-width: 640px)">';

--- a/tests/system/Helpers/TextHelperTest.php
+++ b/tests/system/Helpers/TextHelperTest.php
@@ -144,7 +144,7 @@ final class TextHelperTest extends CIUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'You must set an even number to the second parameter when you use `crypto`'
+            'You must set an even number to the second parameter when you use `crypto`',
         );
 
         random_string('crypto', 9);

--- a/tests/system/Helpers/URLHelper/MiscUrlTest.php
+++ b/tests/system/Helpers/URLHelper/MiscUrlTest.php
@@ -902,12 +902,12 @@ final class MiscUrlTest extends CIUnitTestCase
         $routes->add(
             '{locale}/path/(:segment)/to/(:num)',
             'myController::goto/$1/$2',
-            ['as' => 'path-to']
+            ['as' => 'path-to'],
         );
 
         $this->assertSame(
             'http://example.com/index.php/en/path/string/to/13',
-            url_to('path-to', 'string', 13, 'en')
+            url_to('path-to', 'string', 13, 'en'),
         );
     }
 
@@ -928,7 +928,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             'http://example.com/index.php/docs/10.9/install',
-            url_to('docs.version', '10.9', 'install')
+            url_to('docs.version', '10.9', 'install'),
         );
     }
 
@@ -944,7 +944,7 @@ final class MiscUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             'http://example.com/index.php/images/test.jpg',
-            url_to('Images::getFile', 'test.jpg')
+            url_to('Images::getFile', 'test.jpg'),
         );
     }
 

--- a/tests/system/Helpers/URLHelper/SiteUrlCliTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlCliTest.php
@@ -81,7 +81,7 @@ final class SiteUrlCliTest extends CIUnitTestCase
         $secure,
         $path,
         $expectedSiteUrl,
-        $expectedBaseUrl
+        $expectedBaseUrl,
     ): void {
         // Set the config
         $this->config->baseURL                   = $baseURL;

--- a/tests/system/Helpers/URLHelper/SiteUrlCliTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlCliTest.php
@@ -325,11 +325,11 @@ final class SiteUrlCliTest extends CIUnitTestCase
 
         $this->assertSame(
             '//example.com/index.php/test',
-            site_url('test', '', $this->config)
+            site_url('test', '', $this->config),
         );
         $this->assertSame(
             '//example.com/img/test.jpg',
-            base_url('img/test.jpg', '')
+            base_url('img/test.jpg', ''),
         );
     }
 }

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -91,7 +91,7 @@ final class SiteUrlTest extends CIUnitTestCase
         $secure,
         $path,
         $expectedSiteUrl,
-        $expectedBaseUrl
+        $expectedBaseUrl,
     ): void {
         // Set the config
         $this->config->baseURL                   = $baseURL;

--- a/tests/system/Helpers/URLHelper/SiteUrlTest.php
+++ b/tests/system/Helpers/URLHelper/SiteUrlTest.php
@@ -335,11 +335,11 @@ final class SiteUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             '//example.com/index.php/test',
-            site_url('test', '', $this->config)
+            site_url('test', '', $this->config),
         );
         $this->assertSame(
             '//example.com/img/test.jpg',
-            base_url('img/test.jpg', '')
+            base_url('img/test.jpg', ''),
         );
     }
 
@@ -380,11 +380,11 @@ final class SiteUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             'http://example.com/ci/v4/index.php/controller/method',
-            site_url('controller/method', null, $this->config)
+            site_url('controller/method', null, $this->config),
         );
         $this->assertSame(
             'http://example.com/ci/v4/controller/method',
-            base_url('controller/method', null)
+            base_url('controller/method', null),
         );
     }
 
@@ -398,11 +398,11 @@ final class SiteUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             'http://example.com/index.php/controller/method',
-            site_url('controller/method', null, $this->config)
+            site_url('controller/method', null, $this->config),
         );
         $this->assertSame(
             'http://example.com/controller/method',
-            base_url('controller/method', null)
+            base_url('controller/method', null),
         );
     }
 
@@ -419,7 +419,7 @@ final class SiteUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             'http://www.example.jp/public/index.php/controller/method',
-            site_url('controller/method')
+            site_url('controller/method'),
         );
     }
 
@@ -439,7 +439,7 @@ final class SiteUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             'http://alt.example.com/public/index.php/controller/method',
-            site_url('controller/method', null, $altConfig)
+            site_url('controller/method', null, $altConfig),
         );
     }
 
@@ -456,7 +456,7 @@ final class SiteUrlTest extends CIUnitTestCase
 
         $this->assertSame(
             'http://www.example.jp/public/controller/method',
-            base_url('controller/method', null)
+            base_url('controller/method', null),
         );
     }
 }

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -199,7 +199,7 @@ final class HoneypotTest extends CIUnitTestCase
 
         $this->assertSame(
             '<div style="display:none">{template}</div>',
-            $this->getPrivateProperty($honeypot, 'config')->container
+            $this->getPrivateProperty($honeypot, 'config')->container,
         );
     }
 
@@ -211,7 +211,7 @@ final class HoneypotTest extends CIUnitTestCase
 
         $this->assertSame(
             '<div style="display:none">{template}</div>',
-            $this->getPrivateProperty($honeypot, 'config')->container
+            $this->getPrivateProperty($honeypot, 'config')->container,
         );
     }
 }

--- a/tests/system/I18n/TimeLegacyTest.php
+++ b/tests/system/I18n/TimeLegacyTest.php
@@ -63,7 +63,7 @@ final class TimeLegacyTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'America/Chicago', // Default for CodeIgniter
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new TimeLegacy('', 'America/Chicago');
@@ -78,7 +78,7 @@ final class TimeLegacyTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'Europe/London', // Default for CodeIgniter
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new TimeLegacy('now', 'Europe/London');
@@ -94,7 +94,7 @@ final class TimeLegacyTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'Europe/London', // Default for CodeIgniter
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new TimeLegacy('now', 'Europe/London', 'fr_FR');
@@ -110,7 +110,7 @@ final class TimeLegacyTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'Europe/London',
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new TimeLegacy('now', new DateTimeZone('Europe/London'), 'fr_FR');

--- a/tests/system/I18n/TimeTest.php
+++ b/tests/system/I18n/TimeTest.php
@@ -63,7 +63,7 @@ final class TimeTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'America/Chicago', // Default for CodeIgniter
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new Time('', 'America/Chicago');
@@ -78,7 +78,7 @@ final class TimeTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'Europe/London', // Default for CodeIgniter
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new Time('now', 'Europe/London');
@@ -94,7 +94,7 @@ final class TimeTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'Europe/London', // Default for CodeIgniter
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new Time('now', 'Europe/London', 'fr_FR');
@@ -110,7 +110,7 @@ final class TimeTest extends CIUnitTestCase
             IntlDateFormatter::SHORT,
             'Europe/London',
             IntlDateFormatter::GREGORIAN,
-            'yyyy-MM-dd HH:mm:ss'
+            'yyyy-MM-dd HH:mm:ss',
         );
 
         $time = new Time('now', new DateTimeZone('Europe/London'), 'fr_FR');

--- a/tests/system/Images/GDHandlerTest.php
+++ b/tests/system/Images/GDHandlerTest.php
@@ -303,7 +303,7 @@ final class GDHandlerTest extends CIUnitTestCase
         $this->handler->withFile($this->path);
         $this->handler->text(
             'vertical',
-            ['hAlign' => 'right', 'vAlign' => 'bottom', 'opacity' => 0.5]
+            ['hAlign' => 'right', 'vAlign' => 'bottom', 'opacity' => 0.5],
         );
         $this->assertSame(155, $this->handler->getWidth());
         $this->assertSame(200, $this->handler->getHeight());
@@ -346,7 +346,7 @@ final class GDHandlerTest extends CIUnitTestCase
 
             $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                $this->root->getChild('work/ci-logo.' . $type)->getContent()
+                $this->root->getChild('work/ci-logo.' . $type)->getContent(),
             );
         }
     }
@@ -360,7 +360,7 @@ final class GDHandlerTest extends CIUnitTestCase
 
             $this->assertSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                file_get_contents($this->origin . 'ci-logo.' . $type)
+                file_get_contents($this->origin . 'ci-logo.' . $type),
             );
         }
     }
@@ -380,7 +380,7 @@ final class GDHandlerTest extends CIUnitTestCase
 
             $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                $this->root->getChild('work/ci-logo.' . $type)->getContent()
+                $this->root->getChild('work/ci-logo.' . $type)->getContent(),
             );
         }
     }
@@ -401,7 +401,7 @@ final class GDHandlerTest extends CIUnitTestCase
 
             $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                $this->root->getChild('work/ci-logo.' . $type)->getContent()
+                $this->root->getChild('work/ci-logo.' . $type)->getContent(),
             );
         }
     }

--- a/tests/system/Images/ImageMagickHandlerTest.php
+++ b/tests/system/Images/ImageMagickHandlerTest.php
@@ -382,7 +382,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                file_get_contents($this->root . 'ci-logo.' . $type)
+                file_get_contents($this->root . 'ci-logo.' . $type),
             );
         }
     }
@@ -396,7 +396,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->assertSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                file_get_contents($this->origin . 'ci-logo.' . $type)
+                file_get_contents($this->origin . 'ci-logo.' . $type),
             );
         }
     }
@@ -416,7 +416,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                file_get_contents($this->root . 'ci-logo.' . $type)
+                file_get_contents($this->root . 'ci-logo.' . $type),
             );
         }
     }
@@ -437,7 +437,7 @@ final class ImageMagickHandlerTest extends CIUnitTestCase
 
             $this->assertNotSame(
                 file_get_contents($this->origin . 'ci-logo.' . $type),
-                file_get_contents($this->root . 'ci-logo.' . $type)
+                file_get_contents($this->root . 'ci-logo.' . $type),
             );
         }
     }

--- a/tests/system/Language/LanguageTest.php
+++ b/tests/system/Language/LanguageTest.php
@@ -74,11 +74,11 @@ final class LanguageTest extends CIUnitTestCase
 
         $this->assertSame(
             'We kept the book free from the boogeyman',
-            $this->lang->getLine('books.bookSaved.foo')
+            $this->lang->getLine('books.bookSaved.foo'),
         );
         $this->assertSame(
             'We saved some more',
-            $this->lang->getLine('books.booksSaved.bar.baz')
+            $this->lang->getLine('books.booksSaved.bar.baz'),
         );
     }
 
@@ -93,11 +93,11 @@ final class LanguageTest extends CIUnitTestCase
 
         $this->assertSame(
             'books.bookSaved.foo', // Can't get the message.
-            $this->lang->getLine('books.bookSaved.foo')
+            $this->lang->getLine('books.bookSaved.foo'),
         );
         $this->assertSame(
             'books.booksSaved.bar.baz', // Can't get the message.
-            $this->lang->getLine('books.booksSaved.bar.baz')
+            $this->lang->getLine('books.booksSaved.bar.baz'),
         );
     }
 
@@ -112,11 +112,11 @@ final class LanguageTest extends CIUnitTestCase
 
         $this->assertSame(
             'books.bookSaved.foo', // Can't get the message.
-            $this->lang->getLine('books.bookSaved.foo')
+            $this->lang->getLine('books.bookSaved.foo'),
         );
         $this->assertSame(
             'books.booksSaved.bar.baz', // Can't get the message.
-            $this->lang->getLine('books.booksSaved.bar.baz')
+            $this->lang->getLine('books.booksSaved.bar.baz'),
         );
     }
 

--- a/tests/system/Models/DeleteModelTest.php
+++ b/tests/system/Models/DeleteModelTest.php
@@ -249,7 +249,7 @@ final class DeleteModelTest extends LiveModelTestCase
         // BaseBuilder throws Exception.
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage(
-            'Deletes are not allowed unless they contain a "where" or "like" clause.'
+            'Deletes are not allowed unless they contain a "where" or "like" clause.',
         );
 
         // $useSoftDeletes = false
@@ -267,7 +267,7 @@ final class DeleteModelTest extends LiveModelTestCase
         // Model throws Exception.
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage(
-            'Deletes are not allowed unless they contain a "where" or "like" clause.'
+            'Deletes are not allowed unless they contain a "where" or "like" clause.',
         );
 
         // $useSoftDeletes = true

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -57,7 +57,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $result = $this->model->where('name', 'Senior Developer')->first();
         $this->assertSame(
             Time::createFromTimestamp($time)->toDateTimeString(),
-            $result->created_at->toDateTimeString()
+            $result->created_at->toDateTimeString(),
         );
     }
 

--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -159,7 +159,7 @@ final class UpdateModelTest extends LiveModelTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The index ("not_exist") for updateBatch() is missing in the data: {"name":"Derek Jones","country":"Greece"}'
+            'The index ("not_exist") for updateBatch() is missing in the data: {"name":"Derek Jones","country":"Greece"}',
         );
 
         $data = [
@@ -473,7 +473,7 @@ final class UpdateModelTest extends LiveModelTestCase
 
         // See https://github.com/codeigniter4/CodeIgniter4/pull/8282#issuecomment-1836974182
         $this->markTestSkipped(
-            'batchUpdate() is currently not working due to data type issues in the generated SQL statement.'
+            'batchUpdate() is currently not working due to data type issues in the generated SQL statement.',
         );
 
         $this->createUuidTable();

--- a/tests/system/Models/ValidationModelRuleGroupTest.php
+++ b/tests/system/Models/ValidationModelRuleGroupTest.php
@@ -398,7 +398,7 @@ final class ValidationModelRuleGroupTest extends LiveModelTestCase
         $this->assertCount(1, $errors);
         $this->assertSame(
             'The field1 field is required when field2,field3,field4 is present.',
-            $errors['field1']
+            $errors['field1'],
         );
     }
 
@@ -438,7 +438,7 @@ final class ValidationModelRuleGroupTest extends LiveModelTestCase
         $this->assertCount(1, $errors);
         $this->assertSame(
             'The field1 field is required when field2,field3,field4 is present.',
-            $errors['field1']
+            $errors['field1'],
         );
     }
 
@@ -471,7 +471,7 @@ final class ValidationModelRuleGroupTest extends LiveModelTestCase
         $this->assertCount(1, $errors);
         $this->assertSame(
             'The field2 field is required.',
-            $errors['field2']
+            $errors['field2'],
         );
     }
 }

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -411,7 +411,7 @@ final class ValidationModelTest extends LiveModelTestCase
         $this->assertCount(1, $errors);
         $this->assertSame(
             'The field1 field is required when field2,field3,field4 is present.',
-            $errors['field1']
+            $errors['field1'],
         );
     }
 
@@ -451,7 +451,7 @@ final class ValidationModelTest extends LiveModelTestCase
         $this->assertCount(1, $errors);
         $this->assertSame(
             'The field1 field is required when field2,field3,field4 is present.',
-            $errors['field1']
+            $errors['field1'],
         );
     }
 
@@ -484,7 +484,7 @@ final class ValidationModelTest extends LiveModelTestCase
         $this->assertCount(1, $errors);
         $this->assertSame(
             'The field2 field is required.',
-            $errors['field2']
+            $errors['field2'],
         );
     }
 }

--- a/tests/system/Pager/PagerTest.php
+++ b/tests/system/Pager/PagerTest.php
@@ -58,7 +58,7 @@ final class PagerTest extends CIUnitTestCase
             $config,
             new SiteURI($config, ltrim($requestUri, '/')),
             'php://input',
-            new UserAgent()
+            new UserAgent(),
         );
         $request = $request->withMethod('GET');
         Services::injectMock('request', $request);
@@ -165,11 +165,11 @@ final class PagerTest extends CIUnitTestCase
         $this->assertSame('http://example.com/?page=5&foo=bar', $this->pager->getPageURI(5));
         $this->assertSame(
             'http://example.com/?foo=bar&page=5',
-            $this->pager->only(['foo'])->getPageURI(5)
+            $this->pager->only(['foo'])->getPageURI(5),
         );
         $this->assertSame(
             'http://example.com/?page=5',
-            $this->pager->only([])->getPageURI(5)
+            $this->pager->only([])->getPageURI(5),
         );
     }
 
@@ -185,11 +185,11 @@ final class PagerTest extends CIUnitTestCase
         $this->assertSame('http://example.com/5?page=3&foo=bar', $this->pager->getPageURI(5));
         $this->assertSame(
             'http://example.com/5?foo=bar',
-            $this->pager->only(['foo'])->getPageURI(5)
+            $this->pager->only(['foo'])->getPageURI(5),
         );
         $this->assertSame(
             'http://example.com/5',
-            $this->pager->only([])->getPageURI(5)
+            $this->pager->only([])->getPageURI(5),
         );
     }
 
@@ -371,15 +371,15 @@ final class PagerTest extends CIUnitTestCase
 
         $this->assertSame(
             $this->pager->only($onlyQueries)->getPreviousPageURI(),
-            (string) $uri->setQuery('search=foo&order=asc&page=1')
+            (string) $uri->setQuery('search=foo&order=asc&page=1'),
         );
         $this->assertSame(
             $this->pager->only($onlyQueries)->getNextPageURI(),
-            (string) $uri->setQuery('search=foo&order=asc&page=3')
+            (string) $uri->setQuery('search=foo&order=asc&page=3'),
         );
         $this->assertSame(
             $this->pager->only($onlyQueries)->getPageURI(4),
-            (string) $uri->setQuery('search=foo&order=asc&page=4')
+            (string) $uri->setQuery('search=foo&order=asc&page=4'),
         );
     }
 
@@ -406,47 +406,47 @@ final class PagerTest extends CIUnitTestCase
     {
         $this->assertStringContainsString(
             '<ul class="pagination">',
-            $this->pager->makeLinks(4, 10, 50)
+            $this->pager->makeLinks(4, 10, 50),
         );
         $this->assertStringContainsString(
             '<ul class="pagination">',
-            $this->pager->makeLinks(4, 10, 50, 'default_full')
+            $this->pager->makeLinks(4, 10, 50, 'default_full'),
         );
         $this->assertStringContainsString(
             '<ul class="pager">',
-            $this->pager->makeLinks(4, 10, 50, 'default_simple')
+            $this->pager->makeLinks(4, 10, 50, 'default_simple'),
         );
         $this->assertStringContainsString(
             '<link rel="canonical"',
-            $this->pager->makeLinks(4, 10, 50, 'default_head')
+            $this->pager->makeLinks(4, 10, 50, 'default_head'),
         );
         $this->assertStringContainsString(
             '?page=1',
-            $this->pager->makeLinks(1, 10, 1, 'default_full', 0)
+            $this->pager->makeLinks(1, 10, 1, 'default_full', 0),
         );
         $this->assertStringContainsString(
             '?page=1',
-            $this->pager->makeLinks(1, 10, 1, 'default_full', 0, '')
+            $this->pager->makeLinks(1, 10, 1, 'default_full', 0, ''),
         );
         $this->assertStringContainsString(
             '?page=1',
-            $this->pager->makeLinks(1, 10, 1, 'default_full', 0, 'default')
+            $this->pager->makeLinks(1, 10, 1, 'default_full', 0, 'default'),
         );
         $this->assertStringContainsString(
             '?page_custom=1',
-            $this->pager->makeLinks(1, 10, 1, 'default_full', 0, 'custom')
+            $this->pager->makeLinks(1, 10, 1, 'default_full', 0, 'custom'),
         );
         $this->assertStringContainsString(
             '?page_custom=1',
-            $this->pager->makeLinks(1, null, 1, 'default_full', 0, 'custom')
+            $this->pager->makeLinks(1, null, 1, 'default_full', 0, 'custom'),
         );
         $this->assertStringContainsString(
             '/1',
-            $this->pager->makeLinks(1, 10, 1, 'default_full', 1)
+            $this->pager->makeLinks(1, 10, 1, 'default_full', 1),
         );
         $this->assertStringContainsString(
             '<li class="active">',
-            $this->pager->makeLinks(1, 10, 1, 'default_full', 1)
+            $this->pager->makeLinks(1, 10, 1, 'default_full', 1),
         );
     }
 
@@ -487,7 +487,7 @@ final class PagerTest extends CIUnitTestCase
             $config,
             new SiteURI($config, 'x/y'),
             'php://input',
-            new UserAgent()
+            new UserAgent(),
         );
         $request = $request->withMethod('GET');
         Services::injectMock('request', $request);

--- a/tests/system/Publisher/PublisherContentReplaceTest.php
+++ b/tests/system/Publisher/PublisherContentReplaceTest.php
@@ -47,14 +47,14 @@ final class PublisherContentReplaceTest extends CIUnitTestCase
         $result = $this->publisher->addLineAfter(
             $this->file,
             '    public int $myOwnConfig = 1000;',
-            'public bool $CSPEnabled = false;'
+            'public bool $CSPEnabled = false;',
         );
 
         $this->assertTrue($result);
         $this->assertStringContainsString(
             '    public bool $CSPEnabled = false;
     public int $myOwnConfig = 1000;',
-            file_get_contents($this->file)
+            file_get_contents($this->file),
         );
     }
 
@@ -63,14 +63,14 @@ final class PublisherContentReplaceTest extends CIUnitTestCase
         $result = $this->publisher->addLineBefore(
             $this->file,
             '    public int $myOwnConfig = 1000;',
-            'public bool $CSPEnabled = false;'
+            'public bool $CSPEnabled = false;',
         );
 
         $this->assertTrue($result);
         $this->assertStringContainsString(
             '    public int $myOwnConfig = 1000;
     public bool $CSPEnabled = false;',
-            file_get_contents($this->file)
+            file_get_contents($this->file),
         );
     }
 
@@ -81,21 +81,21 @@ final class PublisherContentReplaceTest extends CIUnitTestCase
             [
                 'use CodeIgniter\Config\BaseConfig;' . "\n" => '',
                 'class App extends BaseConfig'              => 'class App extends \Some\Package\SomeConfig',
-            ]
+            ],
         );
 
         $this->assertTrue($result);
         $this->assertStringNotContainsString(
             'use CodeIgniter\Config\BaseConfig;',
-            file_get_contents($this->file)
+            file_get_contents($this->file),
         );
         $this->assertStringContainsString(
             'class App extends \Some\Package\SomeConfig',
-            file_get_contents($this->file)
+            file_get_contents($this->file),
         );
         $this->assertStringNotContainsString(
             'class App extends BaseConfig',
-            file_get_contents($this->file)
+            file_get_contents($this->file),
         );
     }
 }

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -51,7 +51,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
             $namespace,
             $this->collection->getDefaultController(),
             $this->collection->getDefaultMethod(),
-            true
+            true,
         );
     }
 
@@ -151,7 +151,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage(
-            'Handler:\CodeIgniter\Router\Controllers\Mycontroller::getSomemethod, URI:mycontroller/somemethod/a/b'
+            'Handler:\CodeIgniter\Router\Controllers\Mycontroller::getSomemethod, URI:mycontroller/somemethod/a/b',
         );
 
         $router = $this->createNewAutoRouter();
@@ -213,7 +213,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $this->assertSame('Dash_folder/', $directory);
         $this->assertSame(
             '\\' . Controllers\Dash_folder\Mycontroller::class,
-            $controller
+            $controller,
         );
         $this->assertSame('getSomemethod', $method);
         $this->assertSame([], $params);
@@ -410,7 +410,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage(
-            'AutoRouterImproved does not support `_remap()` method. Controller:\CodeIgniter\Router\Controllers\Remap'
+            'AutoRouterImproved does not support `_remap()` method. Controller:\CodeIgniter\Router\Controllers\Remap',
         );
 
         $router = $this->createNewAutoRouter();
@@ -422,7 +422,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage(
-            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_folder")'
+            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_folder")',
         );
 
         $router = $this->createNewAutoRouter();
@@ -434,7 +434,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage(
-            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_controller")'
+            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_controller")',
         );
 
         $router = $this->createNewAutoRouter();
@@ -446,7 +446,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage(
-            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_method")'
+            'AutoRouterImproved prohibits access to the URI containing underscores ("dash_method")',
         );
 
         $router = $this->createNewAutoRouter();
@@ -557,7 +557,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
     {
         $this->expectException(PageNotFoundException::class);
         $this->expectExceptionMessage(
-            $expMsg
+            $expMsg,
         );
 
         $config                          = config(Routing::class);

--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -488,7 +488,7 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         string $expMethod,
         int $controllerPos,
         ?int $methodPos,
-        ?int $paramPos
+        ?int $paramPos,
     ): void {
         $config                          = config(Routing::class);
         $config->translateUriToCamelCase = true;

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -294,7 +294,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             'admin',
             static function ($routes): void {
                 $routes->add('users/list', '\Users::list');
-            }
+            },
         );
 
         $expected = [
@@ -312,7 +312,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             '<script>admin',
             static function ($routes): void {
                 $routes->add('users/list', '\Users::list');
-            }
+            },
         );
 
         $expected = [
@@ -331,7 +331,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             ['namespace' => 'Admin'],
             static function ($routes): void {
                 $routes->add('users/list', 'Users::list');
-            }
+            },
         );
 
         $expected = [
@@ -356,7 +356,7 @@ final class RouteCollectionTest extends CIUnitTestCase
                     $routes->get('/', static function (): void {
                     });
                 });
-            }
+            },
         );
 
         $expected = [
@@ -389,9 +389,9 @@ final class RouteCollectionTest extends CIUnitTestCase
                     static function ($routes): void {
                         $routes->get('/', static function (): void {
                         });
-                    }
+                    },
                 );
-            }
+            },
         );
 
         $expected = [
@@ -422,9 +422,9 @@ final class RouteCollectionTest extends CIUnitTestCase
                     static function ($routes): void {
                         $routes->get('/', static function (): void {
                         });
-                    }
+                    },
                 );
-            }
+            },
         );
 
         $expected = [
@@ -463,7 +463,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             '',
             static function ($routes): void {
                 $routes->add('users/list', '\Users::list');
-            }
+            },
         );
 
         $expected = [
@@ -488,7 +488,7 @@ final class RouteCollectionTest extends CIUnitTestCase
                     $routes->group('delegate', static function ($routes): void {
                         $routes->add('foo', '\Users::foo');
                     });
-                }
+                },
             );
         });
 
@@ -518,7 +518,7 @@ final class RouteCollectionTest extends CIUnitTestCase
                     $routes->group('delegate', static function ($routes): void {
                         $routes->add('foo', '\Users::foo');
                     });
-                }
+                },
             );
         });
 
@@ -975,14 +975,14 @@ final class RouteCollectionTest extends CIUnitTestCase
             'testing',
             static function ($routes): void {
                 $routes->get('here', 'there');
-            }
+            },
         );
 
         $routes->environment(
             'badenvironment',
             static function ($routes): void {
                 $routes->get('from', 'to');
-            }
+            },
         );
 
         $this->assertSame($expected, $routes->getRoutes());
@@ -1043,12 +1043,12 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->post(
             'user/insert',
             static function (): void {},
-            ['as' => 'namedRoute2']
+            ['as' => 'namedRoute2'],
         );
         $routes->put(
             'user/insert',
             static function (): void {},
-            ['as' => 'namedRoute3']
+            ['as' => 'namedRoute3'],
         );
 
         $match1 = $routes->reverseRoute('namedRoute1');
@@ -1072,13 +1072,13 @@ final class RouteCollectionTest extends CIUnitTestCase
             '{locale}/user/insert',
             static function (): void {
             },
-            ['as' => 'namedRoute2']
+            ['as' => 'namedRoute2'],
         );
         $routes->put(
             '{locale}/user/insert',
             static function (): void {
             },
-            ['as' => 'namedRoute3']
+            ['as' => 'namedRoute3'],
         );
 
         $match1 = $routes->reverseRoute('namedRoute1');
@@ -1329,7 +1329,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->add(
             'administrator',
             static function (): void {},
-            $options
+            $options,
         );
 
         $options = $routes->getRoutesOptions('administrator');
@@ -1346,13 +1346,13 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->get(
             'administrator',
             static function (): void {},
-            $options1
+            $options1,
         );
         // The second route for `administrator` should be ignored.
         $routes->get(
             'administrator',
             static function (): void {},
-            $options2
+            $options2,
         );
 
         $options = $routes->getRoutesOptions('administrator');
@@ -1421,17 +1421,17 @@ final class RouteCollectionTest extends CIUnitTestCase
         $routes->get(
             'administrator',
             static function (): void {},
-            $options1
+            $options1,
         );
         $routes->post(
             'administrator',
             static function (): void {},
-            $options2
+            $options2,
         );
         $routes->add(
             'administrator',
             static function (): void {},
-            $options3
+            $options3,
         );
 
         $options = $routes->getRoutesOptions('administrator');
@@ -1457,7 +1457,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             ['filter' => 'role'],
             static function ($routes): void {
                 $routes->add('users', '\Users::list');
-            }
+            },
         );
 
         $this->assertTrue($routes->isFiltered('admin/users'));
@@ -1476,7 +1476,7 @@ final class RouteCollectionTest extends CIUnitTestCase
             ['filter' => 'role:admin,manager'],
             static function ($routes): void {
                 $routes->add('users', '\Users::list');
-            }
+            },
         );
 
         $this->assertTrue($routes->isFiltered('admin/users'));

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -505,7 +505,7 @@ final class RouteCollectionTest extends CIUnitTestCase
     public function testNestedGroupingWorksWithRootPrefix(
         string $group,
         string $subgroup,
-        array $expected
+        array $expected,
     ): void {
         $routes = $this->getCollector();
 

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -938,7 +938,7 @@ final class RouterTest extends CIUnitTestCase
         string $redirectTo,
         string $url,
         string $expectedPath,
-        string $alias
+        string $alias,
     ): void {
         $collection = clone $this->collection;
         $collection->resetRoutes();

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -492,7 +492,7 @@ final class RouterTest extends CIUnitTestCase
     public function testRouteWithSlashInControllerName(): void
     {
         $this->expectExceptionMessage(
-            'The namespace delimiter is a backslash (\), not a slash (/). Route handler: "\App/Admin/Admins::edit_show/$1"'
+            'The namespace delimiter is a backslash (\), not a slash (/). Route handler: "\App/Admin/Admins::edit_show/$1"',
         );
 
         $router = new Router($this->collection, $this->request);

--- a/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFCookieRandomizeTokenTest.php
@@ -66,7 +66,7 @@ final class SecurityCSRFCookieRandomizeTokenTest extends CIUnitTestCase
 
         $this->assertSame(
             $this->randomizedToken,
-            $security->getHash()
+            $security->getHash(),
         );
     }
 

--- a/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
+++ b/tests/system/Security/SecurityCSRFSessionRandomizeTokenTest.php
@@ -129,7 +129,7 @@ final class SecurityCSRFSessionRandomizeTokenTest extends CIUnitTestCase
 
         $this->assertSame(
             $this->randomizedToken,
-            $security->getHash()
+            $security->getHash(),
         );
     }
 

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -67,7 +67,7 @@ final class SecurityTest extends CIUnitTestCase
 
         $this->assertSame(
             '8b9218a55906f9dcc1dc263dce7f005a',
-            $security->getHash()
+            $security->getHash(),
         );
     }
 
@@ -116,7 +116,7 @@ final class SecurityTest extends CIUnitTestCase
             $config,
             new SiteURI($config),
             null,
-            new UserAgent()
+            new UserAgent(),
         );
     }
 
@@ -176,7 +176,7 @@ final class SecurityTest extends CIUnitTestCase
         $request  = $this->createIncomingRequest();
 
         $request->setBody(
-            '{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a"}'
+            '{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a"}',
         );
 
         $this->expectException(SecurityException::class);
@@ -192,7 +192,7 @@ final class SecurityTest extends CIUnitTestCase
         $request  = $this->createIncomingRequest();
 
         $request->setBody(
-            '{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a","foo":"bar"}'
+            '{"csrf_test_name":"8b9218a55906f9dcc1dc263dce7f005a","foo":"bar"}',
         );
 
         $this->assertInstanceOf(Security::class, $security->verify($request));
@@ -210,7 +210,7 @@ final class SecurityTest extends CIUnitTestCase
         $request  = $this->createIncomingRequest();
 
         $request->setBody(
-            'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a'
+            'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a',
         );
 
         $this->expectException(SecurityException::class);
@@ -226,7 +226,7 @@ final class SecurityTest extends CIUnitTestCase
         $request  = $this->createIncomingRequest();
 
         $request->setBody(
-            'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a&foo=bar'
+            'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a&foo=bar',
         );
 
         $this->assertInstanceOf(Security::class, $security->verify($request));

--- a/tests/system/Session/SessionTest.php
+++ b/tests/system/Session/SessionTest.php
@@ -277,7 +277,7 @@ final class SessionTest extends CIUnitTestCase
                 'cooking' => 'baking',
                 'sport'   => 'tennis',
             ],
-            $session->get('hobbies')
+            $session->get('hobbies'),
         );
     }
 

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -524,7 +524,7 @@ final class FabricatorTest extends CIUnitTestCase
 
         $this->assertLessThan(
             count($result),
-            count(array_filter($result))
+            count(array_filter($result)),
         );
     }
 
@@ -544,7 +544,7 @@ final class FabricatorTest extends CIUnitTestCase
             $this->assertSame(
                 0,
                 $digit % 2,
-                sprintf('Failed asserting that %s is even.', number_format($digit))
+                sprintf('Failed asserting that %s is even.', number_format($digit)),
             );
         }
     }

--- a/tests/system/Test/FeatureTestTraitTest.php
+++ b/tests/system/Test/FeatureTestTraitTest.php
@@ -423,7 +423,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertStringContainsString(
             // All GET values will be strings.
             '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
-            $response->getBody()
+            $response->getBody(),
         );
     }
 
@@ -450,7 +450,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertStringContainsString(
             // All GET values will be strings.
             '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
-            $response->getBody()
+            $response->getBody(),
         );
     }
 
@@ -477,7 +477,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertStringContainsString(
             // All POST values will be strings.
             '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
-            $response->getBody()
+            $response->getBody(),
         );
     }
 
@@ -504,7 +504,7 @@ final class FeatureTestTraitTest extends CIUnitTestCase
         $this->assertStringContainsString(
             // All POST values will be strings.
             '{"true":"1","false":"","int":"2","null":"","float":"1.23","string":"foo"}',
-            $response->getBody()
+            $response->getBody(),
         );
     }
 
@@ -619,11 +619,11 @@ final class FeatureTestTraitTest extends CIUnitTestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode(['foo1' => 'bar1']),
-            $request->getBody()
+            $request->getBody(),
         );
         $this->assertSame(
             'application/json',
-            $request->header('Content-Type')->getValue()
+            $request->header('Content-Type')->getValue(),
         );
     }
 

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -40,7 +40,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
     {
         $actual = $this->getPrivateProperty(
             TestForReflectionHelper::class,
-            'static_private'
+            'static_private',
         );
         $this->assertSame('xyz', $actual);
     }
@@ -51,7 +51,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
         $this->setPrivateProperty(
             $obj,
             'private',
-            'open'
+            'open',
         );
         $this->assertSame('open', $obj->getPrivate());
     }
@@ -61,11 +61,11 @@ final class ReflectionHelperTest extends CIUnitTestCase
         $this->setPrivateProperty(
             TestForReflectionHelper::class,
             'static_private',
-            'abc'
+            'abc',
         );
         $this->assertSame(
             'abc',
-            TestForReflectionHelper::getStaticPrivate()
+            TestForReflectionHelper::getStaticPrivate(),
         );
     }
 
@@ -74,11 +74,11 @@ final class ReflectionHelperTest extends CIUnitTestCase
         $obj    = new TestForReflectionHelper();
         $method = $this->getPrivateMethodInvoker(
             $obj,
-            'privateMethod'
+            'privateMethod',
         );
         $this->assertSame(
             'private param1param2',
-            $method('param1', 'param2')
+            $method('param1', 'param2'),
         );
     }
 
@@ -86,11 +86,11 @@ final class ReflectionHelperTest extends CIUnitTestCase
     {
         $method = $this->getPrivateMethodInvoker(
             TestForReflectionHelper::class,
-            'privateStaticMethod'
+            'privateStaticMethod',
         );
         $this->assertSame(
             'private_static param1param2',
-            $method('param1', 'param2')
+            $method('param1', 'param2'),
         );
     }
 }

--- a/tests/system/Validation/RulesTest.php
+++ b/tests/system/Validation/RulesTest.php
@@ -375,7 +375,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
         $this->assertSame(
             ['alias.0' => 'The alias.* field does not match the name field.'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
     }
 
@@ -456,7 +456,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
         $this->assertSame(
             ['alias.1' => 'The alias.* field must differ from the name field.'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
     }
 
@@ -1007,7 +1007,7 @@ class RulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
         $this->assertSame(
             ['fiz.*.baz' => 'The fiz.*.baz field must exist.'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
     }
 }

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1863,7 +1863,7 @@ class ValidationTest extends CIUnitTestCase
         array $data = [],
         array $rules = [],
         bool $expectedCheck = false,
-        array $expectedData = []
+        array $expectedData = [],
     ): void {
         $this->validation->setRules($rules);
 

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -250,12 +250,12 @@ class ValidationTest extends CIUnitTestCase
         $this->validation->setRules([]);
         $this->validation->run([]);
         $count1 = count(
-            $this->getPrivateProperty($this->validation, 'ruleSetInstances')
+            $this->getPrivateProperty($this->validation, 'ruleSetInstances'),
         );
 
         $this->validation->run([]);
         $count2 = count(
-            $this->getPrivateProperty($this->validation, 'ruleSetInstances')
+            $this->getPrivateProperty($this->validation, 'ruleSetInstances'),
         );
 
         $this->assertSame($count1, $count2);
@@ -301,7 +301,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($result);
         $this->assertSame(
             ['foo' => 'The value is not "abc"'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
         $this->assertSame([], $this->validation->getValidated());
     }
@@ -329,7 +329,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($result);
         $this->assertSame(
             ['foo' => 'The foo value is not "abc"'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
         $this->assertSame([], $this->validation->getValidated());
     }
@@ -353,7 +353,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($result);
         $this->assertSame(
             ['secret' => 'The シークレット is invalid'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
     }
 
@@ -388,7 +388,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($result);
         $this->assertSame(
             ['foo' => 'The value is not "abc"'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
         $this->assertSame([], $this->validation->getValidated());
     }
@@ -424,7 +424,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($result);
         $this->assertSame(
             ['foo' => 'The foo value is not "abc"'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
         $this->assertSame([], $this->validation->getValidated());
     }
@@ -448,7 +448,7 @@ class ValidationTest extends CIUnitTestCase
         $this->assertFalse($result);
         $this->assertSame(
             ['secret' => 'The シークレット is invalid'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
     }
 
@@ -589,13 +589,13 @@ class ValidationTest extends CIUnitTestCase
             'foo',
             'Foo',
             ['foo'        => 'is_numeric'],
-            ['is_numeric' => 'Nope. Not a number.']
+            ['is_numeric' => 'Nope. Not a number.'],
         );
         $this->validation->setRule(
             'bar',
             'Bar',
             ['bar'        => 'is_numeric'],
-            ['is_numeric' => 'Nope. Not a number.']
+            ['is_numeric' => 'Nope. Not a number.'],
         );
         $result = $this->validation->run($data);
 
@@ -733,7 +733,7 @@ class ValidationTest extends CIUnitTestCase
         ];
         $this->validation->setRules(
             ['foo.*.bar' => ['label' => 'foo bar', 'rules' => 'required']],
-            ['foo.*.bar' => ['required' => 'Required']]
+            ['foo.*.bar' => ['required' => 'Required']],
         );
         $this->validation->run($data);
         $this->assertSame([
@@ -1097,7 +1097,7 @@ class ValidationTest extends CIUnitTestCase
             ['Username' => 'min_length[6]'],
             ['Username' => [
                 'min_length' => 'Supplied value ({value}) for {field} must have at least {param} characters.',
-            ]]
+            ]],
         );
         $result = $this->validation->run($data);
 
@@ -1277,11 +1277,11 @@ class ValidationTest extends CIUnitTestCase
         $this->assertSame(
             "The name_user.* field may only contain alphabetical characters.\n"
             . 'The name_user.* field may only contain alphabetical characters.',
-            $this->validation->getError('name_user.*')
+            $this->validation->getError('name_user.*'),
         );
         $this->assertSame(
             'The contacts.friends.*.name field is required.',
-            $this->validation->getError('contacts.friends.*.name')
+            $this->validation->getError('contacts.friends.*.name'),
         );
     }
 
@@ -1385,7 +1385,7 @@ class ValidationTest extends CIUnitTestCase
             ]],
             ['Username' => [
                 'min_length' => 'Foo.bar.min_length2',
-            ]]
+            ]],
         );
         $result = $this->validation->run($data);
 
@@ -1620,7 +1620,7 @@ class ValidationTest extends CIUnitTestCase
         // to test if placeholderReplacementResultDetermination() works we provoke and expect an exception
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage(
-            'Failed asserting that \'filter[{id}]\' [ASCII](length: 12) does not contain "{id}" [ASCII](length: 4).'
+            'Failed asserting that \'filter[{id}]\' [ASCII](length: 12) does not contain "{id}" [ASCII](length: 4).',
         );
 
         $this->validation->setRule('foo', 'foo-label', 'required|filter[{id}]');
@@ -1801,7 +1801,7 @@ class ValidationTest extends CIUnitTestCase
 
         $this->assertSame(
             'The a.*.c field is required when a.*.b is not present.',
-            $this->validation->getError('a.1.c')
+            $this->validation->getError('a.1.c'),
         );
     }
 
@@ -1827,7 +1827,7 @@ class ValidationTest extends CIUnitTestCase
         ];
 
         $this->validation->setRules(
-            ['contacts.just.friends.*.name' => 'required|max_length[1]']
+            ['contacts.just.friends.*.name' => 'required|max_length[1]'],
         );
         $this->assertFalse($this->validation->run($data));
         $this->assertSame(
@@ -1835,19 +1835,19 @@ class ValidationTest extends CIUnitTestCase
                 'contacts.just.friends.0.name' => 'The contacts.just.friends.*.name field cannot exceed 1 characters in length.',
                 'contacts.just.friends.1.name' => 'The contacts.just.friends.*.name field cannot exceed 1 characters in length.',
             ],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
 
         $this->validation->reset();
         $this->validation->setRules(
-            ['contacts.*.name' => 'required|max_length[1]']
+            ['contacts.*.name' => 'required|max_length[1]'],
         );
         $this->assertFalse($this->validation->run($data));
         $this->assertSame(
             // The data for `contacts.*.name` does not exist. So it is interpreted
             // as `null`, and this error message returns.
             ['contacts.*.name' => 'The contacts.*.name field is required.'],
-            $this->validation->getErrors()
+            $this->validation->getErrors(),
         );
     }
 

--- a/tests/system/View/CellTest.php
+++ b/tests/system/View/CellTest.php
@@ -265,7 +265,7 @@ final class CellTest extends CIUnitTestCase
     {
         $this->assertSame(
             Response::class,
-            $this->cell->render('\Tests\Support\View\SampleClassWithInitController::index')
+            $this->cell->render('\Tests\Support\View\SampleClassWithInitController::index'),
         );
     }
 

--- a/tests/system/View/ParserFilterTest.php
+++ b/tests/system/View/ParserFilterTest.php
@@ -122,7 +122,7 @@ final class ParserFilterTest extends CIUnitTestCase
         $parser->setData($data);
         $this->assertSame(
             'foo bar baz test { undef|default(far) }',
-            $parser->renderString($template)
+            $parser->renderString($template),
         );
     }
 

--- a/tests/system/View/ParserPluginTest.php
+++ b/tests/system/View/ParserPluginTest.php
@@ -152,7 +152,7 @@ final class ParserPluginTest extends CIUnitTestCase
 
         $this->assertMatchesRegularExpression(
             '/aaa nonce="[0-9a-z]{24}" bbb/',
-            $this->parser->renderString($template)
+            $this->parser->renderString($template),
         );
     }
 }

--- a/tests/system/View/TableTest.php
+++ b/tests/system/View/TableTest.php
@@ -75,7 +75,7 @@ final class TableTest extends CIUnitTestCase
                 ['data' => 'color'],
                 ['data' => 'size'],
             ],
-            $this->table->heading
+            $this->table->heading,
         );
     }
 
@@ -94,7 +94,7 @@ final class TableTest extends CIUnitTestCase
                 ['data' => 'Subtotal'],
                 ['data' => $subtotal],
             ],
-            $this->table->footing
+            $this->table->footing,
         );
     }
 
@@ -120,7 +120,7 @@ final class TableTest extends CIUnitTestCase
                     'style' => $this->styleTableOne,
                 ],
             ],
-            $this->table->heading
+            $this->table->heading,
         );
     }
 
@@ -146,7 +146,7 @@ final class TableTest extends CIUnitTestCase
                     'style' => $this->styleTableTwo,
                 ],
             ],
-            $this->table->footing
+            $this->table->footing,
         );
     }
 
@@ -169,7 +169,7 @@ final class TableTest extends CIUnitTestCase
                 ['data' => 'pony'],
                 ['data' => 'stinks'],
             ],
-            $this->table->rows[1]
+            $this->table->rows[1],
         );
     }
 
@@ -202,7 +202,7 @@ final class TableTest extends CIUnitTestCase
 
         $this->assertSame(
             $expected,
-            $this->table->prepArgs(['name', 'color', 'size'])
+            $this->table->prepArgs(['name', 'color', 'size']),
         );
 
         // with cell attributes
@@ -214,7 +214,7 @@ final class TableTest extends CIUnitTestCase
 
         $this->assertSame(
             $expected,
-            $this->table->prepArgs(['name', 'color', 'size', ['data' => 'weight', 'class' => 'awesome']])
+            $this->table->prepArgs(['name', 'color', 'size', ['data' => 'weight', 'class' => 'awesome']]),
         );
     }
 
@@ -285,7 +285,7 @@ final class TableTest extends CIUnitTestCase
         // No column count - no changes to the array
         $this->assertSame(
             $fiveValues,
-            $this->table->makeColumns($fiveValues)
+            $this->table->makeColumns($fiveValues),
         );
 
         // Column count of 3 leaves us with one &nbsp;
@@ -294,7 +294,7 @@ final class TableTest extends CIUnitTestCase
                 ['Laura', 'Red', '15'],
                 ['Katie', 'Blue', '&nbsp;'],
             ],
-            $this->table->makeColumns($fiveValues, 3)
+            $this->table->makeColumns($fiveValues, 3),
         );
     }
 

--- a/user_guide_src/source/cli/cli_library/017.php
+++ b/user_guide_src/source/cli/cli_library/017.php
@@ -21,11 +21,11 @@ for ($i = 0; $i < count($titles); $i++) {
         substr(
             $titles[$i] . str_repeat(' ', $maxlen + 3),
             0,
-            $maxlen + 3
+            $maxlen + 3,
         ) .
         // Wrap the descriptions in a right-hand column
         // with its left side 3 characters wider than
         // the longest item on the left.
-        CLI::wrap($descriptions[$i], 40, $maxlen + 3)
+        CLI::wrap($descriptions[$i], 40, $maxlen + 3),
     );
 }

--- a/user_guide_src/source/database/events/001.php
+++ b/user_guide_src/source/database/events/001.php
@@ -14,5 +14,5 @@ Events::on(
     'DBQuery',
     static function (\CodeIgniter\Database\Query $query) {
         log_message('info', (string) $query);
-    }
+    },
 );

--- a/user_guide_src/source/general/common_functions/011.php
+++ b/user_guide_src/source/general/common_functions/011.php
@@ -4,7 +4,7 @@
 $routes->add(
     '{locale}/users/(:num)/gallery/(:num)',
     'Galleries::showUserGallery/$1/$2',
-    ['as' => 'user_gallery']
+    ['as' => 'user_gallery'],
 );
 
 ?>

--- a/user_guide_src/source/general/errors/015.php
+++ b/user_guide_src/source/general/errors/015.php
@@ -18,7 +18,7 @@ class MyExceptionHandler extends BaseExceptionHandler implements ExceptionHandle
         RequestInterface $request,
         ResponseInterface $response,
         int $statusCode,
-        int $exitCode
+        int $exitCode,
     ): void {
         $this->render($exception, $statusCode, $this->viewPath . "error_{$statusCode}.php");
 

--- a/user_guide_src/source/helpers/html_helper/014.php
+++ b/user_guide_src/source/helpers/html_helper/014.php
@@ -11,7 +11,7 @@ echo video(
     'http://www.codeigniter.com/test.mp4',
     'Your browser does not support the video tag.',
     'controls',
-    $tracks
+    $tracks,
 );
 
 echo video(
@@ -23,5 +23,5 @@ echo video(
     ],
     'Your browser does not support the video tag.',
     'class="test" controls',
-    $tracks
+    $tracks,
 );

--- a/user_guide_src/source/helpers/html_helper/017.php
+++ b/user_guide_src/source/helpers/html_helper/017.php
@@ -9,5 +9,5 @@ echo object(
     [
         param('foo', 'bar', 'ref', 'class="test"'),
         param('hello', 'world', 'ref', 'class="test"'),
-    ]
+    ],
 );

--- a/user_guide_src/source/helpers/url_helper/025.php
+++ b/user_guide_src/source/helpers/url_helper/025.php
@@ -4,7 +4,7 @@
 $routes->add(
     '{locale}/users/(:num)/gallery/(:num)',
     'Galleries::showUserGallery/$1/$2',
-    ['as' => 'user_gallery']
+    ['as' => 'user_gallery'],
 );
 
 ?>

--- a/user_guide_src/source/incoming/controllers/023.php
+++ b/user_guide_src/source/incoming/controllers/023.php
@@ -11,7 +11,7 @@ class Product extends BaseController
     public function initController(
         RequestInterface $request,
         ResponseInterface $response,
-        LoggerInterface $logger
+        LoggerInterface $logger,
     ) {
         parent::initController($request, $response, $logger);
 

--- a/user_guide_src/source/installation/upgrade_444/001.php
+++ b/user_guide_src/source/installation/upgrade_444/001.php
@@ -18,7 +18,7 @@ $data = [
 ];
 
 $validation->setRules(
-    ['contacts.*.name' => 'required|max_length[8]']
+    ['contacts.*.name' => 'required|max_length[8]'],
 );
 
 $validation->run($data); // false

--- a/user_guide_src/source/libraries/cookies/001.php
+++ b/user_guide_src/source/libraries/cookies/001.php
@@ -16,7 +16,7 @@ $cookie = new Cookie(
         'httponly' => true,
         'raw'      => false,
         'samesite' => Cookie::SAMESITE_LAX,
-    ]
+    ],
 );
 
 // Supplying a Set-Cookie header string

--- a/user_guide_src/source/libraries/cookies/004.php
+++ b/user_guide_src/source/libraries/cookies/004.php
@@ -16,7 +16,7 @@ $cookie = new Cookie(
         'httponly' => true,
         'raw'      => false,
         'samesite' => Cookie::SAMESITE_LAX,
-    ]
+    ],
 );
 
 $cookie->getName();             // 'remember_token'

--- a/user_guide_src/source/libraries/cookies/017.php
+++ b/user_guide_src/source/libraries/cookies/017.php
@@ -9,7 +9,7 @@ $cookie = new Cookie(
     'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6',
     [
         'max-age' => 3600 * 2, // Expires in 2 hours
-    ]
+    ],
 );
 
 $response->setCookie($cookie);

--- a/user_guide_src/source/libraries/cookies/018.php
+++ b/user_guide_src/source/libraries/cookies/018.php
@@ -9,7 +9,7 @@ $cookie = new Cookie(
     'f699c7fd18a8e082d0228932f3acd40e1ef5ef92efcedda32842a211d62f0aa6',
     [
         'max-age' => 3600 * 2, // Expires in 2 hours
-    ]
+    ],
 );
 
 set_cookie($cookie);

--- a/user_guide_src/source/libraries/curlrequest/004.php
+++ b/user_guide_src/source/libraries/curlrequest/004.php
@@ -6,5 +6,5 @@ $client = new \CodeIgniter\HTTP\CURLRequest(
     config(App::class),
     new \CodeIgniter\HTTP\URI(),
     new \CodeIgniter\HTTP\Response(config(App::class)),
-    $options
+    $options,
 );

--- a/user_guide_src/source/libraries/curlrequest/035.php
+++ b/user_guide_src/source/libraries/curlrequest/035.php
@@ -3,5 +3,5 @@
 $client->request(
     'GET',
     'http://example.com',
-    ['proxy' => 'http://localhost:3128']
+    ['proxy' => 'http://localhost:3128'],
 );

--- a/user_guide_src/source/libraries/publisher/013.php
+++ b/user_guide_src/source/libraries/publisher/013.php
@@ -12,5 +12,5 @@ $publisher->replace(
     [
         'use CodeIgniter\Config\BaseConfig;' . "\n" => '',
         'class App extends BaseConfig'              => 'class App extends \Some\Package\SomeConfig',
-    ]
+    ],
 );

--- a/user_guide_src/source/libraries/publisher/014.php
+++ b/user_guide_src/source/libraries/publisher/014.php
@@ -10,5 +10,5 @@ $file = APPPATH . 'Config/App.php';
 $publisher->addLineAfter(
     $file,
     '    public int $myOwnConfig = 1000;', // Adds this line
-    'public bool $CSPEnabled = false;'     // After this line
+    'public bool $CSPEnabled = false;',     // After this line
 );

--- a/user_guide_src/source/libraries/publisher/015.php
+++ b/user_guide_src/source/libraries/publisher/015.php
@@ -10,5 +10,5 @@ $file = APPPATH . 'Config/App.php';
 $publisher->addLineBefore(
     $file,
     '    public int $myOwnConfig = 1000;', // Add this line
-    'public bool $CSPEnabled = false;'     // Before this line
+    'public bool $CSPEnabled = false;',     // Before this line
 );

--- a/user_guide_src/source/libraries/validation/023.php
+++ b/user_guide_src/source/libraries/validation/023.php
@@ -12,5 +12,5 @@ $validation->setRules(
         'password' => [
             'min_length' => 'Your password is too short. You want to get hacked?',
         ],
-    ]
+    ],
 );

--- a/user_guide_src/source/models/model/058.php
+++ b/user_guide_src/source/models/model/058.php
@@ -11,7 +11,7 @@ class CastBase64 extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);
@@ -29,7 +29,7 @@ class CastBase64 extends BaseCast
     public static function set(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);

--- a/user_guide_src/source/models/model/060.php
+++ b/user_guide_src/source/models/model/060.php
@@ -10,7 +10,7 @@ class CastBase64 extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): string {
         if (! is_string($value)) {
             self::invalidTypeValueError($value);

--- a/user_guide_src/source/models/model/062.php
+++ b/user_guide_src/source/models/model/062.php
@@ -9,7 +9,7 @@ class SomeHandler extends BaseCast
     public static function get(
         mixed $value,
         array $params = [],
-        ?object $helper = null
+        ?object $helper = null,
     ): mixed {
         var_dump($params);
         /*

--- a/user_guide_src/source/outgoing/view_cells/019.php
+++ b/user_guide_src/source/outgoing/view_cells/019.php
@@ -15,7 +15,7 @@ class RecentPostsCell extends Cell
         $this->posts = model('PostModel')
             ->when(
                 $categoryId,
-                static fn ($query, $categoryId) => $query->where('category_id', $categoryId)
+                static fn ($query, $categoryId) => $query->where('category_id', $categoryId),
             )
             ->orderBy('created_at', 'DESC')
             ->findAll(10);

--- a/user_guide_src/source/testing/controllers/006.php
+++ b/user_guide_src/source/testing/controllers/006.php
@@ -4,7 +4,7 @@ $request = new \CodeIgniter\HTTP\IncomingRequest(
     new \Config\App(),
     new \CodeIgniter\HTTP\URI('http://example.com'),
     null,
-    new \CodeIgniter\HTTP\UserAgent()
+    new \CodeIgniter\HTTP\UserAgent(),
 );
 
 $request->setLocale($locale);

--- a/utils/check_permission_x.php
+++ b/utils/check_permission_x.php
@@ -44,7 +44,7 @@ function findExecutableFiles($dir)
 
     // Create a Recursive Directory Iterator
     $iterator = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($dir)
+        new RecursiveDirectoryIterator($dir),
     );
 
     // Iterate over each item in the directory

--- a/utils/src/Rector/RemoveErrorSuppressInTryCatchStmtsRector.php
+++ b/utils/src/Rector/RemoveErrorSuppressInTryCatchStmtsRector.php
@@ -39,7 +39,7 @@ final class RemoveErrorSuppressInTryCatchStmtsRector extends AbstractRector
                     try {
                     	rmdir($dirname);
                     } catch (Exception $e) {}
-                    CODE_SAMPLE
+                    CODE_SAMPLE,
             ),
         ]);
     }
@@ -73,7 +73,7 @@ final class RemoveErrorSuppressInTryCatchStmtsRector extends AbstractRector
                 }
 
                 return null;
-            }
+            },
         );
 
         if ($hasChanged) {

--- a/utils/src/Rector/UnderscoreToCamelCaseVariableNameRector.php
+++ b/utils/src/Rector/UnderscoreToCamelCaseVariableNameRector.php
@@ -67,7 +67,7 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
                             $someValue = $aB;
                         }
                     }
-                    CODE_SAMPLE
+                    CODE_SAMPLE,
             ),
         ]);
     }
@@ -99,7 +99,7 @@ final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
                 }
 
                 return null;
-            }
+            },
         );
 
         if ($this->hasChanged) {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Done thru the `trailing_comma_in_multiline` fixer.

PHP allows trailing commas in other places aside from multiline arrays:
* function/method calls (since PHP 7.3)
* parameters in function/method declarations (since PHP 8.0)
* closure uses (since PHP 8.0)
* match (since PHP 8.0)
* array destructuring (since PHP 7.1)

This PR is a no-brainer. I add the element, run `cs-fix`, and do nothing else.
I am doing the changes per commit as GitHub hangs on the overall diff.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
