### PR TITLE
test: ensure all test methods have native return types

### DIFF
--- a/.php-cs-fixer.tests.php
+++ b/.php-cs-fixer.tests.php
@@ -31,7 +31,8 @@ $finder = Finder::create()
     ->notName('#Foobar.php$#');
 
 $overrides = [
-    'void_return' => true,
+    'phpdoc_to_return_type' => true,
+    'void_return'           => true,
 ];
 
 return $config

--- a/tests/_support/Autoloader/FatalLocator.php
+++ b/tests/_support/Autoloader/FatalLocator.php
@@ -34,7 +34,7 @@ class FatalLocator extends FileLocator
      *
      * @return false|string The path to the file, or false if not found.
      */
-    public function locateFile(string $file, ?string $folder = null, string $ext = 'php')
+    public function locateFile(string $file, ?string $folder = null, string $ext = 'php'): false|string
     {
         $folder ??= 'null';
 

--- a/tests/_support/Config/Services.php
+++ b/tests/_support/Config/Services.php
@@ -31,10 +31,8 @@ class Services extends BaseServices
      * The URI class provides a way to model and manipulate URIs.
      *
      * @param string|null $uri The URI string
-     *
-     * @return URI
      */
-    public static function uri(?string $uri = null, bool $getShared = true)
+    public static function uri(?string $uri = null, bool $getShared = true): URI
     {
         // Intercept our test case
         if ($uri === 'testCanReplaceFrameworkServices') {

--- a/tests/_support/Entity/Cast/CastPassParameters.php
+++ b/tests/_support/Entity/Cast/CastPassParameters.php
@@ -22,10 +22,8 @@ class CastPassParameters extends BaseCast
      *
      * @param mixed $value  Data
      * @param array $params Additional param
-     *
-     * @return mixed
      */
-    public static function set($value, array $params = [])
+    public static function set($value, array $params = []): string
     {
         return $value . ':' . json_encode($params);
     }

--- a/tests/system/Files/FileTest.php
+++ b/tests/system/Files/FileTest.php
@@ -172,7 +172,7 @@ final class FileTest extends CIUnitTestCase
     /**
      * @return array<string, array<int, FileSizeUnit>>
      */
-    public static function provideGetSizeData()
+    public static function provideGetSizeData(): array
     {
         return [
             'returns KB binary' => [

--- a/tests/system/Models/TimestampModelTest.php
+++ b/tests/system/Models/TimestampModelTest.php
@@ -40,7 +40,7 @@ final class TimestampModelTest extends LiveModelTestCase
     /**
      * @return int|string Insert ID
      */
-    private function allowDatesPrepareOneRecord(array $data)
+    private function allowDatesPrepareOneRecord(array $data): int|string
     {
         $this->createModel(UserTimestampModel::class);
         $this->db->table('user')->truncate();
@@ -60,7 +60,7 @@ final class TimestampModelTest extends LiveModelTestCase
     /**
      * @return int|string Insert ID
      */
-    private function doNotAllowDatesPrepareOneRecord(array $data)
+    private function doNotAllowDatesPrepareOneRecord(array $data): int|string
     {
         $this->createModel(UserTimestampModel::class);
         $this->db->table('user')->truncate();

--- a/tests/system/Test/BootstrapFCPATHTest.php
+++ b/tests/system/Test/BootstrapFCPATHTest.php
@@ -100,10 +100,7 @@ final class BootstrapFCPATHTest extends CIUnitTestCase
         return $fileContents . 'echo FCPATH;' . PHP_EOL;
     }
 
-    /**
-     * @return false|string
-     */
-    private function readOutput(string $file)
+    private function readOutput(string $file): false|string
     {
         ob_start();
         system('php -f ' . $file);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Enforce the `phpdoc_to_return_type` fixer to the tests. I have to manually fix some transformations particularly on unions with `false` changing to `bool`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
