### PR TITLE
chore: bump to `ubuntu-24.04` as latest ubuntu image

### DIFF
--- a/.github/workflows/deploy-apidocs.yml
+++ b/.github/workflows/deploy-apidocs.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
     if: github.repository == 'codeigniter4/CodeIgniter4'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Setup credentials

--- a/.github/workflows/deploy-distributables.yml
+++ b/.github/workflows/deploy-distributables.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check-version:
     name: Check for updated version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -38,7 +38,7 @@ jobs:
       # Allow actions/github-script to create release
       contents: write
     if: github.repository == 'codeigniter4/CodeIgniter4'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: check-version
 
     steps:
@@ -88,7 +88,7 @@ jobs:
       # Allow actions/github-script to create release
       contents: write
     if: github.repository == 'codeigniter4/CodeIgniter4'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: check-version
 
     steps:
@@ -138,7 +138,7 @@ jobs:
       # Allow actions/github-script to create release
       contents: write
     if: github.repository == 'codeigniter4/CodeIgniter4'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: check-version
 
     steps:

--- a/.github/workflows/label-add-conflict-all-pr.yml
+++ b/.github/workflows/label-add-conflict-all-pr.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: write
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-coveralls.yml
+++ b/.github/workflows/reusable-coveralls.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   coveralls:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout base branch for PR

--- a/.github/workflows/reusable-phpunit-test.yml
+++ b/.github/workflows/reusable-phpunit-test.yml
@@ -61,7 +61,7 @@ env:
 jobs:
   tests:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Service containers cannot be extracted to caller workflows yet
     services:
@@ -138,13 +138,16 @@ jobs:
     steps:
       - name: Create database for MSSQL Server
         if: ${{ inputs.db-platform == 'SQLSRV' }}
-        run: sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q "CREATE DATABASE test COLLATE Latin1_General_100_CS_AS_SC_UTF8"
+        run: |
+          sudo apt-get install -y mssql-tools18 unixodbc-dev
+          sudo ln -sfn /opt/mssql-tools18/bin/sqlcmd /usr/bin/sqlcmd
+          sqlcmd -S 127.0.0.1 -U sa -P 1Secure*Password1 -Q "CREATE DATABASE test COLLATE Latin1_General_100_CS_AS_SC_UTF8" -C
 
       - name: Install latest ImageMagick
         if: ${{ contains(inputs.extra-extensions, 'imagick') }}
         run: |
           sudo apt-get update
-          sudo apt-get install --reinstall libgs9-common fonts-noto-mono libgs9:amd64 libijs-0.35:amd64 fonts-urw-base35 ghostscript poppler-data libjbig2dec0:amd64 libopenjp2-7:amd64 fonts-droid-fallback fonts-dejavu-core
+          sudo apt-get install --reinstall libgs-common fonts-noto-mono libgs10:amd64 libijs-0.35:amd64 fonts-urw-base35 ghostscript poppler-data libjbig2dec0:amd64 libopenjp2-7:amd64 fonts-droid-fallback fonts-dejavu-core
           sudo apt-get install -y gsfonts libmagickwand-dev imagemagick
           sudo apt-get install --fix-broken
 

--- a/.github/workflows/reusable-serviceless-phpunit-test.yml
+++ b/.github/workflows/reusable-serviceless-phpunit-test.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   tests:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Install latest ImageMagick

--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   lint:
     name: PHP ${{ matrix.php-version }} Lint with PHP CS Fixer
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-deptrac.yml
+++ b/.github/workflows/test-deptrac.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   build:
     name: Architectural Inspection
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout base branch for PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test-file-permissions.yml
+++ b/.github/workflows/test-file-permissions.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   permission-check:
     name: Check File Permission
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-phpstan.yml
+++ b/.github/workflows/test-phpstan.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   build:
     name: PHP ${{ matrix.php-versions }} Static Analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/test-phpunit.yml
+++ b/.github/workflows/test-phpunit.yml
@@ -41,7 +41,7 @@ jobs:
   # in the caller workflow are not propagated to the called workflow.
   coverage-php-version:
     name: Setup PHP Version for Code Coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.coverage-php-version.outputs.version }}
     steps:

--- a/.github/workflows/test-rector.yml
+++ b/.github/workflows/test-rector.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   build:
     name: PHP ${{ matrix.php-versions }} Analyze code (Rector)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-scss.yml
+++ b/.github/workflows/test-scss.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   build:
     name: Compilation of SCSS (Dart Sass)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-userguide.yml
+++ b/.github/workflows/test-userguide.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   syntax_check:
     name: Check User Guide syntax
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
`ubuntu-latest` is now `ubuntu-24.04`. see https://github.com/actions/runner-images?tab=readme-ov-file#available-images

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
