### PR TITLE
fix: return 403 for Honeypot bot detection

### DIFF
--- a/system/Honeypot/Exceptions/HoneypotException.php
+++ b/system/Honeypot/Exceptions/HoneypotException.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace CodeIgniter\Honeypot\Exceptions;
 
 use CodeIgniter\Exceptions\ConfigException;
+use CodeIgniter\Exceptions\HTTPExceptionInterface;
 
-class HoneypotException extends ConfigException
+class HoneypotException extends ConfigException implements HTTPExceptionInterface
 {
     /**
      * Thrown when the template value of config is empty.
@@ -24,7 +25,7 @@ class HoneypotException extends ConfigException
      */
     public static function forNoTemplate()
     {
-        return new static(lang('Honeypot.noTemplate'));
+        return new static(lang('Honeypot.noTemplate'), 500);
     }
 
     /**
@@ -34,7 +35,7 @@ class HoneypotException extends ConfigException
      */
     public static function forNoNameField()
     {
-        return new static(lang('Honeypot.noNameField'));
+        return new static(lang('Honeypot.noNameField'), 500);
     }
 
     /**
@@ -46,7 +47,7 @@ class HoneypotException extends ConfigException
      */
     public static function forNoHiddenValue()
     {
-        return new static(lang('Honeypot.noHiddenValue'));
+        return new static(lang('Honeypot.noHiddenValue'), 500);
     }
 
     /**
@@ -56,6 +57,6 @@ class HoneypotException extends ConfigException
      */
     public static function isBot()
     {
-        return new static(lang('Honeypot.theClientIsABot'));
+        return new static(lang('Honeypot.theClientIsABot'), 403);
     }
 }

--- a/tests/system/Debug/ExceptionsTest.php
+++ b/tests/system/Debug/ExceptionsTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Entity\Exceptions\CastException;
 use CodeIgniter\Exceptions\ConfigException;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Exceptions\RuntimeException;
+use CodeIgniter\Honeypot\Exceptions\HoneypotException;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\ReflectionHelper;
 use Config\Exceptions as ExceptionsConfig;
@@ -124,6 +125,7 @@ final class ExceptionsTest extends CIUnitTestCase
         $this->assertSame([500, EXIT_CONFIG], $determineCodes(new ConfigException('This.')));
         $this->assertSame([500, EXIT_CONFIG], $determineCodes(CastException::forInvalidInterface('This.')));
         $this->assertSame([500, EXIT_DATABASE], $determineCodes(new DatabaseException('This.')));
+        $this->assertSame([403, EXIT_CONFIG], $determineCodes(HoneypotException::isBot()));
     }
 
     public function testMaskSensitiveData(): void

--- a/tests/system/Honeypot/HoneypotTest.php
+++ b/tests/system/Honeypot/HoneypotTest.php
@@ -153,6 +153,7 @@ final class HoneypotTest extends CIUnitTestCase
     {
         $this->config->template = '';
         $this->expectException(HoneypotException::class);
+        $this->expectExceptionCode(500);
         $this->honeypot = new Honeypot($this->config);
     }
 
@@ -160,6 +161,7 @@ final class HoneypotTest extends CIUnitTestCase
     {
         $this->config->name = '';
         $this->expectException(HoneypotException::class);
+        $this->expectExceptionCode(500);
         $this->honeypot = new Honeypot($this->config);
     }
 
@@ -173,6 +175,7 @@ final class HoneypotTest extends CIUnitTestCase
         $uri     = 'admin/foo/bar';
 
         $this->expectException(HoneypotException::class);
+        $this->expectExceptionCode(403);
         $filters->run($uri, 'before');
     }
 

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -37,6 +37,7 @@ Bugs Fixed
 - **CLIRequest:** Fixed a bug where ``parseCommand()`` could throw a TypeError when ``argv`` is missing.
 - **Content Security Policy:** Fixed a bug where empty ``Content-Security-Policy``, ``Content-Security-Policy-Report-Only``, and ``Reporting-Endpoints`` response headers were generated when no corresponding values existed.
 - **Helpers:** Fixed a bug where ``get_dir_file_info()`` returned incomplete entries for subdirectories and missing files instead of omitting them.
+- **Honeypot:** Fixed a bug where bot detection returned an HTTP 500 response instead of 403 (Forbidden).
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
 
 See the repo's

--- a/user_guide_src/source/libraries/honeypot.rst
+++ b/user_guide_src/source/libraries/honeypot.rst
@@ -5,7 +5,8 @@ Honeypot Class
 The Honeypot Class makes it possible to determine when a Bot makes a request to a CodeIgniter4 application,
 if it's enabled in **app/Config/Filters.php** file. This is done by attaching form fields to any form,
 and this form field is hidden from a human but accessible to a Bot. When data is entered into the field, it's
-assumed the request is coming from a Bot, and you can throw a ``HoneypotException``.
+assumed the request is coming from a Bot. The bundled Honeypot filter throws a ``HoneypotException`` with
+an HTTP status code of 403 (Forbidden).
 
 .. contents::
     :local:


### PR DESCRIPTION
**Description**
This PR fixes a bug where Honeypot bot detection caused an HTTP 500 response instead of 403 Forbidden.

`HoneypotException` now implements `HTTPExceptionInterface`, allowing the exception handler to use its exception code as the HTTP status code.

Fixes #10489

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
