### PR TITLE
fix: URI authority generation for schemes without default ports

### DIFF
--- a/system/HTTP/URI.php
+++ b/system/HTTP/URI.php
@@ -376,7 +376,7 @@ class URI implements Stringable
         }
 
         // Don't add port if it's a standard port for this scheme
-        if ((int) $this->port !== 0 && ! $ignorePort && $this->port !== $this->defaultPorts[$this->scheme]) {
+        if ((int) $this->port !== 0 && ! $ignorePort && $this->port !== ($this->defaultPorts[$this->scheme] ?? null)) {
             $authority .= ':' . $this->port;
         }
 

--- a/tests/system/HTTP/URITest.php
+++ b/tests/system/HTTP/URITest.php
@@ -622,6 +622,22 @@ final class URITest extends CIUnitTestCase
                 'http://me@foo.com:3000/bar',
                 'me@foo.com:3000',
             ],
+            'rtsp-with-port' => [
+                'rtsp://localhost:1234/stream',
+                'localhost:1234',
+            ],
+            'rtsp-no-port' => [
+                'rtsp://localhost/stream',
+                'localhost',
+            ],
+            'custom-scheme-with-port' => [
+                'myscheme://server:9999/resource',
+                'server:9999',
+            ],
+            'custom-scheme-no-port' => [
+                'myscheme://server/resource',
+                'server',
+            ],
         ];
     }
 
@@ -1225,5 +1241,18 @@ final class URITest extends CIUnitTestCase
         $uri      = new URI($expected);
 
         $this->assertSame($expected, (string) $uri);
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/9604
+     */
+    public function testAuthorityIncludesPortForCustomSchemes(): void
+    {
+        $url = 'rtsp://localhost:1234/stream';
+        $uri = new URI($url);
+
+        $this->assertSame('rtsp://localhost:1234/stream', (string) $uri);
+        $this->assertSame('localhost:1234', $uri->getAuthority());
+        $this->assertSame(1234, $uri->getPort());
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -40,7 +40,7 @@ Bugs Fixed
 - **Email:** Fixed a bug where ``Email::getHostname()`` failed to use ``$_SERVER['SERVER_ADDR']`` when ``$_SERVER['SERVER_NAME']`` was not set.
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 - **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.
-- **URI:** Fixes a bug in ``URI::getAuthority()`` where schemes without defined default ports (like ``rtsp://``) would cause issues due to missing array key handling.
+- **URI:** Fixed a bug in ``URI::getAuthority()`` where schemes without defined default ports (like ``rtsp://``) would cause issues due to missing array key handling.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -40,6 +40,7 @@ Bugs Fixed
 - **Email:** Fixed a bug where ``Email::getHostname()`` failed to use ``$_SERVER['SERVER_ADDR']`` when ``$_SERVER['SERVER_NAME']`` was not set.
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 - **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.
+- **URI:** Fixes a bug in ``URI::getAuthority()`` where schemes without defined default ports (like ``rtsp://``) would cause issues due to missing array key handling.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug in `URI` authority generation where schemes without defined default ports (like `rtsp://`) would cause issues due to missing array key handling.

Fixes: #9604

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
