### PR TITLE
refactor: deprecate redundant `FileHandler` cache methods

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -63,6 +63,8 @@ class FileHandler extends BaseHandler
 
         $this->mode   = $config->file['mode'] ?? 0640;
         $this->prefix = $config->prefix;
+
+        helper('filesystem');
     }
 
     /**
@@ -96,7 +98,7 @@ class FileHandler extends BaseHandler
             'data' => $value,
         ];
 
-        if ($this->writeFile($this->path . $key, serialize($contents))) {
+        if (write_file($this->path . $key, serialize($contents))) {
             try {
                 chmod($this->path . $key, $this->mode);
 
@@ -176,7 +178,7 @@ class FileHandler extends BaseHandler
      */
     public function clean()
     {
-        return $this->deleteFiles($this->path, false, true);
+        return delete_files($this->path, false, true);
     }
 
     /**
@@ -184,7 +186,7 @@ class FileHandler extends BaseHandler
      */
     public function getCacheInfo()
     {
-        return $this->getDirFileInfo($this->path);
+        return get_dir_file_info($this->path);
     }
 
     /**
@@ -251,6 +253,8 @@ class FileHandler extends BaseHandler
     /**
      * Writes a file to disk, or returns false if not successful.
      *
+     * @deprecated 4.6.1 Use `write_file()` instead.
+     *
      * @param string $path
      * @param string $data
      * @param string $mode
@@ -282,6 +286,8 @@ class FileHandler extends BaseHandler
      * Files must be writable or owned by the system in order to be deleted.
      * If the second parameter is set to TRUE, any directories contained
      * within the supplied base directory will be nuked as well.
+     *
+     * @deprecated 4.6.1 Use `delete_files()` instead.
      *
      * @param string $path   File path
      * @param bool   $delDir Whether to delete any directories found in the path
@@ -317,6 +323,8 @@ class FileHandler extends BaseHandler
      * filesize, dates, and permissions
      *
      * Any sub-folders contained within the specified path are read as well.
+     *
+     * @deprecated 4.6.1 Use `get_dir_file_info()` instead.
      *
      * @param string $sourceDir    Path to source
      * @param bool   $topLevelOnly Look only at the top level directory specified?
@@ -359,6 +367,8 @@ class FileHandler extends BaseHandler
      * Second parameter allows you to explicitly declare what information you want returned
      * Options are: name, server_path, size, date, readable, writable, executable, fileperms
      * Returns FALSE if the file cannot be found.
+     *
+     * @deprecated 4.6.1 Use `get_file_info()` instead.
      *
      * @param string       $file           Path to file
      * @param array|string $returnedValues Array or comma separated string of information returned

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -26,6 +26,11 @@ Changes
 Deprecations
 ************
 
+- **Cache:** The ``FileHandler::writeFile()`` method is deprecated. Use ``write_file()`` instead.
+- **Cache:** The ``FileHandler::deleteFiles()`` method is deprecated. Use ``delete_files()`` instead.
+- **Cache:** The ``FileHandler::getDirFileInfo()`` method is deprecated. Use ``get_dir_file_info()`` instead.
+- **Cache:** The ``FileHandler::getFileInfo()`` method is deprecated. Use ``get_file_info()`` instead.
+
 **********
 Bugs Fixed
 **********


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Deprecates the following protected methods of `FileHandler` as being redundant from related `filesystem_helper` functions:
- `FileHandler::writeFile()`
- `FileHandler::deleteFiles()`
- `FileHandler::getDirFileInfo()`
- `FileHandler::getFileInfo()`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
