### PR TITLE
docs: `CookieStore::get()` does not give an array of Cookie objects

### DIFF
--- a/user_guide_src/source/libraries/cookies/013.php
+++ b/user_guide_src/source/libraries/cookies/013.php
@@ -1,9 +1,6 @@
 <?php
 
-cookies()->get(); // array of Cookie objects
-
-// alternatively, you can use the display method
-cookies()->display();
+cookies()->display(); // array of Cookie objects
 
 // or even from the Response
 service('response')->getCookies();


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
`CookieStore::get()` requires a `$name` parameter and does not give an array of Cookie objects

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
