### PR TITLE
fix: prevent non-shared DB instances from polluting shared cache

### DIFF
--- a/system/Database/Config.php
+++ b/system/Database/Config.php
@@ -81,7 +81,9 @@ class Config extends BaseConfig
 
         $connection = static::$factory->load($config, $group);
 
-        static::$instances[$group] = $connection;
+        if ($getShared) {
+            static::$instances[$group] = $connection;
+        }
 
         return $connection;
     }

--- a/tests/system/Database/Live/ConnectTest.php
+++ b/tests/system/Database/Live/ConnectTest.php
@@ -115,4 +115,22 @@ final class ConnectTest extends CIUnitTestCase
 
         $this->assertGreaterThanOrEqual(0, count($db1->listTables()));
     }
+
+    public function testNonSharedInstanceDoesNotAffectSharedInstances(): void
+    {
+        $firstSharedDb      = Database::connect('tests');
+        $originalDebugValue = (bool) self::getPrivateProperty($firstSharedDb, 'DBDebug');
+
+        $nonSharedDb = Database::connect('tests', false);
+        self::setPrivateProperty($nonSharedDb, 'DBDebug', ! $originalDebugValue);
+
+        $secondSharedDb = Database::connect('tests');
+
+        $this->assertSame($firstSharedDb, $secondSharedDb);
+        $this->assertNotSame($firstSharedDb, $nonSharedDb);
+
+        $this->assertSame($originalDebugValue, self::getPrivateProperty($firstSharedDb, 'DBDebug'));
+        $this->assertSame($originalDebugValue, self::getPrivateProperty($secondSharedDb, 'DBDebug'));
+        $this->assertSame(! $originalDebugValue, self::getPrivateProperty($nonSharedDb, 'DBDebug'));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -30,6 +30,8 @@ Deprecations
 Bugs Fixed
 **********
 
+- **Database:** Fixed a bug in ``Database::connect()`` which was causing storing non-shared connection instances in shared cache.
+
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_
 for a complete list of bugs fixed.

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -30,7 +30,7 @@ Deprecations
 Bugs Fixed
 **********
 
-- **Database:** Fixed a bug in ``Database::connect()`` which was causing storing non-shared connection instances in shared cache.
+- **Database:** Fixed a bug in ``Database::connect()`` which was causing to store non-shared connection instances in shared cache.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug where non-shared database instances were incorrectly stored in the shared instances cache, causing modifications to non-shared instances to affect subsequent shared connections.

Fixes #9678

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
