### PR TITLE
fix: codeigniter in a subdirectory + indexPage results in 404

### DIFF
--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -111,32 +111,36 @@ final class SiteURIFactory
      */
     private function parseRequestURI(): string
     {
-        $appConfig = config(\Config\App::class);
-        $baseUrl = $appConfig->baseURL;
+        $appConfig = config(App::class);
+        $baseUrl   = $appConfig->baseURL;
         $indexPage = $appConfig->indexPage;
-        $baseUri = false;
+        $baseUri   = false;
         $parsedUrl = parse_url($baseUrl);
-        
-        if(isset($parsedUrl['path'])){ // The path could be empty if the url is just a domain
+
+        if (isset($parsedUrl['path'])) { // The path could be empty if the url is just a domain
             $baseUri = $parsedUrl['path'];
         }
-        if($baseUri){
+        if ($baseUri) {
             $baseUriArray = explode('/', $baseUri);
             $baseUriArray = array_filter($baseUriArray); // We remove the empty strings from the array
-            $baseUri = implode('/', $baseUriArray); // We join the array back into a string with slashes
-            if(strlen($baseUri) > 0){
-                $baseUri = "/" . $baseUri; // We add a slash at the beginning of the base Uri as implode will not do that
-            }else{
+            $baseUri      = implode('/', $baseUriArray); // We join the array back into a string with slashes
+            if ($baseUri !== '') {
+                $baseUri = '/' . $baseUri; // We add a slash at the beginning of the base Uri as implode will not do that
+            } else {
                 $baseUri = false;
             }
         }
 
         $serverRequestUri = $this->superglobals->server('REQUEST_URI'); // We get the request URI from the server superglobals
 
-        if(!is_null($serverRequestUri)){
-            if($baseUri && str_starts_with($serverRequestUri, $baseUri)) $serverRequestUri = substr($serverRequestUri, strlen($baseUri)); // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
-            if($indexPage != false && str_starts_with($serverRequestUri, "/" . $indexPage)) $serverRequestUri = substr($serverRequestUri, strlen("/" . $indexPage)); // We remove the index page from the request URI if it exists
-            $serverRequestUri = "/". ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
+        if (null !== $serverRequestUri) {
+            if ($baseUri && str_starts_with($serverRequestUri, $baseUri)) {
+                $serverRequestUri = substr($serverRequestUri, strlen($baseUri));
+            } // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
+            if ($indexPage !== false && str_starts_with($serverRequestUri, '/' . $indexPage)) {
+                $serverRequestUri = substr($serverRequestUri, strlen('/' . $indexPage));
+            } // We remove the index page from the request URI if it exists
+            $serverRequestUri = '/' . ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
         }
 
         if (

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -132,8 +132,10 @@ final class SiteURIFactory
         }
 
         $serverRequestUri = $this->superglobals->server('REQUEST_URI'); // We get the request URI from the server superglobals
-        if($baseUri) $serverRequestUri = ltrim($serverRequestUri, $baseUri); // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
-        if($indexPage) $serverRequestUri = ltrim($serverRequestUri, "/" . $indexPage); // We remove the index page from the request URI if it exists
+
+        if($baseUri && !is_null($serverRequestUri)) $serverRequestUri = ltrim($serverRequestUri, $baseUri); // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
+        if($indexPage && !is_null($serverRequestUri)) $serverRequestUri = ltrim($serverRequestUri, "/" . $indexPage); // We remove the index page from the request URI if it exists
+        $serverRequestUri = "/". ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
 
         if (
             $serverRequestUri === null

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -111,7 +111,7 @@ final class SiteURIFactory
      */
     private function parseRequestURI(): string
     {
-        $appConfig = $this->appConfig;
+        $appConfig = config(App::class);
         $baseUrl   = $appConfig->baseURL;
         $indexPage = $appConfig->indexPage;
         $baseUri   = false;

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -111,43 +111,9 @@ final class SiteURIFactory
      */
     private function parseRequestURI(): string
     {
-        $serverScriptName = $this->superglobals->server('SCRIPT_NAME'); // This is the SCRIPT_NAME, it's a variable that contains the name of the script being executed, it's used from the codeigniter framework to perform the routing process.
-        // We need to check if the project is in a subdirectory
-        $projectIsInSubDir = false; // Variable used to check if the project is in a subdirectory
-        $baseURLConfig = config(\Config\App::class)->baseURL; // Base URL configuration from the Config\App class or .env file
-        $baseUrlParsed = parse_url($baseURLConfig); // PHP function to parse the URL
-        $baseUrlPath = ""; // If the url does not have a / at the end like https://example.com the path will not be set by parse_url
-        if(isset($baseUrlParsed['path'])) { // Check if the path is set in the parsed URL (read the line above)
-            $baseUrlPath = $baseUrlParsed['path'] ?? "";
-        }
-
-        // We need to check that the project is in a subdirectory, if it is in a subdirectory we need to remove the public directory from the script name
-        $baseUrlPathArr = explode('/', $baseUrlPath);
-        foreach($baseUrlPathArr as $i => $pathFragment){
-            if($pathFragment === "") unset($baseUrlPathArr[$i]);
-        }
-        if(count($baseUrlPathArr) > 0){ // Check that the path has at least one fragment
-            $projectIsInSubDir = true; // The project is running in a subdirectory
-        }
-
-        // We need to remove public from the script name, this way we can correctly perform the routing
-        if($projectIsInSubDir){
-            $subDirPath = "/" . implode("/", $baseUrlPathArr); // This is the path of the subdirectory, we are using arrays because it can be multiple levels deep
-            $subDirPathPosition = strpos($serverScriptName, $subDirPath."/public"); // This is the position of the public directory in the script name. The strpos function returns only the first instance
-            if ($subDirPathPosition !== false) { // We are checking if the public directory is found in the script name.
-                $serverScriptName = substr_replace(
-                    $serverScriptName, // The input string.
-                    $subDirPath, // The replacement string.
-                    $subDirPathPosition, // The offset from where we are replacing.
-                    strlen($subDirPath."/public") // The length of the portion of string which is to be replaced.
-                );
-            }
-        }
-
-
         if (
             $this->superglobals->server('REQUEST_URI') === null
-            || $serverScriptName === null
+            || $this->superglobals->server('SCRIPT_NAME') === null
         ) {
             return '';
         }
@@ -162,13 +128,13 @@ final class SiteURIFactory
 
         // Strip the SCRIPT_NAME path from the URI
         if (
-            $path !== '' && $serverScriptName !== ''
-            && pathinfo($serverScriptName, PATHINFO_EXTENSION) === 'php'
+            $path !== '' && $this->superglobals->server('SCRIPT_NAME') !== ''
+            && pathinfo($this->superglobals->server('SCRIPT_NAME'), PATHINFO_EXTENSION) === 'php'
         ) {
             // Compare each segment, dropping them until there is no match
             $segments = $keep = explode('/', $path);
 
-            foreach (explode('/', $serverScriptName) as $i => $segment) {
+            foreach (explode('/', $this->superglobals->server('SCRIPT_NAME')) as $i => $segment) {
                 // If these segments are not the same then we're done
                 if (! isset($segments[$i]) || $segment !== $segments[$i]) {
                     break;

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -111,7 +111,7 @@ final class SiteURIFactory
      */
     private function parseRequestURI(): string
     {
-        $appConfig = config(App::class);
+        $appConfig = $this->appConfig;
         $baseUrl   = $appConfig->baseURL;
         $indexPage = $appConfig->indexPage;
         $baseUri   = false;

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -133,9 +133,11 @@ final class SiteURIFactory
 
         $serverRequestUri = $this->superglobals->server('REQUEST_URI'); // We get the request URI from the server superglobals
 
-        if($baseUri && !is_null($serverRequestUri)) $serverRequestUri = ltrim($serverRequestUri, $baseUri); // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
-        if($indexPage && !is_null($serverRequestUri)) $serverRequestUri = ltrim($serverRequestUri, "/" . $indexPage); // We remove the index page from the request URI if it exists
-        if(!is_null($serverRequestUri)) $serverRequestUri = "/". ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
+        if(!is_null($serverRequestUri)){
+            if($baseUri && str_starts_with($serverRequestUri, $baseUri)) $serverRequestUri = substr($serverRequestUri, strlen($baseUri)); // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
+            if($indexPage && str_starts_with($serverRequestUri, "/" . $indexPage)) $serverRequestUri = substr($serverRequestUri, strlen("/" . $indexPage)); // We remove the index page from the request URI if it exists
+            $serverRequestUri = "/". ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
+        }
 
         if (
             $serverRequestUri === null

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -135,7 +135,7 @@ final class SiteURIFactory
 
         if($baseUri && !is_null($serverRequestUri)) $serverRequestUri = ltrim($serverRequestUri, $baseUri); // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
         if($indexPage && !is_null($serverRequestUri)) $serverRequestUri = ltrim($serverRequestUri, "/" . $indexPage); // We remove the index page from the request URI if it exists
-        $serverRequestUri = "/". ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
+        if(!is_null($serverRequestUri)) $serverRequestUri = "/". ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
 
         if (
             $serverRequestUri === null

--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -135,7 +135,7 @@ final class SiteURIFactory
 
         if(!is_null($serverRequestUri)){
             if($baseUri && str_starts_with($serverRequestUri, $baseUri)) $serverRequestUri = substr($serverRequestUri, strlen($baseUri)); // We remove the base Uri from the request URI if it exists, baseUri is the path to the subdirectory
-            if($indexPage && str_starts_with($serverRequestUri, "/" . $indexPage)) $serverRequestUri = substr($serverRequestUri, strlen("/" . $indexPage)); // We remove the index page from the request URI if it exists
+            if($indexPage != false && str_starts_with($serverRequestUri, "/" . $indexPage)) $serverRequestUri = substr($serverRequestUri, strlen("/" . $indexPage)); // We remove the index page from the request URI if it exists
             $serverRequestUri = "/". ltrim($serverRequestUri, '/'); // makes sure that the uri starts with a slash
         }
 

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -171,4 +171,44 @@ final class SiteURIFactoryTest extends CIUnitTestCase
             ],
         ];
     }
+
+    public function testCreateFromStringWithIndexPageSubDirCombinations(){
+        $standardUrl = "http://localhost:8080";
+        $subDirectoryAppsOptions = array(
+            array(
+                "subDir" => "",
+                "indexPage" => ""
+            ),
+            array(
+                "subDir" => "",
+                "indexPage" => "index.php"
+            ),
+            array(
+                "subDir" => "/subdir",
+                "indexPage" => ""
+            ),
+            array(
+                "subDir" => "/subdir",
+                "indexPage" => "index.php"
+            ),
+            array(
+                "subDir" => "/subdir/subsubdir",
+                "indexPage" => "index.php"
+            ),
+        );
+        foreach($subDirectoryAppsOptions as $option){
+            $route = "woot";
+            config(App::class)->baseURL = $standardUrl . $option["subDir"];
+            config(App::class)->indexPage = $option["indexPage"];
+            
+            $_SERVER['PATH_INFO']    = '/' . $route;
+            $_SERVER['REQUEST_URI']  = $option["subDir"] . "/" . $option["indexPage"] . $_SERVER['PATH_INFO'];
+            $_SERVER['SCRIPT_NAME']  = $option["subDir"] . "/" .$option["indexPage"];
+            $_SERVER['HTTP_HOST']    = $standardUrl;
+
+            $factory = $this->createSiteURIFactory();
+            $detectedRoutePath = $factory->detectRoutePath();
+            $this->assertSame($route, $detectedRoutePath);
+        }
+    }
 }

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -180,16 +180,17 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         $standardUrl        = 'http://localhost:8080';
         $standardScriptName = '/public/index.php';
 
-        $route                        = 'controller/method';
-        config(App::class)->baseURL   = $standardUrl . $subDir;
-        config(App::class)->indexPage = $indexPage;
+        $route                = 'controller/method';
+        $appConfig            = new App();
+        $appConfig->baseURL   = $standardUrl . $subDir;
+        $appConfig->indexPage = $indexPage;
 
         $_SERVER['PATH_INFO']   = '/' . $route;
         $_SERVER['REQUEST_URI'] = $subDir . '/' . $indexPage . $_SERVER['PATH_INFO'];
         $_SERVER['SCRIPT_NAME'] = $subDir . $standardScriptName;
         $_SERVER['HTTP_HOST']   = $standardUrl;
 
-        $factory           = $this->createSiteURIFactory();
+        $factory           = $this->createSiteURIFactory($appConfig);
         $detectedRoutePath = $factory->detectRoutePath();
         $this->assertSame($route, $detectedRoutePath);
     }

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -174,28 +174,28 @@ final class SiteURIFactoryTest extends CIUnitTestCase
 
     public function testCreateFromStringWithIndexPageSubDirCombinations(){
         $standardUrl = "http://localhost:8080";
-        $subDirectoryAppsOptions = array(
-            array(
+        $subDirectoryAppsOptions = [
+            [
                 "subDir" => "",
                 "indexPage" => ""
-            ),
-            array(
+            ],
+            [
                 "subDir" => "",
                 "indexPage" => "index.php"
-            ),
-            array(
+            ],
+            [
                 "subDir" => "/subdir",
                 "indexPage" => ""
-            ),
-            array(
+            ],
+            [
                 "subDir" => "/subdir",
                 "indexPage" => "index.php"
-            ),
-            array(
+            ],
+            [
                 "subDir" => "/subdir/subsubdir",
                 "indexPage" => "index.php"
-            ),
-        );
+            ],
+        ];
         foreach($subDirectoryAppsOptions as $option){
             $route = "woot";
             config(App::class)->baseURL = $standardUrl . $option["subDir"];

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -172,45 +172,51 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         ];
     }
 
-    public function testCreateFromStringWithIndexPageSubDirCombinations(): void
+    #[DataProvider('provideCreateFromStringWithIndexPageSubDirCombinations')]
+    public function testCreateFromStringWithIndexPageSubDirCombinations(
+        string $subDir,
+        string $indexPage,
+    ): void {
+        $standardUrl        = 'http://localhost:8080';
+        $standardScriptName = '/public/index.php';
+
+        $route                        = 'controller/method';
+        config(App::class)->baseURL   = $standardUrl . $subDir;
+        config(App::class)->indexPage = $indexPage;
+
+        $_SERVER['PATH_INFO']   = '/' . $route;
+        $_SERVER['REQUEST_URI'] = $subDir . '/' . $indexPage . $_SERVER['PATH_INFO'];
+        $_SERVER['SCRIPT_NAME'] = $subDir . $standardScriptName;
+        $_SERVER['HTTP_HOST']   = $standardUrl;
+
+        $factory           = $this->createSiteURIFactory();
+        $detectedRoutePath = $factory->detectRoutePath();
+        $this->assertSame($route, $detectedRoutePath);
+    }
+
+    public static function provideCreateFromStringWithIndexPageSubDirCombinations(): iterable
     {
-        $standardUrl             = 'http://localhost:8080';
-        $subDirectoryAppsOptions = [
-            [
-                'subDir'    => '',
-                'indexPage' => '',
+        return [
+            'no subdir and no index' => [
+                '',
+                '',
             ],
-            [
-                'subDir'    => '',
-                'indexPage' => 'index.php',
+            'no subdir and index' => [
+                '',
+                'index.php',
             ],
-            [
-                'subDir'    => '/subdir',
-                'indexPage' => '',
+            'subdir and no index' => [
+                '/subdir',
+                '',
             ],
-            [
-                'subDir'    => '/subdir',
-                'indexPage' => 'index.php',
+            'subdir and index' => [
+                '/subdir',
+                'index.php',
             ],
-            [
-                'subDir'    => '/subdir/subsubdir',
-                'indexPage' => 'index.php',
+            'subdir 2 levels deep string and index' => [
+                '/subdir/subsubdir',
+                'index.php',
             ],
         ];
-
-        foreach ($subDirectoryAppsOptions as $option) {
-            $route                        = 'woot';
-            config(App::class)->baseURL   = $standardUrl . $option['subDir'];
-            config(App::class)->indexPage = $option['indexPage'];
-
-            $_SERVER['PATH_INFO']   = '/' . $route;
-            $_SERVER['REQUEST_URI'] = $option['subDir'] . '/' . $option['indexPage'] . $_SERVER['PATH_INFO'];
-            $_SERVER['SCRIPT_NAME'] = $option['subDir'] . '/' . $option['indexPage'];
-            $_SERVER['HTTP_HOST']   = $standardUrl;
-
-            $factory           = $this->createSiteURIFactory();
-            $detectedRoutePath = $factory->detectRoutePath();
-            $this->assertSame($route, $detectedRoutePath);
-        }
     }
 }

--- a/tests/system/HTTP/SiteURIFactoryTest.php
+++ b/tests/system/HTTP/SiteURIFactoryTest.php
@@ -172,41 +172,43 @@ final class SiteURIFactoryTest extends CIUnitTestCase
         ];
     }
 
-    public function testCreateFromStringWithIndexPageSubDirCombinations(){
-        $standardUrl = "http://localhost:8080";
+    public function testCreateFromStringWithIndexPageSubDirCombinations(): void
+    {
+        $standardUrl             = 'http://localhost:8080';
         $subDirectoryAppsOptions = [
             [
-                "subDir" => "",
-                "indexPage" => ""
+                'subDir'    => '',
+                'indexPage' => '',
             ],
             [
-                "subDir" => "",
-                "indexPage" => "index.php"
+                'subDir'    => '',
+                'indexPage' => 'index.php',
             ],
             [
-                "subDir" => "/subdir",
-                "indexPage" => ""
+                'subDir'    => '/subdir',
+                'indexPage' => '',
             ],
             [
-                "subDir" => "/subdir",
-                "indexPage" => "index.php"
+                'subDir'    => '/subdir',
+                'indexPage' => 'index.php',
             ],
             [
-                "subDir" => "/subdir/subsubdir",
-                "indexPage" => "index.php"
+                'subDir'    => '/subdir/subsubdir',
+                'indexPage' => 'index.php',
             ],
         ];
-        foreach($subDirectoryAppsOptions as $option){
-            $route = "woot";
-            config(App::class)->baseURL = $standardUrl . $option["subDir"];
-            config(App::class)->indexPage = $option["indexPage"];
-            
-            $_SERVER['PATH_INFO']    = '/' . $route;
-            $_SERVER['REQUEST_URI']  = $option["subDir"] . "/" . $option["indexPage"] . $_SERVER['PATH_INFO'];
-            $_SERVER['SCRIPT_NAME']  = $option["subDir"] . "/" .$option["indexPage"];
-            $_SERVER['HTTP_HOST']    = $standardUrl;
 
-            $factory = $this->createSiteURIFactory();
+        foreach ($subDirectoryAppsOptions as $option) {
+            $route                        = 'woot';
+            config(App::class)->baseURL   = $standardUrl . $option['subDir'];
+            config(App::class)->indexPage = $option['indexPage'];
+
+            $_SERVER['PATH_INFO']   = '/' . $route;
+            $_SERVER['REQUEST_URI'] = $option['subDir'] . '/' . $option['indexPage'] . $_SERVER['PATH_INFO'];
+            $_SERVER['SCRIPT_NAME'] = $option['subDir'] . '/' . $option['indexPage'];
+            $_SERVER['HTTP_HOST']   = $standardUrl;
+
+            $factory           = $this->createSiteURIFactory();
             $detectedRoutePath = $factory->detectRoutePath();
             $this->assertSame($route, $detectedRoutePath);
         }


### PR DESCRIPTION
**Description**
This PR fixes the CodeIgniter routing for projects that run in **subdirectories** and have a **indexPage**.

If you run the framework in the subdirectory of a webserver:
```
/var/www/html/index.html
/var/www/html/your-codeigniter-app
/var/www/html/some-other-app
```
resulting in the following url: `http://localhost:8080/your-codeigniter-app`

And use a indexPage (the `$indexPage` value can be configured in `\Config\App`) whatever route you try to get will result in 404.
`http://localhost:8080/sub-directory/index.php/your-route` will be routed as `/index.php/your-route`, not as `/your-route`

After performing the change I tested it on multiple apps I developed on the CodeIgniter4 framework both on apache and nginx, trying to run them with combinations of `indexPage` configs, inside/outside subdirectories (even multiple levels deep), everything seems to be working fine. I also ran the PHPUnit tests (excluding _DatabaseLive_ and _CacheLive_), all tests passed.

Problem reported here: https://github.com/codeigniter4/CodeIgniter4/issues/9602#issuecomment-2996700517

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
