### PR TITLE
fix: return an empty string when readline() reaches end-of-file

### DIFF
--- a/system/CLI/InputOutput.php
+++ b/system/CLI/InputOutput.php
@@ -46,14 +46,14 @@ class InputOutput
             // @codeCoverageIgnoreStart
             $prompt = $this->readlinePrompt($prefix, readline_info('library_version'));
 
-            if ($prompt !== null) {
-                return readline($prompt);
+            if ($prompt === null) {
+                // The library cannot render the prompt, so write it ourselves and let readline() only read the line.
+                self::fwrite(STDOUT, $prefix ?? '');
             }
 
-            // The library cannot render the prompt, so write it ourselves and let readline() only read the line.
-            self::fwrite(STDOUT, $prefix ?? '');
+            $input = readline($prompt);
 
-            return readline();
+            return $input === false ? '' : $input;
             // @codeCoverageIgnoreEnd
         }
 

--- a/user_guide_src/source/changelogs/v4.7.5.rst
+++ b/user_guide_src/source/changelogs/v4.7.5.rst
@@ -39,6 +39,7 @@ Bugs Fixed
 - **CLI:** Fixed a bug where pressing backspace in a ``CLI::prompt()`` erased the prompt text when the ``readline`` extension is enabled. The prompt is now passed to ``readline()`` so line redraws repaint it.
   ANSI color codes in the prompt (e.g., option defaults) are wrapped in readline's non-printing markers under GNU readline so cursor positioning stays accurate.
   On Windows, where the ``readline`` extension is built on WinEditLine, the prompt is written to STDOUT first because WinEditLine reports no library version and prints ANSI sequences literally.
+- **CLI:** Fixed a bug where ``CLI::input()`` and ``CLI::prompt()`` threw a ``TypeError`` when STDIN reached end-of-file (e.g., Ctrl+D) with the ``readline`` extension enabled. An empty string is now returned, matching the behavior without ``readline``.
 - **CLIRequest:** Fixed a bug where ``parseCommand()`` could throw a TypeError when ``argv`` is missing.
 - **CodeIgniter:** Fixed a bug where ``gatherOutput()`` could be called twice when ``startController()`` returned a ``ResponseInterface`` (e.g., from filter attributes or closure routes).
 - **Content Security Policy:** Fixed a bug where empty ``Content-Security-Policy``, ``Content-Security-Policy-Report-Only``, and ``Reporting-Endpoints`` response headers were generated when no corresponding values existed.


### PR DESCRIPTION
**Description**

`readline()` returns `false` when STDIN reaches end-of-file (e.g., the user presses Ctrl+D at a prompt). `InputOutput::input()` returned that value directly, so under `declare(strict_types=1)` it threw:

```
TypeError: CodeIgniter\CLI\InputOutput::input(): Return value must be of type string, false returned in system/CLI/InputOutput.php:50
```

The `fgets()` path used when the `readline` extension is unavailable already maps EOF to `''`. This does the same for `readline()`, so both paths behave identically.

Before:

```
$ php spark make:controller
Controller class name : ^D
TypeError: CodeIgniter\CLI\InputOutput::input(): Return value must be of type string, false returned
```

After:

```
$ php spark make:controller
Controller class name : ^D
```

The prompt is re-asked or the empty value is returned, exactly as it does today without `readline`.

`readline()` cannot be exercised under PHPUnit (the branch is skipped in the `testing` environment and is `@codeCoverageIgnore`d), so this was verified manually through a pty with `expect` on macOS libedit.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
