### PR TITLE
docs: Update running.rst to fix the reference for adding host alias in wind…

### DIFF
--- a/user_guide_src/source/installation/running.rst
+++ b/user_guide_src/source/installation/running.rst
@@ -218,7 +218,7 @@ Adding Host Alias
 -----------------
 
 Add a host alias in your "hosts" file, typically **/etc/hosts** on unix-type platforms,
-or **c:\Windows\System32\drivers\etc\hosts** on Windows.
+or **c:\\Windows\\System32\\drivers\\etc\\hosts** on Windows.
 
 Add a line to the file.
 This could be ``myproject.local`` or ``myproject.test``, for instance::


### PR DESCRIPTION
…ows.

**Description**
Reference shows in the user guide like "c:WindowsSystem32driversetchosts" without any backslash. Used double backslash to fix the reference.
