### PR TITLE
docs: Fixed typo

### DIFF
--- a/user_guide_src/source/extending/composer_packages.rst
+++ b/user_guide_src/source/extending/composer_packages.rst
@@ -22,7 +22,7 @@ Here's a typical directory structure for a Composer package::
     ├── README.md
     ├── composer.json
     ├── src/
-    │   └── YourClass.php
+    │   └── YourClass.php
     └── tests/
         └── YourClassTest.php
 


### PR DESCRIPTION
**Description**

Delete invisible spaces at `Creating Composer Packages`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide