### PR TITLE
chore: add missing EscaperInterface to the AutoloadConfig

### DIFF
--- a/system/Config/AutoloadConfig.php
+++ b/system/Config/AutoloadConfig.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Config;
 
 use Laminas\Escaper\Escaper;
+use Laminas\Escaper\EscaperInterface;
 use Laminas\Escaper\Exception\ExceptionInterface;
 use Laminas\Escaper\Exception\InvalidArgumentException as EscaperInvalidArgumentException;
 use Laminas\Escaper\Exception\RuntimeException;
@@ -119,6 +120,7 @@ class AutoloadConfig
         ExceptionInterface::class              => SYSTEMPATH . 'ThirdParty/Escaper/Exception/ExceptionInterface.php',
         EscaperInvalidArgumentException::class => SYSTEMPATH . 'ThirdParty/Escaper/Exception/InvalidArgumentException.php',
         RuntimeException::class                => SYSTEMPATH . 'ThirdParty/Escaper/Exception/RuntimeException.php',
+        EscaperInterface::class                => SYSTEMPATH . 'ThirdParty/Escaper/EscaperInterface.php',
         Escaper::class                         => SYSTEMPATH . 'ThirdParty/Escaper/Escaper.php',
     ];
 


### PR DESCRIPTION
**Description**
This PR adds missing `EscaperInterface` to the `AutoloadConfig`.

See: https://github.com/codeigniter4/CodeIgniter4/pull/9558#issuecomment-2882383840

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
