### PR TITLE
feat: make `insertBatch()` and `updateBatch()` respect model rules

### DIFF
--- a/tests/system/Models/UpdateModelTest.php
+++ b/tests/system/Models/UpdateModelTest.php
@@ -249,7 +249,9 @@ final class UpdateModelTest extends LiveModelTestCase
         $entity2->deleted = 0;
         $entity2->syncOriginal();
 
-        $this->assertSame(2, $this->createModel(UserModel::class)->updateBatch([$entity1, $entity2], 'id'));
+        $model = $this->createModel(UserModel::class);
+        $this->setPrivateProperty($model, 'updateOnlyChanged', false);
+        $this->assertSame(2, $model->updateBatch([$entity1, $entity2], 'id'));
     }
 
     public function testUpdateNoPrimaryKey(): void

--- a/user_guide_src/source/changelogs/v4.7.0.rst
+++ b/user_guide_src/source/changelogs/v4.7.0.rst
@@ -33,6 +33,13 @@ update it to use double braces: ``regex_match[/^{{placeholder}}$/]``.
 This change was introduced to avoid ambiguity with regular expression syntax,
 where single curly braces (e.g., ``{1,3}``) are used for quantifiers.
 
+BaseModel
+---------
+
+The ``insertBatch()`` and ``updateBatch()`` methods now honor model settings like
+``updateOnlyChanged`` and ``allowEmptyInserts``. This change ensures consistent handling
+across all insert/update operations.
+
 Interface Changes
 =================
 
@@ -45,6 +52,7 @@ Removed Deprecated Items
 ========================
 
 - **Text Helper:** The deprecated types in ``random_string()`` function: ``basic``, ``md5``, and ``sha1`` has been removed.
+- **BaseModel:** The deprecated method ``transformDataRowToArray()`` has been removed.
 
 ************
 Enhancements
@@ -55,7 +63,7 @@ Libraries
 
 - **CURLRequest:** Added ``shareConnection`` config item to change default share connection.
 - **CURLRequest:** Added ``dns_cache_timeout`` option to change default DNS cache timeout.
-- **CURLRequest:** Added ``fresh_connect`` options to enable/disabled request fresh connection.
+- **CURLRequest:** Added ``fresh_connect`` options to enable/disable request fresh connection.
 - **Email:** Added support for choosing the SMTP authorization method. You can change it via ``Config\Email::$SMTPAuthMethod`` option.
 - **Image:** The ``ImageMagickHandler`` has been rewritten to rely solely on the PHP ``imagick`` extension.
 - **Image:** Added ``ImageMagickHandler::clearMetadata()`` method to remove image metadata for privacy protection.
@@ -70,7 +78,7 @@ Testing
 Database
 ========
 
-- **Exception Logging:** All DB drivers now log database exceptions uniformly. Previously, each driver has its own log format.
+- **Exception Logging:** All DB drivers now log database exceptions uniformly. Previously, each driver had its own log format.
 
 Query Builder
 -------------

--- a/utils/phpstan-baseline/missingType.property.neon
+++ b/utils/phpstan-baseline/missingType.property.neon
@@ -473,42 +473,42 @@ parameters:
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$_options has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$_options has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$country has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$country has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$created_at has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$created_at has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$deleted has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$deleted has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$email has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$email has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$id has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$id has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$name has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$name has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 
         -
-            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:351\:\:\$updated_at has no type specified\.$#'
+            message: '#^Property CodeIgniter\\Entity\\Entity@anonymous/tests/system/Models/UpdateModelTest\.php\:353\:\:\$updated_at has no type specified\.$#'
             count: 1
             path: ../../tests/system/Models/UpdateModelTest.php
 


### PR DESCRIPTION
**Description**
This PR updates `BaseModel` so that `insertBatch()` and `updateBatch()` now respect model-level properties, like `updateOnlyChanged` and `allowEmptyInserts`. Previously, these methods bypassed these settings, which caused inconsistent behavior compared to `insert()` and `update()`. With this change, all insert and update operations are handled consistently.

This is a follow-up for #9698

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
