### PR TITLE
fix: add error handling for corrupted cache files in `FileHandler`

### DIFF
--- a/system/Cache/Handlers/FileHandler.php
+++ b/system/Cache/Handlers/FileHandler.php
@@ -217,7 +217,7 @@ class FileHandler extends BaseHandler
 
     /**
      * Does the heavy lifting of actually retrieving the file and
-     * verifying it's age.
+     * verifying its age.
      *
      * @return array{data: mixed, ttl: int, time: int}|false
      */
@@ -227,7 +227,17 @@ class FileHandler extends BaseHandler
             return false;
         }
 
-        $data = @unserialize(file_get_contents($this->path . $filename));
+        $content = @file_get_contents($this->path . $filename);
+
+        if ($content === false) {
+            return false;
+        }
+
+        try {
+            $data = unserialize($content);
+        } catch (Throwable) {
+            return false;
+        }
 
         if (! is_array($data)) {
             return false;

--- a/tests/system/Cache/Handlers/FileHandlerTest.php
+++ b/tests/system/Cache/Handlers/FileHandlerTest.php
@@ -363,6 +363,30 @@ final class FileHandlerTest extends AbstractHandlerTestCase
     {
         $this->assertFalse($this->handler->getMetaData(self::$dummy));
     }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function testGetUnreadableFile(): void
+    {
+        $this->handler->save(self::$key1, 'value');
+
+        $filePath = $this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . self::$key1;
+
+        // Make the file unreadable
+        chmod($filePath, 0000);
+
+        $this->assertNull($this->handler->get(self::$key1));
+    }
+
+    public function testGetItemWithCorruptedData(): void
+    {
+        $filePath = $this->config->file['storePath'] . DIRECTORY_SEPARATOR . $this->config->prefix . self::$key1;
+
+        file_put_contents($filePath, 'corrupted_serialized_data_that_cannot_be_unserialized');
+
+        $this->assertFileExists($filePath);
+
+        $this->assertNull($this->handler->get(self::$key1));
+    }
 }
 
 final class BaseTestFileHandler extends FileHandler

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -35,6 +35,7 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Cache:** Fixed a bug where a corrupted or unreadable cache file could cause an unhandled exception in ``FileHandler::getItem()``.
 - **Database:** Fixed a bug where ``when()`` and ``whenNot()`` in ``ConditionalTrait`` incorrectly evaluated certain falsy values (such as ``[]``, ``0``, ``0.0``, and ``'0'``) as truthy, causing callbacks to be executed unexpectedly. These methods now cast the condition to a boolean using ``(bool)`` to ensure consistent behavior with PHP's native truthiness.
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 - **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.


### PR DESCRIPTION
**Description**
This PR fixes the `FileHandler::getItem()` method to gracefully manage corrupted or malformed cache files that cannot be read or unserialized.

* `unserialize()` is now wrapped in a try/catch block, since it may throw a `Throwable` that the `@` operator cannot suppress
* `file_get_contents()` and `unlink()` are prefixed with @ to suppress warnings, as these functions only emit warnings and do not throw exceptions

Fixes #9573

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
