### PR TITLE
fix: Logger - allow variable {line} to be used without variable {file} when logging message

### DIFF
--- a/system/Log/Logger.php
+++ b/system/Log/Logger.php
@@ -341,7 +341,7 @@ class Logger implements LoggerInterface
         $replace['{env}']       = ENVIRONMENT;
 
         // Allow us to log the file/line that we are logging from
-        if (str_contains($message, '{file}')) {
+        if (str_contains($message, '{file}') || str_contains($message, '{line}')) {
             [$file, $line] = $this->determineFile();
 
             $replace['{file}'] = $file;

--- a/tests/system/Log/LoggerTest.php
+++ b/tests/system/Log/LoggerTest.php
@@ -236,6 +236,23 @@ final class LoggerTest extends CIUnitTestCase
         $this->assertGreaterThan(1, strpos($logs[0], $expected));
     }
 
+    public function testLogInterpolatesLineOnly(): void
+    {
+        $config = new LoggerConfig();
+
+        $logger = new Logger($config);
+
+        $_ENV['foo'] = 'bar';
+
+        $logger->log('debug', 'Test message Sample {line}');
+        $line     = __LINE__ - 1;
+        $expected = "Sample {$line}";
+
+        $logs = TestHandler::getLogs();
+
+        $this->assertGreaterThan(1, strpos($logs[0], $expected));
+    }
+
     public function testLogInterpolatesExceptions(): void
     {
         $config = new LoggerConfig();

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -34,6 +34,7 @@ Bugs Fixed
 - **Cors:** Fixed a bug in the Cors filter that caused the appropriate headers to not be added when another filter returned a response object in the ``before`` filter.
 - **Database:** Fixed a bug in ``Postgre`` and ``SQLite3`` handlers where composite unique keys were not fully taken into account for ``upsert`` type of queries.
 - **Database:** Fixed a bug in the ``OCI8`` and ``SQLSRV`` drivers where ``getVersion()`` returned an empty string when the database connection was not yet established.
+- **Logger:** Fixed a bug where the ``{line}`` variable couldn't be used without specifying the ``{file}`` variable when logging the message.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,4 +1,4 @@
-# total 147 errors
+# total 148 errors
 
 parameters:
     ignoreErrors:
@@ -229,7 +229,7 @@ parameters:
 
         -
             message: '#^Parameter \#1 \$config of class CodeIgniter\\Log\\Logger constructor expects Config\\Logger, CodeIgniter\\Test\\Mock\\MockLogger given\.$#'
-            count: 24
+            count: 25
             path: ../../tests/system/Log/LoggerTest.php
 
         -

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 3759 errors
+# total 3760 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon


### PR DESCRIPTION
**Description**
This PR fixes a bug where the `{line}` variable in the Logger cannot be used without specifying the `{file}` variable in the logged message.

Fixes #9501

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
