### PR TITLE
chore: Move phpstan.dist.neon order in rector.php config to avoid tmp/schema.php created on run

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -69,10 +69,10 @@ return RectorConfig::configure()
         __DIR__ . '/phpstan-bootstrap.php',
     ])
     ->withPHPStanConfigs([
-        __DIR__ . '/phpstan.dist.neon',
         __DIR__ . '/vendor/codeigniter/phpstan-codeigniter/extension.neon',
         __DIR__ . '/vendor/phpstan/phpstan-strict-rules/rules.neon',
         __DIR__ . '/vendor/shipmonk/phpstan-baseline-per-identifier/extension.neon',
+        __DIR__ . '/phpstan.dist.neon',
     ])
     // is there a file you need to skip?
     ->withSkip([


### PR DESCRIPTION

<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**

When I run: 

```bash
vendor/bin/rector
```

It cause `tmp/schema.php` created. It seems due to `phpstan.dist.neon` is loaded early. This PR move it to the last and it seems fix it.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
