### PR TITLE
fix: `RedirectException` no longer defaults to a 302 status code

### DIFF
--- a/system/HTTP/Exceptions/RedirectException.php
+++ b/system/HTTP/Exceptions/RedirectException.php
@@ -26,10 +26,12 @@ use Throwable;
  */
 class RedirectException extends RuntimeException implements ExceptionInterface, ResponsableInterface, HTTPExceptionInterface
 {
+    private const DEFAULT_STATUS_CODE = 302;
+
     /**
      * Status code applied to a Response whose status is outside the 301-308 range.
      */
-    protected int $defaultStatusCode = 302;
+    protected int $defaultStatusCode = self::DEFAULT_STATUS_CODE;
 
     protected ?ResponseInterface $response = null;
 
@@ -37,7 +39,7 @@ class RedirectException extends RuntimeException implements ExceptionInterface, 
      * @param ResponseInterface|string $message Response object or a string containing a relative URI.
      * @param int                      $code    HTTP status code to redirect if $message is a string.
      */
-    public function __construct($message = '', int $code = 0, ?Throwable $previous = null)
+    public function __construct($message = '', int $code = self::DEFAULT_STATUS_CODE, ?Throwable $previous = null)
     {
         if (! is_string($message) && ! $message instanceof ResponseInterface) {
             throw new InvalidArgumentException(

--- a/tests/system/HTTP/RedirectExceptionTest.php
+++ b/tests/system/HTTP/RedirectExceptionTest.php
@@ -88,6 +88,17 @@ final class RedirectExceptionTest extends TestCase
         $this->assertSame(307, $response->getStatusCode());
     }
 
+    public function testStringMessageWithoutExplicitCodeDefaultsTo302(): void
+    {
+        $exception = new RedirectException('relative/uri');
+
+        $this->assertSame(302, $exception->getCode());
+
+        $response = $exception->getResponse();
+
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
     public function testLoggingLocationHeader(): void
     {
         Time::setTestNow('2023-11-25 12:00:00');


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Adds a regression fix to #10465. #10465 dropped `RedirectException`'s `$code` default, so a bare `new RedirectException($uri)` now throws instead of redirecting with 302. Restores the default via a shared constant.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
