### PR TITLE
fix: setting `created_at` field in `Model::replace()` method

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1220,7 +1220,9 @@ abstract class BaseModel
             return false;
         }
 
-        $row = $this->setUpdatedField((array) $row, $this->setDate());
+        $row = (array) $row;
+        $row = $this->setCreatedField($row, $this->setDate());
+        $row = $this->setUpdatedField($row, $this->setDate());
 
         return $this->doReplace($row, $returnSQL);
     }

--- a/tests/system/Models/ReplaceModelTest.php
+++ b/tests/system/Models/ReplaceModelTest.php
@@ -38,11 +38,13 @@ final class ReplaceModelTest extends LiveModelTestCase
         $data['country'] = 'UK';
 
         $sql = $this->model->replace($data, true);
+        $this->assertStringNotContainsString('created_at', (string) $sql);
         $this->assertStringNotContainsString('updated_at', (string) $sql);
 
         $this->model = $this->createModel(UserModel::class);
         $this->setPrivateProperty($this->model, 'useTimestamps', true);
         $sql = $this->model->replace($data, true);
+        $this->assertStringContainsString('created_at', (string) $sql);
         $this->assertStringContainsString('updated_at', (string) $sql);
     }
 }

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -33,6 +33,7 @@ Bugs Fixed
 - **Database:** Fixed a bug in ``Database::connect()`` which was causing to store non-shared connection instances in shared cache.
 - **Database:** Fixed a bug in ``Connection::getFieldData()`` for ``SQLSRV`` and ``OCI8`` where extra characters were returned in column default values (specific to those handlers), instead of following the convention used by other drivers.
 - **Forge:** Fixed a bug in ``Postgre`` and ``SQLSRV`` where changing a column's default value using ``Forge::modifyColumn()`` method produced incorrect SQL syntax.
+- **Model:** Fixed a bug in ``Model::replace()`` where ``created_at`` field (when available) wasn't set correctly.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug where the `created_at` field wasn't set correctly when using the `Model::replace()` method.

Fixes #9692

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
