### PR TITLE
fix: SMTP connection resource validation in `Email` class destructor

### DIFF
--- a/system/Debug/Toolbar/Collectors/Routes.php
+++ b/system/Debug/Toolbar/Collectors/Routes.php
@@ -51,7 +51,7 @@ class Routes extends BaseCollector
      * Returns the data of this collector to be formatted in the toolbar
      *
      * @return array{
-     *      matchedRoute: array<array{
+     *      matchedRoute: list<array{
      *          directory: string,
      *          controller: string,
      *          method: string,

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -2227,7 +2227,7 @@ class Email
 
     public function __destruct()
     {
-        if ($this->SMTPConnect !== null) {
+        if (is_resource($this->SMTPConnect)) {
             try {
                 $this->sendCommand('quit');
             } catch (ErrorException $e) {

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -263,7 +263,7 @@ class Email
     /**
      * SMTP Connection socket placeholder
      *
-     * @var resource|null
+     * @var false|resource|null
      */
     protected $SMTPConnect;
 

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -2292,6 +2292,8 @@ class Email
      */
     protected function isSMTPConnected(): bool
     {
-        return $this->SMTPConnect !== null && get_debug_type($this->SMTPConnect) !== 'resource (closed)';
+        return $this->SMTPConnect !== null
+            && $this->SMTPConnect !== false
+            && get_debug_type($this->SMTPConnect) !== 'resource (closed)';
     }
 }

--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -1886,7 +1886,7 @@ class Email
      */
     protected function SMTPConnect()
     {
-        if (is_resource($this->SMTPConnect)) {
+        if ($this->isSMTPConnected()) {
             return true;
         }
 
@@ -1910,7 +1910,7 @@ class Email
             $this->SMTPTimeout,
         );
 
-        if (! is_resource($this->SMTPConnect)) {
+        if (! $this->isSMTPConnected()) {
             $this->setErrorMessage(lang('Email.SMTPError', [$errno . ' ' . $errstr]));
 
             return false;
@@ -2227,7 +2227,7 @@ class Email
 
     public function __destruct()
     {
-        if (is_resource($this->SMTPConnect)) {
+        if ($this->isSMTPConnected()) {
             try {
                 $this->sendCommand('quit');
             } catch (ErrorException $e) {
@@ -2283,5 +2283,15 @@ class Email
         $this->tmpArchive = [];
 
         return $this->archive;
+    }
+
+    /**
+     * Checks if there is an active SMTP connection.
+     *
+     * @return bool True if SMTP connection is established and open, false otherwise
+     */
+    protected function isSMTPConnected(): bool
+    {
+        return $this->SMTPConnect !== null && get_debug_type($this->SMTPConnect) !== 'resource (closed)';
     }
 }

--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -1724,7 +1724,7 @@ class RouteCollection implements RouteCollectionInterface
      * @return array<
      *     string,
      *     array{
-     *         filter?: string|list<string>, namespace?: string, hostname?: string,
+     *         filter?: list<string>|string, namespace?: string, hostname?: string,
      *         subdomain?: string, offset?: int, priority?: int, as?: string,
      *         redirect?: int
      *     }

--- a/system/Test/Mock/MockConnection.php
+++ b/system/Test/Mock/MockConnection.php
@@ -27,8 +27,8 @@ class MockConnection extends BaseConnection
 {
     /**
      * @var array{
-     *   connect?: object|resource|false|list<object|resource|false>,
-     *   execute?: object|resource|false,
+     *   connect?: false|list<false|object|resource>|object|resource,
+     *   execute?: false|object|resource,
      * }
      */
     protected $returnValues = [];

--- a/user_guide_src/source/changelogs/v4.6.3.rst
+++ b/user_guide_src/source/changelogs/v4.6.3.rst
@@ -31,6 +31,7 @@ Bugs Fixed
 **********
 
 - **Email:** Fixed a bug with CID check when building email attachments.
+- **Email:** Fixed SMTP connection resource validation in the class destructor.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.6.3.rst
+++ b/user_guide_src/source/changelogs/v4.6.3.rst
@@ -31,7 +31,7 @@ Bugs Fixed
 **********
 
 - **Email:** Fixed a bug with CID check when building email attachments.
-- **Email:** Fixed SMTP connection resource validation in the class destructor.
+- **Email:** Fixed a bug with SMTP connection resource validation in the class destructor.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug where the destructor was checking `$this->SMTPConnect !== null` to validate SMTP connections.

However, `fclose()` creates closed resources that are not `null`, which led to unnecessary cleanup attempts on already-closed connections.

When the `SMTPKeepAlive` option is `false` (the default), the `quit` command is called before the destructor is reached.

Fixes #9647

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
