### PR TITLE
docs: clarify Entity array casts

### DIFF
--- a/user_guide_src/source/models/entities.rst
+++ b/user_guide_src/source/models/entities.rst
@@ -287,6 +287,10 @@ the value whenever the property is set:
 
 .. literalinclude:: entities/014.php
 
+.. warning:: The ``array`` cast uses PHP serialization. Only read values previously
+    written through the same Entity cast. Never store untrusted serialized strings
+    directly in an ``array``-cast field.
+
 CSV Casting
 -----------
 


### PR DESCRIPTION
**Description**
This PR clarifies that Entity `array` casts use PHP serialization and should only read values previously written through the same cast.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide