### PR TITLE
fix: Validation headers

### DIFF
--- a/tests/system/HTTP/HeaderTest.php
+++ b/tests/system/HTTP/HeaderTest.php
@@ -15,6 +15,8 @@ namespace CodeIgniter\HTTP;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use Error;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
@@ -233,5 +235,71 @@ final class HeaderTest extends CIUnitTestCase
         $header->setValue('bar')->appendValue(['baz' => 'fuzz']);
 
         $this->assertSame($expected, (string) $header);
+    }
+
+    /**
+     * @param string $name
+     */
+    #[DataProvider('invalidNamesProvider')]
+    public function testInvalidHeaderNames($name): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Header($name, 'text/html');
+    }
+
+    /**
+     * @return list<list<string>>
+     */
+    public static function invalidNamesProvider(): array
+    {
+        return [
+            ["Content-Type\r\n\r\n"],
+            ["Content-Type\r\n"],
+            ["Content-Type\n"],
+            ["\tContent-Type\t"],
+            ["\n\nContent-Type\n\n"],
+            ["\r\nContent-Type"],
+            ["\nContent-Type"],
+            ["Content\r\n-Type"],
+            ["\n"],
+            ["\r\n"],
+            ["\t"],
+            ['   Content-Type   '],
+            ['Content - Type'],
+            [''],
+        ];
+    }
+
+    /**
+     * @param array<int|string, array<string, string>|string>|string|null $value
+     */
+    #[DataProvider('invalidValuesProvider')]
+    public function testInvalidHeaderValues($value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Header('X-Test-Header', $value);
+    }
+
+    /**
+     * @return list<list<list<string>|string>>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            ["Header\n Value"],
+            ["Header\r\n Value"],
+            ["Header\r Value"],
+            ["Header Value\n"],
+            ["\nHeader Value"],
+            ["Header Value\r\n"],
+            ["\n\rHeader Value"],
+            ["\n\nHeader Value\n\n"],
+            [
+                ["Header\n Value"],
+                ["Header\r\n Value"],
+            ],
+        ];
     }
 }

--- a/user_guide_src/source/changelogs/v4.5.8.rst
+++ b/user_guide_src/source/changelogs/v4.5.8.rst
@@ -14,6 +14,11 @@ Release Date: Unreleased
 BREAKING
 ********
 
+Header
+======
+
+Added validation of the name and value for ``CodeIgniter\HTTP\Header``. Some specific headers can cause the system to crash.
+
 ***************
 Message Changes
 ***************
@@ -31,6 +36,7 @@ Bugs Fixed
 **********
 
 - **Database:** Fixed a bug where ``Builder::affectedRows()`` threw an error when the previous query call failed in ``Postgre`` and ``SQLSRV`` drivers.
+- **Header:** Improper headers parsing. Line breaks and other incorrect characters in headers (``CodeIgniter\HTTP\Header``) may break the HTTP request. See https://datatracker.ietf.org/doc/html/rfc7230 for more details.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This is a security fix, therefore, the **develop** branch.
Headers should not contain bad characters like a newline.
If desired, we can perform `trim()`.
As always, I need help with the documentation.

See also:
https://github.com/advisories/GHSA-wxmh-65f7-jcvw 
https://github.com/advisories/GHSA-xv3h-4844-9h36

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
