### PR TITLE
fix(CURLRequest): multiple header sections after redirects

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -385,6 +385,29 @@ class CURLRequest extends OutgoingRequest
         // Set the string we want to break our response from
         $breakString = "\r\n\r\n";
 
+        // Strip out multiple redirect header sections
+        if (isset($this->config['allow_redirects']) && $this->config['allow_redirects'] !== false) {
+            while (preg_match('/^HTTP\/\d(?:\.\d)? 3\d\d/', $output)) {
+                $breakStringPos        = strpos($output, $breakString);
+                $redirectHeaderSection = substr($output, 0, $breakStringPos);
+                $redirectHeaders       = explode("\n", $redirectHeaderSection);
+                $locationHeaderFound   = false;
+
+                foreach ($redirectHeaders as $header) {
+                    if (str_starts_with(strtolower($header), 'location:')) {
+                        $locationHeaderFound = true;
+                        break;
+                    }
+                }
+
+                if ($locationHeaderFound) {
+                    $output = substr($output, $breakStringPos + 4);
+                } else {
+                    break;
+                }
+            }
+        }
+
         while (str_starts_with($output, 'HTTP/1.1 100 Continue')) {
             $output = substr($output, strpos($output, $breakString) + 4);
         }

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1330,7 +1330,7 @@ content-length: 211
 location: http://example.com
 date: Mon, 20 Jan 2025 11:46:34 GMT
 server: nginx/1.21.6
-vary: Origin\r\n\r\nHTTP/1.1 307 Temporary Redirect
+vary: Origin\r\n\r\nHTTP/1.1 399 Custom Redirect
 content-type: text/html; charset=utf-8
 content-length: 211
 location: http://example.com

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -1360,7 +1360,8 @@ vary: Origin\r\n\r\n" . $testBody;
         $this->assertSame($testBody, $response->getBody());
     }
 
-    public function testNotRemoveMultipleRedirectHeaderSectionsWithoutLocationHeader() {
+    public function testNotRemoveMultipleRedirectHeaderSectionsWithoutLocationHeader(): void
+    {
         $testBody = 'Hello world';
 
         $output = "HTTP/1.1 301 Moved Permanently

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **CURLRequest:** Fixed returning multiple header sections as body after redirects.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -30,7 +30,7 @@ Deprecations
 Bugs Fixed
 **********
 
-- **CURLRequest:** Fixed returning multiple header sections as body after redirects.
+- **CURLRequest:** Fixed an issue where multiple header sections appeared in the CURL response body during multiple redirects from the target server.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Fixes an issue where multiple header sections are returned if there are redirects. The original code would only parse the first header section, and treated the rest as body. For example:

With output:

```http
HTTP/2 308
content-type: text/html; charset=utf-8
content-length: 211
location: http://example.com
date: Mon, 20 Jan 2025 11:46:34 GMT
server: nginx/1.21.6
vary: Origin

HTTP/2 200
content-type: text/html; charset=utf-8
content-length: 211
date: Mon, 20 Jan 2025 11:46:34 GMT
server: nginx/1.21.6
vary: Origin

Hello world
```

`$response->getBody()` returns:

```http
HTTP/2 200
content-type: text/html; charset=utf-8
content-length: 211
date: Mon, 20 Jan 2025 11:46:34 GMT
server: nginx/1.21.6
vary: Origin

Hello world
```

With these changes, the redirect header section is stripped out, only the latest header section is parsed (the 200 one in this example), and body is `Hello world`.

Not sure if this issue has been discussed before but I couldn't find an issue related to this.

My machine details:
Ubuntu 24.04
PHP 8.2.27
libcurl 7.88.1

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
