### PR TITLE
refactor: Remove deprecated `View::$currentSection`

### DIFF
--- a/system/View/View.php
+++ b/system/View/View.php
@@ -128,16 +128,6 @@ class View implements RendererInterface
      * The name of the current section being rendered,
      * if any.
      *
-     * @var string|null
-     *
-     * @deprecated
-     */
-    protected $currentSection;
-
-    /**
-     * The name of the current section being rendered,
-     * if any.
-     *
      * @var list<string>
      */
     protected $sectionStack = [];
@@ -420,8 +410,6 @@ class View implements RendererInterface
      */
     public function section(string $name)
     {
-        // Saved to prevent BC.
-        $this->currentSection = $name;
         $this->sectionStack[] = $name;
 
         ob_start();

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -200,6 +200,7 @@ Removed Deprecated Items
   ``clean_path()`` function instead.
 - **Router:** The deprecated ``CodeIgniter\Router\Exceptions\RedirectException`` has been removed. Use ``CodeIgniter\HTTP\Exceptions\RedirectException`` instead.
 - **Constants:** The deprecated constants ``EVENT_PRIORITY_*`` in has been removed. Use the class constants ``CodeIgniter\Events\Events::PRIORITY_LOW``, ``CodeIgniter\Events\Events::PRIORITY_NORMAL`` and ``CodeIgniter\Events\Events::PRIORITY_HIGH`` instead.
+- **View:** The deprecated property ``CodeIgniter\View\View::$currentSection`` has been removed.
 
 ************
 Enhancements


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/4622 **v4.1.2**
The property is no longer in use. Only in special cases when extending the `View`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
