### PR TITLE
docs: changelog entry for phpini:check command

### DIFF
--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -235,6 +235,8 @@ Commands
   arguments.
 - The ``spark filter:check`` command now displays filter classnames.
 - The ``spark lang:sync`` command to synchronize translation files. See :ref:`sync-translations-command`
+- The ``spark phpini:check`` command now has an optional ``opcache`` argument,
+  which when used will display information about opcache settings.
 
 Routing
 =======


### PR DESCRIPTION
**Description**
This PR adds a missing changelog entry for `phpini:check` command.

Ref: #9032

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
