### PR TITLE
fix: support for multibyte folder names when the app is served from a subfolder

### DIFF
--- a/system/HTTP/SiteURIFactory.php
+++ b/system/HTTP/SiteURIFactory.php
@@ -132,7 +132,8 @@ final class SiteURIFactory
             && pathinfo($this->superglobals->server('SCRIPT_NAME'), PATHINFO_EXTENSION) === 'php'
         ) {
             // Compare each segment, dropping them until there is no match
-            $segments = $keep = explode('/', $path);
+            $segments = explode('/', rawurldecode($path));
+            $keep     = explode('/', $path);
 
             foreach (explode('/', $this->superglobals->server('SCRIPT_NAME')) as $i => $segment) {
                 // If these segments are not the same then we're done

--- a/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
+++ b/tests/system/HTTP/SiteURIFactoryDetectRoutePathTest.php
@@ -402,6 +402,18 @@ final class SiteURIFactoryDetectRoutePathTest extends CIUnitTestCase
                 'indexPage'  => 'index.php',
                 'expected'   => 'myindex.php/route',
             ],
+            'multibyte_characters' => [
+                'requestUri' => '/%ED%85%8C%EC%8A%A4%ED%8A%B81/index.php/route',
+                'scriptName' => '/테스트1/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'route',
+            ],
+            'multibyte_characters_with_nested_subfolder' => [
+                'requestUri' => '/%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82/%D1%82%D0%B5%D1%81%D1%821/index.php/route',
+                'scriptName' => '/проект/тест1/public/index.php',
+                'indexPage'  => 'index.php',
+                'expected'   => 'route',
+            ],
         ];
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -42,6 +42,7 @@ Bugs Fixed
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 - **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.
 - **SiteURI:** Fixed a bug in ``SiteURIFactory::parseRequestURI()`` where serving the app from a subfolder using ``mod_rewrite`` while preserving the ``index.php`` file would cause incorrect route path detection.
+- **SiteURI:** Fixed a bug in ``SiteURIFactory::parseRequestURI()`` where folder names containing multibyte (non-ASCII) characters were not correctly resolved when the application was served from a subfolder.
 - **URI:** Fixed a bug in ``URI::getAuthority()`` where schemes without defined default ports (like ``rtsp://``) would cause issues due to missing array key handling.
 
 See the repo's


### PR DESCRIPTION
**Description**
This PR fixes a bug where folder names containing multibyte (non-ASCII) characters were not correctly resolved by `SiteURIFactory::parseRequestURI()` when the application was served from a subfolder.

The problem was spotted here: https://github.com/codeigniter4/CodeIgniter4/pull/9613#discussion_r2168053386

Needs #9613

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
