### PR TITLE
Alternative to timezone_select()

### DIFF
--- a/system/Helpers/form_helper.php
+++ b/system/Helpers/form_helper.php
@@ -256,6 +256,61 @@ if (! function_exists('form_multiselect')) {
     }
 }
 
+if (! function_exists('form_dropdown_timezone')) {
+    /**
+     * Timezone Drop-down Menu
+     *
+     * @param array|string        $data
+     * @param array|string        $selected
+     * @param array|object|string $extra         string, array, object that can be cast to array
+     * @param int|null            $timezoneGroup DateTimeZone class constants
+     * @param string|null         $countryCode   ISO 3166-1 compatible country code
+     * @param bool                $showOffset    Whether to show UTC offset or not
+     */
+	function form_dropdown_timezone($data = '', $selected = [], $extra = '', $useOptgroups = true, ?int $timezoneGroup = null, ?string $countryCode = null, bool $showOffset = true): string {
+		if (!$timezoneGroup) {
+			$timezoneGroup = ($countryCode) ? DateTimeZone::PER_COUNTRY : DateTimeZone::ALL;
+		}
+		
+		if ($countryCode && $timezoneGroup !== DateTimeZone::PER_COUNTRY) {
+			throw new InvalidArgumentException('$timezoneGroup must be DateTimeZone::PER_COUNTRY when specifying $countryCode');
+		}
+		
+		if ($showOffset) {
+			$datetime = new DateTime();
+		}
+		
+		$options = [];
+		
+		foreach (DateTimeZone::listIdentifiers($timezoneGroup, $countryCode) as $identifier) {
+			if ($useOptgroups) {
+				list($group) = explode('/', $identifier);
+				
+				$options[$group][$identifier] = substr($identifier, strlen($group) + 1) ?: $group;
+			} else {
+				$options[$identifier] = $identifier;
+			}
+			
+			if ($showOffset) {
+				$datetime->setTimezone(new DateTimeZone($identifier));
+				$seconds = $datetime->getOffset();
+				$hours = intval($seconds / 3600);
+				$minutes = abs(intval(($seconds % 3600) / 60));
+				$formatted = sprintf(' (%+03d:%02d)', $hours, $minutes);
+				
+				
+				if ($useOptgroups) {
+					$options[$group][$identifier] .= $formatted;
+				} else {
+					$options[$identifier] .= $formatted;
+				}
+			}
+		}
+		
+        return form_dropdown($data, $options, $selected, $extra);
+	}
+}
+
 if (! function_exists('form_dropdown')) {
     /**
      * Drop-down Menu


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
`form_dropdown_timezone()` supports all parameters of form_dropdown() and timezone-specific parameters.
`timezone_select()` in date_helper.php is too limited. Cannot specify field name or extra attributes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
