### PR TITLE
fix: strip the table prefix correctly when rebuilding a SQLite3 table

### DIFF
--- a/system/Database/SQLite3/Table.php
+++ b/system/Database/SQLite3/Table.php
@@ -333,9 +333,16 @@ class Table
         }
 
         foreach ($this->foreignKeys as $foreignKey) {
+            $foreignTableName = $foreignKey->foreign_table_name;
+            $prefix           = $this->db->DBPrefix;
+
+            if ($prefix !== '' && str_starts_with($foreignTableName, $prefix)) {
+                $foreignTableName = substr($foreignTableName, strlen($prefix));
+            }
+
             $this->forge->addForeignKey(
                 $foreignKey->column_name,
-                trim($foreignKey->foreign_table_name, $this->db->DBPrefix),
+                $foreignTableName,
                 $foreignKey->foreign_column_name,
             );
         }

--- a/tests/system/Database/Live/SQLite3/AlterTableTest.php
+++ b/tests/system/Database/Live/SQLite3/AlterTableTest.php
@@ -271,6 +271,68 @@ final class AlterTableTest extends CIUnitTestCase
         $this->seeInDatabase('foo', ['email' => 'funkalicious@example.com']);
     }
 
+    public function testDropColumnKeepsForeignKeyTableNameWhenPrefixIsSet(): void
+    {
+        $config = [
+            'DBDriver' => 'SQLite3',
+            'database' => ':memory:',
+            'DBDebug'  => true,
+            'DBPrefix' => 'db_',
+        ];
+
+        $db = db_connect($config, false);
+        $this->assertInstanceOf(Connection::class, $db);
+
+        $forge = Database::forge($db);
+        $this->assertInstanceOf(Forge::class, $forge);
+
+        // The referenced table must begin with a character that also appears in
+        // the prefix, or the prefix stripping cannot damage its name.
+        $forge->addField([
+            'id' => [
+                'type'           => 'integer',
+                'constraint'     => 11,
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+        ]);
+        $forge->addPrimaryKey('id');
+        $forge->createTable('bandit_fk');
+
+        $forge->addField([
+            'id' => [
+                'type'           => 'integer',
+                'constraint'     => 11,
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+            'key_id' => [
+                'type'       => 'integer',
+                'constraint' => 11,
+                'unsigned'   => true,
+            ],
+            'name' => [
+                'type'       => 'varchar',
+                'constraint' => 255,
+                'null'       => true,
+            ],
+        ]);
+        $forge->addPrimaryKey('id');
+        $forge->addForeignKey('key_id', 'bandit_fk', 'id');
+        $forge->createTable('bandit');
+
+        // Dropping a column rebuilds the table, recreating its foreign keys.
+        $this->assertTrue($forge->dropColumn('bandit', 'name'));
+
+        $keys = array_values($db->getForeignKeyData('bandit'));
+
+        $this->assertCount(1, $keys);
+        $this->assertSame($db->DBPrefix . 'bandit_fk', $keys[0]->foreign_table_name);
+
+        $forge->dropTable('bandit', true);
+        $forge->dropTable('bandit_fk', true);
+    }
+
     protected function createTable(string $tableName = 'foo'): void
     {
         // Create support table for foreign keys

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -42,6 +42,7 @@ Bugs Fixed
 - **CodeIgniter:** Fixed a bug where ``gatherOutput()`` could be called twice when ``startController()`` returned a ``ResponseInterface`` (e.g., from filter attributes or closure routes).
 - **Content Security Policy:** Fixed a bug where empty ``Content-Security-Policy``, ``Content-Security-Policy-Report-Only``, and ``Reporting-Endpoints`` response headers were generated when no corresponding values existed.
 - **Cookie:** Fixed a bug where ``Cookie`` instances created with ``raw: true`` allowed invalid characters in cookie values rejected by ``setrawcookie()``.
+- **Database:** Fixed a bug where rebuilding a SQLite3 table (e.g., ``Forge::dropColumn()``, ``Forge::modifyColumn()``, ``Forge::dropForeignKey()`` and ``Forge::dropPrimaryKey()``) corrupted the table names referenced by its foreign keys when ``DBPrefix`` was set.
 - **Files:** Fixed a bug where ``File::move()`` and ``UploadedFile::move()`` set executable and overly permissive file permissions (``0777 & ~umask()`` instead of ``0666 & ~umask()``), and ``UploadedFile::move()`` targeted the parent directory instead of the destination file for ``chmod()``.
 - **Helpers:** Fixed a bug where ``get_dir_file_info()`` returned incomplete entries for subdirectories and missing files instead of omitting them.
 - **Honeypot:** Fixed a bug where bot detection returned an HTTP 500 response instead of 403 (Forbidden).


### PR DESCRIPTION
Fixes #10508 
SQLite cannot alter or drop a column in place, so `SQLite3\Table` rebuilds the whole table and recreates its foreign keys from the metadata it collected. That metadata holds prefixed table names, and `createTable()` stripped the prefix with `trim($name, $this->db->DBPrefix)`.

`trim()`'s second argument is a set of characters, not a prefix. It removes any of those characters from either end of the string, repeatedly, so with the prefix `db_` it turns `db_bandit_fk` into `andit_fk` — the leading `b` of the table's own name is eaten as well, and characters are stripped from the end too.

The rebuilt table's foreign keys then reference tables that do not exist. Nothing fails at that point, because foreign key enforcement is off for the duration of the rebuild; the error surfaces at the next write to the referenced table, naming a table that appears nowhere in the schema. Whether a given table is affected depends on which characters its name happens to begin and end with, so most tables come through untouched.

Strip the prefix the way `fromTable()` in the same class already does.

The existing tests could not catch this: `AlterTableTest` builds its own connection without a `DBPrefix`, and the damage is invisible until the constraint is used. The regression test therefore sets a prefix and names the referenced table so that it begins with a character the prefix also contains, which is what makes the bug reproduce.

<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [X] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
