### PR TITLE
chore: Fix phpunit deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,6 @@
     failOnWarning="true"
     cacheDirectory="build/.phpunit.cache">
     <coverage
-        includeUncoveredFiles="true"
         pathCoverage="false"
         ignoreDeprecatedCodeUnits="true"
         disableCodeCoverageIgnore="true">

--- a/tests/system/DebugTraceableTraitTest.php
+++ b/tests/system/DebugTraceableTraitTest.php
@@ -16,13 +16,11 @@ namespace CodeIgniter;
 use CodeIgniter\Exceptions\DebugTraceableTrait;
 use CodeIgniter\Exceptions\FrameworkException;
 use CodeIgniter\Test\CIUnitTestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @internal
  */
-#[CoversClass(DebugTraceableTrait::class)]
 #[Group('Others')]
 final class DebugTraceableTraitTest extends CIUnitTestCase
 {


### PR DESCRIPTION
**Description**
- I don't know why, but `includeUncoveredFiles` is missing from XSD for **11.5**. Although this parameter is available in the documentation.
- `CoversTrait` is deprecated. I didn't understand what it was for. Tell me if this is a test error. See https://github.com/sebastianbergmann/phpunit/issues/5958 
- 
**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
