### PR TITLE
feat: update `CookieInterface::EXPIRES_FORMAT` to use date format per RFC 7231

### DIFF
--- a/system/Cookie/CookieInterface.php
+++ b/system/Cookie/CookieInterface.php
@@ -57,7 +57,7 @@ interface CookieInterface
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
      * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2
      */
-    public const EXPIRES_FORMAT = 'D, d-M-Y H:i:s T';
+    public const EXPIRES_FORMAT = DATE_RFC7231;
 
     /**
      * Returns a unique identifier for the cookie consisting

--- a/tests/system/Cookie/CookieTest.php
+++ b/tests/system/Cookie/CookieTest.php
@@ -155,14 +155,14 @@ final class CookieTest extends CIUnitTestCase
         // expires => 0
         $cookie = new Cookie('test', 'value');
         $this->assertSame(0, $cookie->getExpiresTimestamp());
-        $this->assertSame('Thu, 01-Jan-1970 00:00:00 GMT', $cookie->getExpiresString());
+        $this->assertSame('Thu, 01 Jan 1970 00:00:00 GMT', $cookie->getExpiresString());
         $this->assertTrue($cookie->isExpired());
         $this->assertSame(0, $cookie->getMaxAge());
 
         $date   = new DateTimeImmutable('2021-01-10 00:00:00 GMT', new DateTimeZone('UTC'));
         $cookie = new Cookie('test', 'value', ['expires' => $date]);
         $this->assertSame((int) $date->format('U'), $cookie->getExpiresTimestamp());
-        $this->assertSame('Sun, 10-Jan-2021 00:00:00 GMT', $cookie->getExpiresString());
+        $this->assertSame('Sun, 10 Jan 2021 00:00:00 GMT', $cookie->getExpiresString());
     }
 
     /**
@@ -272,7 +272,7 @@ final class CookieTest extends CIUnitTestCase
             $a->toHeaderString(),
         );
         $this->assertSame(
-            "cookie=monster; Expires=Sun, 14-Feb-2021 00:00:00 GMT; Max-Age={$max}; Path=/web; Domain=localhost; HttpOnly; SameSite=Lax",
+            "cookie=monster; Expires=Sun, 14 Feb 2021 00:00:00 GMT; Max-Age={$max}; Path=/web; Domain=localhost; HttpOnly; SameSite=Lax",
             (string) $b,
         );
         $this->assertSame(
@@ -280,7 +280,7 @@ final class CookieTest extends CIUnitTestCase
             (string) $c,
         );
         $this->assertSame(
-            'cookie=deleted; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly; SameSite=Lax',
+            'cookie=deleted; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/; HttpOnly; SameSite=Lax',
             (string) $d,
         );
 

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -83,6 +83,8 @@ Message Changes
 Changes
 *******
 
+- **Cookie:** The ``CookieInterface::EXPIRES_FORMAT`` has been changed to ``D, d M Y H:i:s \G\M\T`` to follow the recommended format in RFC 7231.
+
 ************
 Deprecations
 ************

--- a/user_guide_src/source/libraries/cookies/004.php
+++ b/user_guide_src/source/libraries/cookies/004.php
@@ -23,7 +23,7 @@ $cookie->getName();             // 'remember_token'
 $cookie->getPrefix();           // '__Secure-'
 $cookie->getPrefixedName();     // '__Secure-remember_token'
 $cookie->getExpiresTimestamp(); // UNIX timestamp
-$cookie->getExpiresString();    // 'Fri, 14-Feb-2025 00:00:00 GMT'
+$cookie->getExpiresString();    // 'Fri, 14 Feb 2025 00:00:00 GMT'
 $cookie->isExpired();           // false
 $cookie->getMaxAge();           // the difference from time() to expires
 $cookie->isRaw();               // false


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
When I first made this Cookie component, the [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie) states that the date format is `D, d-M-Y H:i:s T` (RFC 850). Now, it seems this format is obsolete and recommends using RFC 5322 format (`D, d M Y H:i:s \G\M\T` - without dashes`). This PR updates the date format to that.

This change will not be breaking as per RFC 7231 section 7.1.1.1. Although RFC 850 is obsolete, it SHOULD still be accepted. Since we're moving from obsolete to recommended, I think we should not have any problems.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
