### PR TITLE
docs: Typo fix, classname misspelled

### DIFF
--- a/user_guide_src/source/outgoing/localization.rst
+++ b/user_guide_src/source/outgoing/localization.rst
@@ -120,7 +120,7 @@ Language Locale
 ---------------
 
 The ``Language`` class used in the :php:func:`lang()` function also has the current
-locale. This is set to the ``IncommingRequest`` locale during instantiating.
+locale. This is set to the ``IncomingRequest`` locale during instantiating.
 
 If you want to change the locale after instantiating the language class, use the
 ``Language::setLocale()`` method.


### PR DESCRIPTION
**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
- [x] Conforms to style guide
