### PR TITLE
refactor: fix `codeigniter.modelArgumentType` errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -43,6 +43,8 @@ parameters:
     codeigniter:
         additionalServices:
             - AfterAutoloadModule\Config\Services
+        additionalModelNamespaces:
+            - Tests\Support\Models
         checkArgumentTypeOfModel: false
     shipmonkBaselinePerIdentifier:
         directory: %currentWorkingDirectory%

--- a/system/Test/Fabricator.php
+++ b/system/Test/Fabricator.php
@@ -119,8 +119,7 @@ class Fabricator
      */
     public function __construct($model, ?array $formatters = null, ?string $locale = null)
     {
-        if (is_string($model)) {
-            // Create a new model instance
+        if (is_string($model) && class_exists($model)) {
             $model = model($model, false);
         }
 

--- a/utils/phpstan-baseline/codeigniter.modelArgumentType.neon
+++ b/utils/phpstan-baseline/codeigniter.modelArgumentType.neon
@@ -1,17 +1,7 @@
-# total 3 errors
+# total 1 error
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^Parameter \#1 \$name of function model expects a valid class string, string given\.$#'
-            count: 1
-            path: ../../system/Test/Fabricator.php
-
-        -
-            message: '#^Parameter \#1 \$name of function model expects a valid class string, ''JobModel'' given\.$#'
-            count: 1
-            path: ../../tests/system/CommonFunctionsTest.php
-
         -
             message: '#^Parameter \#1 \$name of function model expects a valid class string, ''CodeIgniter\\\\Shield\\\\Models\\\\UserModel'' given\.$#'
             count: 1

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 3373 errors
+# total 3371 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
1. Save the model call from instantiating non class-strings.
2. Added `Tests\Support\Models` namespace as known model namespaces.
~3. Adding Shield's namespace is not enough since PHPStan must know the class do exist, so we required shield as a dev dependency.~

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
