### PR TITLE
fix: set headers for CORS

### DIFF
--- a/system/Filters/Cors.php
+++ b/system/Filters/Cors.php
@@ -100,6 +100,24 @@ class Cors implements FilterInterface
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null)
     {
-        return null;
+        if (! $request instanceof IncomingRequest) {
+            return null;
+        }
+
+        $this->createCorsService($arguments);
+
+        if ($this->cors->hasResponseHeaders($request, $response)) {
+            return null;
+        }
+
+        // Always adds `Vary: Access-Control-Request-Method` header for cacheability.
+        // If there is an intermediate cache server such as a CDN, if a plain
+        // OPTIONS request is sent, it may be cached. But valid preflight requests
+        // have this header, so it will be cached separately.
+        if ($request->is('OPTIONS')) {
+            $response->appendHeader('Vary', 'Access-Control-Request-Method');
+        }
+
+        return $this->cors->addResponseHeaders($request, $response);
     }
 }

--- a/system/Filters/Cors.php
+++ b/system/Filters/Cors.php
@@ -61,16 +61,24 @@ class Cors implements FilterInterface
         /** @var ResponseInterface $response */
         $response = service('response');
 
+        if ($this->cors->isPreflightRequest($request)) {
+            $response = $this->cors->handlePreflightRequest($request, $response);
+
+            // Always adds `Vary: Access-Control-Request-Method` header for cacheability.
+            // If there is an intermediate cache server such as a CDN, if a plain
+            // OPTIONS request is sent, it may be cached. But valid preflight requests
+            // have this header, so it will be cached separately.
+            $response->appendHeader('Vary', 'Access-Control-Request-Method');
+
+            return $response;
+        }
+
         if ($request->is('OPTIONS')) {
             // Always adds `Vary: Access-Control-Request-Method` header for cacheability.
             // If there is an intermediate cache server such as a CDN, if a plain
             // OPTIONS request is sent, it may be cached. But valid preflight requests
             // have this header, so it will be cached separately.
             $response->appendHeader('Vary', 'Access-Control-Request-Method');
-        }
-
-        if ($this->cors->isPreflightRequest($request)) {
-            return $this->cors->handlePreflightRequest($request, $response);
         }
 
         $this->cors->addResponseHeaders($request, $response);

--- a/system/HTTP/Cors.php
+++ b/system/HTTP/Cors.php
@@ -227,4 +227,28 @@ class Cors
             );
         }
     }
+
+    /**
+     * Check if response headers were set
+     */
+    public function hasResponseHeaders(RequestInterface $request, ResponseInterface $response): bool
+    {
+        if (! $response->hasHeader('Access-Control-Allow-Origin')) {
+            return false;
+        }
+
+        if ($this->config['supportsCredentials']
+            && ! $response->hasHeader('Access-Control-Allow-Credentials')) {
+            return false;
+        }
+
+        if ($this->config['exposedHeaders'] !== [] && (! $response->hasHeader('Access-Control-Expose-Headers') || ! str_contains(
+            $response->getHeaderLine('Access-Control-Expose-Headers'),
+            implode(', ', $this->config['exposedHeaders']),
+        ))) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/system/HTTP/Cors.php
+++ b/system/HTTP/Cors.php
@@ -242,13 +242,9 @@ class Cors
             return false;
         }
 
-        if ($this->config['exposedHeaders'] !== [] && (! $response->hasHeader('Access-Control-Expose-Headers') || ! str_contains(
+        return ! ($this->config['exposedHeaders'] !== [] && (! $response->hasHeader('Access-Control-Expose-Headers') || ! str_contains(
             $response->getHeaderLine('Access-Control-Expose-Headers'),
             implode(', ', $this->config['exposedHeaders']),
-        ))) {
-            return false;
-        }
-
-        return true;
+        )));
     }
 }

--- a/tests/system/HTTP/CorsTest.php
+++ b/tests/system/HTTP/CorsTest.php
@@ -521,4 +521,41 @@ final class CorsTest extends CIUnitTestCase
             $response->hasHeader('Access-Control-Allow-Methods'),
         );
     }
+
+    public function testHasResponseHeadersFalse(): void
+    {
+        $config                   = $this->getDefaultConfig();
+        $config['allowedOrigins'] = ['http://localhost:8080'];
+        $config['allowedMethods'] = ['GET', 'POST', 'PUT'];
+        $cors                     = $this->createCors($config);
+
+        $request = $this->createRequest()
+            ->withMethod('GET')
+            ->setHeader('Origin', 'http://localhost:8080');
+
+        $response = service('redirectresponse', null, false);
+
+        $this->assertFalse(
+            $cors->hasResponseHeaders($request, $response),
+        );
+    }
+
+    public function testHasResponseHeadersTrue(): void
+    {
+        $config                   = $this->getDefaultConfig();
+        $config['allowedOrigins'] = ['http://localhost:8080'];
+        $config['allowedMethods'] = ['GET', 'POST'];
+        $cors                     = $this->createCors($config);
+
+        $request = $this->createRequest()
+            ->withMethod('GET')
+            ->setHeader('Origin', 'http://localhost:8080');
+
+        $response = service('redirectresponse', null, false);
+        $response = $cors->addResponseHeaders($request, $response);
+
+        $this->assertTrue(
+            $cors->hasResponseHeaders($request, $response),
+        );
+    }
 }

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -22,8 +22,6 @@ Message Changes
 Changes
 *******
 
-- **Cors:** From now on only the ``before`` filter is used. You can remove all the ``after`` filter occurrences from your configuration for CORS.
-
 ************
 Deprecations
 ************
@@ -33,7 +31,7 @@ Bugs Fixed
 **********
 
 - **CURLRequest:** Fixed an issue where multiple header sections appeared in the CURL response body during multiple redirects from the target server.
-- **Cors:** Fixed a bug in the Cors filter that caused the appropriate headers to not be added when another filter returned a response object. From now on all CORS headers are added in the ``before`` filter and the ``after`` filter is no longer used.
+- **Cors:** Fixed a bug in the Cors filter that caused the appropriate headers to not be added when another filter returned a response object in the ``before`` filter.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -22,6 +22,8 @@ Message Changes
 Changes
 *******
 
+- **Cors:** From now on only the ``before`` filter is used. You can remove all the ``after`` filter occurrences from your configuration for CORS.
+
 ************
 Deprecations
 ************
@@ -31,6 +33,7 @@ Bugs Fixed
 **********
 
 - **CURLRequest:** Fixed an issue where multiple header sections appeared in the CURL response body during multiple redirects from the target server.
+- **Cors:** Fixed a bug in the Cors filter that caused the appropriate headers to not be added when another filter returned a response object. From now on all CORS headers are added in the ``before`` filter and the ``after`` filter is no longer used.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/libraries/cors/002.php
+++ b/user_guide_src/source/libraries/cors/002.php
@@ -13,6 +13,7 @@ class Filters extends BaseFilters
         // ...
         'cors' => [
             'before' => ['api/*'],
+            'after'  => ['api/*'],
         ],
     ];
 }

--- a/user_guide_src/source/libraries/cors/002.php
+++ b/user_guide_src/source/libraries/cors/002.php
@@ -13,7 +13,6 @@ class Filters extends BaseFilters
         // ...
         'cors' => [
             'before' => ['api/*'],
-            'after'  => ['api/*'],
         ],
     ];
 }


### PR DESCRIPTION
**Description**
This PR fixes a bug where CORS was not set correctly due to the response object being returned in the `before` filter. ~~Now all CORS headers are set in the `before` filter, and the `after` filter is no longer used.~~

This change should not break anyone's code.

Fixes #9431

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
