### PR TITLE
fix: `getVersion()` for OCI8 and SQLSRV drivers

### DIFF
--- a/system/Database/OCI8/Connection.php
+++ b/system/Database/OCI8/Connection.php
@@ -193,9 +193,14 @@ class Connection extends BaseConnection
             return $this->dataCache['version'];
         }
 
-        if (! $this->connID || ($versionString = oci_server_version($this->connID)) === false) {
+        if ($this->connID === false) {
+            $this->initialize();
+        }
+
+        if (($versionString = oci_server_version($this->connID)) === false) {
             return '';
         }
+
         if (preg_match('#Release\s(\d+(?:\.\d+)+)#', $versionString, $match)) {
             return $this->dataCache['version'] = $match[1];
         }

--- a/system/Database/SQLSRV/Connection.php
+++ b/system/Database/SQLSRV/Connection.php
@@ -561,11 +561,15 @@ class Connection extends BaseConnection
             return $this->dataCache['version'];
         }
 
-        if (! $this->connID || ($info = sqlsrv_server_info($this->connID)) === []) {
+        if (! $this->connID) {
             $this->initialize();
         }
 
-        return isset($info['SQLServerVersion']) ? $this->dataCache['version'] = $info['SQLServerVersion'] : false;
+        if (($info = sqlsrv_server_info($this->connID)) === []) {
+            return '';
+        }
+
+        return isset($info['SQLServerVersion']) ? $this->dataCache['version'] = $info['SQLServerVersion'] : '';
     }
 
     /**

--- a/tests/system/Database/Live/GetVersionTest.php
+++ b/tests/system/Database/Live/GetVersionTest.php
@@ -29,6 +29,12 @@ final class GetVersionTest extends CIUnitTestCase
 
     public function testGetVersion(): void
     {
+        if ($this->db->DBDriver === 'MySQLi') {
+            $this->db->mysqli = false;
+        }
+
+        $this->db->connID = false;
+
         $version = $this->db->getVersion();
 
         $this->assertMatchesRegularExpression('/\A\d+(\.\d+)*\z/', $version);

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -33,6 +33,7 @@ Bugs Fixed
 - **CURLRequest:** Fixed an issue where multiple header sections appeared in the CURL response body during multiple redirects from the target server.
 - **Cors:** Fixed a bug in the Cors filter that caused the appropriate headers to not be added when another filter returned a response object in the ``before`` filter.
 - **Database:** Fixed a bug in ``Postgre`` and ``SQLite3`` handlers where composite unique keys were not fully taken into account for ``upsert`` type of queries.
+- **Database:** Fixed a bug in the ``OCI8`` driver where ``getVersion()`` returned an empty string when the database connection was not yet established.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -33,7 +33,7 @@ Bugs Fixed
 - **CURLRequest:** Fixed an issue where multiple header sections appeared in the CURL response body during multiple redirects from the target server.
 - **Cors:** Fixed a bug in the Cors filter that caused the appropriate headers to not be added when another filter returned a response object in the ``before`` filter.
 - **Database:** Fixed a bug in ``Postgre`` and ``SQLite3`` handlers where composite unique keys were not fully taken into account for ``upsert`` type of queries.
-- **Database:** Fixed a bug in the ``OCI8`` driver where ``getVersion()`` returned an empty string when the database connection was not yet established.
+- **Database:** Fixed a bug in the ``OCI8`` and ``SQLSRV`` drivers where ``getVersion()`` returned an empty string when the database connection was not yet established.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/utils/phpstan-baseline/property.notFound.neon
+++ b/utils/phpstan-baseline/property.notFound.neon
@@ -1,4 +1,4 @@
-# total 58 errors
+# total 59 errors
 
 parameters:
     ignoreErrors:
@@ -41,6 +41,11 @@ parameters:
             message: '#^Access to an undefined property CodeIgniter\\Test\\Mock\\MockConnection\:\:\$foobar\.$#'
             count: 2
             path: ../../tests/system/Database/BaseConnectionTest.php
+
+        -
+            message: '#^Access to an undefined property CodeIgniter\\Database\\BaseConnection\:\:\$mysqli\.$#'
+            count: 1
+            path: ../../tests/system/Database/Live/GetVersionTest.php
 
         -
             message: '#^Access to an undefined property CodeIgniter\\Database\\BaseConnection\:\:\$foundRows\.$#'


### PR DESCRIPTION
**Description**
This PR fixes a bug in OCI8 and SQLSRV `getVersion()` method, which will return an empty string when no connection is established.

Issue discovered in #9469

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
