### PR TITLE
refactor: fix phpstan errors in `Encryption`

### DIFF
--- a/system/Encryption/EncrypterInterface.php
+++ b/system/Encryption/EncrypterInterface.php
@@ -26,8 +26,8 @@ interface EncrypterInterface
     /**
      * Encrypt - convert plaintext into ciphertext
      *
-     * @param string            $data   Input data
-     * @param array|string|null $params Overridden parameters, specifically the key
+     * @param string                           $data   Input data
+     * @param array<string, mixed>|string|null $params Overridden parameters, specifically the key
      *
      * @return string
      *
@@ -38,8 +38,8 @@ interface EncrypterInterface
     /**
      * Decrypt - convert ciphertext into plaintext
      *
-     * @param string            $data   Encrypted data
-     * @param array|string|null $params Overridden parameters, specifically the key
+     * @param string                           $data   Encrypted data
+     * @param array<string, mixed>|string|null $params Overridden parameters, specifically the key
      *
      * @return string
      *

--- a/system/Encryption/Encryption.php
+++ b/system/Encryption/Encryption.php
@@ -70,7 +70,7 @@ class Encryption
     /**
      * Map of drivers to handler classes, in preference order
      *
-     * @var array
+     * @var list<string>
      */
     protected $drivers = [
         'OpenSSL',
@@ -138,8 +138,14 @@ class Encryption
         $handlerName     = 'CodeIgniter\\Encryption\\Handlers\\' . $this->driver . 'Handler';
         $this->encrypter = new $handlerName($config);
 
-        if (($config->previousKeys ?? []) !== []) {
-            $this->encrypter = new KeyRotationDecorator($this->encrypter, $config->previousKeys);
+        // (array) '' is [''], not [], so the unset default must be filtered out here.
+        $previousKeys = array_values(array_filter(
+            (array) ($config->previousKeys ?? []),
+            static fn ($key): bool => $key !== '',
+        ));
+
+        if ($previousKeys !== []) {
+            $this->encrypter = new KeyRotationDecorator($this->encrypter, $previousKeys);
         }
 
         return $this->encrypter;
@@ -162,7 +168,7 @@ class Encryption
      *
      * @param string $key Property name
      *
-     * @return array|string|null
+     * @return list<string>|string|null
      */
     public function __get($key)
     {

--- a/system/Encryption/Handlers/OpenSSLHandler.php
+++ b/system/Encryption/Handlers/OpenSSLHandler.php
@@ -19,6 +19,9 @@ use SensitiveParameter;
 /**
  * Encryption handling for OpenSSL library
  *
+ * @property-read string $cipher
+ * @property-read string $key
+ *
  * @see \CodeIgniter\Encryption\Handlers\OpenSSLHandlerTest
  */
 class OpenSSLHandler extends BaseHandler
@@ -33,7 +36,7 @@ class OpenSSLHandler extends BaseHandler
     /**
      * List of supported HMAC algorithms
      *
-     * @var array [name => digest size]
+     * @var array<string, int> [name => digest size]
      */
     protected array $digestSize = [
         'SHA224' => 28,

--- a/system/Encryption/Handlers/SodiumHandler.php
+++ b/system/Encryption/Handlers/SodiumHandler.php
@@ -20,6 +20,9 @@ use SodiumException;
 /**
  * SodiumHandler uses libsodium in encryption.
  *
+ * @property-read int         $blockSize
+ * @property-read string|null $key
+ *
  * @see https://github.com/jedisct1/libsodium/issues/392
  * @see \CodeIgniter\Encryption\Handlers\SodiumHandlerTest
  */
@@ -124,7 +127,7 @@ class SodiumHandler extends BaseHandler
     /**
      * Parse the $params before doing assignment.
      *
-     * @param array|string|null $params
+     * @param array<string, mixed>|string|null $params
      *
      * @return void
      *

--- a/system/Encryption/KeyRotationDecorator.php
+++ b/system/Encryption/KeyRotationDecorator.php
@@ -22,6 +22,9 @@ use SensitiveParameter;
  * Wraps any EncrypterInterface implementation to provide automatic
  * fallback to previous encryption keys during decryption. This enables
  * seamless key rotation without requiring re-encryption of existing data.
+ *
+ * @property-read string|null $cipher
+ * @property-read string|null $key
  */
 class KeyRotationDecorator implements EncrypterInterface
 {

--- a/tests/system/Encryption/EncryptionTest.php
+++ b/tests/system/Encryption/EncryptionTest.php
@@ -15,6 +15,7 @@ namespace CodeIgniter\Encryption;
 
 use CodeIgniter\Config\Services as CodeIgniterServices;
 use CodeIgniter\Encryption\Exceptions\EncryptionException;
+use CodeIgniter\Encryption\Handlers\OpenSSLHandler;
 use CodeIgniter\Superglobals;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Encryption as EncryptionConfig;
@@ -156,6 +157,7 @@ final class EncryptionTest extends CIUnitTestCase
 
         $config->key = 'Abracadabra';
         $encrypter   = Services::encrypter($config, true);
+        $this->assertInstanceOf(OpenSSLHandler::class, $encrypter);
         $this->assertSame('anything', $encrypter->key);
     }
 
@@ -166,7 +168,7 @@ final class EncryptionTest extends CIUnitTestCase
 
     public function testMagicIssetFalse(): void
     {
-        $this->assertFalse(isset($this->encryption->bogus));
+        $this->assertFalse(isset($this->encryption->bogus)); // @phpstan-ignore property.notFound
     }
 
     public function testMagicGet(): void
@@ -176,7 +178,7 @@ final class EncryptionTest extends CIUnitTestCase
 
     public function testMagicGetMissing(): void
     {
-        $this->assertNull($this->encryption->bogus);
+        $this->assertNull($this->encryption->bogus); // @phpstan-ignore property.notFound
     }
 
     public function testDecryptEncryptedDataByCI3AES128CBC(): void

--- a/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
+++ b/tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
@@ -46,6 +46,7 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $params->key    = 'Something other than an empty string';
 
         $encrypter = $this->encryption->initialize($params);
+        $this->assertInstanceOf(OpenSSLHandler::class, $encrypter);
 
         $this->assertSame('AES-256-CTR', $encrypter->cipher);
         $this->assertSame('Something other than an empty string', $encrypter->key);
@@ -64,6 +65,7 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $params->key    = '\xd0\xc9\x08\xc4\xde\x52\x12\x6e\xf8\xcc\xdb\x03\xea\xa0\x3a\x5c';
         // Default state (AES-256/Rijndael-256 in CTR mode)
         $encrypter = $this->encryption->initialize($params);
+        $this->assertInstanceOf(OpenSSLHandler::class, $encrypter);
 
         // Was the key properly set?
         $this->assertSame($params->key, $encrypter->key);
@@ -145,6 +147,7 @@ final class OpenSSLHandlerTest extends CIUnitTestCase
         $params->key    = 'original-key-value';
 
         $encrypter = $this->encryption->initialize($params);
+        $this->assertInstanceOf(OpenSSLHandler::class, $encrypter);
 
         $this->assertSame('original-key-value', $encrypter->key);
 

--- a/tests/system/Encryption/Handlers/SodiumHandlerTest.php
+++ b/tests/system/Encryption/Handlers/SodiumHandlerTest.php
@@ -47,10 +47,11 @@ final class SodiumHandlerTest extends CIUnitTestCase
         $this->config->key       = sodium_crypto_secretbox_keygen();
         $this->config->blockSize = 256;
         $encrypter               = $this->encryption->initialize($this->config);
+        $this->assertInstanceOf(SodiumHandler::class, $encrypter);
 
         $this->assertSame($this->config->key, $encrypter->key);
         $this->assertSame($this->config->blockSize, $encrypter->blockSize);
-        $this->assertNull($encrypter->driver);
+        $this->assertNull($encrypter->driver); // @phpstan-ignore property.notFound
     }
 
     public function testEmptyKeyThrowsErrorOnInitialize(): void
@@ -136,6 +137,7 @@ final class SodiumHandlerTest extends CIUnitTestCase
 
         $this->config->key = $originalKey;
         $encrypter         = $this->encryption->initialize($this->config);
+        $this->assertInstanceOf(SodiumHandler::class, $encrypter);
 
         $this->assertSame($originalKey, $encrypter->key);
 

--- a/tests/system/Encryption/KeyRotationDecoratorTest.php
+++ b/tests/system/Encryption/KeyRotationDecoratorTest.php
@@ -193,6 +193,7 @@ final class KeyRotationDecoratorTest extends CIUnitTestCase
         $params->previousKeys = ['old-key'];
 
         $encrypter = $this->encryption->initialize($params);
+        $this->assertInstanceOf(KeyRotationDecorator::class, $encrypter);
 
         $this->assertSame('AES-128-CBC', $encrypter->cipher);
         $this->assertSame('test-key-very-long', $encrypter->key);

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 210 errors
+# total 185 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 139 errors
+# total 127 errors
 
 parameters:
     ignoreErrors:
@@ -161,66 +161,6 @@ parameters:
             message: '#^Property CodeIgniter\\Email\\Email\:\:\$tmpArchive type has no value type specified in iterable type array\.$#'
             count: 1
             path: ../../system/Email/Email.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\EncrypterInterface\:\:decrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/EncrypterInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\EncrypterInterface\:\:encrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/EncrypterInterface.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\Encryption\:\:__get\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Encryption.php
-
-        -
-            message: '#^Property CodeIgniter\\Encryption\\Encryption\:\:\$drivers type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Encryption.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\Handlers\\OpenSSLHandler\:\:decrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Handlers/OpenSSLHandler.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\Handlers\\OpenSSLHandler\:\:encrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Handlers/OpenSSLHandler.php
-
-        -
-            message: '#^Property CodeIgniter\\Encryption\\Handlers\\OpenSSLHandler\:\:\$digestSize type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Handlers/OpenSSLHandler.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\Handlers\\SodiumHandler\:\:decrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Handlers/SodiumHandler.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\Handlers\\SodiumHandler\:\:encrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Handlers/SodiumHandler.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\Handlers\\SodiumHandler\:\:parseParams\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/Handlers/SodiumHandler.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\KeyRotationDecorator\:\:decrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/KeyRotationDecorator.php
-
-        -
-            message: '#^Method CodeIgniter\\Encryption\\KeyRotationDecorator\:\:encrypt\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/Encryption/KeyRotationDecorator.php
 
         -
             message: '#^Method CodeIgniter\\Exceptions\\PageNotFoundException\:\:lang\(\) has parameter \$args with no value type specified in iterable type array\.$#'

--- a/utils/phpstan-baseline/property.notFound.neon
+++ b/utils/phpstan-baseline/property.notFound.neon
@@ -1,52 +1,7 @@
-# total 19 errors
+# total 6 errors
 
 parameters:
     ignoreErrors:
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$key\.$#'
-            count: 1
-            path: ../../tests/system/Encryption/EncryptionTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\Encryption\:\:\$bogus\.$#'
-            count: 2
-            path: ../../tests/system/Encryption/EncryptionTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$cipher\.$#'
-            count: 1
-            path: ../../tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$key\.$#'
-            count: 3
-            path: ../../tests/system/Encryption/Handlers/OpenSSLHandlerTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$blockSize\.$#'
-            count: 1
-            path: ../../tests/system/Encryption/Handlers/SodiumHandlerTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$driver\.$#'
-            count: 1
-            path: ../../tests/system/Encryption/Handlers/SodiumHandlerTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$key\.$#'
-            count: 2
-            path: ../../tests/system/Encryption/Handlers/SodiumHandlerTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$cipher\.$#'
-            count: 1
-            path: ../../tests/system/Encryption/KeyRotationDecoratorTest.php
-
-        -
-            message: '#^Access to an undefined property CodeIgniter\\Encryption\\EncrypterInterface\:\:\$key\.$#'
-            count: 1
-            path: ../../tests/system/Encryption/KeyRotationDecoratorTest.php
-
         -
             message: '#^Access to an undefined property CodeIgniter\\I18n\\TimeLegacy\:\:\$foobar\.$#'
             count: 1


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Fixes the iterable types and property access on `Encryption`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
