### PR TITLE
refactor: Remove deprecated `EVENT_PRIORITY_*`

### DIFF
--- a/app/Config/Constants.php
+++ b/app/Config/Constants.php
@@ -77,18 +77,3 @@ defined('EXIT_USER_INPUT')     || define('EXIT_USER_INPUT', 7);     // invalid u
 defined('EXIT_DATABASE')       || define('EXIT_DATABASE', 8);       // database error
 defined('EXIT__AUTO_MIN')      || define('EXIT__AUTO_MIN', 9);      // lowest automatically-assigned error code
 defined('EXIT__AUTO_MAX')      || define('EXIT__AUTO_MAX', 125);    // highest automatically-assigned error code
-
-/**
- * @deprecated Use \CodeIgniter\Events\Events::PRIORITY_LOW instead.
- */
-define('EVENT_PRIORITY_LOW', 200);
-
-/**
- * @deprecated Use \CodeIgniter\Events\Events::PRIORITY_NORMAL instead.
- */
-define('EVENT_PRIORITY_NORMAL', 100);
-
-/**
- * @deprecated Use \CodeIgniter\Events\Events::PRIORITY_HIGH instead.
- */
-define('EVENT_PRIORITY_HIGH', 10);

--- a/tests/system/Events/EventsTest.php
+++ b/tests/system/Events/EventsTest.php
@@ -29,6 +29,8 @@ final class EventsTest extends CIUnitTestCase
 {
     /**
      * Accessible event manager instance
+     *
+     * @var MockEvents
      */
     private Events $manager;
 
@@ -96,8 +98,8 @@ final class EventsTest extends CIUnitTestCase
         $callback2 = static function (): void {
         };
 
-        Events::on('foo', $callback1, EVENT_PRIORITY_HIGH);
-        Events::on('foo', $callback2, EVENT_PRIORITY_NORMAL);
+        Events::on('foo', $callback1, Events::PRIORITY_HIGH);
+        Events::on('foo', $callback2, Events::PRIORITY_NORMAL);
 
         $this->assertSame([$callback1, $callback2], Events::listeners('foo'));
     }
@@ -142,14 +144,14 @@ final class EventsTest extends CIUnitTestCase
             $result = 1;
 
             return false;
-        }, EVENT_PRIORITY_NORMAL);
+        }, Events::PRIORITY_NORMAL);
         // Since this has a higher priority, it will
         // run first.
         Events::on('foo', static function () use (&$result): bool {
             $result = 2;
 
             return false;
-        }, EVENT_PRIORITY_HIGH);
+        }, Events::PRIORITY_HIGH);
 
         $this->assertFalse(Events::trigger('foo', 'bar'));
         $this->assertSame(2, $result);

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -198,7 +198,8 @@ Removed Deprecated Items
 - **Logger:** The deprecated ``CodeIgniter\Log\Logger::cleanFilenames()`` and
   ``CodeIgniter\Test\TestLogger::cleanup()`` have been removed. Use the
   ``clean_path()`` function instead.
-  **Router:** The deprecated ``CodeIgniter\Router\Exceptions\RedirectException`` has been removed. Use ``CodeIgniter\HTTP\Exceptions\RedirectException`` instead.
+- **Router:** The deprecated ``CodeIgniter\Router\Exceptions\RedirectException`` has been removed. Use ``CodeIgniter\HTTP\Exceptions\RedirectException`` instead.
+- **Constants:** The deprecated constants ``EVENT_PRIORITY_*`` in has been removed. Use the class constants ``CodeIgniter\Events\Events::PRIORITY_LOW``, ``CodeIgniter\Events\Events::PRIORITY_NORMAL`` and ``CodeIgniter\Events\Events::PRIORITY_HIGH`` instead.
 
 ************
 Enhancements

--- a/user_guide_src/source/extending/events.rst
+++ b/user_guide_src/source/extending/events.rst
@@ -51,7 +51,7 @@ but you might find they aid readability:
 
 .. literalinclude:: events/004.php
 
-.. important:: The constants ``EVENT_PRIORITY_LOW``, ``EVENT_PRIORITY_NORMAL`` and ``EVENT_PRIORITY_HIGH`` are deprecated, and the definitions are moved to ``app/Config/Constants.php``. These will be removed in future releases.
+.. important:: The constants ``EVENT_PRIORITY_LOW``, ``EVENT_PRIORITY_NORMAL`` and ``EVENT_PRIORITY_HIGH`` has been removed in v4.6.0.
 
 Once sorted, all subscribers are executed in order. If any subscriber returns a boolean false value, then execution of
 the subscribers will stop.

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -222,3 +222,4 @@ This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
 - app/Config/Feature.php
+- app/Config/Constants.php

--- a/utils/phpstan-baseline/method.notFound.neon
+++ b/utils/phpstan-baseline/method.notFound.neon
@@ -1,4 +1,4 @@
-# total 41 errors
+# total 40 errors
 
 parameters:
     ignoreErrors:
@@ -46,11 +46,6 @@ parameters:
             message: '#^Call to an undefined method CodeIgniter\\HTTP\\ResponseInterface\:\:pretend\(\)\.$#'
             count: 3
             path: ../../tests/system/Debug/ExceptionHandlerTest.php
-
-        -
-            message: '#^Call to an undefined method CodeIgniter\\Events\\Events\:\:unInitialize\(\)\.$#'
-            count: 1
-            path: ../../tests/system/Events/EventsTest.php
 
         -
             message: '#^Call to an undefined method CodeIgniter\\HTTP\\Request\:\:getCookie\(\)\.$#'


### PR DESCRIPTION
**Description**
See #6000 (**v4.2.0**)
Constants are used a little in the system, so there are few updates. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
