### PR TITLE
refactor: OCI8 `limit()` method

### DIFF
--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -49,16 +49,6 @@ class Builder extends BaseBuilder
     protected $countString = 'SELECT COUNT(1) ';
 
     /**
-     * Limit used flag
-     *
-     * If we use LIMIT, we'll add a field that will
-     * throw off num_fields later.
-     *
-     * @var bool
-     */
-    protected $limitUsed = false;
-
-    /**
      * A reference to the database connection.
      *
      * @var Connection
@@ -221,15 +211,6 @@ class Builder extends BaseBuilder
         }
 
         return $sql . ' OFFSET ' . $offset . ' ROWS FETCH NEXT ' . $this->QBLimit . ' ROWS ONLY';
-    }
-
-    /**
-     * Resets the query builder values.  Called by the get() function
-     */
-    protected function resetSelect()
-    {
-        $this->limitUsed = false;
-        parent::resetSelect();
     }
 
     /**

--- a/system/Database/OCI8/Builder.php
+++ b/system/Database/OCI8/Builder.php
@@ -214,19 +214,13 @@ class Builder extends BaseBuilder
     protected function _limit(string $sql, bool $offsetIgnore = false): string
     {
         $offset = (int) ($offsetIgnore === false ? $this->QBOffset : 0);
-        if (version_compare($this->db->getVersion(), '12.1', '>=')) {
-            // OFFSET-FETCH can be used only with the ORDER BY clause
-            if (empty($this->QBOrderBy)) {
-                $sql .= ' ORDER BY 1';
-            }
 
-            return $sql . ' OFFSET ' . $offset . ' ROWS FETCH NEXT ' . $this->QBLimit . ' ROWS ONLY';
+        // OFFSET-FETCH can be used only with the ORDER BY clause
+        if (empty($this->QBOrderBy)) {
+            $sql .= ' ORDER BY 1';
         }
 
-        $this->limitUsed    = true;
-        $limitTemplateQuery = 'SELECT * FROM (SELECT INNER_QUERY.*, ROWNUM RNUM FROM (%s) INNER_QUERY WHERE ROWNUM < %d)' . ($offset !== 0 ? ' WHERE RNUM >= %d' : '');
-
-        return sprintf($limitTemplateQuery, $sql, $offset + $this->QBLimit + 1, $offset);
+        return $sql . ' OFFSET ' . $offset . ' ROWS FETCH NEXT ' . $this->QBLimit . ' ROWS ONLY';
     }
 
     /**

--- a/utils/phpstan-baseline/missingType.return.neon
+++ b/utils/phpstan-baseline/missingType.return.neon
@@ -1,4 +1,4 @@
-# total 201 errors
+# total 200 errors
 
 parameters:
     ignoreErrors:
@@ -111,11 +111,6 @@ parameters:
             message: '#^Method CodeIgniter\\Database\\MigrationRunner\:\:removeHistory\(\) has no return type specified\.$#'
             count: 1
             path: ../../system/Database/MigrationRunner.php
-
-        -
-            message: '#^Method CodeIgniter\\Database\\OCI8\\Builder\:\:resetSelect\(\) has no return type specified\.$#'
-            count: 1
-            path: ../../system/Database/OCI8/Builder.php
 
         -
             message: '#^Method CodeIgniter\\Database\\Postgre\\Connection\:\:buildDSN\(\) has no return type specified\.$#'


### PR DESCRIPTION
**Description**
This PR refactors the `limit()` method in the OCI8 driver by removing legacy code that was only required for OCI8 versions below `12.1`, which are no longer supported by CodeIgniter.

Reference: https://github.com/codeigniter4/CodeIgniter4/blob/develop/user_guide_src/source/intro/requirements.rst?plain=1#L69

Closes: #9469

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
