### PR TITLE
refactor: Remove deprecated `Config\Format::getFormatter()`

### DIFF
--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -3,7 +3,6 @@
 namespace Config;
 
 use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Format\FormatterInterface;
 use CodeIgniter\Format\JSONFormatter;
 use CodeIgniter\Format\XMLFormatter;
 
@@ -62,16 +61,4 @@ class Format extends BaseConfig
         'application/xml'  => 0,
         'text/xml'         => 0,
     ];
-
-    /**
-     * A Factory method to return the appropriate formatter for the given mime type.
-     *
-     * @return FormatterInterface
-     *
-     * @deprecated This is an alias of `\CodeIgniter\Format\Format::getFormatter`. Use that instead.
-     */
-    public function getFormatter(string $mime)
-    {
-        return service('format')->getFormatter($mime);
-    }
 }

--- a/user_guide_src/source/changelogs/v4.6.0.rst
+++ b/user_guide_src/source/changelogs/v4.6.0.rst
@@ -202,6 +202,7 @@ Removed Deprecated Items
 - **Constants:** The deprecated constants ``EVENT_PRIORITY_*`` in has been removed. Use the class constants ``CodeIgniter\Events\Events::PRIORITY_LOW``, ``CodeIgniter\Events\Events::PRIORITY_NORMAL`` and ``CodeIgniter\Events\Events::PRIORITY_HIGH`` instead.
 - **View:** The deprecated property ``CodeIgniter\View\View::$currentSection`` has been removed.
 - **Config:** The deprecated property ``Config\Cache::$storePath`` has been removed. Use ``Config\Cache::$file['storePath']`` instead.
+- **Formatter:** The deprecated ``Config\Format::getFormatter()`` has been removed. Use ``CodeIgniter\Format\Format::getFormatter()`` instead.
 
 ************
 Enhancements

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -224,3 +224,4 @@ many will be simple comments or formatting that have no effect on the runtime:
 - app/Config/Feature.php
 - app/Config/Constants.php
 - app/Config/Cache.php
+- app/Config/Format.php


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/CodeIgniter4/pull/3563 **v4.0.5**

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
