### PR TITLE
chore: label PRs by title type with Carson's `auto-labeler`

### DIFF
--- a/.github/carson.yml
+++ b/.github/carson.yml
@@ -19,6 +19,12 @@ settings:
       - label: testing
         files:
           all: ['tests/**']
+      - label: bug
+        title: ['^fix(\([^)]*\))?: ']
+      - label: enhancement
+        title: ['^perf(\([^)]*\))?: ']
+      - label: refactor
+        title: ['^refactor(\([^)]*\))?: ']
   conflicts-notifier:
     label: stale
     message: |-


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion.
- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- Your branch name and the target name should be different.
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch.

-->
**Description**
Adds three title-based rules to Carson's `auto-labeler` so the changelog labels that `admin/check-pr-labels.php` suggests after the fact are applied when the PR is opened.

| Title type | Label |
| --- | --- |
| `fix` | `bug` |
| `perf` | `enhancement` |
| `refactor` | `refactor` |

Each rule matches the Conventional Commits prefix with an optional scope, e.g. `fix:` or `fix(Cookie):`.

What is deliberately left out:
- `feat:` is not mapped. It can be either `new feature` or `enhancement` depending on context so it needs to be manually added
- `breaking change` is not derived from the title, matching the script.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value (without duplication)
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide