### PR TITLE
docs: add changelog and upgrade for v4.7.0

### DIFF
--- a/user_guide_src/source/changelogs/index.rst
+++ b/user_guide_src/source/changelogs/index.rst
@@ -12,6 +12,7 @@ See all the changes.
 .. toctree::
     :titlesonly:
 
+    v4.7.0
     v4.6.1
     v4.6.0
     v4.5.8

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -1,0 +1,84 @@
+#############
+Version 4.7.0
+#############
+
+Release Date: Unreleased
+
+**4.7.0 release of CodeIgniter4**
+
+.. contents::
+    :local:
+    :depth: 3
+
+**********
+Highlights
+**********
+
+- TBD
+
+********
+BREAKING
+********
+
+Behavior Changes
+================
+
+Interface Changes
+=================
+
+Method Signature Changes
+========================
+
+************
+Enhancements
+************
+
+Commands
+========
+
+Testing
+=======
+
+Database
+========
+
+Query Builder
+-------------
+
+Forge
+-----
+
+Others
+------
+
+Model
+=====
+
+Libraries
+=========
+
+Helpers and Functions
+=====================
+
+Others
+======
+
+***************
+Message Changes
+***************
+
+*******
+Changes
+*******
+
+************
+Deprecations
+************
+
+**********
+Bugs Fixed
+**********
+
+See the repo's
+`CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
+for a complete list of bugs fixed.

--- a/user_guide_src/source/installation/upgrade_470.rst
+++ b/user_guide_src/source/installation/upgrade_470.rst
@@ -1,0 +1,55 @@
+#############################
+Upgrading from 4.6.x to 4.7.0
+#############################
+
+Please refer to the upgrade instructions corresponding to your installation method.
+
+- :ref:`Composer Installation App Starter Upgrading <app-starter-upgrading>`
+- :ref:`Composer Installation Adding CodeIgniter4 to an Existing Project Upgrading <adding-codeigniter4-upgrading>`
+- :ref:`Manual Installation Upgrading <installing-manual-upgrading>`
+
+.. contents::
+    :local:
+    :depth: 2
+
+**********************
+Mandatory File Changes
+**********************
+
+****************
+Breaking Changes
+****************
+
+*********************
+Breaking Enhancements
+*********************
+
+*************
+Project Files
+*************
+
+Some files in the **project space** (root, app, public, writable) received updates. Due to
+these files being outside of the **system** scope they will not be changed without your intervention.
+
+.. note:: There are some third-party CodeIgniter modules available to assist
+    with merging changes to the project space:
+    `Explore on Packagist <https://packagist.org/explore/?query=codeigniter4%20updates>`_.
+
+Content Changes
+===============
+
+The following files received significant changes (including deprecations or visual adjustments)
+and it is recommended that you merge the updated versions with your application:
+
+Config
+------
+
+- @TODO
+
+All Changes
+===========
+
+This is a list of all files in the **project space** that received changes;
+many will be simple comments or formatting that have no effect on the runtime:
+
+- @TODO

--- a/user_guide_src/source/installation/upgrading.rst
+++ b/user_guide_src/source/installation/upgrading.rst
@@ -16,6 +16,7 @@ See also :doc:`./backward_compatibility_notes`.
 
     backward_compatibility_notes
 
+    upgrade_470
     upgrade_461
     upgrade_460
     upgrade_458


### PR DESCRIPTION
**Description**

The changelog for 4.7.0 is missing.

```cli
php admin/create-new-changelog.php 4.6.x 4.7.0
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
