### PR TITLE
fix: anchor function not updating hostname when Config\App::$allowedHostnames is set

### DIFF
--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -150,11 +150,8 @@ if (! function_exists('anchor')) {
      * @param array|object|string $attributes Any attributes
      * @param App|null            $altConfig  Alternate configuration to use
      */
-    function anchor($uri = '', string $title = '', $attributes = '', ?App $altConfig = null): string
+    function anchor($uri = '', string $title = '', $attributes = '', ?App $config = null): string
     {
-        // use alternate config if provided, else default one
-        $config = $altConfig ?? config(App::class);
-
         $siteUrl = is_array($uri) ? site_url($uri, null, $config) : (preg_match('#^(\w+:)?//#i', $uri) ? $uri : site_url($uri, null, $config));
         // eliminate trailing slash
         $siteUrl = rtrim($siteUrl, '/');

--- a/system/Helpers/url_helper.php
+++ b/system/Helpers/url_helper.php
@@ -148,7 +148,7 @@ if (! function_exists('anchor')) {
      * @param array|string        $uri        URI string or array of URI segments
      * @param string              $title      The link title
      * @param array|object|string $attributes Any attributes
-     * @param App|null            $altConfig  Alternate configuration to use
+     * @param App|null            $config  Alternate configuration to use
      */
     function anchor($uri = '', string $title = '', $attributes = '', ?App $config = null): string
     {
@@ -178,13 +178,10 @@ if (! function_exists('anchor_popup')) {
      * @param string                    $uri        the URL
      * @param string                    $title      the link title
      * @param array|false|object|string $attributes any attributes
-     * @param App|null                  $altConfig  Alternate configuration to use
+     * @param App|null                  $config  Alternate configuration to use
      */
-    function anchor_popup($uri = '', string $title = '', $attributes = false, ?App $altConfig = null): string
+    function anchor_popup($uri = '', string $title = '', $attributes = false, ?App $config = null): string
     {
-        // use alternate config if provided, else default one
-        $config = $altConfig ?? config(App::class);
-
         $siteUrl = preg_match('#^(\w+:)?//#i', $uri) ? $uri : site_url($uri, null, $config);
         $siteUrl = rtrim($siteUrl, '/');
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
When you have set **Config\App::$allowedHostnames** the hostname should be set in it if the current URL matches. This is working as expected with with the functions **base_url** and **site_url** but NOT working with **anchor**.

It isn't working as expected because when the **anchor** function is called with a NULL **$altConfig** parameter, this parameter is modified to the default **Config\App** value, then it calls **site_url** and **SiteUri::siteUrl** with the default **Config\App** value instead of NULL which causes the line of code that checks for the host and updates it to be ignored.

The fix is quite simple, the function **anchor** should keep the parameter **$altConfig** as NULL and do not modify it to the default **Config\App** value because this will be done by the **SiteUri::siteUrl** function.

**Checklist:**
- 

- [x] Securely signed commits
- [ ]  Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
