### PR TITLE
refactor: Fix phpstan `varTag.type` errors

### DIFF
--- a/system/Cache/Handlers/RedisHandler.php
+++ b/system/Cache/Handlers/RedisHandler.php
@@ -181,7 +181,7 @@ class RedisHandler extends BaseHandler
         $iterator    = null;
 
         do {
-            /** @var false|list<string>|Redis $keys */
+            /** @var false|list<string> $keys */
             $keys = $this->redis->scan($iterator, $pattern);
 
             if (is_array($keys)) {

--- a/system/Commands/Generators/MigrationGenerator.php
+++ b/system/Commands/Generators/MigrationGenerator.php
@@ -112,10 +112,7 @@ class MigrationGenerator extends BaseCommand
             $data['DBGroup']  = is_string($DBGroup) ? $DBGroup : 'default';
             $data['DBDriver'] = config(Database::class)->{$data['DBGroup']}['DBDriver'];
 
-            /** @var SessionConfig|null $session */
-            $session = config(SessionConfig::class);
-
-            $data['matchIP'] = $session->matchIP;
+            $data['matchIP'] = config(SessionConfig::class)->matchIP;
         }
 
         return $this->parseTemplate($class, [], [], $data);

--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -125,9 +125,7 @@ class CURLRequest extends OutgoingRequest
         $this->baseURI        = $uri->useRawQueryString();
         $this->defaultOptions = $options;
 
-        /** @var ConfigCURLRequest|null $configCURLRequest */
-        $configCURLRequest  = config(ConfigCURLRequest::class);
-        $this->shareOptions = $configCURLRequest->shareOptions ?? true;
+        $this->shareOptions = config(ConfigCURLRequest::class)->shareOptions ?? true;
 
         $this->config = $this->defaultConfig;
         $this->parseOptions($options);

--- a/system/I18n/TimeTrait.php
+++ b/system/I18n/TimeTrait.php
@@ -32,7 +32,7 @@ use ReturnTypeWillChange;
 trait TimeTrait
 {
     /**
-     * @var DateTimeZone
+     * @var DateTimeZone|string
      */
     protected $timezone;
 

--- a/system/Test/ReflectionHelper.php
+++ b/system/Test/ReflectionHelper.php
@@ -31,8 +31,7 @@ trait ReflectionHelper
      * @param object|string $obj    object or class name
      * @param string        $method method name
      *
-     * @return         Closure
-     * @phpstan-return Closure(mixed ...$args): mixed
+     * @return Closure(mixed ...$args): mixed
      *
      * @throws ReflectionException
      */

--- a/tests/system/Commands/Utilities/ConfigCheckTest.php
+++ b/tests/system/Commands/Utilities/ConfigCheckTest.php
@@ -89,7 +89,9 @@ final class ConfigCheckTest extends CIUnitTestCase
 
     public function testConfigCheckWithKintEnabledUsesKintD(): void
     {
-        /** @var Closure(object): string $command */
+        /**
+         * @var Closure(mixed...): string
+         */
         $command = $this->getPrivateMethodInvoker(
             new ConfigCheck(service('logger'), service('commands')),
             'getKintD',
@@ -105,7 +107,9 @@ final class ConfigCheckTest extends CIUnitTestCase
 
     public function testConfigCheckWithKintDisabledUsesVarDump(): void
     {
-        /** @var Closure(object): string $command */
+        /**
+         * @var Closure(mixed...): string
+         */
         $command = $this->getPrivateMethodInvoker(
             new ConfigCheck(service('logger'), service('commands')),
             'getVarDump',

--- a/utils/phpstan-baseline/varTag.type.neon
+++ b/utils/phpstan-baseline/varTag.type.neon
@@ -1,37 +1,7 @@
-# total 9 errors
+# total 2 errors
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^PHPDoc tag @var with type list\<string\>\|Redis\|false is not subtype of type array\<int, string\>\|false\.$#'
-            count: 1
-            path: ../../system/Cache/Handlers/RedisHandler.php
-
-        -
-            message: '#^PHPDoc tag @var with type Config\\Session\|null is not subtype of type Config\\Session\.$#'
-            count: 1
-            path: ../../system/Commands/Generators/MigrationGenerator.php
-
-        -
-            message: '#^PHPDoc tag @var with type Config\\CURLRequest\|null is not subtype of type Config\\CURLRequest\.$#'
-            count: 1
-            path: ../../system/HTTP/CURLRequest.php
-
-        -
-            message: '#^PHPDoc tag @var with type string is not subtype of type DateTimeZone\.$#'
-            count: 1
-            path: ../../system/I18n/Time.php
-
-        -
-            message: '#^PHPDoc tag @var with type string is not subtype of type DateTimeZone\.$#'
-            count: 1
-            path: ../../system/I18n/TimeLegacy.php
-
-        -
-            message: '#^PHPDoc tag @var with type Closure\(object\)\: string is not subtype of type Closure\(mixed \.\.\.\)\: mixed\.$#'
-            count: 2
-            path: ../../tests/system/Commands/Utilities/ConfigCheckTest.php
-
         -
             message: '#^PHPDoc tag @var with type Tests\\Support\\Entity\\UserWithCasts is not subtype of type list\<array\{\}\>\|null\.$#'
             count: 1


### PR DESCRIPTION
**Description**
- `Redis::scan()` does not return `Redis`.
- `config()` already supports the hint for classes. Removed the creation of a one-time variable.
- `TimeTrait::$timezone` it can be a `string` during initialization.
- It seems that `Closure(mixed...)` cannot be specified, so I only changed the return type.  

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
