### PR TITLE
fix: model event consistency in `BaseModel::paginate()`

### DIFF
--- a/tests/_support/Models/UserWithEventsModel.php
+++ b/tests/_support/Models/UserWithEventsModel.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Support\Models;
+
+use CodeIgniter\Model;
+
+/**
+ * @method int affectedRows()
+ */
+class UserWithEventsModel extends Model
+{
+    protected $table         = 'user';
+    protected $allowedFields = [
+        'name',
+        'email',
+        'country',
+        'deleted_at',
+    ];
+    protected $returnType     = 'object';
+    protected $useSoftDeletes = true;
+    protected $dateFormat     = 'datetime';
+    public $name              = '';
+    public $email             = '';
+    public $country           = '';
+    protected $beforeFind     = ['onlyUS'];
+
+    protected function onlyUS(array $data): array
+    {
+        $this->where('country', 'US');
+
+        return $data;
+    }
+}

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -39,6 +39,7 @@ Bugs Fixed
 - **Database:** Fixed a bug where ``when()`` and ``whenNot()`` in ``ConditionalTrait`` incorrectly evaluated certain falsy values (such as ``[]``, ``0``, ``0.0``, and ``'0'``) as truthy, causing callbacks to be executed unexpectedly. These methods now cast the condition to a boolean using ``(bool)`` to ensure consistent behavior with PHP's native truthiness.
 - **Database:** Fixed encapsulation violation in ``BasePreparedQuery`` when accessing ``BaseConnection::transStatus`` protected property.
 - **Email:** Fixed a bug where ``Email::getHostname()`` failed to use ``$_SERVER['SERVER_ADDR']`` when ``$_SERVER['SERVER_NAME']`` was not set.
+- **Model:** Fixed a bug in ``BaseModel::paginate()`` where ``beforeFind`` events were not applied to the count query, causing inconsistent pagination metadata. The total count now correctly reflects the same filters applied to the paginated results.
 - **Security:** Fixed a bug where the ``sanitize_filename()`` function from the Security helper would throw an error when used in CLI requests.
 - **Session:** Fixed a bug where using the ``DatabaseHandler`` with an unsupported database driver (such as ``SQLSRV``, ``OCI8``, or ``SQLite3``) did not throw an appropriate error.
 - **URI:** Fixed a bug in ``URI::getAuthority()`` where schemes without defined default ports (like ``rtsp://``) would cause issues due to missing array key handling.


### PR DESCRIPTION
**Description**
This PR fixes `BaseModel::paginate()` to trigger `beforeFind` events before calling `countAllResults()`, ensuring both the count and results are consistently filtered.

Currently, `BaseModel::paginate()` has an inconsistency where `beforeFind` events are only applied to the data retrieval query (`findAll()`) but not to the count query (`countAllResults()`). This causes pagination metadata to be incorrect when model events filter or modify the underlying query. More details and examples are available in #8412.

**The solution in short:**
- We use a temporary pager instance to determine the actual pagination parameters
- Trigger `beforeFind` events before counting to apply query modifications
- Disable callbacks during `findAll()` to prevent duplicate event execution
- Then manually trigger `afterFind` events to maintain a complete event flow

I'm not 100% certain this is the proper way to solve this issue. While it fixes the consistency problem, it does change the execution flow a bit. If anyone sees any drawbacks, please share.

Also, I feel like the changes are a bit messy, so feedback is much appreciated on both the technical implementation and whether this change should be made at all.

Fixes #8412

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
