### PR TITLE
fix: use native PHP truthiness for condition evaluation in when()/whenNot()

### DIFF
--- a/system/Traits/ConditionalTrait.php
+++ b/system/Traits/ConditionalTrait.php
@@ -29,7 +29,7 @@ trait ConditionalTrait
      */
     public function when($condition, callable $callback, ?callable $defaultCallback = null): self
     {
-        if ($condition !== '' && $condition !== false && $condition !== null) {
+        if ((bool) $condition) {
             $callback($this, $condition);
         } elseif ($defaultCallback !== null) {
             $defaultCallback($this);
@@ -52,7 +52,7 @@ trait ConditionalTrait
      */
     public function whenNot($condition, callable $callback, ?callable $defaultCallback = null): self
     {
-        if ($condition === '' || $condition === null || $condition === false || $condition === '0') {
+        if (! (bool) $condition) {
             $callback($this, $condition);
         } elseif ($defaultCallback !== null) {
             $defaultCallback($this);

--- a/tests/system/Database/Builder/WhenTest.php
+++ b/tests/system/Database/Builder/WhenTest.php
@@ -15,7 +15,9 @@ namespace CodeIgniter\Database\Builder;
 
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Mock\MockConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use stdClass;
 
 /**
  * @internal
@@ -101,6 +103,23 @@ final class WhenTest extends CIUnitTestCase
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
     }
 
+    #[DataProvider('provideConditionValues')]
+    public function testWhenRunsDefaultCallbackBasedOnCondition(mixed $condition, bool $expectDefault): void
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->when($condition, static function ($query): void {
+            $query->select('id');
+        }, static function ($query): void {
+            $query->select('name');
+        });
+
+        $expected    = $expectDefault ? 'name' : 'id';
+        $expectedSQL = 'SELECT "' . $expected . '" FROM "jobs"';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
     public function testWhenNotFalse(): void
     {
         $builder = $this->db->table('jobs');
@@ -165,5 +184,44 @@ final class WhenTest extends CIUnitTestCase
 
         $expectedSQL = 'SELECT * FROM "jobs" WHERE "name" = \'0\'';
         $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    #[DataProvider('provideConditionValues')]
+    public function testWhenNotRunsDefaultCallbackBasedOnCondition(mixed $condition, bool $expectDefault): void
+    {
+        $builder = $this->db->table('jobs');
+
+        $builder = $builder->whenNot($condition, static function ($query): void {
+            $query->select('id');
+        }, static function ($query): void {
+            $query->select('name');
+        });
+
+        $expected    = $expectDefault ? 'id' : 'name';
+        $expectedSQL = 'SELECT "' . $expected . '" FROM "jobs"';
+
+        $this->assertSame($expectedSQL, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
+
+    /**
+     * @return array<string, array{0: mixed, 1: bool}>
+     */
+    public static function provideConditionValues(): array
+    {
+        return [
+            'false'            => [false, true], // [condition, expectedDefaultCallbackRuns]
+            'int 0'            => [0, true],
+            'float 0.0'        => [0.0, true],
+            'empty string'     => ['', true],
+            'string 0'         => ['0', true],
+            'empty array'      => [[], true],
+            'null'             => [null, true],
+            'true'             => [true, false],
+            'int 1'            => [1, false],
+            'float 1.1'        => [1.1, false],
+            'non-empty string' => ['foo', false],
+            'non-empty array'  => [[1], false],
+            'object'           => [new stdClass(), false],
+        ];
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -35,6 +35,7 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Database:** Fixed a bug where ``when()`` and ``whenNot()`` in ``ConditionalTrait`` incorrectly evaluated certain falsy values (such as ``[]``, ``0``, ``0.0``, and ``'0'``) as truthy, causing callbacks to be executed unexpectedly. These methods now cast the condition to a boolean using ``(bool)`` to ensure consistent behavior with PHP's native truthiness.
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 
 See the repo's

--- a/user_guide_src/source/database/query_builder.rst
+++ b/user_guide_src/source/database/query_builder.rst
@@ -1272,9 +1272,10 @@ $builder->when()
 .. versionadded:: 4.3.0
 
 This allows modifying the query based on a condition without breaking out of the
-query builder chain. The first parameter is the condition, and it should evaluate
-to a boolean. The second parameter is a callable that will be ran
-when the condition is true.
+query builder chain. The first parameter is the condition, and it is evaluated
+using PHP's native boolean logic - meaning that values like ``false``, ``null``,
+``0``, ``'0'``, ``0.0``, empty string ``''`` and empty array ``[]`` will be considered false.
+The second parameter is a callable that will be ran when the condition is true.
 
 For example, you might only want to apply a given WHERE statement based on the
 value sent within an HTTP request:


### PR DESCRIPTION
**Description**
This PR fixes a bug where the `when()` and `whenNot()` methods did not treat certain falsy values like `0`, `'0'`, `null`, and empty arrays consistently with native PHP conditionals. 

The condition checks are now explicitly cast to boolean using `(bool)`, ensuring consistent and expected behavior across all falsy and truthy values.

Fixes #9575

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
