### PR TITLE
refactor: fix `notIdentical.alwaysTrue` error

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1093,9 +1093,7 @@ abstract class BaseModel
                 $row = $this->doProtectFields($row);
 
                 // Restore updateIndex value in case it was wiped out
-                if ($updateIndex !== null) {
-                    $row[$index] = $updateIndex;
-                }
+                $row[$index] = $updateIndex;
 
                 $row = $this->setUpdatedField($row, $this->setDate());
             }

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 3271 errors
+# total 3270 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon
@@ -19,7 +19,6 @@ includes:
     - missingType.iterableValue.neon
     - missingType.parameter.neon
     - missingType.property.neon
-    - notIdentical.alwaysTrue.neon
     - nullCoalesce.property.neon
     - offsetAccess.notFound.neon
     - property.defaultValue.neon

--- a/utils/phpstan-baseline/notIdentical.alwaysTrue.neon
+++ b/utils/phpstan-baseline/notIdentical.alwaysTrue.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Strict comparison using \!\=\= between mixed and null will always evaluate to true\.$#'
-            count: 1
-            path: ../../system/BaseModel.php


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
According to PHPStan, the `null` is already eliminated from `$updateIndex` in the check above.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
