### PR TITLE
chore: update phpstan baseline count of errors

### DIFF
--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,4 +1,4 @@
-# total 73 errors
+# total 147 errors
 
 parameters:
     ignoreErrors:
@@ -119,11 +119,6 @@ parameters:
 
         -
             message: '#^Parameter \#1 \$db of class CodeIgniter\\Database\\SQLite3\\Table constructor expects CodeIgniter\\Database\\SQLite3\\Connection, CodeIgniter\\Database\\BaseConnection given\.$#'
-            count: 1
-            path: ../../tests/system/Database/Live/SQLite3/AlterTableTest.php
-
-        -
-            message: '#^Parameter \#2 \$forge of class CodeIgniter\\Database\\SQLite3\\Table constructor expects CodeIgniter\\Database\\SQLite3\\Forge, CodeIgniter\\Database\\Forge given\.$#'
             count: 1
             path: ../../tests/system/Database/Live/SQLite3/AlterTableTest.php
 

--- a/utils/phpstan-baseline/assign.propertyType.neon
+++ b/utils/phpstan-baseline/assign.propertyType.neon
@@ -1,4 +1,4 @@
-# total 20 errors
+# total 29 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/codeigniter.cacheHandlerInstance.neon
+++ b/utils/phpstan-baseline/codeigniter.cacheHandlerInstance.neon
@@ -1,4 +1,4 @@
-# total 6 errors
+# total 14 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/codeigniter.getReassignArray.neon
+++ b/utils/phpstan-baseline/codeigniter.getReassignArray.neon
@@ -1,4 +1,4 @@
-# total 13 errors
+# total 22 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/codeigniter.superglobalAccess.neon
+++ b/utils/phpstan-baseline/codeigniter.superglobalAccess.neon
@@ -1,4 +1,4 @@
-# total 53 errors
+# total 83 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/codeigniter.superglobalAccessAssign.neon
+++ b/utils/phpstan-baseline/codeigniter.superglobalAccessAssign.neon
@@ -1,4 +1,4 @@
-# total 260 errors
+# total 582 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/codeigniter.unknownServiceMethod.neon
+++ b/utils/phpstan-baseline/codeigniter.unknownServiceMethod.neon
@@ -1,4 +1,4 @@
-# total 6 errors
+# total 9 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -1,4 +1,4 @@
-# total 77 errors
+# total 271 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/method.alreadyNarrowedType.neon
+++ b/utils/phpstan-baseline/method.alreadyNarrowedType.neon
@@ -1,4 +1,4 @@
-# total 16 errors
+# total 22 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/method.childReturnType.neon
+++ b/utils/phpstan-baseline/method.childReturnType.neon
@@ -1,4 +1,4 @@
-# total 39 errors
+# total 40 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/method.notFound.neon
+++ b/utils/phpstan-baseline/method.notFound.neon
@@ -1,4 +1,4 @@
-# total 40 errors
+# total 83 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1665 errors
+# total 1672 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/missingType.property.neon
+++ b/utils/phpstan-baseline/missingType.property.neon
@@ -1,4 +1,4 @@
-# total 127 errors
+# total 130 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/nullCoalesce.property.neon
+++ b/utils/phpstan-baseline/nullCoalesce.property.neon
@@ -1,4 +1,4 @@
-# total 15 errors
+# total 22 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/offsetAccess.notFound.neon
+++ b/utils/phpstan-baseline/offsetAccess.notFound.neon
@@ -1,4 +1,4 @@
-# total 6 errors
+# total 19 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/property.nonObject.neon
+++ b/utils/phpstan-baseline/property.nonObject.neon
@@ -1,4 +1,4 @@
-# total 25 errors
+# total 54 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/property.notFound.neon
+++ b/utils/phpstan-baseline/property.notFound.neon
@@ -1,4 +1,4 @@
-# total 30 errors
+# total 58 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/property.protected.neon
+++ b/utils/phpstan-baseline/property.protected.neon
@@ -1,4 +1,4 @@
-# total 9 errors
+# total 15 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/property.readOnlyByPhpDocAssignOutOfClass.neon
+++ b/utils/phpstan-baseline/property.readOnlyByPhpDocAssignOutOfClass.neon
@@ -1,4 +1,4 @@
-# total 16 errors
+# total 33 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/property.readOnlyByPhpDocDefaultValue.neon
+++ b/utils/phpstan-baseline/property.readOnlyByPhpDocDefaultValue.neon
@@ -1,4 +1,4 @@
-# total 7 errors
+# total 20 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/staticMethod.notFound.neon
+++ b/utils/phpstan-baseline/staticMethod.notFound.neon
@@ -1,4 +1,4 @@
-# total 7 errors
+# total 20 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/ternary.shortNotAllowed.neon
+++ b/utils/phpstan-baseline/ternary.shortNotAllowed.neon
@@ -1,4 +1,4 @@
-# total 27 errors
+# total 38 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/varTag.type.neon
+++ b/utils/phpstan-baseline/varTag.type.neon
@@ -1,4 +1,4 @@
-# total 8 errors
+# total 9 errors
 
 parameters:
     ignoreErrors:

--- a/utils/phpstan-baseline/variable.undefined.neon
+++ b/utils/phpstan-baseline/variable.undefined.neon
@@ -1,4 +1,4 @@
-# total 15 errors
+# total 21 errors
 
 parameters:
     ignoreErrors:


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
The update brings the correct count of baselined errors. To date, that's a whopping 3,800 errors.
```
composer phpstan:baseline
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
