### PR TITLE
refactor: fix iterable types in `Router` tests

### DIFF
--- a/tests/system/Router/AutoRouterImprovedTest.php
+++ b/tests/system/Router/AutoRouterImprovedTest.php
@@ -528,6 +528,9 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         ], $router->getPos());
     }
 
+    /**
+     * @return iterable<string, array{string, string|null, string, string, int, int|null, int|null}>
+     */
     public static function provideTranslateUriToCamelCase(): iterable
     {
         yield from [
@@ -587,6 +590,9 @@ final class AutoRouterImprovedTest extends CIUnitTestCase
         $router->getRoute($uri, Method::GET);
     }
 
+    /**
+     * @return iterable<string, array{string, string}>
+     */
     public static function provideRejectTranslateUriToCamelCase(): iterable
     {
         yield from [

--- a/tests/system/Router/DefinedRouteCollectorTest.php
+++ b/tests/system/Router/DefinedRouteCollectorTest.php
@@ -25,6 +25,9 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('Others')]
 final class DefinedRouteCollectorTest extends CIUnitTestCase
 {
+    /**
+     * @param array<non-empty-string, list<non-empty-string>|non-empty-string> $config
+     */
     private function createRouteCollection(array $config = [], ?Modules $moduleConfig = null): RouteCollection
     {
         $defaults = [

--- a/tests/system/Router/RouteCollectionReverseRouteTest.php
+++ b/tests/system/Router/RouteCollectionReverseRouteTest.php
@@ -35,6 +35,10 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
         $this->resetFactories();
     }
 
+    /**
+     * @param array<non-empty-string, list<non-empty-string>|non-empty-string> $config
+     * @param array<array-key, mixed>                                          $files
+     */
     protected function getCollector(array $config = [], array $files = [], ?Modules $moduleConfig = null): RouteCollection
     {
         $defaults = [
@@ -147,6 +151,9 @@ final class RouteCollectionReverseRouteTest extends CIUnitTestCase
         $this->assertSame('/users/15/gallery12', $match);
     }
 
+    /**
+     * @return iterable<string, array{string}>
+     */
     public static function provideReverseRoutingDefaultNamespaceAppController(): iterable
     {
         return yield from [

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -44,6 +44,10 @@ final class RouteCollectionTest extends CIUnitTestCase
         Services::injectMock('superglobals', new Superglobals());
     }
 
+    /**
+     * @param array<non-empty-string, list<non-empty-string>|non-empty-string> $config
+     * @param array<array-key, mixed>                                          $files
+     */
     protected function getCollector(array $config = [], array $files = [], ?Modules $moduleConfig = null): RouteCollection
     {
         $defaults = [
@@ -507,6 +511,9 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutes());
     }
 
+    /**
+     * @param array<string, string> $expected
+     */
     #[DataProvider('provideNestedGroupingWorksWithRootPrefix')]
     public function testNestedGroupingWorksWithRootPrefix(
         string $group,
@@ -531,6 +538,9 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($expected, $routes->getRoutes());
     }
 
+    /**
+     * @return iterable<int, array{string, string, array<string, string>}>
+     */
     public static function provideNestedGroupingWorksWithRootPrefix(): iterable
     {
         yield from [
@@ -1343,6 +1353,10 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($options, ['as' => 'admin', 'foo' => 'baz']);
     }
 
+    /**
+     * @param array<string, string> $options1
+     * @param array<string, string> $options2
+     */
     #[DataProvider('provideRoutesOptionsWithSameFromTwoRoutes')]
     public function testRoutesOptionsWithSameFromTwoRoutes(array $options1, array $options2): void
     {
@@ -1366,6 +1380,9 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame($options, $options1);
     }
 
+    /**
+     * @return iterable<int, array{array<string, string>, array<string, string>}>
+     */
     public static function provideRoutesOptionsWithSameFromTwoRoutes(): iterable
     {
         yield from [
@@ -1860,6 +1877,9 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame('\\' . Product::class, $router->controllerName());
     }
 
+    /**
+     * @return iterable<string, array{string}>
+     */
     public static function provideRouteDefaultNamespace(): iterable
     {
         return [

--- a/tests/system/Router/RouterTest.php
+++ b/tests/system/Router/RouterTest.php
@@ -963,6 +963,9 @@ final class RouterTest extends CIUnitTestCase
         $router->handle($url);
     }
 
+    /**
+     * @return iterable<int, array{string, string, string, string, string, string}>
+     */
     public static function provideRedirectRoute(): iterable
     {
         // [$route, $redirectFrom, $redirectTo, $url, $expectedPath, $alias]

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 168 errors
+# total 153 errors
 
 includes:
     - argument.type.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,4 +1,4 @@
-# total 110 errors
+# total 95 errors
 
 parameters:
     ignoreErrors:
@@ -466,81 +466,6 @@ parameters:
             message: '#^Method CodeIgniter\\RESTful\\ResourceControllerTest\:\:invoke\(\) has parameter \$args with no value type specified in iterable type array\.$#'
             count: 1
             path: ../../tests/system/RESTful/ResourceControllerTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\AutoRouterImprovedTest\:\:provideRejectTranslateUriToCamelCase\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/Router/AutoRouterImprovedTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\AutoRouterImprovedTest\:\:provideTranslateUriToCamelCase\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/Router/AutoRouterImprovedTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\DefinedRouteCollectorTest\:\:createRouteCollection\(\) has parameter \$config with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/DefinedRouteCollectorTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionReverseRouteTest\:\:getCollector\(\) has parameter \$config with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionReverseRouteTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionReverseRouteTest\:\:getCollector\(\) has parameter \$files with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionReverseRouteTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionReverseRouteTest\:\:provideReverseRoutingDefaultNamespaceAppController\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionReverseRouteTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:getCollector\(\) has parameter \$config with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:getCollector\(\) has parameter \$files with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:provideNestedGroupingWorksWithRootPrefix\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:provideRouteDefaultNamespace\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:provideRoutesOptionsWithSameFromTwoRoutes\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:testNestedGroupingWorksWithRootPrefix\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:testRoutesOptionsWithSameFromTwoRoutes\(\) has parameter \$options1 with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouteCollectionTest\:\:testRoutesOptionsWithSameFromTwoRoutes\(\) has parameter \$options2 with no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouteCollectionTest.php
-
-        -
-            message: '#^Method CodeIgniter\\Router\\RouterTest\:\:provideRedirectRoute\(\) return type has no value type specified in iterable type iterable\.$#'
-            count: 1
-            path: ../../tests/system/Router/RouterTest.php
 
         -
             message: '#^Method CodeIgniter\\Throttle\\ThrottleTest\:\:provideTokenTimeCalculationUCs\(\) return type has no value type specified in iterable type iterable\.$#'


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Missed the tests' iterable types on the `Router` pass.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
