### PR TITLE
fix: Memcached decrement() gives the wrong sign on a missing key

### DIFF
--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -180,10 +180,10 @@ class MemcachedHandler extends BaseHandler
 
         $key = static::validateKey($key, $this->prefix);
 
-        // Memcached counters are unsigned, so a missing key can't be
-        // initialized to a negative value like the other handlers do.
-        // Fall back to Memcached::decrement()'s own default of 0 instead
-        // of $offset, so a new key no longer starts positive.
+        // Memcached counters are unsigned and saturate at 0, so a missing
+        // key can only ever be initialized to 0, never a negative value.
+        // Use Memcached::decrement()'s own default of 0 as the initial
+        // value instead of $offset, so a new key no longer starts positive.
         return $this->memcached->decrement($key, $offset, 0, 60);
     }
 

--- a/system/Cache/Handlers/MemcachedHandler.php
+++ b/system/Cache/Handlers/MemcachedHandler.php
@@ -180,9 +180,11 @@ class MemcachedHandler extends BaseHandler
 
         $key = static::validateKey($key, $this->prefix);
 
-        // FIXME: third parameter isn't other handler actions.
-
-        return $this->memcached->decrement($key, $offset, $offset, 60);
+        // Memcached counters are unsigned, so a missing key can't be
+        // initialized to a negative value like the other handlers do.
+        // Fall back to Memcached::decrement()'s own default of 0 instead
+        // of $offset, so a new key no longer starts positive.
+        return $this->memcached->decrement($key, $offset, 0, 60);
     }
 
     public function clean(): bool

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -154,7 +154,9 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
         // A key that doesn't exist yet starts at 0, not at the offset
         // (Memcached counters are unsigned, so it can't start negative).
         $this->assertSame(0, $memcachedHandler->decrement(self::$key3, 5));
-        $this->assertSame(0, $memcachedHandler->get(self::$key3));
+        // Memcached stores counter values as decimal strings on the wire, so
+        // a plain get() on a counter key returns a string, not an int.
+        $this->assertSame('0', $memcachedHandler->get(self::$key3));
     }
 
     public function testClean(): void

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -151,7 +151,9 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
 
         $this->assertSame(9, $memcachedHandler->decrement(self::$key1, 1));
         $this->assertFalse($memcachedHandler->decrement(self::$key2, 1));
-        $this->assertSame(1, $memcachedHandler->decrement(self::$key3, 1));
+        // A key that doesn't exist yet starts at 0, not at the offset
+        // (Memcached counters are unsigned, so it can't start negative).
+        $this->assertSame(0, $memcachedHandler->decrement(self::$key3, 1));
     }
 
     public function testClean(): void

--- a/tests/system/Cache/Handlers/MemcachedHandlerTest.php
+++ b/tests/system/Cache/Handlers/MemcachedHandlerTest.php
@@ -153,7 +153,8 @@ final class MemcachedHandlerTest extends AbstractHandlerTestCase
         $this->assertFalse($memcachedHandler->decrement(self::$key2, 1));
         // A key that doesn't exist yet starts at 0, not at the offset
         // (Memcached counters are unsigned, so it can't start negative).
-        $this->assertSame(0, $memcachedHandler->decrement(self::$key3, 1));
+        $this->assertSame(0, $memcachedHandler->decrement(self::$key3, 5));
+        $this->assertSame(0, $memcachedHandler->get(self::$key3));
     }
 
     public function testClean(): void

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -39,6 +39,7 @@ Bugs Fixed
 - **Helpers:** Fixed a bug where ``get_dir_file_info()`` returned incomplete entries for subdirectories and missing files instead of omitting them.
 - **Honeypot:** Fixed a bug where bot detection returned an HTTP 500 response instead of 403 (Forbidden).
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
+- **Cache:** Fixed a bug where ``MemcachedHandler::decrement()`` on a non-existent key returned a positive value instead of ``0``, the opposite sign of what ``FileHandler``, ``RedisHandler``, and ``PredisHandler`` return.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -39,7 +39,7 @@ Bugs Fixed
 - **Helpers:** Fixed a bug where ``get_dir_file_info()`` returned incomplete entries for subdirectories and missing files instead of omitting them.
 - **Honeypot:** Fixed a bug where bot detection returned an HTTP 500 response instead of 403 (Forbidden).
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.
-- **Cache:** Fixed a bug where ``MemcachedHandler::decrement()`` on a non-existent key returned a positive value instead of ``0``, the opposite sign of what ``FileHandler``, ``RedisHandler``, and ``PredisHandler`` return.
+- **Cache:** Fixed ``MemcachedHandler::decrement()`` initializing a non-existent counter to the positive offset. Missing counters are now initialized to ``0``, reflecting Memcached's unsigned, saturating counter semantics.
 
 See the repo's
 `CHANGELOG.md <https://github.com/codeigniter4/CodeIgniter4/blob/develop/CHANGELOG.md>`_

--- a/user_guide_src/source/libraries/caching.rst
+++ b/user_guide_src/source/libraries/caching.rst
@@ -212,6 +212,11 @@ Class Reference
 
         .. literalinclude:: caching/008.php
 
+        .. important:: Memcached counters are unsigned and saturate at ``0`` instead of
+            going negative. Decrementing a key that does not yet exist initializes it
+            to ``0`` (rather than ``-$offset``, as the File, Redis, and Predis handlers
+            do), and decrementing an existing counter below ``0`` clamps it at ``0``.
+
     .. php:method:: clean()
 
         :returns: ``true`` on success, ``false`` on failure


### PR DESCRIPTION
Fixes #10510 (https://github.com/codeigniter4/CodeIgniter4/issues/10510)

Small follow-up to that issue: `MemcachedHandler::decrement()` was passing
`$offset` as the initial value for a key that doesn't exist yet, which made
a fresh key end up at `+$offset` instead of `-$offset` like every other
cache handler (File, Redis, Predis) gives you.

I swapped it to use `0` instead, since Memcached counters are unsigned and
can't actually go negative — so `0` is the closest sane starting point,
and it matches what `Memcached::decrement()` already defaults to on its
own.

**What I changed:**
- `MemcachedHandler::decrement()` now passes `0` instead of `$offset` as
  the initial value
- Updated the one test that was asserting the old (backwards) behavior
- Added a changelog entry
