### PR TITLE
refactor: fix tests after smarter `getPrivateMethodInvoker()` return

### DIFF
--- a/tests/system/ControllerTest.php
+++ b/tests/system/ControllerTest.php
@@ -89,13 +89,17 @@ final class ControllerTest extends CIUnitTestCase
         $_SERVER = $original; // restore so code coverage doesn't break
     }
 
-    public function testCachePage(): void
+    public function testCachePageSetsTtl(): void
     {
         $this->controller = new Controller();
         $this->controller->initController($this->request, $this->response, $this->logger);
 
         $method = self::getPrivateMethodInvoker($this->controller, 'cachePage');
-        $this->assertNull($method(10));
+
+        $this->assertSame(0, self::getPrivateProperty(service('responsecache'), 'ttl'));
+
+        $method(10);
+        $this->assertSame(10, self::getPrivateProperty(service('responsecache'), 'ttl'));
     }
 
     public function testValidate(): void

--- a/tests/system/Database/ConfigTest.php
+++ b/tests/system/Database/ConfigTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database;
 
+use CodeIgniter\Database\Postgre\Connection as PostgreConnection;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -149,7 +150,7 @@ final class ConfigTest extends CIUnitTestCase
     public function testConnectionGroupWithDSNPostgre(): void
     {
         $conn = Config::connect($this->dsnGroupPostgre, false);
-        $this->assertInstanceOf(BaseConnection::class, $conn);
+        $this->assertInstanceOf(PostgreConnection::class, $conn);
 
         $this->assertSame('', $this->getPrivateProperty($conn, 'DSN'));
         $this->assertSame('localhost', $this->getPrivateProperty($conn, 'hostname'));
@@ -205,7 +206,7 @@ final class ConfigTest extends CIUnitTestCase
         //      Should deprecate?
         $this->dsnGroupPostgreNative['DSN'] = $input;
         $conn                               = Config::connect($this->dsnGroupPostgreNative, false);
-        $this->assertInstanceOf(BaseConnection::class, $conn);
+        $this->assertInstanceOf(PostgreConnection::class, $conn);
 
         $method = self::getPrivateMethodInvoker($conn, 'convertDSN');
         $method();


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Fixes the following phpstan errors after having smarter return type for `getPrivateMethodInvoker()`.
```
------ ------------------------------------ 
  Line   tests/system/ControllerTest.php     
 ------ ------------------------------------ 
  :98    Result of closure (void) is used.   
         🪪  callable.void                   
         ✏️  tests/system/ControllerTest.php  
 ------ ------------------------------------ 

 ------ ------------------------------------------------------- 
  Line   tests/system/Database/ConfigTest.php                   
 ------ ------------------------------------------------------- 
  :171   Unreachable statement - code above always terminates.  
         🪪  deadCode.unreachable                               
         ✏️  tests/system/Database/ConfigTest.php               
  :211   Unreachable statement - code above always terminates.  
         🪪  deadCode.unreachable                               
         ✏️  tests/system/Database/ConfigTest.php               
 ------ ------------------------------------------------------- 
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
