### PR TITLE
docs: Add description of conflicts between named and unnamed routes

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -543,6 +543,14 @@ with the name of the route:
 
 This has the added benefit of making the views more readable, too.
 
+.. note:: By default, all defined routes have names matching their paths, with placeholders replaced by their corresponding
+    regular expressions. For example, if you define a route like ``$routes->get('edit/(:num)', 'PostController::edit/$1');``,
+    you can generate the corresponding URL using ``route_to('edit/([0-9]+)', 12)``.
+
+.. warning:: According to :ref:`routing-priority`, if a not-named route is defined first (e.g., ``$routes->get('edit', 'PostController::edit');``)
+    and another named route is defined later with the same name as the path of the first route (e.g., ``$routes->get('edit/(:num)', 'PostController::edit/$1', ['as' => 'edit']);``),
+    the second route will not be registered because its name will conflict with the automatically assigned name of the first route.
+
 Grouping Routes
 ***************
 


### PR DESCRIPTION
It fixes the case described me in the forum topic https://forum.codeigniter.com/showthread.php?tid=92672

If we have two routes and the name of the second route is the same as the path of the first route, they conflict, and the second route is not added to the list of all routes.
```php
$routes->match(['GET', 'POST'], 'edit', 'PostController::edit');
$routes->match(['GET', 'POST'], 'edit/(:num)', 'PostController::edit/$1', ['as' => 'edit']); 
```
So, with this route configuration, we get a 404 on **/edit/10**.