### PR TITLE
docs: note removal of `AbstractRenderer::SORT_FULL` and `$richSort` in Kint config

### DIFF
--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -210,6 +210,8 @@ Config
     - ``Config\Feature::$strictLocaleNegotiation`` has been added.
 - app/Config/Routing.php
     - ``Config\Routing::$translateUriToCamelCase`` has been changed to ``true``.
+- app/Config/Kint.php
+    - ``Config\Kint::$richSort`` has been removed.
 
 All Changes
 ===========
@@ -222,7 +224,6 @@ many will be simple comments or formatting that have no effect on the runtime:
 - app/Config/Database.php
 - app/Config/Feature.php
 - app/Config/Format.php
-- app/Config/Kint.php
 - app/Config/Routing.php
 - app/Config/Security.php
 - app/Views/errors/html/debug.css

--- a/user_guide_src/source/installation/upgrade_460.rst
+++ b/user_guide_src/source/installation/upgrade_460.rst
@@ -211,7 +211,7 @@ Config
 - app/Config/Routing.php
     - ``Config\Routing::$translateUriToCamelCase`` has been changed to ``true``.
 - app/Config/Kint.php
-    - ``Config\Kint::$richSort`` has been removed.
+    - ``Config\Kint::$richSort`` has been removed. Kint in v6 no longer uses ``AbstractRenderer::SORT_FULL``. Leaving this property in your code will cause a runtime error due to the undefined constant.
 
 All Changes
 ===========


### PR DESCRIPTION
**Description**
This PR updates the upgrade instructions for v4.6.0 to reflect that `Config\Kint::$richSort` is no longer used in Kint v6 and may cause errors due to the removal of `AbstractRenderer::SORT_FULL`.

Fixes #9601

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
