### PR TITLE
test: remove useless `DotEnvTest` test

### DIFF
--- a/tests/system/Config/DotEnvTest.php
+++ b/tests/system/Config/DotEnvTest.php
@@ -22,7 +22,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
-use TypeError;
 
 /**
  * @internal
@@ -113,13 +112,6 @@ final class DotEnvTest extends CIUnitTestCase
 
         $this->assertSame('base64:L40bKo6b8Nu541LeVeZ1i5RXfGgnkar42CPTfukhGhw=', getenv('encryption.key'));
         $this->assertSame('OpenSSL', getenv('encryption.driver'));
-    }
-
-    public function testLoadsNoneStringFiles(): void
-    {
-        $this->expectException(TypeError::class);
-
-        new DotEnv($this->fixturesFolder, 2);
     }
 
     public function testCommentedLoadsVars(): void

--- a/utils/phpstan-baseline/argument.type.neon
+++ b/utils/phpstan-baseline/argument.type.neon
@@ -1,4 +1,4 @@
-# total 88 errors
+# total 87 errors
 
 parameters:
     ignoreErrors:
@@ -51,11 +51,6 @@ parameters:
             message: '#^Parameter \#2 \$mock of static method CodeIgniter\\Config\\BaseService\:\:injectMock\(\) expects object, null given\.$#'
             count: 4
             path: ../../tests/system/Commands/RoutesTest.php
-
-        -
-            message: '#^Parameter \#2 \$file of class CodeIgniter\\Config\\DotEnv constructor expects string, int given\.$#'
-            count: 1
-            path: ../../tests/system/Config/DotEnvTest.php
 
         -
             message: '#^Parameter \#1 \$expected of method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) expects class\-string\<Config\\TestRegistrar\>, string given\.$#'

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2837 errors
+# total 2836 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
The test is useless as it does not test the class itself but PHP's strict typing.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
