### PR TITLE
refactor: Improve types for phpstan

### DIFF
--- a/system/Common.php
+++ b/system/Common.php
@@ -1226,7 +1226,7 @@ if (! function_exists('class_basename')) {
     /**
      * Get the class "basename" of the given object / class.
      *
-     * @param object|string $class
+     * @param class-string|object $class
      *
      * @return string
      *
@@ -1244,9 +1244,9 @@ if (! function_exists('class_uses_recursive')) {
     /**
      * Returns all traits used by a class, its parent classes and trait of their traits.
      *
-     * @param object|string $class
+     * @param class-string|object $class
      *
-     * @return array
+     * @return array<class-string, class-string>
      *
      * @codeCoverageIgnore
      */
@@ -1270,9 +1270,9 @@ if (! function_exists('trait_uses_recursive')) {
     /**
      * Returns all traits used by a trait and its traits.
      *
-     * @param string $trait
+     * @param class-string $trait
      *
-     * @return array
+     * @return array<class-string, class-string>
      *
      * @codeCoverageIgnore
      */

--- a/system/Test/CIUnitTestCase.php
+++ b/system/Test/CIUnitTestCase.php
@@ -19,6 +19,7 @@ use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\MigrationRunner;
 use CodeIgniter\Database\Seeder;
 use CodeIgniter\Events\Events;
+use CodeIgniter\HTTP\Header;
 use CodeIgniter\Router\RouteCollection;
 use CodeIgniter\Session\Handlers\ArrayHandler;
 use CodeIgniter\Test\Mock\MockCache;
@@ -72,6 +73,8 @@ abstract class CIUnitTestCase extends TestCase
 
     /**
      * Store of identified traits.
+     *
+     * @var array<class-string, class-string>|null
      */
     private ?array $traits = null;
 
@@ -109,9 +112,9 @@ abstract class CIUnitTestCase extends TestCase
 
     /**
      * The seed file(s) used for all tests within this test case.
-     * Should be fully-namespaced or relative to $basePath
+     * Should be fully-namespaced or relative to $basePath.
      *
-     * @var class-string<Seeder>|list<class-string<Seeder>>
+     * @var ''|class-string<Seeder>|list<class-string<Seeder>>
      */
     protected $seed = '';
 
@@ -127,9 +130,9 @@ abstract class CIUnitTestCase extends TestCase
      * The namespace(s) to help us find the migration classes.
      * `null` is equivalent to running `spark migrate --all`.
      * Note that running "all" runs migrations in date order,
-     * but specifying namespaces runs them in namespace order (then date)
+     * but specifying namespaces runs them in namespace order (then date).
      *
-     * @var array|string|null
+     * @var list<string>|string|null
      */
     protected $namespace = 'Tests\Support';
 
@@ -156,17 +159,17 @@ abstract class CIUnitTestCase extends TestCase
     protected $migrations;
 
     /**
-     * Seeder instance
+     * Seeder instance.
      *
-     * @var Seeder
+     * @var Seeder|null
      */
     protected $seeder;
 
     /**
      * Stores information needed to remove any
-     * rows inserted via $this->hasInDatabase();
+     * rows inserted via $this->hasInDatabase().
      *
-     * @var array
+     * @var list<array<int|string, mixed>>
      */
     protected $insertCache = [];
 
@@ -186,27 +189,27 @@ abstract class CIUnitTestCase extends TestCase
      * Values to be set in the SESSION global
      * before running the test.
      *
-     * @var array
+     * @var array<int|string, mixed>
      */
     protected $session = [];
 
     /**
-     * Enabled auto clean op buffer after request call
+     * Enabled auto clean op buffer after request call.
      *
      * @var bool
      */
     protected $clean = true;
 
     /**
-     * Custom request's headers
+     * Custom request's headers.
      *
-     * @var array
+     * @var array<string, Header|list<Header>>
      */
     protected $headers = [];
 
     /**
      * Allows for formatting the request body to what
-     * the controller is going to expect
+     * the controller is going to expect.
      *
      * @var string
      */
@@ -276,7 +279,7 @@ abstract class CIUnitTestCase extends TestCase
      * Checks for traits with corresponding
      * methods for setUp or tearDown.
      *
-     * @param string $stage 'setUp' or 'tearDown'
+     * @param 'setUp'|'tearDown' $stage
      */
     private function callTraitMethods(string $stage): void
     {
@@ -298,7 +301,7 @@ abstract class CIUnitTestCase extends TestCase
     // --------------------------------------------------------------------
 
     /**
-     * Resets shared instanced for all Factories components
+     * Resets shared instanced for all Factories components.
      *
      * @return void
      */
@@ -308,7 +311,7 @@ abstract class CIUnitTestCase extends TestCase
     }
 
     /**
-     * Resets shared instanced for all Services
+     * Resets shared instanced for all Services.
      *
      * @return void
      */
@@ -318,7 +321,7 @@ abstract class CIUnitTestCase extends TestCase
     }
 
     /**
-     * Injects the mock Cache driver to prevent filesystem collisions
+     * Injects the mock Cache driver to prevent filesystem collisions.
      *
      * @return void
      */
@@ -328,7 +331,7 @@ abstract class CIUnitTestCase extends TestCase
     }
 
     /**
-     * Injects the mock email driver so no emails really send
+     * Injects the mock email driver so no emails really send.
      *
      * @return void
      */
@@ -338,7 +341,7 @@ abstract class CIUnitTestCase extends TestCase
     }
 
     /**
-     * Injects the mock session driver into Services
+     * Injects the mock session driver into Services.
      *
      * @return void
      */

--- a/system/Test/DatabaseTestTrait.php
+++ b/system/Test/DatabaseTestTrait.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace CodeIgniter\Test;
 
 use CodeIgniter\Database\BaseBuilder;
+use CodeIgniter\Database\BaseConnection;
 use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\MigrationRunner;
+use CodeIgniter\Database\Seeder;
 use CodeIgniter\Test\Constraints\SeeInDatabase;
 use Config\Database;
 use Config\Migrations;
-use Config\Services;
 use PHPUnit\Framework\Attributes\AfterClass;
 
 /**
@@ -26,6 +28,12 @@ use PHPUnit\Framework\Attributes\AfterClass;
  *
  * Provides functionality for refreshing/seeding
  * the database during testing.
+ *
+ * @property BaseConnection                 $db
+ * @property list<array<int|string, mixed>> $insertCache
+ * @property Seeder|null                    $seeder
+ * @property MigrationRunner|null           $migrations
+ * @property list<string>|string|null       $namespace
  *
  * @mixin CIUnitTestCase
  */
@@ -88,7 +96,7 @@ trait DatabaseTestTrait
             $config          = new Migrations();
             $config->enabled = true;
 
-            $this->migrations = Services::migrations($config, $this->db, false);
+            $this->migrations = service('migrations', $config, $this->db, false);
             $this->migrations->setSilent(false);
         }
 

--- a/system/Test/FeatureTestTrait.php
+++ b/system/Test/FeatureTestTrait.php
@@ -13,13 +13,17 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Test;
 
+use Closure;
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\Exceptions\RedirectException;
+use CodeIgniter\HTTP\Header;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Method;
 use CodeIgniter\HTTP\Request;
+use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\HTTP\SiteURI;
 use CodeIgniter\HTTP\URI;
+use CodeIgniter\Router\RouteCollection;
 use Config\App;
 use Config\Services;
 use Exception;
@@ -30,6 +34,12 @@ use ReflectionException;
  *
  * Provides additional utilities for doing full HTTP testing
  * against your application in trait format.
+ *
+ * @property array<int|string, mixed>           $session
+ * @property array<string, Header|list<Header>> $headers
+ * @property RouteCollection|null               $routes
+ *
+ * @mixin CIUnitTestCase
  */
 trait FeatureTestTrait
 {
@@ -42,7 +52,12 @@ trait FeatureTestTrait
      *    ['GET', 'home', 'Home::index'],
      * ]
      *
-     * @param array|null $routes Array to set routes
+     * @param array<int, array{
+     *      0: string,
+     *      1: string,
+     *      2: ((Closure(mixed...): (ResponseInterface|string|void)))|string,
+     *      3?: array<string, mixed>
+     *  }>|null $routes Array to set routes
      *
      * @return $this
      */
@@ -84,7 +99,7 @@ trait FeatureTestTrait
     /**
      * Sets any values that should exist during this session.
      *
-     * @param array|null $values Array of values, or null to use the current $_SESSION
+     * @param array<int|string, mixed>|null $values Array of values, or null to use the current $_SESSION
      *
      * @return $this
      */
@@ -103,7 +118,7 @@ trait FeatureTestTrait
      *  'Authorization' => 'Token'
      * ])
      *
-     * @param array $headers Array of headers
+     * @param array<string, Header|list<Header>> $headers Array of headers
      *
      * @return $this
      */

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -29,29 +29,9 @@ final class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    /**
-     * Should run db migration only once?
-     *
-     * @var bool
-     */
     protected $migrateOnce = true;
-
-    /**
-     * Should the db be refreshed before test?
-     *
-     * @var bool
-     */
-    protected $refresh = true;
-
-    /**
-     * The namespace(s) to help us find the migration classes.
-     * Empty is equivalent to running `spark migrate -all`.
-     * Note that running "all" runs migrations in date order,
-     * but specifying namespaces runs them in namespace order (then date)
-     *
-     * @var list<string>|string|null
-     */
-    protected $namespace = [
+    protected $refresh     = true;
+    protected $namespace   = [
         'Tests\Support\MigrationTestMigrations',
     ];
 

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
@@ -49,7 +49,7 @@ final class DatabaseTestCaseMigrationOnce1Test extends CIUnitTestCase
      * Note that running "all" runs migrations in date order,
      * but specifying namespaces runs them in namespace order (then date)
      *
-     * @var array|string|null
+     * @var list<string>|string|null
      */
     protected $namespace = [
         'Tests\Support\MigrationTestMigrations',

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -29,29 +29,9 @@ final class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    /**
-     * Should run db migration only once?
-     *
-     * @var bool
-     */
     protected $migrateOnce = true;
-
-    /**
-     * Should the db be refreshed before test?
-     *
-     * @var bool
-     */
-    protected $refresh = true;
-
-    /**
-     * The namespace(s) to help us find the migration classes.
-     * Empty is equivalent to running `spark migrate -all`.
-     * Note that running "all" runs migrations in date order,
-     * but specifying namespaces runs them in namespace order (then date)
-     *
-     * @var list<string>|string|null
-     */
-    protected $namespace = [
+    protected $refresh     = true;
+    protected $namespace   = [
         'Tests\Support\MigrationTestMigrations',
     ];
 

--- a/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
+++ b/tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
@@ -49,7 +49,7 @@ final class DatabaseTestCaseMigrationOnce2Test extends CIUnitTestCase
      * Note that running "all" runs migrations in date order,
      * but specifying namespaces runs them in namespace order (then date)
      *
-     * @var array|string|null
+     * @var list<string>|string|null
      */
     protected $namespace = [
         'Tests\Support\MigrationTestMigrations',

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -28,33 +28,11 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    /**
-     * Should the db be refreshed before
-     * each test?
-     *
-     * @var bool
-     */
     protected $refresh = true;
-
-    /**
-     * The seed file(s) used for all tests within this test case.
-     * Should be fully-namespaced or relative to $basePath
-     *
-     * @var ''|class-string<Seeder>|list<class-string<Seeder>>
-     */
-    protected $seed = [
+    protected $seed    = [
         CITestSeeder::class,
         AnotherSeeder::class,
     ];
-
-    /**
-     * The namespace(s) to help us find the migration classes.
-     * Empty is equivalent to running `spark migrate -all`.
-     * Note that running "all" runs migrations in date order,
-     * but specifying namespaces runs them in namespace order (then date)
-     *
-     * @var list<string>|string|null
-     */
     protected $namespace = [
         'Tests\Support',
         'Tests\Support\MigrationTestMigrations',

--- a/tests/system/Database/DatabaseTestCaseTest.php
+++ b/tests/system/Database/DatabaseTestCaseTest.php
@@ -40,7 +40,7 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
      * The seed file(s) used for all tests within this test case.
      * Should be fully-namespaced or relative to $basePath
      *
-     * @var array|string
+     * @var ''|class-string<Seeder>|list<class-string<Seeder>>
      */
     protected $seed = [
         CITestSeeder::class,
@@ -53,7 +53,7 @@ final class DatabaseTestCaseTest extends CIUnitTestCase
      * Note that running "all" runs migrations in date order,
      * but specifying namespaces runs them in namespace order (then date)
      *
-     * @var array|string|null
+     * @var list<string>|string|null
      */
     protected $namespace = [
         'Tests\Support',

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
+use CodeIgniter\Database\Seeder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
@@ -30,7 +31,7 @@ final class MetadataTest extends CIUnitTestCase
     /**
      * The seed file used for all tests within this test case.
      *
-     * @var string
+     * @var ''|class-string<Seeder>|list<class-string<Seeder>>
      */
     protected $seed = CITestSeeder::class;
 

--- a/tests/system/Database/Live/MetadataTest.php
+++ b/tests/system/Database/Live/MetadataTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Database\Live;
 
-use CodeIgniter\Database\Seeder;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Config\Database;
@@ -28,13 +27,7 @@ final class MetadataTest extends CIUnitTestCase
 {
     use DatabaseTestTrait;
 
-    /**
-     * The seed file used for all tests within this test case.
-     *
-     * @var ''|class-string<Seeder>|list<class-string<Seeder>>
-     */
-    protected $seed = CITestSeeder::class;
-
+    protected $seed               = CITestSeeder::class;
     private array $expectedTables = [];
 
     protected function setUp(): void

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2837 errors
+# total 2807 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 2807 errors
+# total 2808 errors
 includes:
     - argument.type.neon
     - assign.propertyType.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 1409 errors
+# total 1388 errors
 
 parameters:
     ignoreErrors:
@@ -338,11 +338,6 @@ parameters:
             path: ../../system/Commands/Utilities/Routes/FilterFinder.php
 
         -
-            message: '#^Function class_uses_recursive\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
             message: '#^Function log_message\(\) has parameter \$context with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Common.php
@@ -364,11 +359,6 @@ parameters:
 
         -
             message: '#^Function stringify_attributes\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Common.php
-
-        -
-            message: '#^Function trait_uses_recursive\(\) return type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Common.php
 
@@ -4588,31 +4578,6 @@ parameters:
             path: ../../system/Superglobals.php
 
         -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$headers type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Test/CIUnitTestCase.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$insertCache type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Test/CIUnitTestCase.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$namespace type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Test/CIUnitTestCase.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$session type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Test/CIUnitTestCase.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$traits type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Test/CIUnitTestCase.php
-
-        -
             message: '#^Method CodeIgniter\\Test\\Constraints\\SeeInDatabase\:\:__construct\(\) has parameter \$data with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Test/Constraints/SeeInDatabase.php
@@ -5633,26 +5598,6 @@ parameters:
             path: ../../tests/system/Database/ConfigTest.php
 
         -
-            message: '#^Property CodeIgniter\\Database\\DatabaseTestCase\\DatabaseTestCaseMigrationOnce1Test\:\:\$namespace type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce1Test.php
-
-        -
-            message: '#^Property CodeIgniter\\Database\\DatabaseTestCase\\DatabaseTestCaseMigrationOnce2Test\:\:\$namespace type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Database/DatabaseTestCase/DatabaseTestCaseMigrationOnce2Test.php
-
-        -
-            message: '#^Property CodeIgniter\\Database\\DatabaseTestCaseTest\:\:\$namespace type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Database/DatabaseTestCaseTest.php
-
-        -
-            message: '#^Property CodeIgniter\\Database\\DatabaseTestCaseTest\:\:\$seed type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Database/DatabaseTestCaseTest.php
-
-        -
             message: '#^Property CodeIgniter\\Database\\Live\\MetadataTest\:\:\$expectedTables type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../tests/system/Database/Live/MetadataTest.php
@@ -5671,11 +5616,6 @@ parameters:
             message: '#^Method CodeIgniter\\Database\\Live\\UpdateTest\:\:testUpdateBatch\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../tests/system/Database/Live/UpdateTest.php
-
-        -
-            message: '#^Property CodeIgniter\\Database\\Migrations\\MigrationRunnerTest\:\:\$namespace type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Database/Migrations/MigrationRunnerTest.php
 
         -
             message: '#^Method CodeIgniter\\Debug\\ExceptionHandlerTest\:\:backupIniValues\(\) has parameter \$keys with no value type specified in iterable type array\.$#'
@@ -6133,21 +6073,6 @@ parameters:
             path: ../../tests/system/HomeTest.php
 
         -
-            message: '#^Method CodeIgniter\\HomeTest\:\:withHeaders\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/HomeTest.php
-
-        -
-            message: '#^Method CodeIgniter\\HomeTest\:\:withRoutes\(\) has parameter \$routes with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/HomeTest.php
-
-        -
-            message: '#^Method CodeIgniter\\HomeTest\:\:withSession\(\) has parameter \$values with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/HomeTest.php
-
-        -
             message: '#^Method CodeIgniter\\I18n\\TimeLegacyTest\:\:provideToStringDoesNotDependOnLocale\(\) return type has no value type specified in iterable type iterable\.$#'
             count: 1
             path: ../../tests/system/I18n/TimeLegacyTest.php
@@ -6348,21 +6273,6 @@ parameters:
             path: ../../tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
 
         -
-            message: '#^Method CodeIgniter\\Test\\FeatureTestAutoRoutingImprovedTest\:\:withHeaders\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Test\\FeatureTestAutoRoutingImprovedTest\:\:withRoutes\(\) has parameter \$routes with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Test\\FeatureTestAutoRoutingImprovedTest\:\:withSession\(\) has parameter \$values with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
-
-        -
             message: '#^Method CodeIgniter\\Test\\FeatureTestTraitTest\:\:call\(\) has parameter \$params with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../tests/system/Test/FeatureTestTraitTest.php
@@ -6409,21 +6319,6 @@ parameters:
 
         -
             message: '#^Method CodeIgniter\\Test\\FeatureTestTraitTest\:\:setRequestBody\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestTraitTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Test\\FeatureTestTraitTest\:\:withHeaders\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestTraitTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Test\\FeatureTestTraitTest\:\:withRoutes\(\) has parameter \$routes with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestTraitTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Test\\FeatureTestTraitTest\:\:withSession\(\) has parameter \$values with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../tests/system/Test/FeatureTestTraitTest.php
 

--- a/utils/phpstan-baseline/nullCoalesce.property.neon
+++ b/utils/phpstan-baseline/nullCoalesce.property.neon
@@ -1,4 +1,4 @@
-# total 19 errors
+# total 16 errors
 
 parameters:
     ignoreErrors:
@@ -36,21 +36,6 @@ parameters:
             message: '#^Property CodeIgniter\\Throttle\\Throttler\:\:\$testTime \(int\) on left side of \?\? is not nullable\.$#'
             count: 1
             path: ../../system/Throttle/Throttler.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$session \(array\) on left side of \?\? is not nullable\.$#'
-            count: 1
-            path: ../../tests/system/HomeTest.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$session \(array\) on left side of \?\? is not nullable\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestAutoRoutingImprovedTest.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$session \(array\) on left side of \?\? is not nullable\.$#'
-            count: 1
-            path: ../../tests/system/Test/FeatureTestTraitTest.php
 
         -
             message: '#^Property CodeIgniter\\Test\\FilterTestTraitTest\:\:\$request \(CodeIgniter\\HTTP\\RequestInterface\) on left side of \?\?\= is not nullable\.$#'

--- a/utils/phpstan-baseline/property.defaultValue.neon
+++ b/utils/phpstan-baseline/property.defaultValue.neon
@@ -1,4 +1,4 @@
-# total 4 errors
+# total 1 error
 
 parameters:
     ignoreErrors:
@@ -6,18 +6,3 @@ parameters:
             message: '#^Property CodeIgniter\\Config\\View\:\:\$coreFilters \(array\<string, callable\(mixed\)\: mixed&string\>\) does not accept default value of type array\{abs\: ''\\\\abs'', capitalize\: ''\\\\CodeIgniter\\\\View…'', date\: ''\\\\CodeIgniter\\\\View…'', date_modify\: ''\\\\CodeIgniter\\\\View…'', default\: ''\\\\CodeIgniter\\\\View…'', esc\: ''\\\\CodeIgniter\\\\View…'', excerpt\: ''\\\\CodeIgniter\\\\View…'', highlight\: ''\\\\CodeIgniter\\\\View…'', \.\.\.\}\.$#'
             count: 1
             path: ../../system/Config/View.php
-
-        -
-            message: '#^Property CodeIgniter\\Test\\CIUnitTestCase\:\:\$seed \(class\-string\<CodeIgniter\\Database\\Seeder\>\|list\<class\-string\<CodeIgniter\\Database\\Seeder\>\>\) does not accept default value of type ''''\.$#'
-            count: 1
-            path: ../../system/Test/CIUnitTestCase.php
-
-        -
-            message: '#^Property CodeIgniter\\Models\\DataConverterModelTest\:\:\$seed \(class\-string\<CodeIgniter\\Database\\Seeder\>\|list\<class\-string\<CodeIgniter\\Database\\Seeder\>\>\) does not accept default value of type ''''\.$#'
-            count: 1
-            path: ../../tests/system/Models/DataConverterModelTest.php
-
-        -
-            message: '#^Property CodeIgniter\\Models\\TimestampModelTest\:\:\$seed \(class\-string\<CodeIgniter\\Database\\Seeder\>\|list\<class\-string\<CodeIgniter\\Database\\Seeder\>\>\) does not accept default value of type ''''\.$#'
-            count: 1
-            path: ../../tests/system/Models/TimestampModelTest.php

--- a/utils/phpstan-baseline/property.phpDocType.neon
+++ b/utils/phpstan-baseline/property.phpDocType.neon
@@ -1,4 +1,4 @@
-# total 46 errors
+# total 44 errors
 
 parameters:
     ignoreErrors:
@@ -196,16 +196,6 @@ parameters:
             message: '#^PHPDoc type CodeIgniter\\Test\\Mock\\MockConnection of property CodeIgniter\\Database\\Builder\\WhereTest\:\:\$db is not the same as PHPDoc type CodeIgniter\\Database\\BaseConnection of overridden property CodeIgniter\\Test\\CIUnitTestCase\:\:\$db\.$#'
             count: 1
             path: ../../tests/system/Database/Builder/WhereTest.php
-
-        -
-            message: '#^PHPDoc type array\|string of property CodeIgniter\\Database\\DatabaseTestCaseTest\:\:\$seed is not the same as PHPDoc type class\-string\<CodeIgniter\\Database\\Seeder\>\|list\<class\-string\<CodeIgniter\\Database\\Seeder\>\> of overridden property CodeIgniter\\Test\\CIUnitTestCase\:\:\$seed\.$#'
-            count: 1
-            path: ../../tests/system/Database/DatabaseTestCaseTest.php
-
-        -
-            message: '#^PHPDoc type string of property CodeIgniter\\Database\\Live\\MetadataTest\:\:\$seed is not the same as PHPDoc type class\-string\<CodeIgniter\\Database\\Seeder\>\|list\<class\-string\<CodeIgniter\\Database\\Seeder\>\> of overridden property CodeIgniter\\Test\\CIUnitTestCase\:\:\$seed\.$#'
-            count: 1
-            path: ../../tests/system/Database/Live/MetadataTest.php
 
         -
             message: '#^PHPDoc type CodeIgniter\\Database\\SQLite3\\Connection of property CodeIgniter\\Database\\Live\\SQLite3\\GetIndexDataTest\:\:\$db is not the same as PHPDoc type CodeIgniter\\Database\\BaseConnection of overridden property CodeIgniter\\Test\\CIUnitTestCase\:\:\$db\.$#'


### PR DESCRIPTION
**Description**
Improved typing. 
What is done:
- [x] Added a "dot" at the end of the descriptions
- [x] Since `CIUnitTestCase`, the dependent code has been updated
- [x] Updated types in related functions in **Common.php**
- [x] Properties have been added for traits. If it is redundant, some can be deleted, phpstan does not consider this a mistake. 

_OFFTOP:_ I'll ask again: Do we really need repeated code descriptions? (You answered **Yes**.)
Because of this, it needs to be fixed in several places. See, example  `$namespace` property. Modern IDEs fully support type highlighting and you can switch to declarations. If not, then is it worth adding missing comments everywhere? I would leave it as it is now, but this contradicts the desire to duplicate the code: Everywhere without repeating, or always duplicate typing.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
