### PR TITLE
feat: Mask sensitive data debug server

### DIFF
--- a/app/Config/Exceptions.php
+++ b/app/Config/Exceptions.php
@@ -60,6 +60,17 @@ class Exceptions extends BaseConfig
 
     /**
      * --------------------------------------------------------------------------
+     * HIDE FROM DEBUG SERVER
+     * --------------------------------------------------------------------------
+     * Any data that you would like to hide from the debug server.
+     * ex. ['database.default.password']
+     *
+     * @var list<string>
+     */
+    public array $sensitiveDataInServer = ['database.default.password'];
+
+    /**
+     * --------------------------------------------------------------------------
      * WHETHER TO THROW AN EXCEPTION ON DEPRECATED ERRORS
      * --------------------------------------------------------------------------
      * If set to `true`, DEPRECATED errors are only logged and no exceptions are

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -179,7 +179,9 @@ $errorId = uniqid('error', true);
                             <tr>
                                 <td><?= esc($key) ?></td>
                                 <td>
-                                    <?php if (is_string($value)) : ?>
+                                    <?php if (in_array($key, config('exceptions')->sensitiveDataInServer ?? [])) : ?>
+                                        <?= esc('**********') ?>
+                                    <?php elseif (is_string($value)) : ?>
                                         <?= esc($value) ?>
                                     <?php else: ?>
                                         <pre><?= esc(print_r($value, true)) ?></pre>

--- a/app/Views/errors/html/error_exception.php
+++ b/app/Views/errors/html/error_exception.php
@@ -179,7 +179,7 @@ $errorId = uniqid('error', true);
                             <tr>
                                 <td><?= esc($key) ?></td>
                                 <td>
-                                    <?php if (in_array($key, config('exceptions')->sensitiveDataInServer ?? [])) : ?>
+                                    <?php if (in_array($key, config('exceptions')->sensitiveDataInServer ?? [], true)) : ?>
                                         <?= esc('**********') ?>
                                     <?php elseif (is_string($value)) : ?>
                                         <?= esc($value) ?>


### PR DESCRIPTION
**Description**
The error page displays a server tab that contains all $_SERVER variable values ​​including environment variables. Many credential data that we store in the .env file and they are displayed in this server tab as is. This is quite vulnerable considering that programmers sometimes make mistakes by not setting the production environment on the production server and potentially exposing credential data in .env.

I have added the `$sensitiveDataInServer` property in Config\Exceptions to set which variables in .env to be masked in the error page.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
