### PR TITLE
fix: `compileOrderBy()` method

### DIFF
--- a/system/Database/BaseBuilder.php
+++ b/system/Database/BaseBuilder.php
@@ -3257,6 +3257,9 @@ class BaseBuilder
     {
         if (is_array($this->QBOrderBy) && $this->QBOrderBy !== []) {
             foreach ($this->QBOrderBy as &$orderBy) {
+                if (is_string($orderBy)) {
+                    continue;
+                }
                 if ($orderBy['escape'] !== false && ! $this->isLiteral($orderBy['field'])) {
                     $orderBy['field'] = $this->db->protectIdentifiers($orderBy['field']);
                 }
@@ -3264,11 +3267,7 @@ class BaseBuilder
                 $orderBy = $orderBy['field'] . $orderBy['direction'];
             }
 
-            return $this->QBOrderBy = "\nORDER BY " . implode(', ', $this->QBOrderBy);
-        }
-
-        if (is_string($this->QBOrderBy)) {
-            return $this->QBOrderBy;
+            return "\nORDER BY " . implode(', ', $this->QBOrderBy);
         }
 
         return '';

--- a/tests/system/Database/Builder/SelectTest.php
+++ b/tests/system/Database/Builder/SelectTest.php
@@ -407,4 +407,24 @@ final class SelectTest extends CIUnitTestCase
             str_replace("\n", ' ', $sql),
         );
     }
+
+    /**
+     * @see https://github.com/codeigniter4/CodeIgniter4/issues/9696
+     */
+    public function testGetCompiledSelect(): void
+    {
+        $builder = new BaseBuilder('users', $this->db);
+
+        $builder->select('name, role')->orderBy('name', 'desc');
+
+        $expected = 'SELECT "name", "role" FROM "users" ORDER BY "name" DESC';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect(false)));
+
+        $builder->orderBy('role', 'desc');
+
+        $expected = 'SELECT "name", "role" FROM "users" ORDER BY "name" DESC, "role" DESC';
+
+        $this->assertSame($expected, str_replace("\n", ' ', $builder->getCompiledSelect()));
+    }
 }

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -32,6 +32,7 @@ Bugs Fixed
 
 - **Database:** Fixed a bug in ``Database::connect()`` which was causing to store non-shared connection instances in shared cache.
 - **Database:** Fixed a bug in ``Connection::getFieldData()`` for ``SQLSRV`` and ``OCI8`` where extra characters were returned in column default values (specific to those handlers), instead of following the convention used by other drivers.
+- **Database:** Fixed a bug in ``BaseBuilder::compileOrderBy()`` where the method could overwrite ``QBOrderBy`` with a string instead of keeping it as an array, causing type errors and preventing additional ``ORDER BY`` clauses from being appended.
 - **Forge:** Fixed a bug in ``Postgre`` and ``SQLSRV`` where changing a column's default value using ``Forge::modifyColumn()`` method produced incorrect SQL syntax.
 - **Model:** Fixed a bug in ``Model::replace()`` where ``created_at`` field (when available) wasn't set correctly.
 


### PR DESCRIPTION
**Description**
This PR fixes a bug in `BaseBuilder::compileOrderBy()` where the method could overwrite `QBOrderBy` with a string instead of keeping it as an array. This caused type errors and made it impossible to append additional `ORDER BY` clauses.

Fixes #9696

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
