### PR TITLE
fix: added "application/octet-stream" to the "stl" mime type in the M…

### DIFF
--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -478,6 +478,7 @@ class Mimes
             'application/sla',
             'application/vnd.ms-pki.stl',
             'application/x-navistyle',
+            'application/octet-stream',
         ],
     ];
 

--- a/app/Config/Mimes.php
+++ b/app/Config/Mimes.php
@@ -478,6 +478,7 @@ class Mimes
             'application/sla',
             'application/vnd.ms-pki.stl',
             'application/x-navistyle',
+            'model/stl',
             'application/octet-stream',
         ],
     ];

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -21,6 +21,7 @@ Message Changes
 *******
 Changes
 *******
+- Added the ``application/octet-stream`` type for the ``stl`` mime inside the ``Config\Mimes`` class.
 
 ************
 Deprecations

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -21,7 +21,7 @@ Message Changes
 *******
 Changes
 *******
-- **Mimes**: Added the ``application/octet-stream`` mime type for the ``stl`` extension inside the ``Config\Mimes`` class.
+- **Mimes**: Added the ``model/stl`` and ``application/octet-stream`` mime types for the ``stl`` extension inside the ``Config\Mimes`` class.
 
 ************
 Deprecations

--- a/user_guide_src/source/changelogs/v4.6.1.rst
+++ b/user_guide_src/source/changelogs/v4.6.1.rst
@@ -21,7 +21,7 @@ Message Changes
 *******
 Changes
 *******
-- Added the ``application/octet-stream`` type for the ``stl`` mime inside the ``Config\Mimes`` class.
+- **Mimes**: Added the ``application/octet-stream`` mime type for the ``stl`` extension inside the ``Config\Mimes`` class.
 
 ************
 Deprecations


### PR DESCRIPTION
**Description**
I added the "application/octet-stream" to the "stl" mime type in the Mimes config class.
When I upload a stl file the mime type returns as "application/octet-stream" and the `ext_in` input validation returns false.
Reference issue:  [Issue: 9510](https://github.com/codeigniter4/CodeIgniter4/issues/9510).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
