### PR TITLE
fix: remove service dependency from sanitize_filename() helper function

### DIFF
--- a/system/Helpers/security_helper.php
+++ b/system/Helpers/security_helper.php
@@ -15,11 +15,69 @@ declare(strict_types=1);
 
 if (! function_exists('sanitize_filename')) {
     /**
-     * Sanitize a filename to use in a URI.
+     * Sanitize Filename
+     *
+     * Tries to sanitize filenames in order to prevent directory traversal attempts
+     * and other security threats, which is particularly useful for files that
+     * were supplied via user input.
+     *
+     * If it is acceptable for the user input to include relative paths,
+     * e.g. file/in/some/approved/folder.txt, you can set the second optional
+     * parameter, $relativePath to TRUE.
+     *
+     * @param string $filename     Input file name
+     * @param bool   $relativePath Whether to preserve paths
      */
-    function sanitize_filename(string $filename): string
+    function sanitize_filename(string $filename, bool $relativePath = false): string
     {
-        return service('security')->sanitizeFilename($filename);
+        // List of sanitized filename strings
+        $bad = [
+            '../',
+            '<!--',
+            '-->',
+            '<',
+            '>',
+            "'",
+            '"',
+            '&',
+            '$',
+            '#',
+            '{',
+            '}',
+            '[',
+            ']',
+            '=',
+            ';',
+            '?',
+            '%20',
+            '%22',
+            '%3c',
+            '%253c',
+            '%3e',
+            '%0e',
+            '%28',
+            '%29',
+            '%2528',
+            '%26',
+            '%24',
+            '%3f',
+            '%3b',
+            '%3d',
+        ];
+
+        if (! $relativePath) {
+            $bad[] = './';
+            $bad[] = '/';
+        }
+
+        $filename = remove_invisible_characters($filename, false);
+
+        do {
+            $old      = $filename;
+            $filename = str_replace($bad, '', $filename);
+        } while ($old !== $filename);
+
+        return stripslashes($filename);
     }
 }
 

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -427,6 +427,8 @@ class Security implements SecurityInterface
      * e.g. file/in/some/approved/folder.txt, you can set the second optional
      * parameter, $relativePath to TRUE.
      *
+     * @deprecated 4.6.2 Use `sanitize_filename()` instead
+     *
      * @param string $str          Input file name
      * @param bool   $relativePath Whether to preserve paths
      */

--- a/system/Security/Security.php
+++ b/system/Security/Security.php
@@ -432,54 +432,9 @@ class Security implements SecurityInterface
      */
     public function sanitizeFilename(string $str, bool $relativePath = false): string
     {
-        // List of sanitize filename strings
-        $bad = [
-            '../',
-            '<!--',
-            '-->',
-            '<',
-            '>',
-            "'",
-            '"',
-            '&',
-            '$',
-            '#',
-            '{',
-            '}',
-            '[',
-            ']',
-            '=',
-            ';',
-            '?',
-            '%20',
-            '%22',
-            '%3c',
-            '%253c',
-            '%3e',
-            '%0e',
-            '%28',
-            '%29',
-            '%2528',
-            '%26',
-            '%24',
-            '%3f',
-            '%3b',
-            '%3d',
-        ];
+        helper('security');
 
-        if (! $relativePath) {
-            $bad[] = './';
-            $bad[] = '/';
-        }
-
-        $str = remove_invisible_characters($str, false);
-
-        do {
-            $old = $str;
-            $str = str_replace($bad, '', $str);
-        } while ($old !== $str);
-
-        return stripslashes($str);
+        return sanitize_filename($str, $relativePath);
     }
 
     /**

--- a/system/Security/SecurityInterface.php
+++ b/system/Security/SecurityInterface.php
@@ -66,6 +66,8 @@ interface SecurityInterface
      * e.g. file/in/some/approved/folder.txt, you can set the second optional
      * parameter, $relativePath to TRUE.
      *
+     * @deprecated 4.6.2 Use `sanitize_filename()` instead
+     *
      * @param string $str          Input file name
      * @param bool   $relativePath Whether to preserve paths
      */

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -22,6 +22,8 @@ Message Changes
 Changes
 *******
 
+- **Security:** The ``sanitize_filename()`` function from the Security helper now supports a second parameter to control whether relative paths are allowed.
+
 ************
 Deprecations
 ************
@@ -29,6 +31,8 @@ Deprecations
 **********
 Bugs Fixed
 **********
+
+- **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -28,6 +28,9 @@ Changes
 Deprecations
 ************
 
+- **Security:** The ``Security::sanitizeFilename()`` method is deprecated. Use ``sanitize_filename()`` instead.
+- **Security:** The ``SecurityInterface::sanitizeFilename()`` method is deprecated.
+
 **********
 Bugs Fixed
 **********

--- a/user_guide_src/source/helpers/security_helper.rst
+++ b/user_guide_src/source/helpers/security_helper.rst
@@ -20,15 +20,15 @@ Available Functions
 
 The following functions are available:
 
-.. php:function:: sanitize_filename($filename)
+.. php:function:: sanitize_filename($filename[, $relativePath = false])
 
     :param    string    $filename: Filename
+    :param    bool      $relativePath: Whether the relative path is acceptable (available since v4.6.2)
     :returns:    Sanitized file name
     :rtype:    string
 
     Provides protection against directory traversal.
 
-    This function is an alias for ``\CodeIgniter\Security::sanitizeFilename()``.
     For more info, please see the :doc:`Security Library <../libraries/security>`
     documentation.
 

--- a/user_guide_src/source/libraries/security.rst
+++ b/user_guide_src/source/libraries/security.rst
@@ -241,3 +241,5 @@ If it is acceptable for the user input to include relative paths, e.g., **file/i
 the second optional parameter, ``$relativePath`` to ``true``.
 
 .. literalinclude:: security/010.php
+
+This method is an alias for the ``sanitize_filename()`` function from the Security helper.


### PR DESCRIPTION
**Description**
This PR fixes a bug where the `sanitize_filename()` helper function could not be used in CLI requests.

The `sanitize_filename()` function in the Security helper now contains the logic that was previously in the `Security::sanitizeFilename()` method. The method has been updated to delegate to the helper function, reversing the previous dependency. This change allows the function to be used in CLI requests without relying on the service.

Fixes: #9555

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
