### PR TITLE
fix: CID check in Email class

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1308,7 +1308,7 @@ class Email
                 . 'Content-Type: ' . $attachment['type'] . '; name="' . $name . '"' . $this->newline
                 . 'Content-Disposition: ' . $attachment['disposition'] . ';' . $this->newline
                 . 'Content-Transfer-Encoding: base64' . $this->newline
-                . ($attachment['cid'] === '' ? '' : 'Content-ID: <' . $attachment['cid'] . '>' . $this->newline)
+                . (isset($attachment['cid']) && $attachment['cid'] !== '' ? 'Content-ID: <' . $attachment['cid'] . '>' . $this->newline : '')
                 . $this->newline
                 . $attachment['content'] . $this->newline;
         }

--- a/user_guide_src/source/changelogs/v4.6.3.rst
+++ b/user_guide_src/source/changelogs/v4.6.3.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Email:** Fixed a bug with CID check when building email attachments.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.


### PR DESCRIPTION
**Description**
This PR fixes a bug introduced during recent refactoring, where we assumed that every attachment includes a `cid` key.

Fixes #9644

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
