### PR TITLE
fix: TypeError in `valid_base64` rule when checking invalid base64 strings

### DIFF
--- a/system/Validation/FormatRules.php
+++ b/system/Validation/FormatRules.php
@@ -284,7 +284,13 @@ class FormatRules
             $str = (string) $str;
         }
 
-        return base64_encode(base64_decode($str, true)) === $str;
+        $decoded = base64_decode($str, true);
+
+        if ($decoded === false) {
+            return false;
+        }
+
+        return base64_encode($decoded) === $str;
     }
 
     /**

--- a/tests/system/Validation/FormatRulesTest.php
+++ b/tests/system/Validation/FormatRulesTest.php
@@ -1054,6 +1054,10 @@ class FormatRulesTest extends CIUnitTestCase
                 false,
             ],
             [
+                'dGVszdA==',
+                false,
+            ],
+            [
                 null,
                 false,
             ],

--- a/user_guide_src/source/changelogs/v4.6.4.rst
+++ b/user_guide_src/source/changelogs/v4.6.4.rst
@@ -44,6 +44,7 @@ Bugs Fixed
 - **Forge:** Fixed a bug in ``Postgre`` and ``SQLSRV`` where changing a column's default value using ``Forge::modifyColumn()`` method produced incorrect SQL syntax.
 - **Model:** Fixed a bug in ``Model::replace()`` where ``created_at`` field (when available) wasn't set correctly.
 - **Model:** Fixed a bug in ``Model::insertBatch()`` and ``Model::updateBatch()`` where casts were not applied to inserted or updated values.
+- **Validation:** Fixed a bug in the ``FormatRules::valid_base64()`` validation rule that caused a TypeError when checking invalid base64 strings.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_


### PR DESCRIPTION
**Description**
This PR fixes a bug in the `valid_base64` validation rule that caused a TypeError when checking invalid base64 strings.

Fixes #9732

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
