### PR TITLE
fix: SQLite3 password handling for empty string

### DIFF
--- a/system/Database/SQLite3/Connection.php
+++ b/system/Database/SQLite3/Connection.php
@@ -107,7 +107,7 @@ class Connection extends BaseConnection
                 $this->database = WRITEPATH . $this->database;
             }
 
-            $sqlite = ($this->password === null || $this->password !== '')
+            $sqlite = ($this->password === null || $this->password === '')
                 ? new SQLite3($this->database)
                 : new SQLite3($this->database, SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, $this->password);
 

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -40,6 +40,7 @@ Bugs Fixed
 - **Database:** Fixed a bug in ``Database::connect()`` which was causing to store non-shared connection instances in shared cache.
 - **Database:** Fixed a bug in ``Connection::getFieldData()`` for ``SQLSRV`` and ``OCI8`` where extra characters were returned in column default values (specific to those handlers), instead of following the convention used by other drivers.
 - **Database:** Fixed a bug in ``BaseBuilder::compileOrderBy()`` where the method could overwrite ``QBOrderBy`` with a string instead of keeping it as an array, causing type errors and preventing additional ``ORDER BY`` clauses from being appended.
+- **Database:** Fixed a bug in ``SQLite3`` where an incorrect condition caused the password parameter to be ignored when it was an empty string.
 - **Forge:** Fixed a bug in ``Postgre`` and ``SQLSRV`` where changing a column's default value using ``Forge::modifyColumn()`` method produced incorrect SQL syntax.
 - **Model:** Fixed a bug in ``Model::replace()`` where ``created_at`` field (when available) wasn't set correctly.
 - **Model:** Fixed a bug in ``Model::insertBatch()`` and ``Model::updateBatch()`` where casts were not applied to inserted or updated values.

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -40,7 +40,7 @@ Bugs Fixed
 - **Database:** Fixed a bug in ``Database::connect()`` which was causing to store non-shared connection instances in shared cache.
 - **Database:** Fixed a bug in ``Connection::getFieldData()`` for ``SQLSRV`` and ``OCI8`` where extra characters were returned in column default values (specific to those handlers), instead of following the convention used by other drivers.
 - **Database:** Fixed a bug in ``BaseBuilder::compileOrderBy()`` where the method could overwrite ``QBOrderBy`` with a string instead of keeping it as an array, causing type errors and preventing additional ``ORDER BY`` clauses from being appended.
-- **Database:** Fixed a bug in ``SQLite3`` where an incorrect condition caused the password parameter to be ignored when it was an empty string.
+- **Database:** Fixed a bug in ``SQLite3`` where the password parameter was ignored unless it was an empty string.
 - **Forge:** Fixed a bug in ``Postgre`` and ``SQLSRV`` where changing a column's default value using ``Forge::modifyColumn()`` method produced incorrect SQL syntax.
 - **Model:** Fixed a bug in ``Model::replace()`` where ``created_at`` field (when available) wasn't set correctly.
 - **Model:** Fixed a bug in ``Model::insertBatch()`` and ``Model::updateBatch()`` where casts were not applied to inserted or updated values.


### PR DESCRIPTION
**Description**
This PR fixes incorrect password handling in the `SQLite3` driver when the password was set to an empty string.

See: https://github.com/codeigniter4/CodeIgniter4/pull/9728#discussion_r2384107915

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
