### PR TITLE
docs: update description for the `(:num)` placeholder in routes

### DIFF
--- a/user_guide_src/source/incoming/routing.rst
+++ b/user_guide_src/source/incoming/routing.rst
@@ -177,7 +177,7 @@ Placeholders Description
 ============ ===========================================================================================================
 (:any)       will match all characters from that point to the end of the URI. This may include multiple URI segments.
 (:segment)   will match any character except for a forward slash (``/``) restricting the result to a single segment.
-(:num)       will match any integer.
+(:num)       will match any positive integer.
 (:alpha)     will match any string of alphabetic characters
 (:alphanum)  will match any string of alphabetic characters or integers, or any combination of the two.
 (:hash)      is the same as ``(:segment)``, but can be used to easily see which routes use hashed ids.


### PR DESCRIPTION
**Description**
This PR updates the description for the `(:num)` placeholder in routes.

We received a question in Slack about why negative numbers don’t work with this placeholder. This update aims to clarify its behavior and address that confusion.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
