### PR TITLE
test: fix `PublisherInputTest::testAddUri(s)` failing due to rate limiting

### DIFF
--- a/tests/system/Publisher/PublisherInputTest.php
+++ b/tests/system/Publisher/PublisherInputTest.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Publisher;
 
+use CodeIgniter\HTTP\CURLRequest;
+use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Services;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -136,16 +139,37 @@ final class PublisherInputTest extends CIUnitTestCase
 
     public function testAddUri(): void
     {
+        $mockCurl = $this->getMockBuilder(CURLRequest::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+        $mockResponse = $this->createStub(ResponseInterface::class);
+
+        $mockResponse->method('getBody')->willReturn('');
+        $mockCurl->method('get')->willReturn($mockResponse);
+        Services::injectMock('curlrequest', $mockCurl);
+
         $publisher = new Publisher();
         $publisher->addUri('https://raw.githubusercontent.com/codeigniter4/CodeIgniter4/develop/composer.json');
 
         $scratch = $this->getPrivateProperty($publisher, 'scratch');
 
         $this->assertSame([$scratch . 'composer.json'], $publisher->get());
+        Services::resetSingle('curlrequest');
     }
 
     public function testAddUris(): void
     {
+        $mockCurl = $this->getMockBuilder(CURLRequest::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+        $mockResponse = $this->createStub(ResponseInterface::class);
+
+        $mockResponse->method('getBody')->willReturn('');
+        $mockCurl->method('get')->willReturn($mockResponse);
+        Services::injectMock('curlrequest', $mockCurl);
+
         $publisher = new Publisher();
         $publisher->addUris([
             'https://raw.githubusercontent.com/codeigniter4/CodeIgniter4/develop/LICENSE',
@@ -155,5 +179,6 @@ final class PublisherInputTest extends CIUnitTestCase
         $scratch = $this->getPrivateProperty($publisher, 'scratch');
 
         $this->assertSame([$scratch . 'LICENSE', $scratch . 'composer.json'], $publisher->get());
+        Services::resetSingle('curlrequest');
     }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Fixes #7470 

It seems the tests are being rate limited by GitHub. So, we instead use a mock curl request to prevent that. The tests do not care anyway of the contents of the queried files so it should be okay.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
