### PR TITLE
refactor: Update phpDoc typing

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -226,7 +226,7 @@ if (! function_exists('cookie')) {
      *     domain?: string,
      *     secure?: bool,
      *     httponly?: bool,
-     *     samesite?: 'Lax'|'None'|'Strict'|string,
+     *     samesite?: string,
      *     raw?: bool
      * } $options Cookie configuration options
      *

--- a/system/Common.php
+++ b/system/Common.php
@@ -216,9 +216,19 @@ if (! function_exists('cookie')) {
     /**
      * Simpler way to create a new Cookie instance.
      *
-     * @param string $name    Name of the cookie
-     * @param string $value   Value of the cookie
-     * @param array  $options Array of options to be passed to the cookie
+     * @param string $name  Name of the cookie
+     * @param string $value Value of the cookie
+     * @param array{
+     *     prefix?: string,
+     *     max-age?: int|numeric-string,
+     *     expires?: DateTimeInterface|int|string,
+     *     path?: string,
+     *     domain?: string,
+     *     secure?: bool,
+     *     httponly?: bool,
+     *     samesite?: 'Lax'|'None'|'Strict'|string,
+     *     raw?: bool
+     * } $options Cookie configuration options
      *
      * @throws CookieException
      */
@@ -352,7 +362,27 @@ if (! function_exists('db_connect')) {
      * If $getShared === false then a new connection instance will be provided,
      * otherwise it will all calls will return the same instance.
      *
-     * @param array|ConnectionInterface|string|null $db
+     * @param array{
+     *     DSN?: string,
+     *     hostname?: string,
+     *     username?: string,
+     *     password?: string,
+     *     database?: string,
+     *     DBDriver?: 'MySQLi'|'OCI8'|'Postgre'|'SQLite3'|'SQLSRV',
+     *     DBPrefix?: string,
+     *     pConnect?: bool,
+     *     DBDebug?: bool,
+     *     charset?: string,
+     *     DBCollat?: string,
+     *     swapPre?: string,
+     *     encrypt?: bool,
+     *     compress?: bool,
+     *     strictOn?: bool,
+     *     failover?: array<string, mixed>,
+     *     port?: int,
+     *     dateFormat?: array<string, string>,
+     *     foreignKeys?: bool
+     * }|ConnectionInterface|string|null $db
      *
      * @return BaseConnection
      */
@@ -402,13 +432,13 @@ if (! function_exists('esc')) {
      * If $data is an array, then it loops over it, escaping each
      * 'value' of the key/value pairs.
      *
-     * @param array|string                         $data
-     * @param 'attr'|'css'|'html'|'js'|'raw'|'url' $context
-     * @param string|null                          $encoding Current encoding for escaping.
-     *                                                       If not UTF-8, we convert strings from this encoding
-     *                                                       pre-escaping and back to this encoding post-escaping.
+     * @param array<int|string, array<int|string, mixed>|string>|string $data
+     * @param 'attr'|'css'|'html'|'js'|'raw'|'url'                      $context
+     * @param string|null                                               $encoding Current encoding for escaping.
+     *                                                                            If not UTF-8, we convert strings from this encoding
+     *                                                                            pre-escaping and back to this encoding post-escaping.
      *
-     * @return array|string
+     * @return ($data is string ? string : array<int|string, array<int|string, mixed>|string>)
      *
      * @throws InvalidArgumentException
      */
@@ -560,7 +590,7 @@ if (! function_exists('helper')) {
      *   2. {namespace}/Helpers
      *   3. system/Helpers
      *
-     * @param array|string $filenames
+     * @param list<string>|string $filenames
      *
      * @throws FileNotFoundException
      */

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -36,7 +36,7 @@ if (! function_exists('set_cookie')) {
      *   domain?: string,
      *   secure?: bool,
      *   httponly?: bool,
-     *   samesite?: 'Lax'|'None'|'Strict'|string,
+     *   samesite?: string,
      *   raw?: bool
      *  }|Cookie|string $name     Cookie name / array containing binds / Cookie object
      * @param string      $value    The value of the cookie

--- a/system/Helpers/cookie_helper.php
+++ b/system/Helpers/cookie_helper.php
@@ -24,16 +24,29 @@ if (! function_exists('set_cookie')) {
      *
      * Accepts seven parameters, or you can submit an associative
      * array in the first parameter containing all the values.
+     * ['', 'value', 'expire', '', '', '', '', '', 'name']
      *
-     * @param array|Cookie|string $name     Cookie name / array containing binds / Cookie object
-     * @param string              $value    The value of the cookie
-     * @param int                 $expire   The number of seconds until expiration
-     * @param string              $domain   For site-wide cookie. Usually: .yourdomain.com
-     * @param string              $path     The cookie path
-     * @param string              $prefix   The cookie prefix ('': the default prefix)
-     * @param bool|null           $secure   True makes the cookie secure
-     * @param bool|null           $httpOnly True makes the cookie accessible via http(s) only (no javascript)
-     * @param string|null         $sameSite The cookie SameSite value
+     * @param array{
+     *   name?: string,
+     *   value?: string,
+     *   prefix?: string,
+     *   max-age?: int|numeric-string,
+     *   expire?: DateTimeInterface|int|string,
+     *   path?: string,
+     *   domain?: string,
+     *   secure?: bool,
+     *   httponly?: bool,
+     *   samesite?: 'Lax'|'None'|'Strict'|string,
+     *   raw?: bool
+     *  }|Cookie|string $name     Cookie name / array containing binds / Cookie object
+     * @param string      $value    The value of the cookie
+     * @param int         $expire   The number of seconds until expiration
+     * @param string      $domain   For site-wide cookie. Usually: .yourdomain.com
+     * @param string      $path     The cookie path
+     * @param string      $prefix   The cookie prefix ('': the default prefix)
+     * @param bool|null   $secure   True makes the cookie secure
+     * @param bool|null   $httpOnly True makes the cookie accessible via http(s) only (no javascript)
+     * @param string|null $sameSite The cookie SameSite value
      *
      * @see \CodeIgniter\HTTP\Response::setCookie()
      */
@@ -62,7 +75,7 @@ if (! function_exists('get_cookie')) {
      *                            '': the prefix in Config\Cookie
      *                            null: no prefix
      *
-     * @return array|string|null
+     * @return array<string, mixed>|string|null
      *
      * @see \CodeIgniter\HTTP\IncomingRequest::getCookie()
      */

--- a/tests/system/CommonFunctionsTest.php
+++ b/tests/system/CommonFunctionsTest.php
@@ -243,13 +243,13 @@ final class CommonFunctionsTest extends CIUnitTestCase
     public function testEscapeBadContext(): void
     {
         $this->expectException('InvalidArgumentException');
-        esc(['width' => '800', 'height' => '600'], 'bogus');
+        esc(['width' => '800', 'height' => '600'], 'bogus'); // @phpstan-ignore argument.type
     }
 
     public function testEscapeBadContextZero(): void
     {
         $this->expectException('InvalidArgumentException');
-        esc('<script>', '0');
+        esc('<script>', '0'); // @phpstan-ignore argument.type
     }
 
     public function testEscapeArray(): void

--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,4 +1,4 @@
-# total 90 errors
+# total 88 errors
 
 parameters:
     ignoreErrors:
@@ -51,16 +51,6 @@ parameters:
             message: '#^Parameter \#2 \$mock of static method CodeIgniter\\Config\\BaseService\:\:injectMock\(\) expects object, null given\.$#'
             count: 4
             path: ../../tests/system/Commands/RoutesTest.php
-
-        -
-            message: '#^Parameter \#2 \$context of function esc expects ''attr''\|''css''\|''html''\|''js''\|''raw''\|''url'', ''0'' given\.$#'
-            count: 1
-            path: ../../tests/system/CommonFunctionsTest.php
-
-        -
-            message: '#^Parameter \#2 \$context of function esc expects ''attr''\|''css''\|''html''\|''js''\|''raw''\|''url'', ''bogus'' given\.$#'
-            count: 1
-            path: ../../tests/system/CommonFunctionsTest.php
 
         -
             message: '#^Parameter \#2 \$file of class CodeIgniter\\Config\\DotEnv constructor expects string, int given\.$#'

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2853 errors
+# total 2844 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1423 errors
+# total 1416 errors
 
 parameters:
     ignoreErrors:
@@ -339,31 +339,6 @@ parameters:
 
         -
             message: '#^Function class_uses_recursive\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
-            message: '#^Function cookie\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
-            message: '#^Function db_connect\(\) has parameter \$db with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
-            message: '#^Function esc\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
-            message: '#^Function esc\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
-            message: '#^Function helper\(\) has parameter \$filenames with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Common.php
 
@@ -3731,16 +3706,6 @@ parameters:
             message: '#^Function dot_array_search\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Helpers/array_helper.php
-
-        -
-            message: '#^Function get_cookie\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/cookie_helper.php
-
-        -
-            message: '#^Function set_cookie\(\) has parameter \$name with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Helpers/cookie_helper.php
 
         -
             message: '#^Function directory_map\(\) return type has no value type specified in iterable type array\.$#'


### PR DESCRIPTION
**Description**
The main task was to update `esc()`, but a little more was done :smile: 
We can use templates (DB, cookies) for dependent functions, but then I might make a mistake with the imports.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
