### PR TITLE
refactor: phpdoc for `Config\Filters::$globals`

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -65,7 +65,10 @@ class Filters extends BaseFilters
      * List of filter aliases that are always
      * applied before and after every request.
      *
-     * @var array<string, array<int|string, array<string, list<string>|string>|string>>
+     * @var array{
+     *     before: array<string, array{except: list<string>|string}>|list<string>,
+     *     after: array<string, array{except: list<string>|string}>|list<string>
+     * }
      */
     public array $globals = [
         'before' => [

--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -65,7 +65,7 @@ class Filters extends BaseFilters
      * List of filter aliases that are always
      * applied before and after every request.
      *
-     * @var array<string, array<string, array<string, string>>>|array<string, list<string>>
+     * @var array<string, array<int|string, array<string, list<string>|string>|string>>
      */
     public array $globals = [
         'before' => [

--- a/system/Config/Filters.php
+++ b/system/Config/Filters.php
@@ -78,7 +78,7 @@ class Filters extends BaseConfig
      * List of filter aliases that are always
      * applied before and after every request.
      *
-     * @var array<string, array<string, array<string, string>>>|array<string, list<string>>
+     * @var array<string, array<int|string, array<string, list<string>|string>|string>>
      */
     public array $globals = [
         'before' => [

--- a/system/Config/Filters.php
+++ b/system/Config/Filters.php
@@ -78,7 +78,10 @@ class Filters extends BaseConfig
      * List of filter aliases that are always
      * applied before and after every request.
      *
-     * @var array<string, array<int|string, array<string, list<string>|string>|string>>
+     * @var array{
+     *    before: array<string, array{except: list<string>|string}>|list<string>,
+     *    after: array<string, array{except: list<string>|string}>|list<string>
+     * }
      */
     public array $globals = [
         'before' => [


### PR DESCRIPTION
**Description**
This PR updates PHPDoc for `Config\Filters::$globals`

Fixes #9651

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
