### PR TITLE
fix: apply rector rule TernaryImplodeToImplodeRector

### DIFF
--- a/system/Validation/Validation.php
+++ b/system/Validation/Validation.php
@@ -869,7 +869,7 @@ class Validation implements ValidationInterface
             ARRAY_FILTER_USE_KEY,
         );
 
-        return $errors === [] ? '' : implode("\n", $errors);
+        return implode("\n", $errors);
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR applies Rector rule `TernaryImplodeToImplodeRector`.


Needed by: #9612

Details: https://github.com/codeigniter4/CodeIgniter4/actions/runs/15880423046/job/44779000194

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
