### PR TITLE
feat: migrations lock

### DIFF
--- a/app/Config/Migrations.php
+++ b/app/Config/Migrations.php
@@ -47,4 +47,19 @@ class Migrations extends BaseConfig
      * - Y_m_d_His_
      */
     public string $timestampFormat = 'Y-m-d-His_';
+
+    /**
+     * --------------------------------------------------------------------------
+     * Enable/Disable Migration Lock
+     * --------------------------------------------------------------------------
+     *
+     * Locking is disabled by default.
+     *
+     * When enabled, it will prevent multiple migration processes
+     * from running at the same time by using a lock mechanism.
+     *
+     * This is useful in production environments to avoid conflicts
+     * or race conditions during concurrent deployments.
+     */
+    public bool $lock = false;
 }

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -883,6 +883,8 @@ class MigrationRunner
         $lockTable = $this->table . '_lock';
 
         if ($this->lockTableChecked || $this->db->tableExists($lockTable)) {
+            $this->lockTableChecked = true;
+
             return $lockTable;
         }
 

--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Database;
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Exceptions\RuntimeException;
@@ -102,6 +103,17 @@ class MigrationRunner
     protected $tableChecked = false;
 
     /**
+     * Lock the migration table.
+     */
+    protected bool $lock = false;
+
+    /**
+     * Tracks whether we have already ensured
+     * the lock table exists or not.
+     */
+    protected bool $lockTableChecked = false;
+
+    /**
      * The full path to locate migration files.
      *
      * @var string
@@ -135,6 +147,7 @@ class MigrationRunner
     {
         $this->enabled = $config->enabled ?? false;
         $this->table   = $config->table ?? 'migrations';
+        $this->lock    = $config->lock ?? false;
 
         $this->namespace = APP_NAMESPACE;
 
@@ -161,52 +174,66 @@ class MigrationRunner
 
         $this->ensureTable();
 
-        if ($group !== null) {
-            $this->groupFilter = $group;
-            $this->setGroup($group);
-        }
+        // Try to acquire lock - exit gracefully if another process is running migrations
+        if ($this->lock && ! $this->acquireMigrationLock()) {
+            $message             = lang('Migrations.locked');
+            $this->cliMessages[] = "\t" . CLI::color($message, 'yellow');
 
-        $migrations = $this->findMigrations();
-
-        if ($migrations === []) {
             return true;
         }
 
-        foreach ($this->getHistory((string) $group) as $history) {
-            unset($migrations[$this->getObjectUid($history)]);
-        }
+        try {
+            if ($group !== null) {
+                $this->groupFilter = $group;
+                $this->setGroup($group);
+            }
 
-        $batch = $this->getLastBatch() + 1;
+            $migrations = $this->findMigrations();
 
-        foreach ($migrations as $migration) {
-            if ($this->migrate('up', $migration)) {
-                if ($this->groupSkip === true) {
-                    $this->groupSkip = false;
+            if ($migrations === []) {
+                return true;
+            }
 
-                    continue;
+            foreach ($this->getHistory((string) $group) as $history) {
+                unset($migrations[$this->getObjectUid($history)]);
+            }
+
+            $batch = $this->getLastBatch() + 1;
+
+            foreach ($migrations as $migration) {
+                if ($this->migrate('up', $migration)) {
+                    if ($this->groupSkip === true) {
+                        $this->groupSkip = false;
+
+                        continue;
+                    }
+
+                    $this->addHistory($migration, $batch);
+                } else {
+                    $this->regress(-1);
+
+                    $message = lang('Migrations.generalFault');
+
+                    if ($this->silent) {
+                        $this->cliMessages[] = "\t" . CLI::color($message, 'red');
+
+                        return false;
+                    }
+
+                    throw new RuntimeException($message);
                 }
+            }
 
-                $this->addHistory($migration, $batch);
-            } else {
-                $this->regress(-1);
+            $data           = get_object_vars($this);
+            $data['method'] = 'latest';
+            Events::trigger('migrate', $data);
 
-                $message = lang('Migrations.generalFault');
-
-                if ($this->silent) {
-                    $this->cliMessages[] = "\t" . CLI::color($message, 'red');
-
-                    return false;
-                }
-
-                throw new RuntimeException($message);
+            return true;
+        } finally {
+            if ($this->lock) {
+                $this->releaseMigrationLock();
             }
         }
-
-        $data           = get_object_vars($this);
-        $data['method'] = 'latest';
-        Events::trigger('migrate', $data);
-
-        return true;
     }
 
     /**
@@ -230,66 +257,27 @@ class MigrationRunner
 
         $this->ensureTable();
 
-        $batches = $this->getBatches();
+        // Try to acquire lock - exit gracefully if another process is running migrations
+        if ($this->lock && ! $this->acquireMigrationLock()) {
+            $message             = lang('Migrations.locked');
+            $this->cliMessages[] = "\t" . CLI::color($message, 'yellow');
 
-        if ($targetBatch < 0) {
-            $targetBatch = $batches[count($batches) - 1 + $targetBatch] ?? 0;
-        }
-
-        if ($batches === [] && $targetBatch === 0) {
             return true;
         }
 
-        if ($targetBatch !== 0 && ! in_array($targetBatch, $batches, true)) {
-            $message = lang('Migrations.batchNotFound') . $targetBatch;
+        try {
+            $batches = $this->getBatches();
 
-            if ($this->silent) {
-                $this->cliMessages[] = "\t" . CLI::color($message, 'red');
-
-                return false;
+            if ($targetBatch < 0) {
+                $targetBatch = $batches[count($batches) - 1 + $targetBatch] ?? 0;
             }
 
-            throw new RuntimeException($message);
-        }
-
-        $tmpNamespace = $this->namespace;
-
-        $this->namespace = null;
-        $allMigrations   = $this->findMigrations();
-
-        $migrations = [];
-
-        while ($batch = array_pop($batches)) {
-            if ($batch <= $targetBatch) {
-                break;
+            if ($batches === [] && $targetBatch === 0) {
+                return true;
             }
 
-            foreach ($this->getBatchHistory($batch, 'desc') as $history) {
-                $uid = $this->getObjectUid($history);
-
-                if (! isset($allMigrations[$uid])) {
-                    $message = lang('Migrations.gap') . ' ' . $history->version;
-
-                    if ($this->silent) {
-                        $this->cliMessages[] = "\t" . CLI::color($message, 'red');
-
-                        return false;
-                    }
-
-                    throw new RuntimeException($message);
-                }
-
-                $migration          = $allMigrations[$uid];
-                $migration->history = $history;
-                $migrations[]       = $migration;
-            }
-        }
-
-        foreach ($migrations as $migration) {
-            if ($this->migrate('down', $migration)) {
-                $this->removeHistory($migration->history);
-            } else {
-                $message = lang('Migrations.generalFault');
+            if ($targetBatch !== 0 && ! in_array($targetBatch, $batches, true)) {
+                $message = lang('Migrations.batchNotFound') . $targetBatch;
 
                 if ($this->silent) {
                     $this->cliMessages[] = "\t" . CLI::color($message, 'red');
@@ -299,15 +287,68 @@ class MigrationRunner
 
                 throw new RuntimeException($message);
             }
+
+            $tmpNamespace = $this->namespace;
+
+            $this->namespace = null;
+            $allMigrations   = $this->findMigrations();
+
+            $migrations = [];
+
+            while ($batch = array_pop($batches)) {
+                if ($batch <= $targetBatch) {
+                    break;
+                }
+
+                foreach ($this->getBatchHistory($batch, 'desc') as $history) {
+                    $uid = $this->getObjectUid($history);
+
+                    if (! isset($allMigrations[$uid])) {
+                        $message = lang('Migrations.gap') . ' ' . $history->version;
+
+                        if ($this->silent) {
+                            $this->cliMessages[] = "\t" . CLI::color($message, 'red');
+
+                            return false;
+                        }
+
+                        throw new RuntimeException($message);
+                    }
+
+                    $migration          = $allMigrations[$uid];
+                    $migration->history = $history;
+                    $migrations[]       = $migration;
+                }
+            }
+
+            foreach ($migrations as $migration) {
+                if ($this->migrate('down', $migration)) {
+                    $this->removeHistory($migration->history);
+                } else {
+                    $message = lang('Migrations.generalFault');
+
+                    if ($this->silent) {
+                        $this->cliMessages[] = "\t" . CLI::color($message, 'red');
+
+                        return false;
+                    }
+
+                    throw new RuntimeException($message);
+                }
+            }
+
+            $data           = get_object_vars($this);
+            $data['method'] = 'regress';
+            Events::trigger('migrate', $data);
+
+            $this->namespace = $tmpNamespace;
+
+            return true;
+        } finally {
+            if ($this->lock) {
+                $this->releaseMigrationLock();
+            }
         }
-
-        $data           = get_object_vars($this);
-        $data['method'] = 'regress';
-        Events::trigger('migrate', $data);
-
-        $this->namespace = $tmpNamespace;
-
-        return true;
     }
 
     /**
@@ -328,14 +369,61 @@ class MigrationRunner
 
         $this->ensureTable();
 
-        if ($group !== null) {
-            $this->groupFilter = $group;
-            $this->setGroup($group);
+        // Try to acquire lock - exit gracefully if another process is running migrations
+        if ($this->lock && ! $this->acquireMigrationLock()) {
+            $message             = lang('Migrations.locked');
+            $this->cliMessages[] = "\t" . CLI::color($message, 'yellow');
+
+            return true;
         }
 
-        $migration = $this->migrationFromFile($path, $namespace);
-        if (empty($migration)) {
-            $message = lang('Migrations.notFound');
+        try {
+            if ($group !== null) {
+                $this->groupFilter = $group;
+                $this->setGroup($group);
+            }
+
+            $migration = $this->migrationFromFile($path, $namespace);
+            if ($migration === false) {
+                $message = lang('Migrations.notFound');
+
+                if ($this->silent) {
+                    $this->cliMessages[] = "\t" . CLI::color($message, 'red');
+
+                    return false;
+                }
+
+                throw new RuntimeException($message);
+            }
+
+            $method = 'up';
+            $this->setNamespace($migration->namespace);
+
+            foreach ($this->getHistory($this->group) as $history) {
+                if ($this->getObjectUid($history) === $migration->uid) {
+                    $method             = 'down';
+                    $migration->history = $history;
+                    break;
+                }
+            }
+
+            if ($method === 'up') {
+                $batch = $this->getLastBatch() + 1;
+
+                if ($this->migrate('up', $migration) && $this->groupSkip === false) {
+                    $this->addHistory($migration, $batch);
+
+                    return true;
+                }
+
+                $this->groupSkip = false;
+            } elseif ($this->migrate('down', $migration)) {
+                $this->removeHistory($migration->history);
+
+                return true;
+            }
+
+            $message = lang('Migrations.generalFault');
 
             if ($this->silent) {
                 $this->cliMessages[] = "\t" . CLI::color($message, 'red');
@@ -344,44 +432,11 @@ class MigrationRunner
             }
 
             throw new RuntimeException($message);
-        }
-
-        $method = 'up';
-        $this->setNamespace($migration->namespace);
-
-        foreach ($this->getHistory($this->group) as $history) {
-            if ($this->getObjectUid($history) === $migration->uid) {
-                $method             = 'down';
-                $migration->history = $history;
-                break;
+        } finally {
+            if ($this->lock) {
+                $this->releaseMigrationLock();
             }
         }
-
-        if ($method === 'up') {
-            $batch = $this->getLastBatch() + 1;
-
-            if ($this->migrate('up', $migration) && $this->groupSkip === false) {
-                $this->addHistory($migration, $batch);
-
-                return true;
-            }
-
-            $this->groupSkip = false;
-        } elseif ($this->migrate('down', $migration)) {
-            $this->removeHistory($migration->history);
-
-            return true;
-        }
-
-        $message = lang('Migrations.generalFault');
-
-        if ($this->silent) {
-            $this->cliMessages[] = "\t" . CLI::color($message, 'red');
-
-            return false;
-        }
-
-        throw new RuntimeException($message);
     }
 
     /**
@@ -815,6 +870,89 @@ class MigrationRunner
         $forge->createTable($this->table, true);
 
         $this->tableChecked = true;
+    }
+
+    /**
+     * Ensures that we have created our migration
+     * lock table in the database.
+     *
+     * @return string The lock table name
+     */
+    protected function ensureLockTable(): string
+    {
+        $lockTable = $this->table . '_lock';
+
+        if ($this->lockTableChecked || $this->db->tableExists($lockTable)) {
+            return $lockTable;
+        }
+
+        $forge = Database::forge($this->db);
+
+        $forge->addField([
+            'id' => [
+                'type'           => 'BIGINT',
+                'auto_increment' => true,
+            ],
+            'lock_name' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+                'null'       => false,
+                'unique'     => true,
+            ],
+            'acquired_at' => [
+                'type' => 'INTEGER',
+                'null' => false,
+            ],
+        ]);
+
+        $forge->addPrimaryKey('id');
+        $forge->createTable($lockTable, true);
+
+        $this->lockTableChecked = true;
+
+        return $lockTable;
+    }
+
+    /**
+     * Acquire exclusive lock on migrations to prevent concurrent execution
+     *
+     * @return bool True if lock was acquired, false if another process holds the lock
+     */
+    protected function acquireMigrationLock(): bool
+    {
+        $lockTable = $this->ensureLockTable();
+
+        try {
+            $this->db->table($lockTable)->insert([
+                'lock_name'   => 'migration_process',
+                'acquired_at' => Time::now()->getTimestamp(),
+            ]);
+
+            return $this->db->insertID() > 0;
+        } catch (DatabaseException) {
+            // Lock already exists or other error
+            return false;
+        }
+    }
+
+    /**
+     * Release migration lock
+     *
+     * @return bool True if successfully released, false on error
+     */
+    protected function releaseMigrationLock(): bool
+    {
+        $lockTable = $this->ensureLockTable();
+
+        $result = $this->db->table($lockTable)
+            ->where('lock_name', 'migration_process')
+            ->delete();
+
+        if ($result === false) {
+            log_message('warning', 'Failed to release migration lock');
+        }
+
+        return $result;
     }
 
     /**

--- a/system/Language/en/Migrations.php
+++ b/system/Language/en/Migrations.php
@@ -22,6 +22,7 @@ return [
     'gap'           => 'There is a gap in the migration sequence near version number: ',
     'classNotFound' => 'The migration class "%s" could not be found.',
     'missingMethod' => 'The migration class is missing an "%s" method.',
+    'locked'        => 'Migrations already running in another process. Skipping.',
 
     // Migration Command
     'migHelpLatest'   => "\t\tMigrates database to latest available migration.",

--- a/tests/system/Database/Migrations/MigrationRunnerTest.php
+++ b/tests/system/Database/Migrations/MigrationRunnerTest.php
@@ -502,7 +502,7 @@ final class MigrationRunnerTest extends CIUnitTestCase
         $this->assertTrue($runner->latest());
         $this->assertTrue($this->db->tableExists('foo'));
 
-        $this->dontSeeInDatabase('migrations_lock', ['lock_name'   => 'migration_process']);
+        $this->dontSeeInDatabase('migrations_lock', ['lock_name' => 'migration_process']);
     }
 
     public function testRegressWithLockingEnabled(): void
@@ -534,11 +534,11 @@ final class MigrationRunnerTest extends CIUnitTestCase
 
         // Should acquire lock successfully
         $this->assertTrue($acquireLock());
-        $this->seeInDatabase('migrations_lock', ['lock_name'   => 'migration_process']);
+        $this->seeInDatabase('migrations_lock', ['lock_name' => 'migration_process']);
 
         // Should release successfully
         $this->assertTrue($releaseLock());
-        $this->dontSeeInDatabase('migrations_lock', ['lock_name'   => 'migration_process']);
+        $this->dontSeeInDatabase('migrations_lock', ['lock_name' => 'migration_process']);
     }
 
     public function testLockPreventsConcurrentAccess(): void

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -76,6 +76,11 @@ Query Builder
 Forge
 -----
 
+Migrations
+----------
+
+- **MigrationRunner:** Added distributed locking support to prevent concurrent migrations in multi-process environments. Enable with ``Config\Migrations::$lock = true``.
+
 Others
 ------
 

--- a/user_guide_src/source/dbmgmt/migration.rst
+++ b/user_guide_src/source/dbmgmt/migration.rst
@@ -244,6 +244,8 @@ Preference           Default      Options       Description
                                                 table is always created in the default database group
                                                 (``$defaultGroup``).
 **timestampFormat**  Y-m-d-His\_                The format to use for timestamps when creating a migration.
+**lock**             false        true / false  Enable distributed locking to prevent concurrent migrations
+                                                in multi-process environments (e.g., Kubernetes).
 ==================== ============ ============= =============================================================
 
 ***************

--- a/user_guide_src/source/installation/upgrade_470.rst
+++ b/user_guide_src/source/installation/upgrade_470.rst
@@ -44,7 +44,8 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
-- @TODO
+- app/Config/Migrations.php
+    - ``Config\Migrations::$lock`` has been added, with a default value set to ``false``.
 
 All Changes
 ===========
@@ -52,4 +53,4 @@ All Changes
 This is a list of all files in the **project space** that received changes;
 many will be simple comments or formatting that have no effect on the runtime:
 
-- @TODO
+- app/Config/Migrations.php

--- a/utils/phpstan-baseline/empty.notAllowed.neon
+++ b/utils/phpstan-baseline/empty.notAllowed.neon
@@ -1,4 +1,4 @@
-# total 231 errors
+# total 230 errors
 
 parameters:
     ignoreErrors:
@@ -69,7 +69,7 @@ parameters:
 
         -
             message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-            count: 5
+            count: 4
             path: ../../system/Database/MigrationRunner.php
 
         -

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2817 errors
+# total 2816 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon


### PR DESCRIPTION
**Description**
This PR introduces a database-agnostic locking system for migrations. It guarantees consistent behavior across all supported databases. Lock cleanup is safe and automatically handled through `finally` blocks, and there are no modifications to the public API, ensuring full compatibility with existing workflows.

Closes #9646

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
