### PR TITLE
docs: fix UPLOAD_ERR_XXX typo in UploadedFile docblocks

### DIFF
--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -57,7 +57,7 @@ class UploadedFile extends File implements UploadedFileInterface
 
     /**
      * The error constant of the upload
-     * (one of PHP's UPLOADERRXXX constants)
+     * (one of PHP's UPLOAD_ERR_XXX constants)
      *
      * @var int|null
      */
@@ -77,7 +77,7 @@ class UploadedFile extends File implements UploadedFileInterface
      * @param string      $originalName The client-provided filename.
      * @param string|null $mimeType     The type of file as provided by PHP
      * @param int|null    $size         The size of the file, in bytes
-     * @param int|null    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param int|null    $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
      * @param string|null $clientPath   The webkit relative path of the uploaded file.
      */
     public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null)

--- a/system/HTTP/Files/UploadedFileInterface.php
+++ b/system/HTTP/Files/UploadedFileInterface.php
@@ -32,7 +32,7 @@ interface UploadedFileInterface
      * @param string      $originalName The client-provided filename.
      * @param string|null $mimeType     The type of file as provided by PHP
      * @param int|null    $size         The size of the file, in bytes
-     * @param int|null    $error        The error constant of the upload (one of PHP's UPLOADERRXXX constants)
+     * @param int|null    $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
      * @param string|null $clientPath   The webkit relative path of the uploaded file.
      */
     public function __construct(string $path, string $originalName, ?string $mimeType = null, ?int $size = null, ?int $error = null, ?string $clientPath = null);


### PR DESCRIPTION
Small docblock fix, nothing functional.

The `$error` param/property docs in `UploadedFile` and
`UploadedFileInterface` call it "UPLOADERRXXX" (no underscores), but the
real PHP constant is `UPLOAD_ERR_XXX`. You can tell it's just a typo
because a few lines down in the same files, the `getError()` docblock
already spells it correctly.

**What I changed:**
- Fixed the typo in 3 spots across `UploadedFile.php` and
  `UploadedFileInterface.php`

No code behavior changes, just the doc comments.

Let me check on the gh auth login status while you've got this.