### PR TITLE
refactor: call `getPrivateMethodInvoker()` statically

### DIFF
--- a/tests/system/API/ResponseTraitTest.php
+++ b/tests/system/API/ResponseTraitTest.php
@@ -661,7 +661,7 @@ final class ResponseTraitTest extends CIUnitTestCase
 
     private function invoke(object $controller, string $method, array $args = [])
     {
-        $method = $this->getPrivateMethodInvoker($controller, $method);
+        $method = self::getPrivateMethodInvoker($controller, $method);
 
         return $method(...$args);
     }

--- a/tests/system/Autoloader/AutoloaderTest.php
+++ b/tests/system/Autoloader/AutoloaderTest.php
@@ -64,7 +64,7 @@ final class AutoloaderTest extends CIUnitTestCase
         $this->loader = new Autoloader();
         $this->loader->initialize($config, $modules)->register();
 
-        $this->classLoader = $this->getPrivateMethodInvoker($this->loader, 'loadInNamespace');
+        $this->classLoader = self::getPrivateMethodInvoker($this->loader, 'loadInNamespace');
     }
 
     protected function tearDown(): void
@@ -111,7 +111,7 @@ final class AutoloaderTest extends CIUnitTestCase
 
     public function testServiceAutoLoaderFromShareInstances(): void
     {
-        $classLoader = $this->getPrivateMethodInvoker(service('autoloader'), 'loadInNamespace');
+        $classLoader = self::getPrivateMethodInvoker(service('autoloader'), 'loadInNamespace');
 
         // look for Home controller, as that should be in base repo
         $actual   = $classLoader(Home::class);
@@ -129,7 +129,7 @@ final class AutoloaderTest extends CIUnitTestCase
         $autoloader->initialize(new Autoload(), new Modules());
         $autoloader->register();
 
-        $classLoader = $this->getPrivateMethodInvoker($autoloader, 'loadInNamespace');
+        $classLoader = self::getPrivateMethodInvoker($autoloader, 'loadInNamespace');
 
         // look for Home controller, as that should be in base repo
         $actual   = $classLoader(Home::class);

--- a/tests/system/CodeIgniterTest.php
+++ b/tests/system/CodeIgniterTest.php
@@ -460,8 +460,8 @@ final class CodeIgniterTest extends CIUnitTestCase
         $codeigniter = new MockCodeIgniter($config);
         $codeigniter->setContext('web');
 
-        $this->getPrivateMethodInvoker($codeigniter, 'getRequestObject')();
-        $this->getPrivateMethodInvoker($codeigniter, 'getResponseObject')();
+        self::getPrivateMethodInvoker($codeigniter, 'getRequestObject')();
+        self::getPrivateMethodInvoker($codeigniter, 'getResponseObject')();
 
         $response = $this->getPrivateProperty($codeigniter, 'response');
         $this->assertNull($response->header('Location'));
@@ -949,7 +949,7 @@ final class CodeIgniterTest extends CIUnitTestCase
     {
         $this->setPrivateProperty($this->codeigniter, 'benchmark', new Timer());
         $this->setPrivateProperty($this->codeigniter, 'controller', '\\' . Home::class);
-        $startController = $this->getPrivateMethodInvoker($this->codeigniter, 'startController');
+        $startController = self::getPrivateMethodInvoker($this->codeigniter, 'startController');
 
         $this->setPrivateProperty($this->codeigniter, 'method', '__invoke');
         $startController();

--- a/tests/system/Commands/Translation/LocalizationSyncTest.php
+++ b/tests/system/Commands/Translation/LocalizationSyncTest.php
@@ -212,7 +212,7 @@ final class LocalizationSyncTest extends CIUnitTestCase
         $langPath = SUPPORTPATH . 'Language';
         $command  = new LocalizationSync(service('logger'), service('commands'));
         $this->setPrivateProperty($command, 'languagePath', $langPath);
-        $runner = $this->getPrivateMethodInvoker($command, 'process');
+        $runner = self::getPrivateMethodInvoker($command, 'process');
 
         $status = $runner('de', 'jp');
 

--- a/tests/system/Commands/Utilities/ConfigCheckTest.php
+++ b/tests/system/Commands/Utilities/ConfigCheckTest.php
@@ -92,7 +92,7 @@ final class ConfigCheckTest extends CIUnitTestCase
         /**
          * @var Closure(mixed...): string
          */
-        $command = $this->getPrivateMethodInvoker(
+        $command = self::getPrivateMethodInvoker(
             new ConfigCheck(service('logger'), service('commands')),
             'getKintD',
         );
@@ -110,7 +110,7 @@ final class ConfigCheckTest extends CIUnitTestCase
         /**
          * @var Closure(mixed...): string
          */
-        $command = $this->getPrivateMethodInvoker(
+        $command = self::getPrivateMethodInvoker(
             new ConfigCheck(service('logger'), service('commands')),
             'getVarDump',
         );

--- a/tests/system/Commands/Utilities/NamespacesTest.php
+++ b/tests/system/Commands/Utilities/NamespacesTest.php
@@ -90,7 +90,7 @@ final class NamespacesTest extends CIUnitTestCase
     public function testTruncateNamespaces(): void
     {
         $commandObject  = new Namespaces(service('logger'), service('commands'));
-        $truncateRunner = $this->getPrivateMethodInvoker($commandObject, 'truncate');
+        $truncateRunner = self::getPrivateMethodInvoker($commandObject, 'truncate');
 
         $this->assertSame('App\Controllers\...', $truncateRunner('App\Controllers\Admin', 19));
         // multibyte namespace

--- a/tests/system/Config/BaseConfigTest.php
+++ b/tests/system/Config/BaseConfigTest.php
@@ -257,7 +257,7 @@ final class BaseConfigTest extends CIUnitTestCase
         $config              = new RegistrarConfig();
         $config::$registrars = [TestRegistrar::class];
         $this->setPrivateProperty($config, 'didDiscovery', true);
-        $method = $this->getPrivateMethodInvoker($config, 'registerProperties');
+        $method = self::getPrivateMethodInvoker($config, 'registerProperties');
         $method();
 
         // no change to unmodified property
@@ -274,7 +274,7 @@ final class BaseConfigTest extends CIUnitTestCase
         $this->setPrivateProperty($config, 'didDiscovery', true);
 
         $this->expectException(RuntimeException::class);
-        $method = $this->getPrivateMethodInvoker($config, 'registerProperties');
+        $method = self::getPrivateMethodInvoker($config, 'registerProperties');
         $method();
 
         $this->assertSame('bar', $config->foo);

--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -94,7 +94,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'cachePage');
+        $method = self::getPrivateMethodInvoker($this->controller, 'cachePage');
         $this->assertNull($method(10));
     }
 
@@ -105,7 +105,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller->initController($this->request, $this->response, $this->logger);
 
         // and that we can attempt validation, with no rules
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method([]));
     }
 
@@ -117,7 +117,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup'));
     }
 
@@ -146,7 +146,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup'));
         $this->assertSame('You must choose a username.', service('validation')->getError('username'));
     }
@@ -167,7 +167,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validate');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validate');
         $this->assertFalse($method('signup', [
             'username' => [
                 'required' => 'You must choose a username.',
@@ -182,7 +182,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validateData');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validateData');
 
         $data = [
             'username' => 'mike',
@@ -205,7 +205,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validateData');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validateData');
 
         $data = [
             'username' => 'a',
@@ -238,7 +238,7 @@ final class ControllerTest extends CIUnitTestCase
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
-        $method = $this->getPrivateMethodInvoker($this->controller, 'validateData');
+        $method = self::getPrivateMethodInvoker($this->controller, 'validateData');
 
         $data = [
             'username' => 'a',

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -167,7 +167,7 @@ final class ConfigTest extends CIUnitTestCase
         $this->assertSame('5', $this->getPrivateProperty($conn, 'connect_timeout'));
         $this->assertSame('1', $this->getPrivateProperty($conn, 'sslmode'));
 
-        $method = $this->getPrivateMethodInvoker($conn, 'buildDSN');
+        $method = self::getPrivateMethodInvoker($conn, 'buildDSN');
         $method();
 
         $expected = "host=localhost port=5432 user=user password='pass' dbname=dbname connect_timeout='5' sslmode='1'";
@@ -207,7 +207,7 @@ final class ConfigTest extends CIUnitTestCase
         $conn                               = Config::connect($this->dsnGroupPostgreNative, false);
         $this->assertInstanceOf(BaseConnection::class, $conn);
 
-        $method = $this->getPrivateMethodInvoker($conn, 'convertDSN');
+        $method = self::getPrivateMethodInvoker($conn, 'convertDSN');
         $method();
 
         $this->assertSame($expected, $this->getPrivateProperty($conn, 'DSN'));

--- a/tests/system/Database/Live/ForgeTest.php
+++ b/tests/system/Database/Live/ForgeTest.php
@@ -371,7 +371,7 @@ final class ForgeTest extends CIUnitTestCase
             ],
         ]);
 
-        $createTable = $this->getPrivateMethodInvoker($this->forge, '_createTable');
+        $createTable = self::getPrivateMethodInvoker($this->forge, '_createTable');
 
         $sql = $createTable('forge_nullable_table', false, []);
 

--- a/tests/system/Database/Live/OCI8/ConnectionTest.php
+++ b/tests/system/Database/Live/OCI8/ConnectionTest.php
@@ -47,7 +47,7 @@ final class ConnectionTest extends CIUnitTestCase
 
         $db = new Connection($this->settings);
 
-        $isValidDSN = $this->getPrivateMethodInvoker($db, 'isValidDSN');
+        $isValidDSN = self::getPrivateMethodInvoker($db, 'isValidDSN');
 
         $this->assertTrue($isValidDSN());
     }

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -156,7 +156,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('20190806235100', $method('20190806235100_Foo'));
     }
@@ -165,7 +165,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('2019-08-06-235100', $method('2019-08-06-235100_Foo'));
     }
@@ -174,7 +174,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('2019_08_06_235100', $method('2019_08_06_235100_Foo'));
     }
@@ -183,7 +183,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationNumber');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationNumber');
 
         $this->assertSame('0', $method('Foo'));
     }
@@ -192,7 +192,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationName');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationName');
 
         $this->assertSame('Foo_bar', $method('2019-08-06-235100_Foo_bar'));
     }
@@ -201,7 +201,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
     {
         $runner = new MigrationRunner($this->config);
 
-        $method = $this->getPrivateMethodInvoker($runner, 'getMigrationName');
+        $method = self::getPrivateMethodInvoker($runner, 'getMigrationName');
 
         $this->assertSame('Foo_bar', $method('2019_08_06_235100_Foo_bar'));
     }

--- a/tests/system/Debug/ExceptionHandlerTest.php
+++ b/tests/system/Debug/ExceptionHandlerTest.php
@@ -43,7 +43,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
     public function testDetermineViewsPageNotFoundException(): void
     {
-        $determineView = $this->getPrivateMethodInvoker($this->handler, 'determineView');
+        $determineView = self::getPrivateMethodInvoker($this->handler, 'determineView');
 
         $exception    = PageNotFoundException::forControllerNotFound('Foo', 'bar');
         $templatePath = APPPATH . 'Views/errors/html';
@@ -54,7 +54,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
     public function testDetermineViewsRuntimeException(): void
     {
-        $determineView = $this->getPrivateMethodInvoker($this->handler, 'determineView');
+        $determineView = self::getPrivateMethodInvoker($this->handler, 'determineView');
 
         $exception    = new RuntimeException('Exception');
         $templatePath = APPPATH . 'Views/errors/html';
@@ -65,7 +65,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
     public function testDetermineViewsRuntimeExceptionCode404(): void
     {
-        $determineView = $this->getPrivateMethodInvoker($this->handler, 'determineView');
+        $determineView = self::getPrivateMethodInvoker($this->handler, 'determineView');
 
         $exception    = new RuntimeException('foo', 404);
         $templatePath = APPPATH . 'Views/errors/html';
@@ -78,7 +78,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
     {
         ini_set('display_errors', '0');
 
-        $determineView = $this->getPrivateMethodInvoker($this->handler, 'determineView');
+        $determineView = self::getPrivateMethodInvoker($this->handler, 'determineView');
 
         $exception    = new RuntimeException('Exception');
         $templatePath = APPPATH . 'Views/errors/html';
@@ -91,7 +91,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
     public function testCollectVars(): void
     {
-        $collectVars = $this->getPrivateMethodInvoker($this->handler, 'collectVars');
+        $collectVars = self::getPrivateMethodInvoker($this->handler, 'collectVars');
 
         $vars = $collectVars(new RuntimeException('This.'), 404);
 
@@ -163,7 +163,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
     public function testMaskSensitiveData(): void
     {
-        $maskSensitiveData = $this->getPrivateMethodInvoker($this->handler, 'maskSensitiveData');
+        $maskSensitiveData = self::getPrivateMethodInvoker($this->handler, 'maskSensitiveData');
 
         $trace = [
             0 => [
@@ -212,7 +212,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
 
     public function testMaskSensitiveDataTraceDataKey(): void
     {
-        $maskSensitiveData = $this->getPrivateMethodInvoker($this->handler, 'maskSensitiveData');
+        $maskSensitiveData = self::getPrivateMethodInvoker($this->handler, 'maskSensitiveData');
 
         $trace = [
             0 => [
@@ -248,7 +248,7 @@ final class ExceptionHandlerTest extends CIUnitTestCase
             'highlight.comment', 'highlight.default', 'highlight.html', 'highlight.keyword', 'highlight.string',
         ]);
 
-        $highlightFile = $this->getPrivateMethodInvoker($this->handler, 'highlightFile');
+        $highlightFile = self::getPrivateMethodInvoker($this->handler, 'highlightFile');
         $result        = $highlightFile(SUPPORTPATH . 'Controllers' . DIRECTORY_SEPARATOR . 'Hello.php', 16);
 
         $resultFile = match (true) {

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -96,7 +96,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testDetermineViews(): void
     {
-        $determineView = $this->getPrivateMethodInvoker($this->exception, 'determineView');
+        $determineView = self::getPrivateMethodInvoker($this->exception, 'determineView');
 
         $this->assertSame('error_404.php', $determineView(PageNotFoundException::forControllerNotFound('Foo', 'bar'), ''));
         $this->assertSame('error_exception.php', $determineView(new RuntimeException('Exception'), ''));
@@ -105,7 +105,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testCollectVars(): void
     {
-        $vars = $this->getPrivateMethodInvoker($this->exception, 'collectVars')(new RuntimeException('This.'), 404);
+        $vars = self::getPrivateMethodInvoker($this->exception, 'collectVars')(new RuntimeException('This.'), 404);
 
         $this->assertIsArray($vars);
         $this->assertCount(7, $vars);
@@ -117,7 +117,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testDetermineCodes(): void
     {
-        $determineCodes = $this->getPrivateMethodInvoker($this->exception, 'determineCodes');
+        $determineCodes = self::getPrivateMethodInvoker($this->exception, 'determineCodes');
 
         $this->assertSame([500, EXIT_ERROR], $determineCodes(new RuntimeException('This.')));
         $this->assertSame([500, EXIT_ERROR], $determineCodes(new RuntimeException('That.', 600)));
@@ -146,7 +146,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testMaskSensitiveData(): void
     {
-        $maskSensitiveData = $this->getPrivateMethodInvoker($this->exception, 'maskSensitiveData');
+        $maskSensitiveData = self::getPrivateMethodInvoker($this->exception, 'maskSensitiveData');
 
         $trace = [
             0 => [
@@ -195,7 +195,7 @@ final class ExceptionsTest extends CIUnitTestCase
 
     public function testMaskSensitiveDataTraceDataKey(): void
     {
-        $maskSensitiveData = $this->getPrivateMethodInvoker($this->exception, 'maskSensitiveData');
+        $maskSensitiveData = self::getPrivateMethodInvoker($this->exception, 'maskSensitiveData');
 
         $trace = [
             0 => [

--- a/tests/system/Files/FileCollectionTest.php
+++ b/tests/system/Files/FileCollectionTest.php
@@ -47,14 +47,14 @@ final class FileCollectionTest extends CIUnitTestCase
 
     public function testResolveDirectoryDirectory(): void
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
 
         $this->assertSame($this->directory, $method($this->directory));
     }
 
     public function testResolveDirectoryFile(): void
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
 
         $this->expectException(FileException::class);
         $this->expectExceptionMessage(lang('Files.expectedDirectory', ['invokeArgs']));
@@ -68,7 +68,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $link = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
         symlink($this->directory, $link);
 
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveDirectory');
 
         $this->assertSame($this->directory, $method($link));
 
@@ -77,7 +77,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
     public function testResolveFileFile(): void
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
 
         $this->assertSame($this->file, $method($this->file));
     }
@@ -88,7 +88,7 @@ final class FileCollectionTest extends CIUnitTestCase
         $link = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
         symlink($this->file, $link);
 
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
 
         $this->assertSame($this->file, $method($link));
 
@@ -97,7 +97,7 @@ final class FileCollectionTest extends CIUnitTestCase
 
     public function testResolveFileDirectory(): void
     {
-        $method = $this->getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
+        $method = self::getPrivateMethodInvoker(FileCollection::class, 'resolveFile');
 
         $this->expectException(FileException::class);
         $this->expectExceptionMessage(lang('Files.expectedFile', ['invokeArgs']));

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -66,7 +66,7 @@ class CURLRequestTest extends CIUnitTestCase
 
         $request = $this->getRequest(['baseURI' => 'http://example.com/v1/']);
 
-        $method = $this->getPrivateMethodInvoker($request, 'prepareURL');
+        $method = self::getPrivateMethodInvoker($request, 'prepareURL');
 
         $this->assertSame('http://example.com/v1/bananas', $method('bananas'));
     }

--- a/tests/system/Models/MiscellaneousModelTest.php
+++ b/tests/system/Models/MiscellaneousModelTest.php
@@ -109,7 +109,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->expectExceptionMessage('Invalid type "whatever" used upon transforming data to array.');
 
         $this->createModel(JobModel::class);
-        $method = $this->getPrivateMethodInvoker($this->model, 'transformDataToArray');
+        $method = self::getPrivateMethodInvoker($this->model, 'transformDataToArray');
         $method([], 'whatever');
     }
 
@@ -119,7 +119,7 @@ final class MiscellaneousModelTest extends LiveModelTestCase
         $this->expectExceptionMessage('There is no data to insert.');
 
         $this->createModel(JobModel::class);
-        $method = $this->getPrivateMethodInvoker($this->model, 'transformDataToArray');
+        $method = self::getPrivateMethodInvoker($this->model, 'transformDataToArray');
         $method([], 'insert');
     }
 }

--- a/tests/system/Models/ValidationModelRuleGroupTest.php
+++ b/tests/system/Models/ValidationModelRuleGroupTest.php
@@ -194,7 +194,7 @@ final class ValidationModelRuleGroupTest extends LiveModelTestCase
 
     public function testCleanValidationRemovesAllWhenNoDataProvided(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',
@@ -207,7 +207,7 @@ final class ValidationModelRuleGroupTest extends LiveModelTestCase
 
     public function testCleanValidationRemovesOnlyForFieldsNotProvided(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',
@@ -225,7 +225,7 @@ final class ValidationModelRuleGroupTest extends LiveModelTestCase
 
     public function testCleanValidationReturnsAllWhenAllExist(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',

--- a/tests/system/Models/ValidationModelTest.php
+++ b/tests/system/Models/ValidationModelTest.php
@@ -182,7 +182,7 @@ final class ValidationModelTest extends LiveModelTestCase
 
     public function testCleanValidationRemovesAllWhenNoDataProvided(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',
@@ -195,7 +195,7 @@ final class ValidationModelTest extends LiveModelTestCase
 
     public function testCleanValidationRemovesOnlyForFieldsNotProvided(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',
@@ -213,7 +213,7 @@ final class ValidationModelTest extends LiveModelTestCase
 
     public function testCleanValidationReturnsAllWhenAllExist(): void
     {
-        $cleaner = $this->getPrivateMethodInvoker($this->model, 'cleanValidationRules');
+        $cleaner = self::getPrivateMethodInvoker($this->model, 'cleanValidationRules');
 
         $rules = [
             'name' => 'required',

--- a/tests/system/Publisher/PublisherSupportTest.php
+++ b/tests/system/Publisher/PublisherSupportTest.php
@@ -141,7 +141,7 @@ final class PublisherSupportTest extends CIUnitTestCase
         mkdir($directory, 0700);
         $this->assertDirectoryExists($directory);
 
-        $method = $this->getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
+        $method = self::getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
         $method($directory);
 
         $this->assertDirectoryDoesNotExist($directory);
@@ -149,7 +149,7 @@ final class PublisherSupportTest extends CIUnitTestCase
 
     public function testWipeIgnoresFiles(): void
     {
-        $method = $this->getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
+        $method = self::getPrivateMethodInvoker(Publisher::class, 'wipeDirectory');
         $method($this->file);
 
         $this->assertFileExists($this->file);

--- a/tests/system/RESTful/ResourceControllerTest.php
+++ b/tests/system/RESTful/ResourceControllerTest.php
@@ -369,7 +369,7 @@ final class ResourceControllerTest extends CIUnitTestCase
 
     private function invoke(object $controller, string $method, array $args = [])
     {
-        $method = $this->getPrivateMethodInvoker($controller, $method);
+        $method = self::getPrivateMethodInvoker($controller, $method);
 
         return $method(...$args);
     }

--- a/tests/system/Security/SecurityTest.php
+++ b/tests/system/Security/SecurityTest.php
@@ -319,7 +319,7 @@ final class SecurityTest extends CIUnitTestCase
     {
         $_POST['csrf_test_name'] = '8b9218a55906f9dcc1dc263dce7f005a';
         $request                 = $this->createIncomingRequest();
-        $method                  = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+        $method                  = self::getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
         $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method($request));
     }
@@ -328,7 +328,7 @@ final class SecurityTest extends CIUnitTestCase
     {
         $_POST   = [];
         $request = $this->createIncomingRequest()->setHeader('X-CSRF-TOKEN', '8b9218a55906f9dcc1dc263dce7f005a');
-        $method  = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+        $method  = self::getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
         $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method($request));
     }
@@ -338,7 +338,7 @@ final class SecurityTest extends CIUnitTestCase
         $_POST    = [];
         $jsonBody = json_encode(['csrf_test_name' => '8b9218a55906f9dcc1dc263dce7f005a']);
         $request  = $this->createIncomingRequest()->setBody($jsonBody);
-        $method   = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+        $method   = self::getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
         $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method($request));
     }
@@ -348,7 +348,7 @@ final class SecurityTest extends CIUnitTestCase
         $_POST    = [];
         $formBody = 'csrf_test_name=8b9218a55906f9dcc1dc263dce7f005a';
         $request  = $this->createIncomingRequest()->setBody($formBody);
-        $method   = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+        $method   = self::getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
         $this->assertSame('8b9218a55906f9dcc1dc263dce7f005a', $method($request));
     }
@@ -356,7 +356,7 @@ final class SecurityTest extends CIUnitTestCase
     #[DataProvider('provideGetPostedTokenReturnsNullForInvalidInputs')]
     public function testGetPostedTokenReturnsNullForInvalidInputs(string $case, IncomingRequest $request): void
     {
-        $method = $this->getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
+        $method = self::getPrivateMethodInvoker($this->createMockSecurity(), 'getPostedToken');
 
         $this->assertNull(
             $method($request),

--- a/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php
+++ b/tests/system/Session/Handlers/Database/AbstractHandlerTestCase.php
@@ -97,13 +97,13 @@ abstract class AbstractHandlerTestCase extends CIUnitTestCase
         $this->setPrivateProperty($handler, 'sessionID', '1f5o06b43phsnnf8if6bo33b635e4p2o');
         $this->setPrivateProperty($handler, 'rowExists', true);
 
-        $lockSession = $this->getPrivateMethodInvoker($handler, 'lockSession');
+        $lockSession = self::getPrivateMethodInvoker($handler, 'lockSession');
         $lockSession('1f5o06b43phsnnf8if6bo33b635e4p2o');
 
         $data = '__ci_last_regenerate|i:1624650854;_ci_previous_url|s:40:\"http://localhost/index.php/home/index\";';
         $this->assertTrue($handler->write('1f5o06b43phsnnf8if6bo33b635e4p2o', $data));
 
-        $releaseLock = $this->getPrivateMethodInvoker($handler, 'releaseLock');
+        $releaseLock = self::getPrivateMethodInvoker($handler, 'releaseLock');
         $releaseLock();
 
         $row = $this->db->table('ci_sessions')

--- a/tests/system/Test/FabricatorTest.php
+++ b/tests/system/Test/FabricatorTest.php
@@ -157,7 +157,7 @@ final class FabricatorTest extends CIUnitTestCase
         $formatters = ['boo' => 'hiss'];
         $fabricator = new Fabricator(UserModel::class, $formatters);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'detectFormatters');
+        $method = self::getPrivateMethodInvoker($fabricator, 'detectFormatters');
 
         $method();
 
@@ -200,7 +200,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'catchPhrase';
         $formatter = $method($field);
@@ -212,7 +212,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'created_at';
         $formatter = $method($field);
@@ -224,7 +224,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'id';
         $formatter = $method($field);
@@ -236,7 +236,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'business_email';
         $formatter = $method($field);
@@ -248,7 +248,7 @@ final class FabricatorTest extends CIUnitTestCase
     {
         $fabricator = new Fabricator(UserModel::class);
 
-        $method = $this->getPrivateMethodInvoker($fabricator, 'guessFormatter');
+        $method = self::getPrivateMethodInvoker($fabricator, 'guessFormatter');
 
         $field     = 'zaboomafoo';
         $formatter = $method($field);

--- a/tests/system/Test/ReflectionHelperTest.php
+++ b/tests/system/Test/ReflectionHelperTest.php
@@ -72,7 +72,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
     public function testGetPrivateMethodInvokerWithObject(): void
     {
         $obj    = new TestForReflectionHelper();
-        $method = $this->getPrivateMethodInvoker(
+        $method = self::getPrivateMethodInvoker(
             $obj,
             'privateMethod',
         );
@@ -84,7 +84,7 @@ final class ReflectionHelperTest extends CIUnitTestCase
 
     public function testGetPrivateMethodInvokerWithStatic(): void
     {
-        $method = $this->getPrivateMethodInvoker(
+        $method = self::getPrivateMethodInvoker(
             TestForReflectionHelper::class,
             'privateStaticMethod',
         );

--- a/tests/system/Validation/ValidationTest.php
+++ b/tests/system/Validation/ValidationTest.php
@@ -1078,14 +1078,14 @@ class ValidationTest extends CIUnitTestCase
      */
     public function testSplitNotRegex(): void
     {
-        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $method = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $result = $method('uploaded[avatar]|max_size[avatar,1024]');
         $this->assertSame('uploaded[avatar]', $result[0]);
     }
 
     public function testSplitRegex(): void
     {
-        $method = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $method = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $result = $method('required|regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]|max_length[10]');
         $this->assertSame('regex_match[/^[0-9]{4}[\-\.\[\/][0-9]{2}[\-\.\[\/][0-9]{2}/]', $result[1]);
     }
@@ -1531,7 +1531,7 @@ class ValidationTest extends CIUnitTestCase
     #[DataProvider('provideSplittingOfComplexStringRules')]
     public function testSplittingOfComplexStringRules(string $input, array $expected): void
     {
-        $splitter = $this->getPrivateMethodInvoker($this->validation, 'splitRules');
+        $splitter = self::getPrivateMethodInvoker($this->validation, 'splitRules');
         $this->assertSame($expected, $splitter($input));
     }
 
@@ -1597,10 +1597,10 @@ class ValidationTest extends CIUnitTestCase
             $data = [$placeholder => '12'];
         }
 
-        $validationRules = $this->getPrivateMethodInvoker($this->validation, 'fillPlaceholders')($this->validation->getRules(), $data);
+        $validationRules = self::getPrivateMethodInvoker($this->validation, 'fillPlaceholders')($this->validation->getRules(), $data);
         $fieldRules      = $validationRules['foo']['rules'] ?? $validationRules['foo'];
         if (is_string($fieldRules)) {
-            $fieldRules = $this->getPrivateMethodInvoker($this->validation, 'splitRules')($fieldRules);
+            $fieldRules = self::getPrivateMethodInvoker($this->validation, 'splitRules')($fieldRules);
         }
 
         // loop all rules for this field

--- a/user_guide_src/source/testing/overview/013.php
+++ b/user_guide_src/source/testing/overview/013.php
@@ -6,7 +6,7 @@ use App\Libraries\Foo;
 $obj = new Foo();
 
 // Get the invoker for the 'privateMethod' method.
-$method = $this->getPrivateMethodInvoker($obj, 'privateMethod');
+$method = self::getPrivateMethodInvoker($obj, 'privateMethod');
 
 // Test the results
 $this->assertEquals('bar', $method('param1', 'param2'));


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
I am developing a new phpstan extension for `ReflectionHelper::getPrivateMethodInvoker()` to give a precise Closure return type instead of just `Closure(mixed...): mixed)` return. To achieve this, I created a `DynamicStaticMethodReturnTypeExtension` since the method is _static_.

Now, the extension is working well pre-testing. The only setback I faced is that here in the repo we use the dynamic call instead of static call. This makes the extension useless as PHPStan does not call it anymore since the call is, well, dynamic. To fix this, I might just need to replicate the extension in a `DynamicMethodReturnTypeExtension` to handle dynamic calls, but that is not very DRY. So, I just opted to fix the calls here to static, as they should have been.

P.S. The amount of characters typed decreased by 1: `$this->` to `self::` 😂

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
