### PR TITLE
refactor: `ArrayIterator` has deprecated on PHP 8.5

### DIFF
--- a/system/Cookie/CookieStore.php
+++ b/system/Cookie/CookieStore.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Cookie;
 
-use ArrayIterator;
 use CodeIgniter\Cookie\Exceptions\CookieException;
 use Countable;
 use IteratorAggregate;
@@ -192,7 +191,9 @@ class CookieStore implements Countable, IteratorAggregate
      */
     public function getIterator(): Traversable
     {
-        return new ArrayIterator($this->cookies);
+        foreach ($this->cookies as $key => $value) {
+            yield $key => $value;
+        }
     }
 
     /**


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.5"__

-->
**Description**
See #9664

Reference : https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_arrayobject_and_arrayiterator_with_objects

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
