### PR TITLE
refactor(Router): remove inappropriate input transformation from RouteCollection identifiers

### DIFF
--- a/system/Router/RouteCollection.php
+++ b/system/Router/RouteCollection.php
@@ -404,22 +404,21 @@ class RouteCollection implements RouteCollectionInterface
 
     public function setDefaultNamespace(string $value): RouteCollectionInterface
     {
-        $this->defaultNamespace = esc(strip_tags($value));
-        $this->defaultNamespace = rtrim($this->defaultNamespace, '\\') . '\\';
+        $this->defaultNamespace = rtrim($value, '\\') . '\\';
 
         return $this;
     }
 
     public function setDefaultController(string $value): RouteCollectionInterface
     {
-        $this->defaultController = esc(strip_tags($value));
+        $this->defaultController = $value;
 
         return $this;
     }
 
     public function setDefaultMethod(string $value): RouteCollectionInterface
     {
-        $this->defaultMethod = esc(strip_tags($value));
+        $this->defaultMethod = $value;
 
         return $this;
     }
@@ -754,7 +753,7 @@ class RouteCollection implements RouteCollectionInterface
         // If a new controller is specified, then we replace the
         // $name value with the name of the new controller.
         if (isset($options['controller'])) {
-            $newName = ucfirst(esc(strip_tags($options['controller'])));
+            $newName = ucfirst($options['controller']);
         }
 
         // In order to allow customization of allowed id values
@@ -848,7 +847,7 @@ class RouteCollection implements RouteCollectionInterface
         // If a new controller is specified, then we replace the
         // $name value with the name of the new controller.
         if (isset($options['controller'])) {
-            $newName = ucfirst(esc(strip_tags($options['controller'])));
+            $newName = ucfirst($options['controller']);
         }
 
         // In order to allow customization of allowed id values

--- a/tests/system/Router/RouteCollectionTest.php
+++ b/tests/system/Router/RouteCollectionTest.php
@@ -272,12 +272,36 @@ final class RouteCollectionTest extends CIUnitTestCase
         $this->assertSame('godzilla', $routes->getDefaultController());
     }
 
+    public function testSetDefaultControllerPreservesSpecialCharacters(): void
+    {
+        $routes = $this->getCollector();
+        $routes->setDefaultController('Foo&Bar');
+
+        $this->assertSame('Foo&Bar', $routes->getDefaultController());
+    }
+
     public function testSetDefaultMethodStoresIt(): void
     {
         $routes = $this->getCollector();
         $routes->setDefaultMethod('biggerBox');
 
         $this->assertSame('biggerBox', $routes->getDefaultMethod());
+    }
+
+    public function testSetDefaultMethodPreservesSpecialCharacters(): void
+    {
+        $routes = $this->getCollector();
+        $routes->setDefaultMethod('get&set');
+
+        $this->assertSame('get&set', $routes->getDefaultMethod());
+    }
+
+    public function testSetDefaultNamespacePreservesSpecialCharacters(): void
+    {
+        $routes = $this->getCollector();
+        $routes->setDefaultNamespace('App\Controllers&Services');
+
+        $this->assertSame('App\Controllers&Services\\', $routes->getDefaultNamespace());
     }
 
     public function testTranslateURIDashesWorks(): void
@@ -732,7 +756,7 @@ final class RouteCollectionTest extends CIUnitTestCase
         service('request')->setMethod(Method::GET);
         $routes = $this->getCollector();
 
-        $routes->resource('photos', ['controller' => '<script>gallery']);
+        $routes->resource('photos', ['controller' => 'gallery']);
 
         $expected = [
             'photos'           => '\Gallery::index',
@@ -742,6 +766,51 @@ final class RouteCollectionTest extends CIUnitTestCase
         ];
 
         $this->assertSame($expected, $routes->getRoutes());
+    }
+
+    public function testPresenterWithCustomController(): void
+    {
+        service('request')->setMethod(Method::GET);
+        $routes = $this->getCollector();
+
+        $routes->presenter('photos', ['controller' => 'gallery']);
+
+        $expected = [
+            'photos'             => '\Gallery::index',
+            'photos/show/(.*)'   => '\Gallery::show/$1',
+            'photos/new'         => '\Gallery::new',
+            'photos/edit/(.*)'   => '\Gallery::edit/$1',
+            'photos/remove/(.*)' => '\Gallery::remove/$1',
+            'photos/(.*)'        => '\Gallery::show/$1',
+        ];
+
+        $this->assertSame($expected, $routes->getRoutes());
+    }
+
+    #[DataProvider('provideGeneratedRouteDoesNotTransformCustomController')]
+    public function testGeneratedRouteDoesNotTransformCustomController(string $method): void
+    {
+        service('request')->setMethod(Method::GET);
+        $routes = $this->getCollector();
+
+        $routes->{$method}('photos', [
+            'controller' => 'gallery&<b>archive</b>',
+        ]);
+
+        $this->assertSame(
+            '\Gallery&<b>archive</b>::index',
+            $routes->getRoutes()['photos'],
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideGeneratedRouteDoesNotTransformCustomController(): iterable
+    {
+        yield 'resource' => ['resource'];
+
+        yield 'presenter' => ['presenter'];
     }
 
     public function testResourcesWithCustomPlaceholder(): void

--- a/user_guide_src/source/changelogs/v4.8.0.rst
+++ b/user_guide_src/source/changelogs/v4.8.0.rst
@@ -43,6 +43,7 @@ Behavior Changes
   (e.g., ``GET``, ``POST``). Lowercase method names (e.g., ``post``) will no longer match.
 - **HTTP:** Routes defined with ``$routes->add()`` now also match HTTP ``QUERY`` requests. If the route has CSRF protection, remember that CSRF verification does not protect safe methods such as ``GET`` and ``QUERY``.
 - **HTTP:** ``CodeIgniter\HTTP\Exceptions\RedirectException`` no longer redeclares the inherited ``$code`` property. The status applied to a ``Response`` passed to the constructor whose status is outside the 301-308 range now comes from the new ``protected int $defaultStatusCode = 302`` property. Subclasses that overrode ``$code`` to change that status must override ``$defaultStatusCode`` instead.
+- **Router:** ``RouteCollection`` no longer applies ``esc(strip_tags())`` to namespace, controller, or method values, including controller options passed to ``resource()`` and ``presenter()``. Applications relying on this implicit transformation must preprocess these values before passing them to the router.
 - **Testing:** Tests using the ``FeatureTestTrait`` must now use uppercase HTTP method names when performing a request when using the ``call()`` method directly
   (e.g., ``$this->call('GET', '/path')`` instead of ``$this->call('get', '/path')``). Additionally, setting method-based routes using ``withRoutes()`` must
   also use uppercase method names (e.g., ``$this->withRoutes([['GET', 'home', 'Home::index']])``).

--- a/user_guide_src/source/installation/upgrade_480.rst
+++ b/user_guide_src/source/installation/upgrade_480.rst
@@ -103,6 +103,16 @@ RedirectException Default Status Code
         protected int $defaultStatusCode = 307;
     }
 
+RouteCollection Identifier Transformation
+=========================================
+
+``RouteCollection`` no longer applies ``esc(strip_tags())`` to namespace,
+controller, and method values, including custom controllers passed to
+``resource()`` and ``presenter()``. Applications relying on HTML tags being
+stripped or special characters being HTML-encoded must preprocess these values
+before passing them to the router. Values originating from untrusted sources
+should be restricted to an explicit allowlist of permitted handlers.
+
 *********************
 Breaking Enhancements
 *********************


### PR DESCRIPTION
**Description**
Removes inappropriate `esc(strip_tags())` input transformations from `RouteCollection` default setters as well as `resource()` and `presenter()` controller options so that internal PHP identifiers are preserved without HTML entity conversion or tag stripping.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide