### PR TITLE
fix: throw exception for unsupported DB drivers in session

### DIFF
--- a/system/Config/Services.php
+++ b/system/Config/Services.php
@@ -683,6 +683,11 @@ class Services extends BaseService
                 $driverName = MySQLiHandler::class;
             } elseif ($driverPlatform === 'Postgre') {
                 $driverName = PostgreHandler::class;
+            } else {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid session database handler "%s" provided. Only "MySQLi" and "Postgre" are supported.',
+                    $driverPlatform,
+                ));
             }
         }
 

--- a/tests/system/Config/ServicesTest.php
+++ b/tests/system/Config/ServicesTest.php
@@ -36,6 +36,7 @@ use CodeIgniter\Pager\Pager;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Router\Router;
 use CodeIgniter\Security\Security;
+use CodeIgniter\Session\Handlers\DatabaseHandler;
 use CodeIgniter\Session\Session;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockResponse;
@@ -46,6 +47,7 @@ use CodeIgniter\Validation\Validation;
 use CodeIgniter\View\Cell;
 use CodeIgniter\View\Parser;
 use Config\App;
+use Config\Database as DatabaseConfig;
 use Config\Exceptions;
 use Config\Security as SecurityConfig;
 use Config\Session as ConfigSession;
@@ -272,6 +274,25 @@ final class ServicesTest extends CIUnitTestCase
         $config = new ConfigSession();
 
         $config->driver = $driver;
+        Services::session($config, false);
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testNewSessionWithInvalidDatabaseHandler(): void
+    {
+        $driver = config(DatabaseConfig::class)->tests['DBDriver'];
+
+        if (in_array($driver, ['MySQLi', 'Postgre'], true)) {
+            $this->markTestSkipped('This test case does not work with MySQLi and Postgre');
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Invalid session database handler "%s" provided. Only "MySQLi" and "Postgre" are supported.', $driver));
+
+        $config = new ConfigSession();
+
+        $config->driver = DatabaseHandler::class;
         Services::session($config, false);
     }
 

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -36,6 +36,7 @@ Bugs Fixed
 **********
 
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
+- **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes the `session` service logic by adding a check for unsupported database platforms. If a developer attempts to use `DatabaseHandler` with an unsupported driver (e.g., SQLSRV, OCI8, SQLite3), an `InvalidArgumentException` will now be thrown with a clear error message.

Problem spotted here: #9572

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
