### PR TITLE
chore: update predis/predis to version 3

### DIFF
--- a/admin/framework/composer.json
+++ b/admin/framework/composer.json
@@ -24,7 +24,7 @@
         "mikey179/vfsstream": "^1.6.12",
         "nexusphp/cs-config": "^3.6",
         "phpunit/phpunit": "^10.5.16 || ^11.2",
-        "predis/predis": "^1.1 || ^2.3"
+        "predis/predis": "^3.0"
     },
     "suggest": {
         "ext-curl": "If you use CURLRequest class",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpcov": "^9.0.2 || ^10.0",
         "phpunit/phpunit": "^10.5.16 || ^11.2",
-        "predis/predis": "^1.1 || ^2.3",
+        "predis/predis": "^3.0",
         "rector/rector": "2.0.15",
         "shipmonk/phpstan-baseline-per-identifier": "^2.0"
     },


### PR DESCRIPTION
**Description**
This PR updates `predis/predis` to v3.

I removed v1, since it's not fully compatible with PHP 8.1 - it may return some deprecation warnings.

v2 and v3 support the same PHP versions without breaking changes, so since this is a dev requirement, it seems fine.

Closes #9548

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
