### PR TITLE
fix: correct path parsing in `SiteURIFactory::parseRequestURI()`

### DIFF
--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -146,6 +146,15 @@ final class SiteURIFactory
             $path = implode('/', $keep);
         }
 
+        // Cleanup: if indexPage is still visible in the path, remove it
+        if ($this->appConfig->indexPage !== '' && str_starts_with($path, $this->appConfig->indexPage)) {
+            $remainingPath = substr($path, strlen($this->appConfig->indexPage));
+            // Only remove if followed by '/' (route) or nothing (root)
+            if ($remainingPath === '' || str_starts_with($remainingPath, '/')) {
+                $path = ltrim($remainingPath, '/');
+            }
+        }
+
         // This section ensures that even on servers that require the URI to
         // contain the query string (Nginx) a correct URI is found, and also
         // fixes the QUERY_STRING Server var and $_GET array.

--- a/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
+++ b/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
@@ -311,4 +311,97 @@ final class SiteURIFactoryDetectRoutePathTest extends CIUnitTestCase
             ],
         ];
     }
+
+    #[DataProvider('provideRequestURIRewrite')]
+    public function testRequestURIRewrite(
+        string $requestUri,
+        string $scriptName,
+        string $indexPage,
+        string $expected,
+    ): void {
+        $server                = [];
+        $server['REQUEST_URI'] = $requestUri;
+        $server['SCRIPT_NAME'] = $scriptName;
+
+        $appConfig            = new App();
+        $appConfig->indexPage = $indexPage;
+
+        $factory = $this->createSiteURIFactory($server, $appConfig);
+
+        $this->assertSame($expected, $factory->detectRoutePath('REQUEST_URI'));
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     requestUri: string,
+     *     scriptName: string,
+     *     indexPage: string,
+     *     expected: string
+     * }>
+     */
+    public static function provideRequestURIRewrite(): iterable
+    {
+        return [
+            'rewrite_with_route' => [
+                'requestUri' => '/ci/index.php/sample/method',
+                'scriptName' => '/ci/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'sample/method',
+            ],
+            'rewrite_root' => [
+                'requestUri' => '/ci/index.php',
+                'scriptName' => '/ci/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => '/',
+            ],
+            'rewrite_no_index_page' => [
+                'requestUri' => '/ci/sample/method',
+                'scriptName' => '/ci/public/index.php',
+                'indexPage'  => '',
+                'expected'   => 'sample/method',
+            ],
+            'rewrite_nested_subfolder' => [
+                'requestUri' => '/projects/index.php/api/users/list',
+                'scriptName' => '/projects/myapp/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'api/users/list',
+            ],
+            'rewrite_multiple_public_folders' => [
+                'requestUri' => '/public-sites/myapp/index.php/content/view',
+                'scriptName' => '/public-sites/myapp/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'content/view',
+            ],
+            'rewrite_custom_app_folder' => [
+                'requestUri' => '/myapp/index.php/products/category/electronics',
+                'scriptName' => '/myapp/web/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'products/category/electronics',
+            ],
+            'multiple_index_php_in_path' => [
+                'requestUri' => '/app/index.php/user/index.php/profile',
+                'scriptName' => '/app/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'user/index.php/profile',
+            ],
+            'custom_index_page_name' => [
+                'requestUri' => '/ci/app.php/users/list',
+                'scriptName' => '/ci/public/app.php',
+                'indexPage'  => 'app.php',
+                'expected'   => 'users/list',
+            ],
+            'custom_index_page_root' => [
+                'requestUri' => '/project/main.php',
+                'scriptName' => '/project/web/main.php',
+                'indexPage'  => 'main.php',
+                'expected'   => '/',
+            ],
+            'partial_match_should_not_remove' => [
+                'requestUri' => '/app/myindex.php/route',
+                'scriptName' => '/app/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'myindex.php/route',
+            ],
+        ];
+    }
 }

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -41,6 +41,7 @@ Bugs Fixed
 - **Email:** Fixed a bug where ``Email::getHostname()`` failed to use ``$_SERVER['SERVER_ADDR']`` when ``$_SERVER['SERVER_NAME']`` was not set.
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 - **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.
+- **SiteURI:** Fixed a bug in ``SiteURIFactory::parseRequestURI()`` where serving the app from a subfolder using ``mod_rewrite`` while preserving the ``index.php`` file would cause incorrect route path detection.
 - **URI:** Fixed a bug in ``URI::getAuthority()`` where schemes without defined default ports (like ``rtsp://``) would cause issues due to missing array key handling.
 
 See the repo's


### PR DESCRIPTION
**Description**
This PR fixes a bug where route path detection was failing when serving the app from a subfolder using Apache `mod_rewrite` (to "hide" `public` directory) while preserving `index.php` in URL.

 So something like: `https://localhost/ci/index.php/controller/method` - when our real directory structure was like: `ci/public/index.php`.  This caused the route path to return: `index.php/controller/method` instead of `controller/method`.
 
 Closes #9607
Fixes #9602 
 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
