### PR TITLE
docs: switch to code syntax for parsing examples

### DIFF
--- a/user_guide_src/source/outgoing/view_parser.rst
+++ b/user_guide_src/source/outgoing/view_parser.rst
@@ -464,23 +464,23 @@ Provided Plugins
 
 The following plugins are available when using the parser:
 
-================== ========================= ============================================ ================================================================
+================== ========================= ============================================ ===================================================================
 Plugin             Arguments                 Description                                    Example
-================== ========================= ============================================ ================================================================
-current_url                                  Alias for the current_url helper function.   {+ current_url +}
-previous_url                                 Alias for the previous_url helper function.  {+ previous_url +}
-siteURL                                      Alias for the site_url helper function.      {+ siteURL "login" +}
-mailto             email, title, attributes  Alias for the mailto helper function.        {+ mailto email=foo@example.com title="Stranger Things" +}
-safe_mailto        email, title, attributes  Alias for the safe_mailto helper function.   {+ safe_mailto email=foo@example.com title="Stranger Things" +}
-lang               language string           Alias for the lang helper function.          {+ lang number.terabyteAbbr +}
-validation_errors  fieldname(optional)       Returns either error string for the field    {+ validation_errors +} , {+ validation_errors field="email" +}
+================== ========================= ============================================ ===================================================================
+current_url                                  Alias for the current_url helper function.   ``{+ current_url +}``
+previous_url                                 Alias for the previous_url helper function.  ``{+ previous_url +}``
+siteURL                                      Alias for the site_url helper function.      ``{+ siteURL "login" +}``
+mailto             email, title, attributes  Alias for the mailto helper function.        ``{+ mailto email=foo@example.com title="Stranger Things" +}``
+safe_mailto        email, title, attributes  Alias for the safe_mailto helper function.   ``{+ safe_mailto email=foo@example.com title="Stranger Things" +}``
+lang               language string           Alias for the lang helper function.          ``{+ lang number.terabyteAbbr +}``
+validation_errors  fieldname(optional)       Returns either error string for the field    ``{+ validation_errors +} , {+ validation_errors field="email" +}``
                                              (if specified) or all validation errors.
-route              route name                Alias for the route_to helper function.      {+ route "login" +}
-csp_script_nonce                             Alias for the csp_script_nonce helper        {+ csp_script_nonce +}
+route              route name                Alias for the route_to helper function.      ``{+ route "login" +}``
+csp_script_nonce                             Alias for the csp_script_nonce helper        ``{+ csp_script_nonce +}``
                                              function.
-csp_style_nonce                              Alias for the csp_style_nonce helper         {+ csp_style_nonce +}
+csp_style_nonce                              Alias for the csp_style_nonce helper         ``{+ csp_style_nonce +}``
                                              function.
-================== ========================= ============================================ ================================================================
+================== ========================= ============================================ ===================================================================
 
 Registering a Plugin
 --------------------


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Some template tags, such as {+ siteURL "login" +}, had extra quotation marks that caused parsing errors. We've resolved this by switching to code syntax for examples, ensuring correct interpretation and execution of the tags.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
