### PR TITLE
feat: added `fresh_connect` options to `CURLRequest`

### DIFF
--- a/system/HTTP/CURLRequest.php
+++ b/system/HTTP/CURLRequest.php
@@ -365,7 +365,6 @@ class CURLRequest extends OutgoingRequest
         $curlOptions[CURLOPT_URL]            = $url;
         $curlOptions[CURLOPT_RETURNTRANSFER] = true;
         $curlOptions[CURLOPT_HEADER]         = true;
-        $curlOptions[CURLOPT_FRESH_CONNECT]  = true;
         // Disable @file uploads in post data.
         $curlOptions[CURLOPT_SAFE_UPLOAD] = true;
 
@@ -620,6 +619,11 @@ class CURLRequest extends OutgoingRequest
         if (isset($config['dns_cache_timeout']) && is_numeric($config['dns_cache_timeout']) && $config['dns_cache_timeout'] >= -1) {
             $curlOptions[CURLOPT_DNS_CACHE_TIMEOUT] = (int) $config['dns_cache_timeout'];
         }
+
+        // Fresh Connect (default true)
+        $curlOptions[CURLOPT_FRESH_CONNECT] = isset($config['fresh_connect']) && is_bool($config['fresh_connect'])
+            ? $config['fresh_connect']
+            : true;
 
         // Timeout
         $curlOptions[CURLOPT_TIMEOUT_MS] = (float) $config['timeout'] * 1000;

--- a/tests/system/HTTP/CURLRequestTest.php
+++ b/tests/system/HTTP/CURLRequestTest.php
@@ -583,6 +583,28 @@ Transfer-Encoding: chunked\x0d\x0a\x0d\x0a<title>Update success! config</title>"
         $this->assertTrue($options[CURLOPT_HTTPPROXYTUNNEL]);
     }
 
+    public function testFreshConnectDefault(): void
+    {
+        $this->request->request('get', 'http://example.com');
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_FRESH_CONNECT, $options);
+        $this->assertTrue($options[CURLOPT_FRESH_CONNECT]);
+    }
+
+    public function testFreshConnectFalseOption(): void
+    {
+        $this->request->request('get', 'http://example.com', [
+            'fresh_connect' => false,
+        ]);
+
+        $options = $this->request->curl_options;
+
+        $this->assertArrayHasKey(CURLOPT_FRESH_CONNECT, $options);
+        $this->assertFalse($options[CURLOPT_FRESH_CONNECT]);
+    }
+
     public function testDebugOptionTrue(): void
     {
         $this->request->request('get', 'http://example.com', [

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -39,6 +39,7 @@ Libraries
 =========
 
 - **CURLRequest:** Added ``dns_cache_timeout`` option to change default DNS cache timeout.
+- **CURLRequest:** Added ``fresh_connect`` options to enable/disabled request fresh connection.
 - **Email:** Added support for choosing the SMTP authorization method. You can change it via ``Config\Email::$SMTPAuthMethod`` option.
 - **Image:** The ``ImageMagickHandler`` has been rewritten to rely solely on the PHP ``imagick`` extension.
 - **Image:** Added ``ImageMagickHandler::clearMetadata()`` method to remove image metadata for privacy protection.

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -283,7 +283,7 @@ fresh_connect
 
 .. versionadded:: 4.7.0
 
-You can send request as fresh connection by the ``fresh_connect`` option:
+By default, the request is sent using a fresh connection. You can disable this behavior using the ``fresh_connect`` option:
 
 .. literalinclude:: curlrequest/038.php
 

--- a/user_guide_src/source/libraries/curlrequest.rst
+++ b/user_guide_src/source/libraries/curlrequest.rst
@@ -278,6 +278,15 @@ if it's not already set:
 
 .. _curlrequest-request-options-headers:
 
+fresh_connect
+=============
+
+.. versionadded:: 4.7.0
+
+You can send request as fresh connection by the ``fresh_connect`` option:
+
+.. literalinclude:: curlrequest/038.php
+
 headers
 =======
 

--- a/user_guide_src/source/libraries/curlrequest/038.php
+++ b/user_guide_src/source/libraries/curlrequest/038.php
@@ -1,0 +1,4 @@
+<?php
+
+$client->request('GET', 'http://example.com', ['fresh_connect' => true]);
+$client->request('GET', 'http://example.com', ['fresh_connect' => false]);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Added option to disable fresh connection.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
