### PR TITLE
refactor: replace anonymous class with bound closure in `PropertiesTrait`

### DIFF
--- a/system/Traits/PropertiesTrait.php
+++ b/system/Traits/PropertiesTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Traits;
 
+use Closure;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -48,17 +49,11 @@ trait PropertiesTrait
      */
     final public function getPublicProperties(): array
     {
-        $worker = new class () {
-            /**
-             * @return array<string, mixed>
-             */
-            public function getProperties(object $obj): array
-            {
-                return get_object_vars($obj);
-            }
-        };
+        $fn = fn (): array => get_object_vars($this);
 
-        return $worker->getProperties($this);
+        $bound = Closure::bind($fn, $this, null);
+
+        return $bound();
     }
 
     /**

--- a/utils/phpstan-baseline/loader.neon
+++ b/utils/phpstan-baseline/loader.neon
@@ -1,4 +1,4 @@
-# total 13 errors
+# total 12 errors
 
 includes:
     - arguments.count.neon
@@ -6,6 +6,5 @@ includes:
     - deadCode.unreachable.neon
     - function.resultUnused.neon
     - method.childReturnType.neon
-    - missingType.iterableValue.neon
     - property.defaultValue.neon
     - property.phpDocType.neon

--- a/utils/phpstan-baseline/missingType.iterableValue.neon
+++ b/utils/phpstan-baseline/missingType.iterableValue.neon
@@ -1,8 +1,0 @@
-# total 1 error
-
-parameters:
-    ignoreErrors:
-        -
-            message: '#^Method class@anonymous/system/Traits/PropertiesTrait\.php\:51\:\:getProperties\(\) return type has no value type specified in iterable type array\.$#'
-            count: 1
-            path: ../../system/View/Cells/Cell.php


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
This one needs a bit of decision.

This refactors `PropertiesTrait::getPublicProperties()` to use a bound Closure instead of an anonymous class in order to delete the 1 remaining `missingType.iterableValue` error. The other solution was to use reflection similar to `getNonPublicProperties()` approach, but here's the bench:

200k iterations each, on an object with 5 public + 1 protected + 1 private property:

| Approach         | Time              | Per call |
|------------------|-------------------|----------|
| Anonymous class  | 0.2721s / 0.2815s | ~1.4μs   |
| Bound closure    | 0.3541s           | ~1.77μs  |
| Reflection       | 1.2148s / 1.2236s | ~6.1μs   |

Bound closure is ~26% slower than the anonymous class but ~3.5x faster than reflection.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
