### PR TITLE
fix: cannot read properties of null in `toggleViewsHints` (`toolbar.js`)

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -337,6 +337,11 @@ var ciDebugBar = {
         const OUTER_ELEMENTS = ["HTML", "BODY", "HEAD"];
 
         var getValidElementInner = function (node, reverse) {
+            // handle null node
+            if (node === null) {
+                return null;
+            }
+
             // handle invalid tags
             if (OUTER_ELEMENTS.indexOf(node.nodeName) !== -1) {
                 for (var i = 0; i < document.body.children.length; ++i) {


### PR DESCRIPTION
**Description**
This PR fixes an `Uncaught TypeError: Cannot read properties of null` in `toolbar.js` within the `toggleViewsHints` method.

Fixes #9726

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
