### PR TITLE
chore: update gpg key for phpdocumentor workflow

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Download latest phpDocumentor
         working-directory: source
-        run: phive --no-progress install --trust-gpg-keys 8AC0BAA79732DD42 phpDocumentor
+        run: phive --no-progress install --trust-gpg-keys 6DA3ACC4991FFAE5 phpDocumentor
 
       - name: Prepare API repo
         working-directory: api


### PR DESCRIPTION
**Description**
This PR updates the GPG key for PHPDocumentor.

See: https://github.com/codeigniter4/CodeIgniter4/actions/runs/13340303631/job/37270601750
GPG key change confirmation: https://github.com/phpDocumentor/phpDocumentor/issues/3873#issuecomment-2660849527

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
