### PR TITLE
fix: ucfirst all cookie samesite values

### DIFF
--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -766,11 +766,11 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
             $samesite = self::SAMESITE_LAX;
         }
 
-        if (! in_array(ucfirst($samesite), self::ALLOWED_SAMESITE_VALUES, true)) {
+        if (! in_array($samesite, self::ALLOWED_SAMESITE_VALUES, true)) {
             throw CookieException::forInvalidSameSite($samesite);
         }
 
-        if (ucfirst($samesite) === self::SAMESITE_NONE && ! $secure) {
+        if ($samesite === self::SAMESITE_NONE && ! $secure) {
             throw CookieException::forInvalidSameSiteNone();
         }
     }

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -766,11 +766,11 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
             $samesite = self::SAMESITE_LAX;
         }
 
-        if (! in_array(strtolower($samesite), self::ALLOWED_SAMESITE_VALUES, true)) {
+        if (! in_array(ucfirst($samesite), self::ALLOWED_SAMESITE_VALUES, true)) {
             throw CookieException::forInvalidSameSite($samesite);
         }
 
-        if (strtolower($samesite) === self::SAMESITE_NONE && ! $secure) {
+        if (ucfirst($samesite) === self::SAMESITE_NONE && ! $secure) {
             throw CookieException::forInvalidSameSiteNone();
         }
     }

--- a/system/Cookie/Cookie.php
+++ b/system/Cookie/Cookie.php
@@ -766,11 +766,11 @@ class Cookie implements ArrayAccess, CloneableCookieInterface
             $samesite = self::SAMESITE_LAX;
         }
 
-        if (! in_array($samesite, self::ALLOWED_SAMESITE_VALUES, true)) {
+        if (! in_array(ucfirst(strtolower($samesite)), self::ALLOWED_SAMESITE_VALUES, true)) {
             throw CookieException::forInvalidSameSite($samesite);
         }
 
-        if ($samesite === self::SAMESITE_NONE && ! $secure) {
+        if (ucfirst(strtolower($samesite)) === self::SAMESITE_NONE && ! $secure) {
             throw CookieException::forInvalidSameSiteNone();
         }
     }

--- a/system/Cookie/CookieInterface.php
+++ b/system/Cookie/CookieInterface.php
@@ -25,20 +25,20 @@ interface CookieInterface
      * first-party and cross-origin requests. If `SameSite=None` is set,
      * the cookie `Secure` attribute must also be set (or the cookie will be blocked).
      */
-    public const SAMESITE_NONE = 'none';
+    public const SAMESITE_NONE = 'None';
 
     /**
      * Cookies are not sent on normal cross-site subrequests (for example to
      * load images or frames into a third party site), but are sent when a
      * user is navigating to the origin site (i.e. when following a link).
      */
-    public const SAMESITE_LAX = 'lax';
+    public const SAMESITE_LAX = 'Lax';
 
     /**
      * Cookies will only be sent in a first-party context and not be sent
      * along with requests initiated by third party websites.
      */
-    public const SAMESITE_STRICT = 'strict';
+    public const SAMESITE_STRICT = 'Strict';
 
     /**
      * RFC 6265 allowed values for the "SameSite" attribute.

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -97,6 +97,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Cookie:** The ``CookieInterface::SAMESITE_STRICT``, ``CookieInterface::SAMESITE_LAX``, and ``CookieInterface::SAMESITE_NONE`` constants are now written in ucfirst style to be consistent with usage in the rest of the framework.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/libraries/cookies/006.php
+++ b/user_guide_src/source/libraries/cookies/006.php
@@ -2,6 +2,6 @@
 
 use CodeIgniter\Cookie\Cookie;
 
-Cookie::SAMESITE_LAX;       // 'lax'
-Cookie::SAMESITE_STRICT;    // 'strict'
-Cookie::SAMESITE_NONE;      // 'none'
+Cookie::SAMESITE_LAX;    // 'Lax'
+Cookie::SAMESITE_STRICT; // 'Strict'
+Cookie::SAMESITE_NONE;   // 'None'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
If you run `vendor/bin/phpunit --filter CookieTest` you get:
```console
❯ vendor/bin/phpunit --filter CookieTest
PHPUnit 11.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.21 with Xdebug 3.4.3
Configuration: /Users/paul/Workspace/CodeIgniter4/phpunit.xml.dist

..F.............................................                                                                                        48 / 48 (100%)

Time: 00:02.209, Memory: 80.00 MB

There was 1 failure:

1) CodeIgniter\Cookie\CookieTest::testCookieInitializationWithDefaults
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'lax'
+'Lax'

/Users/paul/Workspace/CodeIgniter4/tests/system/Cookie/CookieTest.php:58

FAILURES!
Tests: 48, Assertions: 133, Failures: 1.

Generating code coverage report in Clover XML format ... done [00:00.432]

Generating code coverage report in HTML format ... done [00:02.914]
```

This is because when you pass an empty defaults array (or did not pass anything) to `Cookie::setDefaults()`, the samesite value set is `self::SAMESITE_LAX` equal to `lax`. Now, we transform the samesite value to `ucfirst` in the constructor so that it would be consistent everywhere. Even the cookie config's allowed value for samesite is in ucfirst. I thought we have done that pretty much everywhere but found out this case wasn't. This failure was not caught since the test case is run along with the other tests. Running it by itself shows the issue.

I have targeted `4.7` since I'm changing the values of the constants so I think this is a behavior change. Let me know if this is ok in `develop`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
