### PR TITLE
feat: require double curly braces for placeholders in `regex_match` rule

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -823,8 +823,12 @@ class Validation implements ValidationInterface
                             continue;
                         }
 
-                        // Replace the placeholder in the rule
-                        $ruleSet = str_replace('{' . $field . '}', (string) $data[$field], $ruleSet);
+                        // Replace the placeholder in the current rule string
+                        if (str_starts_with($row, 'regex_match[')) {
+                            $row = str_replace('{{' . $field . '}}', (string) $data[$field], $row);
+                        } else {
+                            $row = str_replace('{' . $field . '}', (string) $data[$field], $row);
+                        }
                     }
                 }
             }
@@ -840,7 +844,13 @@ class Validation implements ValidationInterface
      */
     private function retrievePlaceholders(string $rule, array $data): array
     {
-        preg_match_all('/{(.+?)}/', $rule, $matches);
+        if (str_starts_with($rule, 'regex_match[')) {
+            // For regex_match rules, only look for double-bracket placeholders
+            preg_match_all('/\{\{((?:(?![{}]).)+?)\}\}/', $rule, $matches);
+        } else {
+            // For all other rules, use single-bracket placeholders
+            preg_match_all('/{(.+?)}/', $rule, $matches);
+        }
 
         return array_intersect($matches[1], array_keys($data));
     }

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -86,6 +86,48 @@ class FormatRulesTest extends CIUnitTestCase
         $this->assertFalse($this->validation->run($data));
     }
 
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/9596
+     */
+    public function testRegexMatchWithArrayData(): void
+    {
+        $data = [
+            ['uid' => '2025/06/000001'],
+            ['uid' => '2025/06/000002'],
+            ['uid' => '2025/06/000003'],
+            ['uid' => '2025/06/000004'],
+            ['uid' => '2025/06/000005'],
+        ];
+
+        $this->validation->setRules([
+            '*.uid' => 'regex_match[/^(\d{4})\/(0[1-9]|1[0-2])\/\d{6}$/]',
+        ]);
+
+        $this->assertTrue($this->validation->run($data));
+    }
+
+    public function testRegexMatchWithPlaceholder(): void
+    {
+        $data = [
+            'code'       => 'ABC1234',
+            'phone'      => '1234567890',
+            'prefix'     => 'ABC',
+            'min_digits' => 10,
+            'max_digits' => 15
+        ];
+
+        $this->validation->setRules([
+            'prefix'     => 'required|string',
+            'min_digits' => 'required|integer',
+            'max_digits' => 'required|integer',
+            'code'       => 'required|regex_match[/^{{prefix}}\d{4}$/]',
+            'phone'      => 'required|regex_match[/^\d{{{min_digits}},{{max_digits}}}$/]',
+        ]);
+
+        $result = $this->validation->run($data);
+        $this->assertTrue($result);
+    }
+
     #[DataProvider('provideValidUrl')]
     public function testValidURL(?string $url, bool $isLoose, bool $isStrict): void
     {

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -113,7 +113,7 @@ class FormatRulesTest extends CIUnitTestCase
             'phone'      => '1234567890',
             'prefix'     => 'ABC',
             'min_digits' => 10,
-            'max_digits' => 15
+            'max_digits' => 15,
         ];
 
         $this->validation->setRules([

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -23,6 +23,16 @@ BREAKING
 Behavior Changes
 ================
 
+Validation Rules
+----------------
+
+Placeholders in the ``regex_match`` validation rule must now use double curly braces.
+If you previously used single braces like ``regex_match[/^{placeholder}$/]``, you must
+update it to use double braces: ``regex_match[/^{{placeholder}}$/]``.
+
+This change was introduced to avoid ambiguity with regular expression syntax,
+where single curly braces (e.g., ``{1,3}``) are used for quantifiers.
+
 Interface Changes
 =================
 

--- a/user_guide_src/source/libraries/validation.rst
+++ b/user_guide_src/source/libraries/validation.rst
@@ -976,7 +976,10 @@ numeric                 No         Fails if field contains anything other than
 permit_empty            No         Allows the field to receive an empty array,
                                    empty string, null or false.
 regex_match             Yes        Fails if field does not match the regular     ``regex_match[/regex/]``
-                                   expression.
+                                   expression. **Note:** Since v4.7.0, if
+                                   you're using a placeholder with this rule,
+                                   you must use double braces ``{{...}}``
+                                   instead of single ones ``{...}``.
 required                No         Fails if the field is an empty array, empty
                                    string, null or false.
 required_with           Yes        The field is required when any of the other   ``required_with[field1,field2]``


### PR DESCRIPTION
**Description**
This PR updates the validation behavior for the `regex_match` rule to require double curly braces `{{...}}` for placeholders instead of single ones `{...}`.

Using single braces for placeholders conflicts with valid regex syntax, such as quantifiers (`{1,3}`), which can lead to invalid regex patterns and hard-to-debug validation issues.

What changed:
- Placeholder parsing within `regex_match` now requires `{{value}}`
- Single-brace placeholders like `{value}` will no longer be parsed within `regex_match`

Fixes #9596

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
