### PR TITLE
style: fix code styles from php-cs-fixer v3.76

### DIFF
--- a/.github/workflows/test-coding-standards.yml
+++ b/.github/workflows/test-coding-standards.yml
@@ -65,5 +65,3 @@ jobs:
 
       - name: Run lint
         run: composer cs
-        env:
-            PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.php-version == '8.4' }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 use CodeIgniter\CodingStandard\CodeIgniter4;
 use Nexus\CsConfig\Factory;
-use Nexus\CsConfig\Fixer\Comment\NoCodeSeparatorCommentFixer;
-use Nexus\CsConfig\FixerGenerator;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
@@ -44,12 +42,8 @@ $overrides = [
 ];
 
 $options = [
-    'cacheFile'    => 'build/.php-cs-fixer.cache',
-    'finder'       => $finder,
-    'customFixers' => FixerGenerator::create('utils/vendor/nexusphp/cs-config/src/Fixer', 'Nexus\\CsConfig\\Fixer'),
-    'customRules'  => [
-        NoCodeSeparatorCommentFixer::name() => true,
-    ],
+    'cacheFile' => 'build/.php-cs-fixer.cache',
+    'finder'    => $finder,
 ];
 
 return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -532,9 +532,8 @@ abstract class BaseModel
      * Compiles a replace and runs the query.
      * This method works only with dbCalls.
      *
-     * @param         array|null     $row       Row data
-     * @phpstan-param row_array|null $row
-     * @param         bool           $returnSQL Set to true to return Query String
+     * @param row_array|null $row       Row data
+     * @param bool           $returnSQL Set to true to return Query String
      *
      * @return BaseResult|false|Query|string
      */
@@ -552,8 +551,7 @@ abstract class BaseModel
      * Public getter to return the id value using the idValue() method.
      * For example with SQL this will return $data->$this->primaryKey.
      *
-     * @param         array|object     $row Row data
-     * @phpstan-param row_array|object $row
+     * @param object|row_array $row Row data
      *
      * @return array|int|string|null
      */
@@ -737,8 +735,7 @@ abstract class BaseModel
      * you must ensure that the class will provide access to the class
      * variables, even if through a magic method.
      *
-     * @param         array|object     $row Row data
-     * @phpstan-param row_array|object $row
+     * @param object|row_array $row Row data
      *
      * @throws ReflectionException
      */
@@ -789,9 +786,8 @@ abstract class BaseModel
      * Inserts data into the database. If an object is provided,
      * it will attempt to convert it to an array.
      *
-     * @param         array|object|null     $row      Row data
-     * @phpstan-param row_array|object|null $row
-     * @param         bool                  $returnID Whether insert ID should be returned or not.
+     * @param object|row_array|null $row      Row data
+     * @param bool                  $returnID Whether insert ID should be returned or not.
      *
      * @return ($returnID is true ? false|int|string : bool)
      *
@@ -866,8 +862,8 @@ abstract class BaseModel
     /**
      * Set datetime to created field.
      *
-     * @phpstan-param row_array  $row
-     * @param         int|string $date timestamp or datetime string
+     * @param row_array  $row
+     * @param int|string $date timestamp or datetime string
      */
     protected function setCreatedField(array $row, $date): array
     {
@@ -881,8 +877,8 @@ abstract class BaseModel
     /**
      * Set datetime to updated field.
      *
-     * @phpstan-param row_array  $row
-     * @param         int|string $date timestamp or datetime string
+     * @param row_array  $row
+     * @param int|string $date timestamp or datetime string
      */
     protected function setUpdatedField(array $row, $date): array
     {
@@ -896,11 +892,10 @@ abstract class BaseModel
     /**
      * Compiles batch insert runs the queries, validating each row prior.
      *
-     * @param         list<array|object>|null     $set       an associative array of insert values
-     * @phpstan-param list<row_array|object>|null $set
-     * @param         bool|null                   $escape    Whether to escape values
-     * @param         int                         $batchSize The size of the batch to run
-     * @param         bool                        $testing   True means only number of records is returned, false will execute the query
+     * @param list<object|row_array>|null $set       an associative array of insert values
+     * @param bool|null                   $escape    Whether to escape values
+     * @param int                         $batchSize The size of the batch to run
+     * @param bool                        $testing   True means only number of records is returned, false will execute the query
      *
      * @return bool|int Number of rows inserted or FALSE on failure
      *
@@ -1042,11 +1037,10 @@ abstract class BaseModel
     /**
      * Compiles an update and runs the query.
      *
-     * @param         list<array|object>|null     $set       an associative array of insert values
-     * @phpstan-param list<row_array|object>|null $set
-     * @param         string|null                 $index     The where key
-     * @param         int                         $batchSize The size of the batch to run
-     * @param         bool                        $returnSQL True means SQL is returned, false will execute the query
+     * @param list<object|row_array>|null $set       an associative array of insert values
+     * @param string|null                 $index     The where key
+     * @param int                         $batchSize The size of the batch to run
+     * @param bool                        $returnSQL True means SQL is returned, false will execute the query
      *
      * @return false|int|list<string> Number of rows affected or FALSE on failure, SQL array when testMode
      *
@@ -1125,8 +1119,8 @@ abstract class BaseModel
     /**
      * Deletes a single record from the database where $id matches.
      *
-     * @param array|int|string|null $id    The rows primary key(s)
-     * @param bool                  $purge Allows overriding the soft deletes setting.
+     * @param int|list<int|string>|string|null $id    The rows primary key(s)
+     * @param bool                             $purge Allows overriding the soft deletes setting.
      *
      * @return BaseResult|bool
      *
@@ -1214,9 +1208,8 @@ abstract class BaseModel
     /**
      * Compiles a replace and runs the query.
      *
-     * @param         array|null     $row       Row data
-     * @phpstan-param row_array|null $row
-     * @param         bool           $returnSQL Set to true to return Query String
+     * @param row_array|null $row       Row data
+     * @param bool           $returnSQL Set to true to return Query String
      *
      * @return BaseResult|false|Query|string
      */
@@ -1810,9 +1803,8 @@ abstract class BaseModel
     /**
      * Transform data to array.
      *
-     * @param         array|object|null     $row  Row data
-     * @phpstan-param row_array|object|null $row
-     * @param         string                $type Type of data (insert|update)
+     * @param object|row_array|null $row  Row data
+     * @param string                $type Type of data (insert|update)
      *
      * @throws DataException
      * @throws InvalidArgumentException

--- a/system/Model.php
+++ b/system/Model.php
@@ -551,9 +551,8 @@ class Model extends BaseModel
      * Compiles a replace into string and runs the query
      * This method works only with dbCalls.
      *
-     * @param         array|null     $row       Data
-     * @phpstan-param row_array|null $row
-     * @param         bool           $returnSQL Set to true to return Query String
+     * @param row_array|null $row       Data
+     * @param bool           $returnSQL Set to true to return Query String
      *
      * @return BaseResult|false|Query|string
      */
@@ -774,9 +773,8 @@ class Model extends BaseModel
      * Inserts data into the database. If an object is provided,
      * it will attempt to convert it to an array.
      *
-     * @param         array|object|null     $row
-     * @phpstan-param row_array|object|null $row
-     * @param         bool                  $returnID Whether insert ID should be returned or not.
+     * @param object|row_array|null $row
+     * @param bool                  $returnID Whether insert ID should be returned or not.
      *
      * @return ($returnID is true ? false|int|string : bool)
      *

--- a/system/Test/Interfaces/FabricatorModel.php
+++ b/system/Test/Interfaces/FabricatorModel.php
@@ -39,7 +39,7 @@ interface FabricatorModel
      *
      * @param int|list<int|string>|string|null $id One primary key or an array of primary keys
      *
-     * @phpstan-return ($id is int|string ? row_array|object|null : list<row_array|object>)
+     * @return ($id is int|string ? object|row_array|null : list<object|row_array>)
      */
     public function find($id = null);
 
@@ -47,9 +47,8 @@ interface FabricatorModel
      * Inserts data into the current table. If an object is provided,
      * it will attempt to convert it to an array.
      *
-     * @param         array|object|null     $row
-     * @phpstan-param row_array|object|null $row
-     * @param         bool                  $returnID Whether insert ID should be returned or not.
+     * @param object|row_array|null $row
+     * @param bool                  $returnID Whether insert ID should be returned or not.
      *
      * @return bool|int|string
      *

--- a/utils/composer.json
+++ b/utils/composer.json
@@ -3,8 +3,8 @@
         "php": "^8.1",
         "codeigniter/coding-standard": "^1.7",
         "ergebnis/composer-normalize": "^2.28",
-        "friendsofphp/php-cs-fixer": "^3.63.2",
-        "nexusphp/cs-config": "^3.6",
+        "friendsofphp/php-cs-fixer": "^3.76",
+        "nexusphp/cs-config": "^3.26",
         "phpmetrics/phpmetrics": "^2.8 || ^3.0rc6",
         "vimeo/psalm": "^5.0"
     },

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2866 errors
+# total 2865 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1436 errors
+# total 1435 errors
 
 parameters:
     ignoreErrors:
@@ -24,11 +24,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\BaseModel\:\:convertToReturnType\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/BaseModel.php
-
-        -
-            message: '#^Method CodeIgniter\\BaseModel\:\:delete\(\) has parameter \$id with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/BaseModel.php
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
- The `PHP_CS_FIXER_IGNORE_ENV` is deprecated and suggests to use `Config::setUnsupportedPhpVersionAllowed(true)` in config which is already addressed by `coding-standard` latest version
- Third commit manually fixes phpdoc ordering issues: `@phpstan-param` is moved after the `@param` so I just manually merged them
- Removed deprecated fixer from cs-config

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
