### PR TITLE
fix: Toolbar when `maxHistory` is set to `0`

### DIFF
--- a/system/Debug/Toolbar.php
+++ b/system/Debug/Toolbar.php
@@ -512,7 +512,7 @@ class Toolbar
     {
         $data = json_decode($data, true);
 
-        if ($this->config->maxHistory !== 0 && preg_match('/\d+\.\d{6}/s', (string) service('request')->getGet('debugbar_time'), $debugbarTime)) {
+        if (preg_match('/\d+\.\d{6}/s', (string) service('request')->getGet('debugbar_time'), $debugbarTime)) {
             $history = new History();
             $history->setFiles(
                 $debugbarTime[0],

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -27,24 +27,25 @@ var ciDebugBar = {
             .getElementById("debug-icon-link")
             .addEventListener("click", ciDebugBar.toggleToolbar, true);
 
-        if (this.toolbar.querySelector(".ci-history-load")) {
-            // Allows highlighting the row of the current history request
-            var btn = this.toolbar.querySelector(
-                'button[data-time="' + localStorage.getItem("debugbar-time") + '"]'
-            );
-            ciDebugBar.addClass(btn.parentNode.parentNode, "current");
-        }
-
         historyLoad = this.toolbar.getElementsByClassName("ci-history-load");
 
-        for (var i = 0; i < historyLoad.length; i++) {
-            historyLoad[i].addEventListener(
-                "click",
-                function () {
-                    loadDoc(this.getAttribute("data-time"));
-                },
-                true
+        if (historyLoad.length) {
+            // Allows highlighting the row of the current history request
+            var btn = this.toolbar.querySelector(
+                'button[data-time="' + localStorage.getItem("debugbar-time-new") + '"]'
             );
+            ciDebugBar.addClass(btn.parentNode.parentNode, "current");
+
+
+            for (var i = 0; i < historyLoad.length; i++) {
+                historyLoad[i].addEventListener(
+                    "click",
+                    function () {
+                        loadDoc(this.getAttribute("data-time"));
+                    },
+                    true
+                );
+            }
         }
 
         // Display the active Tab on page load

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -27,11 +27,13 @@ var ciDebugBar = {
             .getElementById("debug-icon-link")
             .addEventListener("click", ciDebugBar.toggleToolbar, true);
 
-        // Allows to highlight the row of the current history request
-        var btn = this.toolbar.querySelector(
-            'button[data-time="' + localStorage.getItem("debugbar-time") + '"]'
-        );
-        ciDebugBar.addClass(btn.parentNode.parentNode, "current");
+        if (this.toolbar.querySelector(".ci-history-load")) {
+            // Allows highlighting the row of the current history request
+            var btn = this.toolbar.querySelector(
+                'button[data-time="' + localStorage.getItem("debugbar-time") + '"]'
+            );
+            ciDebugBar.addClass(btn.parentNode.parentNode, "current");
+        }
 
         historyLoad = this.toolbar.getElementsByClassName("ci-history-load");
 
@@ -77,14 +79,14 @@ var ciDebugBar = {
                 links[i].addEventListener("click", function() {
                     ciDebugBar.toggleDataTable(datatable)
                 }, true);
-               
+
             } else if (toggleData === "childrows") {
 
                 let child = links[i].getAttribute("data-child");
                 links[i].addEventListener("click", function() {
                     ciDebugBar.toggleChildRows(child)
                 }, true);
-                
+
             } else {
                 links[i].addEventListener("click", ciDebugBar.toggleRows, true);
             }
@@ -174,10 +176,10 @@ var ciDebugBar = {
             );
 
             if (target.classList.contains("debug-bar-ndisplay")) {
-                ciDebugBar.switchClass(target, "debug-bar-ndisplay", "debug-bar-dtableRow");   
+                ciDebugBar.switchClass(target, "debug-bar-ndisplay", "debug-bar-dtableRow");
             } else {
                 ciDebugBar.switchClass(target, "debug-bar-dtableRow", "debug-bar-ndisplay");
-            } 
+            }
         }
     },
 
@@ -261,7 +263,7 @@ var ciDebugBar = {
         } else {
             ciDebugBar.switchClass(ciDebugBar.icon, "debug-bar-dinlineBlock", "debug-bar-ndisplay");
             ciDebugBar.switchClass(ciDebugBar.toolbar, "debug-bar-ndisplay", "debug-bar-dinlineBlock");
-        } 
+        }
     },
 
     toggleViewsHints: function () {

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -35,6 +35,8 @@ Bugs Fixed
 - **Database:** Fixed a bug in ``Postgre`` and ``SQLite3`` handlers where composite unique keys were not fully taken into account for ``upsert`` type of queries.
 - **Database:** Fixed a bug in the ``OCI8`` and ``SQLSRV`` drivers where ``getVersion()`` returned an empty string when the database connection was not yet established.
 - **Logger:** Fixed a bug where the ``{line}`` variable couldn't be used without specifying the ``{file}`` variable when logging the message.
+- **Toolbar:** Fixed a bug where setting ``maxHistory`` to ``0`` would produce a JavaScript error in the Debug Toolbar.
+- **Toolbar:** Fixed a bug where setting ``maxHistory`` to ``0`` prevented log files from being properly cleared.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes issues with the debug bar when `maxHistory` is set to `0`:

- A JavaScript error occurred because the expected button does not exist.
- Debug toolbar history files were not properly cleaned up.

Fixes #9504

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
