### PR TITLE
refactor: add `system/util_bootstrap.php` to curb overreliance to `system/Test/bootstrap.php`

### DIFF
--- a/system/Boot.php
+++ b/system/Boot.php
@@ -16,6 +16,7 @@ namespace CodeIgniter;
 use CodeIgniter\Cache\FactoriesCache;
 use CodeIgniter\CLI\Console;
 use CodeIgniter\Config\DotEnv;
+use Config\App;
 use Config\Autoload;
 use Config\Modules;
 use Config\Optimize;
@@ -73,6 +74,34 @@ class Boot
         // Exits the application, setting the exit code for CLI-based
         // applications that might be watching.
         return EXIT_SUCCESS;
+    }
+
+    /**
+     * Used by command line scripts other than
+     * * `spark`
+     * * `php-cli`
+     * * `phpunit`
+     *
+     * @used-by `system/util_bootstrap.php`
+     */
+    public static function bootConsole(Paths $paths): void
+    {
+        static::definePathConstants($paths);
+        static::loadConstants();
+        static::checkMissingExtensions();
+
+        static::loadDotEnv($paths);
+        static::loadEnvironmentBootstrap($paths);
+
+        static::loadCommonFunctions();
+        static::loadAutoloader();
+        static::setExceptionHandler();
+        static::initializeKint();
+        static::autoloadHelpers();
+
+        // We need to force the request to be a CLIRequest since we're in console
+        Services::createRequest(new App(), true);
+        service('routes')->loadRoutes();
     }
 
     /**

--- a/system/util_bootstrap.php
+++ b/system/util_bootstrap.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use CodeIgniter\Boot;
+use Config\Paths;
+
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
+
+/*
+ * ---------------------------------------------------------------
+ * DEFINE ENVIRONMENT
+ * ---------------------------------------------------------------
+ *
+ * As this bootstrap file is primarily used by internal scripts
+ * across the framework and other CodeIgniter projects, we need
+ * to make sure it recognizes that we're in development.
+ */
+
+$_SERVER['CI_ENVIRONMENT'] = 'development';
+define('ENVIRONMENT', 'development');
+defined('CI_DEBUG') || define('CI_DEBUG', true);
+
+/*
+ * ---------------------------------------------------------------
+ * SET UP OUR PATH CONSTANTS
+ * ---------------------------------------------------------------
+ *
+ * The path constants provide convenient access to the folders
+ * throughout the application. We have to set them up here
+ * so they are available in the config files that are loaded.
+ */
+
+defined('HOMEPATH') || define('HOMEPATH', realpath(rtrim(getcwd(), '\\/ ')) . DIRECTORY_SEPARATOR);
+
+$source = match (true) {
+    is_dir(HOMEPATH . 'app/')                   => HOMEPATH,
+    is_dir('vendor/codeigniter4/framework/')    => 'vendor/codeigniter4/framework/',
+    is_dir('vendor/codeigniter4/codeigniter4/') => 'vendor/codeigniter4/codeigniter4/',
+    default                                     => throw new RuntimeException('Unable to determine the source directory.'),
+};
+
+defined('CONFIGPATH') || define('CONFIGPATH', realpath($source . 'app/Config') . DIRECTORY_SEPARATOR);
+defined('PUBLICPATH') || define('PUBLICPATH', realpath($source . 'public') . DIRECTORY_SEPARATOR);
+unset($source);
+
+require CONFIGPATH . 'Paths.php';
+$paths = new Paths();
+
+defined('CIPATH') || define('CIPATH', realpath($paths->systemDirectory . '/../') . DIRECTORY_SEPARATOR);
+defined('FCPATH') || define('FCPATH', PUBLICPATH);
+
+if (is_dir(HOMEPATH . 'vendor/')) {
+    define('VENDORPATH', realpath(HOMEPATH . 'vendor/') . DIRECTORY_SEPARATOR);
+    define('COMPOSER_PATH', (string) realpath(HOMEPATH . 'vendor/autoload.php'));
+}
+
+/*
+ *---------------------------------------------------------------
+ * BOOTSTRAP THE APPLICATION
+ *---------------------------------------------------------------
+ *
+ * This process sets up the path constants, loads and registers
+ * our autoloader, along with Composer's, loads our constants
+ * and fires up an environment-specific bootstrapping.
+ */
+
+require $paths->systemDirectory . '/Boot.php';
+Boot::bootConsole($paths);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Replaces and closes #9558 
Ref: https://github.com/codeigniter4/CodeIgniter4/pull/9558#issuecomment-2883805377
Depends on: #9561 

This was trickier than I initially thought, due to the following:
- We cannot use `bootWeb()` as it will require a CLI route registered to `/` (currently throws an Error 404)
- We cannot use `bootSpark()` as it will also print `spark`'s list of commands
- We cannot use `bootTest()` due to the reason outlined in the previous PRs

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
