### PR TITLE
refactor: update PHPStan baseline and fix Rector

### DIFF
--- a/system/HTTP/UserAgent.php
+++ b/system/HTTP/UserAgent.php
@@ -278,7 +278,7 @@ class UserAgent implements Stringable
         $this->setPlatform();
 
         foreach (['setRobot', 'setBrowser', 'setMobile'] as $function) {
-            if ($this->{$function}() === true) {
+            if ($this->{$function}()) {
                 break;
             }
         }

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,3 +1,4 @@
+# total 3759 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon
@@ -25,6 +26,7 @@ includes:
     - notIdentical.alwaysTrue.neon
     - nullCoalesce.property.neon
     - nullCoalesce.variable.neon
+    - offsetAccess.notFound.neon
     - property.defaultValue.neon
     - property.nonObject.neon
     - property.notFound.neon

--- a/utils/phpstan-baseline/method.alreadyNarrowedType.neon
+++ b/utils/phpstan-baseline/method.alreadyNarrowedType.neon
@@ -1,7 +1,17 @@
-# total 22 errors
+# total 24 errors
 
 parameters:
     ignoreErrors:
+        -
+            message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with bool will always evaluate to true\.$#'
+            count: 1
+            path: ../../admin/starter/tests/unit/HealthTest.php
+
+        -
+            message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with bool will always evaluate to true\.$#'
+            count: 1
+            path: ../../tests/system/Autoloader/AutoloaderTest.php
+
         -
             message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsBool\(\) with bool will always evaluate to true\.$#'
             count: 1

--- a/utils/phpstan-baseline/offsetAccess.notFound.neon
+++ b/utils/phpstan-baseline/offsetAccess.notFound.neon
@@ -1,0 +1,8 @@
+# total 2 errors
+
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Offset ''_ci_old_input'' does not exist on array\{\}\.$#'
+            count: 2
+            path: ../../tests/system/HTTP/RedirectResponseTest.php


### PR DESCRIPTION
**Description**
This PR updates the PHPStan baseline and one Rector error that occurred in the last build. IDK if there is a better way to handle PHPStan, but this seemed the simplest approach.

* PHPStan errors: https://github.com/codeigniter4/CodeIgniter4/actions/runs/14101988822/job/39499990729
* Rector error: https://github.com/codeigniter4/CodeIgniter4/actions/runs/14101988834/job/39499990763

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
