### PR TITLE
refactor: Remove deprecated `Cache::$storePath`

### DIFF
--- a/app/Config/Cache.php
+++ b/app/Config/Cache.php
@@ -36,18 +36,6 @@ class Cache extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
-     * Cache Directory Path
-     * --------------------------------------------------------------------------
-     *
-     * The path to where cache files should be stored, if using a file-based
-     * system.
-     *
-     * @deprecated Use the driver-specific variant under $file
-     */
-    public string $storePath = WRITEPATH . 'cache/';
-
-    /**
-     * --------------------------------------------------------------------------
      * Key Prefix
      * --------------------------------------------------------------------------
      *
@@ -86,6 +74,7 @@ class Cache extends BaseConfig
      * --------------------------------------------------------------------------
      * File settings
      * --------------------------------------------------------------------------
+     *
      * Your file storage preferences can be specified below, if you are using
      * the File driver.
      *
@@ -100,6 +89,7 @@ class Cache extends BaseConfig
      * -------------------------------------------------------------------------
      * Memcached settings
      * -------------------------------------------------------------------------
+     *
      * Your Memcached servers can be specified below, if you are using
      * the Memcached drivers.
      *

--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -54,13 +54,6 @@ class FileHandler extends BaseHandler
      */
     public function __construct(Cache $config)
     {
-        if (! property_exists($config, 'file')) {
-            $config->file = [
-                'storePath' => $config->storePath ?? WRITEPATH . 'cache',
-                'mode'      => 0640,
-            ];
-        }
-
         $this->path = ! empty($config->file['storePath']) ? $config->file['storePath'] : WRITEPATH . 'cache';
         $this->path = rtrim($this->path, '/') . '/';
 

--- a/tests/system/Cache/CacheFactoryTest.php
+++ b/tests/system/Cache/CacheFactoryTest.php
@@ -37,14 +37,14 @@ final class CacheFactoryTest extends CIUnitTestCase
 
         // Initialize path
         $this->config = new Cache();
-        $this->config->storePath .= self::$directory;
+        $this->config->file['storePath'] .= self::$directory;
     }
 
     protected function tearDown(): void
     {
-        if (is_dir($this->config->storePath)) {
-            chmod($this->config->storePath, 0777);
-            rmdir($this->config->storePath);
+        if (is_dir($this->config->file['storePath'])) {
+            chmod($this->config->file['storePath'], 0777);
+            rmdir($this->config->file['storePath']);
         }
     }
 
@@ -75,8 +75,8 @@ final class CacheFactoryTest extends CIUnitTestCase
 
     public function testGetDummyHandler(): void
     {
-        if (! is_dir($this->config->storePath)) {
-            mkdir($this->config->storePath, 0555, true);
+        if (! is_dir($this->config->file['storePath'])) {
+            mkdir($this->config->file['storePath'], 0555, true);
         }
 
         $this->config->handler = 'dummy';
@@ -85,13 +85,13 @@ final class CacheFactoryTest extends CIUnitTestCase
 
         // Initialize path
         $this->config = new Cache();
-        $this->config->storePath .= self::$directory;
+        $this->config->file['storePath'] .= self::$directory;
     }
 
     public function testHandlesBadHandler(): void
     {
-        if (! is_dir($this->config->storePath)) {
-            mkdir($this->config->storePath, 0555, true);
+        if (! is_dir($this->config->file['storePath'])) {
+            mkdir($this->config->file['storePath'], 0555, true);
         }
 
         $this->config->handler = 'dummy';
@@ -104,6 +104,6 @@ final class CacheFactoryTest extends CIUnitTestCase
 
         // Initialize path
         $this->config = new Cache();
-        $this->config->storePath .= self::$directory;
+        $this->config->file['storePath'] .= self::$directory;
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -201,6 +201,7 @@ Removed Deprecated Items
 - **Router:** The deprecated ``CodeIgniter\Router\Exceptions\RedirectException`` has been removed. Use ``CodeIgniter\HTTP\Exceptions\RedirectException`` instead.
 - **Constants:** The deprecated constants ``EVENT_PRIORITY_*`` in has been removed. Use the class constants ``CodeIgniter\Events\Events::PRIORITY_LOW``, ``CodeIgniter\Events\Events::PRIORITY_NORMAL`` and ``CodeIgniter\Events\Events::PRIORITY_HIGH`` instead.
 - **View:** The deprecated property ``CodeIgniter\View\View::$currentSection`` has been removed.
+- **Config:** The deprecated property ``Config\Cache::$storePath`` has been removed. Use ``Config\Cache::$file['storePath']`` instead.
 
 ************
 Enhancements

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -223,3 +223,4 @@ many will be simple comments or formatting that have no effect on the runtime:
 
 - app/Config/Feature.php
 - app/Config/Constants.php
+- app/Config/Cache.php

--- a/utils/phpstan-baseline/function.alreadyNarrowedType.neon
+++ b/utils/phpstan-baseline/function.alreadyNarrowedType.neon
@@ -1,12 +1,7 @@
-# total 3 errors
+# total 2 errors
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^Call to function property_exists\(\) with Config\\Cache and ''file'' will always evaluate to true\.$#'
-            count: 1
-            path: ../../system/Cache/Handlers/FileHandler.php
-
         -
             message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
             count: 1


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/4103 **v4.0.5**
`$storePath` has been removed and the tests have been updated.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
