### PR TITLE
fix: ensure `make:test` works on Windows

### DIFF
--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -173,20 +173,17 @@ class TestGenerator extends BaseCommand
     /**
      * Returns test file path for the namespace.
      */
-    private function searchTestFilePath(string $namespace): ?string
+    private function searchTestFilePath(string $testNamespace): ?string
     {
-        $bases = service('autoloader')->getNamespace($namespace);
+        /** @var list<non-empty-string> $testPaths */
+        $testPaths = service('autoloader')->getNamespace($testNamespace);
 
-        $base = null;
-
-        foreach ($bases as $candidate) {
-            if (str_contains($candidate, '/tests/')) {
-                $base = $candidate;
-
-                break;
+        foreach ($testPaths as $candidate) {
+            if (str_contains($candidate, DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR)) {
+                return $candidate;
             }
         }
 
-        return $base;
+        return null;
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.2.rst
+++ b/user_guide_src/source/changelogs/v4.6.2.rst
@@ -36,6 +36,7 @@ Bugs Fixed
 **********
 
 - **Cache:** Fixed a bug where a corrupted or unreadable cache file could cause an unhandled exception in ``FileHandler::getItem()``.
+- **Commands:** Fixed a bug in ``make:test`` where it would always error on Windows.
 - **CURLRequest:** Fixed a bug where intermediate HTTP responses were not properly removed from the response chain in certain scenarios, causing incorrect status codes and headers to be returned instead of the final response.
 - **Database:** Fixed a bug where ``when()`` and ``whenNot()`` in ``ConditionalTrait`` incorrectly evaluated certain falsy values (such as ``[]``, ``0``, ``0.0``, and ``'0'``) as truthy, causing callbacks to be executed unexpectedly. These methods now cast the condition to a boolean using ``(bool)`` to ensure consistent behavior with PHP's native truthiness.
 - **Database:** Fixed encapsulation violation in ``BasePreparedQuery`` when accessing ``BaseConnection::transStatus`` protected property.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
Fixes #9634 . Pending fix confirmation from @b-and-p for Windows.

As this is Windows-related, I cannot write a unit test. But you can test this fix in macOS by reversing the directory separator, the phenomenon experienced in Windows.

```diff
diff --git a/system/Commands/Generators/TestGenerator.php b/system/Commands/Generators/TestGenerator.php
index d37864d76e..55791eaee2 100644
--- a/system/Commands/Generators/TestGenerator.php
+++ b/system/Commands/Generators/TestGenerator.php
@@ -179,7 +179,7 @@ class TestGenerator extends BaseCommand
         $testPaths = service('autoloader')->getNamespace($testNamespace);
 
         foreach ($testPaths as $candidate) {
-            if (str_contains($candidate, DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR)) {
+            if (str_contains($candidate, '\\tests\\')) {
                 return $candidate;
             }
         }

```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
