### PR TITLE
chore: NetBeans IDE-related entries in the framework root's .gitignore file causing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,15 +101,15 @@ _modules/*
 .idea/
 *.iml
 
-# Netbeans
-nbproject/
-build/
-nbbuild/
-dist/
-nbdist/
-nbactions.xml
-nb-configuration.xml
-.nb-gradle/
+# NetBeans
+/nbproject/
+/build/
+/nbbuild/
+/dist/
+/nbdist/
+/nbactions.xml
+/nb-configuration.xml
+/.nb-gradle/
 
 # Sublime Text
 *.tmlanguage.cache


### PR DESCRIPTION
**Description**
Fixes #9423

Ensure that the NetBeans IDE-related entries in the framework root's .gitignore file apply exclusively to the framework root directory.
