### PR TITLE
refactor: Add phpDoc for `Filters`

### DIFF
--- a/system/Config/Filters.php
+++ b/system/Config/Filters.php
@@ -113,6 +113,8 @@ class Filters extends BaseConfig
      *
      * Example:
      * 'isLoggedIn' => ['before' => ['account/*', 'profiles/*']]
+     *
+     * @var array<string, array<string, list<string>>>
      */
     public array $filters = [];
 }

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1672 errors
+# total 1671 errors
 
 parameters:
     ignoreErrors:
@@ -791,11 +791,6 @@ parameters:
             message: '#^Property CodeIgniter\\Config\\Factory\:\:\$models type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Config/Factory.php
-
-        -
-            message: '#^Property CodeIgniter\\Config\\Filters\:\:\$filters type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Config/Filters.php
 
         -
             message: '#^Method CodeIgniter\\Config\\Services\:\:curlrequest\(\) has parameter \$options with no value type specified in iterable type array\.$#'

--- a/utils/phpstan-baseline/property.phpDocType.neon
+++ b/utils/phpstan-baseline/property.phpDocType.neon
@@ -1,12 +1,7 @@
-# total 47 errors
+# total 46 errors
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^PHPDoc type array\<string, array\<string, list\<string\>\>\> of property Config\\Filters\:\:\$filters is not the same as PHPDoc type array of overridden property CodeIgniter\\Config\\Filters\:\:\$filters\.$#'
-            count: 1
-            path: ../../app/Config/Filters.php
-
         -
             message: '#^PHPDoc type string of property CodeIgniter\\Database\\MySQLi\\Connection\:\:\$escapeChar is not the same as PHPDoc type array\|string of overridden property CodeIgniter\\Database\\BaseConnection\<mysqli,mysqli_result\>\:\:\$escapeChar\.$#'
             count: 1


### PR DESCRIPTION
**Description**
Missed PHPDoc in **system/Config/Filters.php**.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
