### PR TITLE
fix: correct file permissions and chmod target in File and UploadedFile move()

### DIFF
--- a/system/Files/File.php
+++ b/system/Files/File.php
@@ -170,7 +170,7 @@ class File extends SplFileInfo
             throw FileException::forUnableToMove($this->getBasename(), $targetPath, strip_tags($error['message']));
         }
 
-        @chmod($destination, 0777 & ~umask());
+        @chmod($destination, 0666 & ~umask());
 
         return new self($destination);
     }

--- a/system/HTTP/Files/UploadedFile.php
+++ b/system/HTTP/Files/UploadedFile.php
@@ -159,7 +159,7 @@ class UploadedFile extends File implements UploadedFileInterface
             throw HTTPException::forMoveFailed(basename($this->path), $targetPath, $message);
         }
 
-        @chmod($targetPath, 0777 & ~umask());
+        @chmod($destination, 0666 & ~umask());
 
         // Success, so store our new information
         $this->path = $targetPath;

--- a/tests/system/Files/FileWithVfsTest.php
+++ b/tests/system/Files/FileWithVfsTest.php
@@ -150,4 +150,13 @@ final class FileWithVfsTest extends CIUnitTestCase
         $this->assertInstanceOf(File::class, $file);
         $this->assertSame($destination . '/apple.php', $file->getPathname());
     }
+
+    public function testMovePermissions(): void
+    {
+        $destination = $this->start . 'baker';
+        $this->file->move($destination);
+
+        $expectedPerms = 0666 & ~umask();
+        $this->assertSame($expectedPerms, $this->root->getChild('baker/apple.php')->getPermissions());
+    }
 }

--- a/tests/system/HTTP/Files/FileMovingTest.php
+++ b/tests/system/HTTP/Files/FileMovingTest.php
@@ -98,6 +98,7 @@ final class FileMovingTest extends CIUnitTestCase
 
         $this->assertTrue($this->root->hasChild('destination/' . $finalFilename . '.txt'));
         $this->assertTrue($this->root->hasChild('destination/' . $finalFilename . '_1.txt'));
+        $this->assertSame(0666 & ~umask(), $this->root->getChild('destination/' . $finalFilename . '.txt')->getPermissions());
     }
 
     public function testMoveSanitizesClientNameByDefault(): void

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -41,6 +41,7 @@ Bugs Fixed
 - **CLIRequest:** Fixed a bug where ``parseCommand()`` could throw a TypeError when ``argv`` is missing.
 - **Content Security Policy:** Fixed a bug where empty ``Content-Security-Policy``, ``Content-Security-Policy-Report-Only``, and ``Reporting-Endpoints`` response headers were generated when no corresponding values existed.
 - **Cookie:** Fixed a bug where ``Cookie`` instances created with ``raw: true`` allowed invalid characters in cookie values rejected by ``setrawcookie()``.
+- **Files:** Fixed a bug where ``File::move()`` and ``UploadedFile::move()`` set executable and overly permissive file permissions (``0777 & ~umask()`` instead of ``0666 & ~umask()``), and ``UploadedFile::move()`` targeted the parent directory instead of the destination file for ``chmod()``.
 - **Helpers:** Fixed a bug where ``get_dir_file_info()`` returned incomplete entries for subdirectories and missing files instead of omitting them.
 - **Honeypot:** Fixed a bug where bot detection returned an HTTP 500 response instead of 403 (Forbidden).
 - **Logger:** Fixed a bug where interpolating a log message with array or non-stringable context values could raise PHP warnings or errors.


### PR DESCRIPTION
**Description**

Fixes file permission issues when moving files:
- Replaced `0777 & ~umask()` with `0666 & ~umask()` in `File::move()` and `UploadedFile::move()` to prevent regular files from being marked as executable (`+x`).
- Fixed `UploadedFile::move()` chmodding `$targetPath` (directory) instead of `$destination` (file).
- Added unit test assertions for file permissions after `move()`.
- Updated v4.7.5 changelog.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
