### PR TITLE
refactor: Add `synchronous` option for SQLite tests

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -182,6 +182,7 @@ class Database extends Config
         'port'        => 3306,
         'foreignKeys' => true,
         'busyTimeout' => 1000,
+        'synchronous' => null,
         'dateFormat'  => [
             'date'     => 'Y-m-d',
             'datetime' => 'Y-m-d H:i:s',

--- a/tests/_support/Config/Registrar.php
+++ b/tests/_support/Config/Registrar.php
@@ -83,6 +83,7 @@ class Registrar
             'failover'    => [],
             'port'        => 3306,
             'foreignKeys' => true,
+            'synchronous' => 0,
         ],
         'SQLSRV' => [
             'DSN'      => '',

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -22,6 +22,8 @@ Message Changes
 Changes
 *******
 
+- **Config:** Added the ``synchronous`` key for ``Config\Database::$tests``. For SQLite3 driver only.
+
 ************
 Deprecations
 ************

--- a/user_guide_src/source/installation/upgrade_464.rst
+++ b/user_guide_src/source/installation/upgrade_464.rst
@@ -44,7 +44,8 @@ and it is recommended that you merge the updated versions with your application:
 Config
 ------
 
-- @TODO
+- app/Config/Database.php
+    - Added the ``synchronous`` key for ``Config\Database::$tests``.
 
 All Changes
 ===========


### PR DESCRIPTION
**Description**
On some systems, there may be a huge drop when reading/writing even to SSD. I think data loss is not critical for tests, you can disable it.
The framework already knows how to work with the option, it's worth leaving at least **NORMAL (1)** in production.
See see https://www.sqlite.org/pragma.html#pragma_synchronous

**UPD:** 
```console
// Before PHP 8.4
Time: 00:34.360, Memory: 80.50 MB
// Before PHP 8.3
Time: 00:25.448, Memory: 78.50 MB

// After PHP 8.4
Time: 00:07.573, Memory: 80.50 MB
// After PHP 8.3
Time: 00:07.320, Memory: 78.50 MB
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
